### PR TITLE
updating takeunder tracking codes

### DIFF
--- a/templates/takeovers/takeunders/_autopilot-takeunder.html
+++ b/templates/takeovers/takeunders/_autopilot-takeunder.html
@@ -3,7 +3,7 @@
         <img class="featured__image featured--right__image not-for-small" src="{{ ASSET_SERVER_URL }}a535811f-icon-cloud.svg" width="150" alt="" />
     </div>
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="/cloud/openstack/autopilot" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'Buy Ubuntu Advantage takeunder', 'Buy Ubuntu Advantage']);">Get Autopilot, build a cloud, profit&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="/cloud/openstack/autopilot" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Buy Ubuntu Advantage takeunder', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });">Get Autopilot, build a cloud, profit&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Canonical's OpenStack Autopilot fully automates the deployment of an OpenStack cloud &mdash; just add servers.</p>
     </div>
 </div>

--- a/templates/takeovers/takeunders/_cio-report.html
+++ b/templates/takeovers/takeunders/_cio-report.html
@@ -1,6 +1,6 @@
 <div class="featured--right equal-height__item">
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/hSzepr" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'CIO report takeunder', 'CIO&rsquo;s guide to SDN, NFV and VNF']);">CIO&rsquo;s guide to <abbr title="Software-Defined Networking">SDN</abbr>, <abbr title="Network Functions Virtualization">NFV</abbr> and <abbr title="Virtualised Network Function">VNF</abbr>&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/hSzepr" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'CIO report takeunder', 'eventLabel' : 'CIO&rsquo;s guide to SDN, NFV and VNF', 'eventValue' : undefined });">CIO&rsquo;s guide to <abbr title="Software-Defined Networking">SDN</abbr>, <abbr title="Network Functions Virtualization">NFV</abbr> and <abbr title="Virtualised Network Function">VNF</abbr>&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Download the eBook and learn about the benefits and solutions for software-enabled networking.</p>
     </div>
     <div class="four-col last-col align-center not-for-small">

--- a/templates/takeovers/takeunders/_flexwebhosting-may-2016.html
+++ b/templates/takeovers/takeunders/_flexwebhosting-may-2016.html
@@ -1,6 +1,6 @@
 <div class="featured featured--right">
     <div class="six-col prepend-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/1KPKrJ" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'Flexwebhosting takeunder', 'Flexwebhosting spins up in record time']);">Flexwebhosting spins up in record time&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/1KPKrJ" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Flexwebhosting takeunder', 'eventLabel' : 'Flexwebhosting spins up in record time', 'eventValue' : undefined });">Flexwebhosting spins up in record time&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Dutch web hosting firm chooses BootStack and Juju, slashing time-to-service from days to minutes.</p>
     </div>
     <div class="four-col align-center append-one not-for-small">

--- a/templates/takeovers/takeunders/_iot-02-2017.html
+++ b/templates/takeovers/takeunders/_iot-02-2017.html
@@ -3,7 +3,7 @@
         <img class="featured__image featured--right__image not-for-small" src="{{ ASSET_SERVER_URL }}f9b91fa8-iot-whitepaper.svg" width="150" alt="" />
     </div>
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="https://pages.ubuntu.com/IoT-Security-whitepaper.html?utm_source=Takeunder&amp;utm_campaign=3)%20Device_FY17_IOT_IoTSecurityWhitepaper&amp;utm_medium=Banner" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'IoT security white paper takeunder', 'The latest on IoT security']);">The latest information on IoT security&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="https://pages.ubuntu.com/IoT-Security-whitepaper.html?utm_source=Takeunder&amp;utm_campaign=3)%20Device_FY17_IOT_IoTSecurityWhitepaper&amp;utm_medium=Banner" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'IoT security white paper takeunder', 'eventLabel' : 'The latest on IoT security', 'eventValue' : undefined });">The latest information on IoT security&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Get rid of security vulnerabilities with help from our newest white&nbsp;paper.</p>
     </div>
 </div>

--- a/templates/takeovers/takeunders/_low-latency-report.html
+++ b/templates/takeovers/takeunders/_low-latency-report.html
@@ -1,6 +1,6 @@
 <div class="featured featured--right">
     <div class="seven-col prepend-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/1KPKrJ" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'Low latency report takeunder', 'Low latency and real-time kernels']);">Low latency and real-time kernels&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/1KPKrJ" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Low latency report takeunder', 'eventLabel' : 'Low latency and real-time kernels', 'eventValue' : undefined });">Low latency and real-time kernels&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Get our special report to help you make an informed choice about Linux kernel technology for your telco and <abbr title="Network Functions Virtualization">NFV</abbr>&nbsp;apps.</p>
     </div>
     <div class="four-col last-col align-center not-for-small">

