### PR TITLE
Fix cloud partner hero text

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -516,6 +516,11 @@
         z-index: 1;
       }
 
+      .hero-content {
+        position: relative;
+        z-index: 10;
+      }
+
       .cloud-row-hero-image {
         position: relative;
         z-index: 3;


### PR DESCRIPTION
## Done
Made the hero text of the cloud partner section sit on top of the cloud.

## QA
- Pull down branch
- Run `./run`
- Go to http://0.0.0.0:8001/cloud/partners
- Zoom out and check the text is not obscured by the clouds

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/1441
