### PR TITLE
make /cloud/openstack/autopilot banner pinned right

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -634,7 +634,7 @@
 
         @media only screen and (min-width : $breakpoint-large) {
           height: 85%;
-          right: 3vw;
+          right: -2vw;
           width: 45vw;
         }
       }

--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -158,6 +158,33 @@
       padding-left: 1.5em;
     }
 
+    .pricing {
+      &__title {
+        font-size: 1.75em;
+        margin-bottom: 12px;
+      }
+
+      &__cost {
+        font-size: 1.75em;
+        text-align: left;
+        color: #333;
+        font-weight: 300;
+        border-top: 1px solid #d2d2d2;
+        padding-top: 12px;
+        margin-top: 12px;
+      }
+
+      &__unit {
+        font-size: .75em;
+        color: $warm-grey;
+      }
+
+      &__detail {
+        border-top: 1px solid #d2d2d2;
+        padding: 15px 0 0;
+      }
+    }
+
     // no-svg and opera-mini fixes for cloud/maas
     &.no-svg,
     &.opera-mini {
@@ -166,33 +193,5 @@
         background-image: url('#{$asset-server-url}6574f6c8-image-picto-maas-40.png');
       }
     }
-  }
-}
-
-
-.pricing {
-  &__title {
-    font-size: 1.75em;
-    margin-bottom: 12px;
-  }
-
-  &__cost {
-    font-size: 1.75em;
-    text-align: left;
-    color: #333;
-    font-weight: 300;
-    border-top: 1px solid #d2d2d2;
-    padding-top: 12px;
-    margin-top: 12px;
-  }
-
-  &__unit {
-    font-size: .75em;
-    color: $warm-grey;
-  }
-
-  &__detail {
-    border-top: 1px solid #d2d2d2;
-    padding: 15px 0 0;
   }
 }


### PR DESCRIPTION
## Done

* pinned the banner image to the right
* DRIVE BY moved pricing css into right area on server.scss

## QA

1. go to /cloud/openstack/autopilot and see the banner image is pinned to the right
2. go to /server/maas and see that pricing still looks ok

## Issue/Card

Fixes #981

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/23846965/0bbffb4e-07c8-11e7-894d-7c947e697a6e.png)
