### PR TITLE
Add Ubuntu Budgie flavour

### DIFF
--- a/templates/about/about-ubuntu/flavours.html
+++ b/templates/about/about-ubuntu/flavours.html
@@ -26,6 +26,7 @@
 			<li><a href="http://ubuntustudio.org/">Ubuntu Studio</a> &mdash; Designed for multimedia editing and creation</li>
 			<li><a href="https://xubuntu.org/">Xubuntu</a> &mdash; Ubuntu with the XFCE desktop environment</li>
 			<li><a href="https://ubuntu-mate.org/">Ubuntu MATE</a> &mdash; Ubuntu with the MATE desktop environment</li>
+			<li><a href="https://budgie-remix.org/">Ubuntu Budgie</a> &mdash; Simplicity &amp; Elegance &ndash; Budgie desktop powered by Ubuntu</li>
 		</ul>
 
 		<h3>Localizations</h3>

--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -98,7 +98,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
             </div>
           </li>
 
-          <li class="grid-list__item four-col last-row">
+          <li class="grid-list__item four-col">
             <div class="one-col ">
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}b89d0c93-mate.svg" alt="Ubuntu MATE icon">
             </div>
@@ -129,9 +129,17 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 <p>Xubuntu is an elegant and easy to use operating system. Xubuntu comes with Xfce, which is a stable, light and configurable desktop environment.</p>
             </div>
           </li>
+          <li class="grid-list__item four-col">
+            <div class="one-col ">
+                <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}49e647f4-budgie-remix-logo-medium.svg" alt="Budgie icon">
+            </div>
+            <div class="three-col last-col">
+                <h3><a class="external" href="https://budgie-remix.org/">Ubuntu Budgie</a></h3>
+                <p>Ubuntu Budgie provides the budgie-desktop environment which focuses on simplicity and elegance. It provides a traditional desktop metaphor based interface utilising a customisable panel based menu driven system.</p>
+            </div>
+          </li>
         </ul>
-
-    </div><!-- /.twelve-col -->
+        </div><!-- /.twelve-col -->
     </div><!-- /.strip-inner-wrapper -->
 </div><!-- /.row -->
 


### PR DESCRIPTION
## Done
Added Ubuntu Budge to our list of flavours in the about and in the download sections. 

## QA
- Run `make run`
- Go to http://localhost:8001/about/about-ubuntu/flavours
- Check Ubuntu Budgie is listed
- Then head over to http://localhost:8001/download/ubuntu-flavours
- Check that Ubuntu Budgie has been added to the grid list

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/1407

## Screenshots
![10516277](https://cloud.githubusercontent.com/assets/1413534/23701927/e2e3b01a-03f0-11e7-88f0-c471b26aafef.png)

