### PR TITLE
Fix contributions for empty fields

### DIFF
--- a/static/js/forms.js
+++ b/static/js/forms.js
@@ -21,7 +21,7 @@ forms.addSliders = function (numberElementsSelector, slidersClass) {
     var updateValueClosure = function (sisterNode) {
       return function(changeEvent) {
         targetNode = changeEvent.target;
-        sisterNode.value = targetNode.value;
+        sisterNode.value = targetNode.value || 0;
       }
     }
 

--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -139,19 +139,6 @@
     );
 
     /**
-     * Get the total amount of all the contribution items selected
-     */
-    var calculateTotal = function (itemsSelector) {
-        var total = 0;
-        document.querySelectorAll(itemsSelector).forEach(
-            function(valueElement) {
-                total += parseInt(valueElement.value);
-            }
-        );
-        return total;
-    }
-
-    /**
      * Select an equivalent item for a certain contribution amount
      */
     var chooseEquivalentItem = function (totalAmount) {
@@ -224,7 +211,13 @@
     }
 
     var updateSummary = function () {
-        var total = calculateTotal('.contribute__option-value');
+        // Get the total amount of all the contribution items selected
+        var total = 0;
+        document.querySelectorAll('.contribute__option-value').forEach(
+            function(valueElement) {
+                total += parseInt(valueElement.value || 0);
+            }
+        );
         var item = chooseEquivalentItem(total);
         document.querySelector('.contribute__total-amount').innerText = total;
         updateEquivalentItem(item);
@@ -256,7 +249,7 @@
         // add the individual items
         document.querySelectorAll('.contribute__option-amount').forEach(function(amountElement) {
             var name = amountElement.parentNode.id;
-            var value = amountElement.querySelector('[type=number]').value;
+            var value = amountElement.querySelector('[type=number]').value || 0;
             if (value > 0) {
                 transactionProducts.push(
                     {
@@ -285,6 +278,22 @@
     document.querySelector('#contributions-form').addEventListener(
         'submit',
         sendContributionFormAnalytics
+    );
+
+    /**
+     * Reset fields back to 0, if missing values
+     */
+    document.querySelectorAll('.contribute__option-value').forEach(
+        function(valueElement) {
+            valueElement.addEventListener(
+                'blur',
+                function () {
+                    if (isNaN(parseInt(valueElement.value))) {
+                        valueElement.value = 0;
+                    }
+                }
+            )
+        }
     );
 
     var optionsArea = document.querySelector('.contribute__options');


### PR DESCRIPTION
If a field has its value deleted:

- Always equate it to zero for all calculations
- Set it back to zero when the field loses focus

Fixes #1288.

QA
--

Run the site and go to <http://127.0.0.1:8001/download/desktop/contribute?version=16.04.2&architecture=amd64>.

Delete the value from a field. See that the form page still looks sane, acting as if the empty field had 0 in it.

Now click off the field. See that it fills in with "0".