### PR TITLE
update cloud training headings

### DIFF
--- a/templates/cloud/training.html
+++ b/templates/cloud/training.html
@@ -15,136 +15,135 @@
 {% block outer_content %}
 {% block content %}
 <section class="row row-hero row--training strip-light">
-    <div class="strip-inner-wrapper row--training__content">
-        <h1>Train with Ubuntu</h1>
-        <div class="six-col">
-            <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack. All classes and materials are provided in English.</p>
-        </div>
-        <img class="row--training__image not-for-small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" />
+  <div class="strip-inner-wrapper row--training__content">
+    <h1>Train with Ubuntu</h1>
+    <div class="six-col">
+      <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack. All classes and materials are provided in English.</p>
     </div>
+    <img class="row--training__image not-for-small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" />
+  </div>
 </section>
 
 <section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h2>OpenStack Fundamentals</h2>
-        </div>
-        <ul class="twelve-col list no-bullets training-list">
-            <li class="training-list__item">
-                <div class="equal-height--vertical-divider">
-                    <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-                        <h3>Online training</h3>
-                        <p>Independent providers of online OpenStack training materials, certified by&nbsp;Canonical.</p>
-                        <p><a href="https://academy.hastexo.com/courses/course-v1:hastexo+hx201+201610-juju/about" class="external">OpenStack 101 by Hastexo</a></p>
-                    </div>
-                </div>
-            </li>
-            <li class="training-list__item">
-                <div class="equal-height--vertical-divider">
-                    <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-                        <h3>On-site training</h3>
-                        <p>3-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
-                        <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/Ubuntu_OpenStack_Fundamentals_Training.pdf">Read the course outline (PDF)</a></p>
-                    </div>
-                    <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-                        <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-                            <dt>Duration</dt>
-                            <dd>3 days</dd>
-                            <dt>Cost</dt>
-                            <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
-                            <dt>Location</dt>
-                            <dd>Your premises</dd>
-                            <dt>Availability</dt>
-                            <dd>Private groups only</dd>
-                        </dl>
-                        <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
-                    </div>
-                </div>
-            </li>
-            <li class="training-list__item">
-                <div class="equal-height--vertical-divider">
-                    <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-                        <h3>High Availability Architecture add-on training</h3>
-                        <p>This is a half day add-on course that is bundled with the OpenStack Fundamentals course, at your premises, for up to 15 students, that will provide fundamental instruction on High Availability for OpenStack.</p>
-                        <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/8032/ubuntu-openstack-high-availability-architecture.pdf">Read the course outline (PDF)</a></p>
-                    </div>
-                    <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-                        <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-                            <dt>Duration</dt>
-                            <dd>4.5 hrs</dd>
-                            <dt>Cost</dt>
-                            <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
-                            <dt>Location</dt>
-                            <dd>Your premises</dd>
-                            <dt>Availability</dt>
-                            <dd>From 26 September 2016</dd>
-                        </dl>
-                        <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
-                    </div>
-                </div>
-            </li>
-            <li class="training-list__item">
-                <h2>Basic Ubuntu Server Administration</h2>
-                <div class="equal-height--vertical-divider">
-                    <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-                        <h3>On-site training</h3>
-                        <p>3-day hands-on course at your premises for up to 15 students, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
-                        <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/1ee7/Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)</a></p>
-                    </div>
-                    <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-                        <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-                            <dt>Duration</dt>
-                            <dd>3 days</dd>
-                            <dt>Cost</dt>
-                            <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
-                            <dt>Location</dt>
-                            <dd>Your premises</dd>
-                            <dt>Availability</dt>
-                            <dd>From 10 October 2016</dd>
-                        </dl>
-                        <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
-                    </div>
-                </div>
-            </li>
-
-            <li class="training-list__item">
-                <h2>Advanced Ubuntu Server Administration</h2>
-                <div class="equal-height--vertical-divider">
-                    <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-                        <h3>On-site training</h3>
-                        <p>You&rsquo;ve been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive 3-day hands-on course in which you will learn and use advanced techniques.</p>
-                        <p><a class="external" href="https://insights.ubuntu.com/wp-content/uploads/138d/Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)</a></p>
-                    </div>
-                    <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-                        <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-                            <dt>Duration</dt>
-                            <dd>3 days</dd>
-                            <dt>Cost</dt>
-                            <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
-                            <dt>Location</dt>
-                            <dd>Your premises</dd>
-                            <dt>Availability</dt>
-                            <dd>From 6 February 2017</dd>
-                        </dl>
-                        <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
-                    </div>
-                </div>
-            </li>
-        </ul>
+  <div class="strip-inner-wrapper">
+    <div class="eight-col">
+      <h2>OpenStack Fundamentals</h2>
     </div>
