### PR TITLE
Correct Ubuntu Budgie website URL and description

### DIFF
--- a/templates/about/about-ubuntu/flavours.html
+++ b/templates/about/about-ubuntu/flavours.html
@@ -26,7 +26,7 @@
 			<li><a href="http://ubuntustudio.org/">Ubuntu Studio</a> &mdash; Designed for multimedia editing and creation</li>
 			<li><a href="https://xubuntu.org/">Xubuntu</a> &mdash; Ubuntu with the XFCE desktop environment</li>
 			<li><a href="https://ubuntu-mate.org/">Ubuntu MATE</a> &mdash; Ubuntu with the MATE desktop environment</li>
-			<li><a href="https://budgie-remix.org/">Ubuntu Budgie</a> &mdash; Simplicity &amp; Elegance &ndash; Budgie desktop powered by Ubuntu</li>
+			<li><a href="https://ubuntubudgie.org/">Ubuntu Budgie</a> &mdash; Simplicity &amp; Elegance &ndash; Budgie desktop powered by Ubuntu</li>
 		</ul>
 
 		<h3>Localizations</h3>

--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -134,8 +134,8 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}49e647f4-budgie-remix-logo-medium.svg" alt="Budgie icon">
             </div>
             <div class="three-col last-col">
-                <h3><a class="external" href="https://budgie-remix.org/">Ubuntu Budgie</a></h3>
-                <p>Ubuntu Budgie provides the budgie-desktop environment which focuses on simplicity and elegance. It provides a traditional desktop metaphor based interface utilising a customisable panel based menu driven system.</p>
+                <h3><a class="external" href="https://ubuntubudgie.org/">Ubuntu Budgie</a></h3>
+                <p>Ubuntu Budgie provides the Budgie desktop environment which focuses on simplicity and elegance. It provides a traditional desktop metaphor based interface utilising a customisable panel based menu driven system.</p>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
- Correct https://budgie-remix.org to https://ubuntubudgie.org
- Refer to Budgie desktop environment instead of budgie-desktop package

## Done

[List of work items including drive-bys]

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