--- a/templates/takeovers/takeunders/_maas-ebook.html
+++ b/templates/takeovers/takeunders/_maas-ebook.html
@@ -3,7 +3,7 @@
         <img class="featured__image featured--right__image not-for-small" src="{{ ASSET_SERVER_URL }}3aa7e9a6-picto-articles-white.svg" width="150" alt="" />
     </div>
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="https://pages.ubuntu.com/eBook-MAAS.html?utm_source=ubuntu.com&utm_medium=Takeunder&utm_campaign=MAAS_ebook&" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'MAAS ebook takeunder', 'Bare Metal Server Provisioning']);">Bare metal server provisioning&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="https://pages.ubuntu.com/eBook-MAAS.html?utm_source=ubuntu.com&utm_medium=Takeunder&utm_campaign=MAAS_ebook&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MAAS ebook takeunder', 'eventLabel' : 'Bare Metal Server Provisioning', 'eventValue' : undefined });">Bare metal server provisioning&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Get the ebook to understand the benefits and how to use it within hyperscale environments.</p>
     </div>
 </div>

--- a/templates/takeovers/takeunders/_maas-webinar.html
+++ b/templates/takeovers/takeunders/_maas-webinar.html
@@ -1,6 +1,6 @@
 <div class="featured--right equal-height__item">
   <div class="six-col prepend-one append-one no-margin-bottom">
-    <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/cE0iPD" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'MAAS webinar takeunder', 'Cloud-ready servers in minutes']);">Cloud-ready servers in minutes&nbsp;&rsaquo;</a></h2>
+    <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/cE0iPD" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MAAS webinar takeunder', 'eventLabel' : 'Cloud-ready servers in minutes', 'eventValue' : undefined });">Cloud-ready servers in minutes&nbsp;&rsaquo;</a></h2>
     <p class="featured__content">Join our webinar and learn how to leverage your hardware infrastructure more efficiently.</p>
   </div>
   <div class="four-col last-col align-center not-for-small">

--- a/templates/takeovers/takeunders/_mwc-2016.html
+++ b/templates/takeovers/takeunders/_mwc-2016.html
@@ -1,6 +1,6 @@
 <div class="featured featured--right featured--event featured--event__mwc six-col">
     <div class="five-col prepend-one no-margin-bottom">
-        <h2 class="featured__title featured--right__title"><a href="http://ubunt.eu/ryU5zv" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'MWC 2016 takeunder', 'Ubuntu at Mobile World Congress 2016']);">Ubuntu at Mobile World Congress 2016&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured__title featured--right__title"><a href="http://ubunt.eu/ryU5zv" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MWC 2016 takeunder', 'eventLabel' : 'Ubuntu at Mobile World Congress 2016', 'eventValue' : undefined });">Ubuntu at Mobile World Congress 2016&nbsp;&rsaquo;</a></h2>
         <p class="featured__desc featured--event__desc three-col">Meet us in Barcelona for demos of our latest OpenStack, <abbr title="Network Functions Virtualization">NFV</abbr>, <abbr title="Internet of Things">IoT</abbr> and phone solutions.</p>
     </div>
 </div>

--- a/templates/takeovers/takeunders/_mwc-2017.html
+++ b/templates/takeovers/takeunders/_mwc-2017.html
@@ -1,6 +1,6 @@
 <div class="featured--right equal-height__item featured--event featured--event__barcelona">
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured__title featured--right__title"><a href="https://pages.ubuntu.com/Book-a-meeting-MWC2017.html" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'MWC 2017 takeunder', 'Ubuntu at Mobile World Congress 2017']);">Mobile World Congress 2017&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured__title featured--right__title"><a href="https://pages.ubuntu.com/Book-a-meeting-MWC2017.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MWC 2017 takeunder', 'eventLabel' : 'Ubuntu at Mobile World Congress 2017', 'eventValue' : undefined });">Mobile World Congress 2017&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Meet us in Barcelona for demos of our latest OpenStack, Kubernetes, 5G, <abbr title="Network Functions Virtualization">NFV</abbr>, <abbr title="Internet of Things">IoT</abbr> and&nbsp;phone.</p>
     </div>
 </div>

--- a/templates/takeovers/takeunders/_ods-2016.html
+++ b/templates/takeovers/takeunders/_ods-2016.html
@@ -1,6 +1,6 @@
 <div class="featured featured--right featured--event featured--event__barcelona">
     <div class="six-col prepend-one no-margin-bottom">
