### PR TITLE
correct webinar title case

### DIFF
--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -36,8 +36,8 @@
     <ul class="no-bullets equal-height--vertical-divider">
       <li class="four-col equal-height--vertical-divider__item">
         <img src="{{ ASSET_SERVER_URL }}c8eb3c73-cloud-econonmics-webinar.png?w=300" alt="">
-        <h3>Learn why Private Open Cloud Makes Financial Sense</h3>
-        <p><a class="external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Watch the webinar<span hidden=""> Learn why Private Open Cloud Makes Financial Sense</span></a></p>
+        <h3>Learn why private open cloud makes financial sense</h3>
+        <p><a class="external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Watch the webinar<span hidden=""> Learn why private open cloud makes financial sense</span></a></p>
       </li>
       <li class="four-col equal-height--vertical-divider__item">
         <img src="{{ ASSET_SERVER_URL }}5b16e994-webinar-2.png?w=300" alt="">


### PR DESCRIPTION
## Done

Fix capitalisation of webinar title

## QA

Check that the webinar title on `/cloud/managed-cloud` is no longer hateful