+    <ul class="twelve-col list no-bullets training-list">
+      <li class="training-list__item">
+        <div class="equal-height--vertical-divider">
+          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
+            <h3>Online training</h3>
+            <p>Independent providers of online OpenStack training materials, certified by&nbsp;Canonical.</p>
+            <p><a href="https://academy.hastexo.com/courses/course-v1:hastexo+hx201+201610-juju/about" class="external">OpenStack 101 by Hastexo</a></p>
+          </div>
+        </div>
+      </li>
+      <li class="training-list__item">
+        <div class="equal-height--vertical-divider">
+          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
+            <h3>On-site training</h3>
+            <p>3-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
+            <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/Ubuntu_OpenStack_Fundamentals_Training.pdf">Read the course outline (PDF)</a></p>
+          </div>
+          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
+            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
+              <dt>Duration</dt>
+              <dd>3 days</dd>
+              <dt>Cost</dt>
+              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
+              <dt>Location</dt>
+              <dd>Your premises</dd>
+              <dt>Availability</dt>
+              <dd>Private groups only</dd>
+            </dl>
+            <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </li>
+      <li class="training-list__item">
+        <div class="equal-height--vertical-divider">
+          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
+            <h3>High Availability Architecture add-on training</h3>
+            <p>This is a half day add-on course that is bundled with the OpenStack Fundamentals course, at your premises, for up to 15 students, that will provide fundamental instruction on High Availability for OpenStack.</p>
+            <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/8032/ubuntu-openstack-high-availability-architecture.pdf">Read the course outline (PDF)</a></p>
+          </div>
+          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
+            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
+              <dt>Duration</dt>
+              <dd>4.5 hrs</dd>
+              <dt>Cost</dt>
+              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
+              <dt>Location</dt>
+              <dd>Your premises</dd>
+              <dt>Availability</dt>
+              <dd>From 26 September 2016</dd>
+            </dl>
+            <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </li>
+      <li class="training-list__item">
+        <h2>Ubuntu Server Administration</h2>
+        <div class="equal-height--vertical-divider">
+          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
+            <h3>Basic on-site training</h3>
+            <p>3-day hands-on course at your premises for up to 15 students, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
+            <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/1ee7/Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)</a></p>
+          </div>
+          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
+            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
+              <dt>Duration</dt>
+              <dd>3 days</dd>
+              <dt>Cost</dt>
+              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+              <dt>Location</dt>
+              <dd>Your premises</dd>
+              <dt>Availability</dt>
+              <dd>From 10 October 2016</dd>
+            </dl>
+            <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </li>
+
+      <li class="training-list__item">
+        <div class="equal-height--vertical-divider">
+          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
+            <h3>Advanced on-site training</h3>
+            <p>You&rsquo;ve been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive 3-day hands-on course in which you will learn and use advanced techniques.</p>
+            <p><a class="external" href="https://insights.ubuntu.com/wp-content/uploads/138d/Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)</a></p>
+          </div>
+          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
+            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
+              <dt>Duration</dt>
+              <dd>3 days</dd>
+              <dt>Cost</dt>
+              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+              <dt>Location</dt>
+              <dd>Your premises</dd>
+              <dt>Availability</dt>
+              <dd>From 6 February 2017</dd>
+            </dl>
+            <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
 </section>
 
 <section class="row no-border strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="seven-col">
-            <h2>Questions about training?</h2>
-            <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
-            <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="five-col align-center last-col">
-            <img src="{{ ASSET_SERVER_URL }}9b170f06-picto-help-orange.svg" width="135" alt="" />
-        </div>
+  <div class="strip-inner-wrapper">
+    <div class="seven-col">
+      <h2>Questions about training?</h2>
+      <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
+      <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="five-col align-center last-col">
+      <img src="{{ ASSET_SERVER_URL }}9b170f06-picto-help-orange.svg" width="135" alt="" />
+    </div>
+  </div>
 </section>
 {% endblock content %}
 {% endblock outer_content %}
@@ -153,7 +152,7 @@
 <script src="https://platform.twitter.com/oct.js"></script>
 <script>twttr.conversion.trackPid('l4pwm');</script>
 <noscript>
-    <img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
-    <img height="1" width="1" style="display:none;" alt="" src="https://t.co/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
+  <img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
+  <img height="1" width="1" style="display:none;" alt="" src="https://t.co/i/adsct?txn_id=l4pwm&amp;p_id=Twitter" />
 </noscript>
 {% endblock footer_extra %}


### PR DESCRIPTION
# Done

* updated headings
* also fixed whitespace

## QA

1. go to /cloud/training
2. compare headings to the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit#heading=h.ylyblt40dd3y)

## Issue/Card

Fixes #1409