### PR TITLE
remove open daylight reference from /cloud/autopilot

### DIFF
--- a/templates/cloud/openstack/autopilot.html
+++ b/templates/cloud/openstack/autopilot.html
@@ -120,7 +120,7 @@
                 </li>
                 <li class="list-stepped__item">
                     <h3 class="list-stepped__title">Build your cloud with Autopilot</h3>
-                    <p>Select your OpenStack configuration. Choose your hypervisor (KVM), networking (Open vSwitch, Open Daylight) and storage components (Ceph, Swift and iSCSI). Add your hardware and install.</p>
+                    <p>Select your OpenStack configuration. Choose your hypervisor (KVM), networking (Open vSwitch) and storage components (Ceph, Swift and iSCSI). Add your hardware and install.</p>
                 </li>
                 <li class="list-stepped__item">
                     <h3 class="list-stepped__title">Start using your cloud</h3>


### PR DESCRIPTION
## DONE

* removed Open Daylight per meeting with Landscape team
* updated [copy doc](https://docs.google.com/document/d/1VmFtp_gEYvioRgGXbiQZpVGBhlJoIZAirLk6IOVUjUE/edit#)

## QA

1. go to /cloud/autopilot
2. search for ‘Open vSwitch’ and find that ‘Open Daylight’ isn’t there

## Issue / Card

[trello card](https://trello.com/c/K5wgkAG3)
