### PR TITLE
update link in maas contextual footer

### DIFF
--- a/templates/shared/contextual_footers/_maas-autopilot.html
+++ b/templates/shared/contextual_footers/_maas-autopilot.html
@@ -1,3 +1,3 @@
 <h3 class="contextual-footer__title">Build your cloud using MAAS and&nbsp;Autopilot</h3>
 <p class="contextual-footer__text">MAAS is perfect for deploying OpenStack with Autopilot  – the fastest and easiest way to build a cloud from the bare metal up.</p>
-<p class="contextual-footer__text"><a href="http://insights.ubuntu.com/2013/08/29/top-10-questions-about-maas/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS page', 'eventLabel' : 'Install Autopilot and MAAS', 'eventValue' : undefined });">Install Autopilot and MAAS&nbsp;&rsaquo;</a></p>
+<p class="contextual-footer__text"><a href="/cloud/openstack/autopilot" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS page', 'eventLabel' : 'Install Autopilot and MAAS', 'eventValue' : undefined });">Install Autopilot and MAAS&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done

* replaced link in the maas contextual footer from https://insights.ubuntu.com/2013/08/29/top-10-questions-about-maas but SHOULD link to https://www.ubuntu.com/cloud/openstack/autopilot.

## QA

1. On https://www.ubuntu.com/server/maas the footer has 3 sections. The section on the right hand side ('Build your cloud using MAAS and Autopilot') 
2. check that the link changed

## Issue / Card

Fixes #1408 