-      <h2 class="featured--right__title"><a href="http://ubunt.eu/V52PG7" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'ODS 2016 takeunder', 'Meet us at the OpenStack Summit']);">Meet us at the OpenStack Summit&nbsp;&rsaquo;</a></h2>
+      <h2 class="featured--right__title"><a href="http://ubunt.eu/V52PG7" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'ODS 2016 takeunder', 'eventLabel' : 'Meet us at the OpenStack Summit', 'eventValue' : undefined });">Meet us at the OpenStack Summit&nbsp;&rsaquo;</a></h2>
       <p class="featured__content">Join us in Barcelona to discuss the right solution for your business.</p>
     </div>
     <div class="four-col align-center append-one not-for-small">

--- a/templates/takeovers/takeunders/_ods-austin.html
+++ b/templates/takeovers/takeunders/_ods-austin.html
@@ -1,6 +1,6 @@
 <div class="featured featured--right featured--event featured--event__ods-austin">
     <div class="six-col prepend-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="https://insights.ubuntu.com/event/openstack-summit-austin/" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'ODS Austin takeunder', 'Ubuntu at OpenStack Summit Austin']);">OpenStack Summit Austin&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="https://insights.ubuntu.com/event/openstack-summit-austin/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'ODS Austin takeunder', 'eventLabel' : 'Ubuntu at OpenStack Summit Austin', 'eventValue' : undefined });">OpenStack Summit Austin&nbsp;&rsaquo;</a></h2>
         <p class="featured__content featured--event__desc">Meet us in Austin from 25 to 28 April for demos of our latest solutions, talks, competitions and more.</p>
     </div>
     <div class="four-col align-center append-one not-for-small">

--- a/templates/takeovers/takeunders/_qt-webinar.html
+++ b/templates/takeovers/takeunders/_qt-webinar.html
@@ -3,7 +3,7 @@
         <img class="featured__image featured--right__image not-for-small" src="{{ ASSET_SERVER_URL }}57fc4abd-Digital+signage+-+Takeunder.svg" width="120" alt="" />
     </div>
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="https://www.brighttalk.com/webcast/6793/246523?utm_source=ubuntuwebsite&utm_medium=takeunder&utm_campaign=3) Device_FY17_IOT_Vertical_DS_Webinar_Qt" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'QT and Core Webinar takeunder', 'Qt and Ubuntu Core: Building IoT devices']);">Qt and Ubuntu Core: Building IoT devices&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="https://www.brighttalk.com/webcast/6793/246523?utm_source=ubuntuwebsite&utm_medium=takeunder&utm_campaign=3) Device_FY17_IOT_Vertical_DS_Webinar_Qt" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'QT and Core Webinar takeunder', 'eventLabel' : 'Qt and Ubuntu Core: Building IoT devices', 'eventValue' : undefined });">Qt and Ubuntu Core: Building IoT devices&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Join our webinar and learn to create apps for digital signage, kiosks and industrial control screens.</p>
     </div>
 </div>

--- a/templates/takeovers/takeunders/_telco.html
+++ b/templates/takeovers/takeunders/_telco.html
@@ -1,6 +1,6 @@
 <div class="featured--right equal-height__item">
     <div class="six-col prepend-one no-margin-bottom">
-        <h2><a class="featured__content" href="http://ubunt.eu/uWtnfa" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'Telco takeunder', 'Analytics and big data for telcos']);">Analytics and big data for telcos&nbsp;&rsaquo;</a></h2>
+        <h2><a class="featured__content" href="http://ubunt.eu/uWtnfa" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Telco takeunder', 'eventLabel' : 'Analytics and big data for telcos', 'eventValue' : undefined });">Analytics and big data for telcos&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Boost revenue and reduce time to identify new markets and solutions.</p>
     </div>
     <div class="four-col align-center append-one not-for-small">

--- a/templates/takeovers/takeunders/_ua-store.html
+++ b/templates/takeovers/takeunders/_ua-store.html
@@ -1,6 +1,6 @@
 <div class="featured featured--right">
     <div class="seven-col prepend-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="https://buy.ubuntu.com/" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'Buy Ubuntu Advantage takeunder', 'Buy Ubuntu Advantage']);">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Buy Ubuntu Advantage takeunder', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Get professional support for Ubuntu from Canonical. We help organisations around the world to manage their Ubuntu cloud, server and desktop deployments.</p>
     </div>
     <div class="four-col last-col align-center not-for-small">


### PR DESCRIPTION
## Done

* updated the out of date takeunders google event code with the google tag manager version
* s/_gaq.push\(\['_trackEvent', '(.*)', '(.*)', ‘(.*)’]\);/dataLayer.push({'event' : 'GAEvent', 'eventCategory' : '$1', 'eventAction' : '$2', 'eventLabel' : '$3', 'eventValue' : undefined });/

## QA

* look at the homepage and test if the onclicks are going to GTM

