### PR TITLE
updating autopilot image on /cloud/openstack page

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -592,12 +592,12 @@
 
       @media only screen and (min-width : $breakpoint-medium) {
         background-image: url('#{$asset-server-url}b72144a5-cloud_landscape_components.png?op=region&rect=0,0,300,600');
-        background-position: top bottom;
+        background-position: right top;
         background-repeat: no-repeat;
       }
 
       @media only screen and (min-width : $breakpoint-large) {
-        background-image: url('#{$asset-server-url}b72144a5-cloud_landscape_components.png?op=region&rect=0,0,550,800');
+        background-image: url('#{$asset-server-url}b72144a5-cloud_landscape_components.png?op=region&rect=0,0,500,800');
         background-position: right top;
         background-repeat: no-repeat;
       }

--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -592,12 +592,12 @@
 
       @media only screen and (min-width : $breakpoint-medium) {
         background-image: url('#{$asset-server-url}b72144a5-cloud_landscape_components.png?op=region&rect=0,0,300,600');
-        background-position: right bottom;
+        background-position: top bottom;
         background-repeat: no-repeat;
       }
 
       @media only screen and (min-width : $breakpoint-large) {
-        background-image: url('#{$asset-server-url}b72144a5-cloud_landscape_components.png?op=region&rect=0,0,450,800');
+        background-image: url('#{$asset-server-url}b72144a5-cloud_landscape_components.png?op=region&rect=0,0,550,800');
         background-position: right top;
         background-repeat: no-repeat;
       }


### PR DESCRIPTION
## Done

* updated the autopilot row to make the image look better in large and medium viewports

## QA

1. go to /cloud/openstack
2. look at the autopilot row in medium and large

## Screenshots

Medium

![image](https://cloud.githubusercontent.com/assets/441217/23855610/3254c2a0-07ee-11e7-8bda-c44c6971614f.png)


Large

![image](https://cloud.githubusercontent.com/assets/441217/23855574/07063b2e-07ee-11e7-9160-6d1c2edc7539.png)
