### PR TITLE
remove 12.04 network installer

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -32,7 +32,6 @@
                 <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/{{latest_release}}/">Download the network installer for {{latest_release_full}}</a></li>
                 <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/16.04/">Download the network installer for 16.04 LTS</a></li>
                 <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
-                <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/12.04/">Download network installer for 12.04 LTS</a></li>
             </ul>
         </div><!-- /.eight-col -->
     </div><!-- /.strip-inner-wrapper -->


### PR DESCRIPTION
## Done

* removed the 12.04 network installer from the alt download page as 12.04 is out of it’s LTS support
* updated the [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit)

## QA

1. go to /download/alternative-downloads
2. see that there is no 12.04 download in the ‘Network installer’ section per the copy doc

