### PR TITLE
Docker copy update

### DIFF
--- a/templates/containers/docker-ubuntu.html
+++ b/templates/containers/docker-ubuntu.html
@@ -21,7 +21,7 @@
       <h1>Docker Engine on Ubuntu</h1>
       <h2>Integrated support service with enterprise&nbsp;SLAs</h2>
       <p>Docker Engine is a lightweight container runtime with robust tooling that builds and runs your container. Over 65% of all Docker-based scale out operations run on Ubuntu.</p>
-      <p>Canonical works closely with Docker Inc. to deliver an integrated Enterprise Edition Docker offering on Ubuntu. This partnership provides customers with the fastest and easiest path for support of Ubuntu and Docker Engine in enterprise Docker operations.</p>
+      <p>Canonical works closely with Docker Inc. to deliver an integrated Docker Enterprise Edition offering on Ubuntu. This partnership provides customers with the fastest and easiest path for support of Ubuntu and Docker Engine in enterprise Docker operations.</p>
       <p><a href="/containers/contact-us?product=docker">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
     </div>
     <div class="four-col last-col equal-height__item equal-height__align-vertically align-center">

--- a/templates/containers/docker-ubuntu.html
+++ b/templates/containers/docker-ubuntu.html
@@ -21,7 +21,7 @@
       <h1>Docker Engine on Ubuntu</h1>
       <h2>Integrated support service with enterprise&nbsp;SLAs</h2>
       <p>Docker Engine is a lightweight container runtime with robust tooling that builds and runs your container. Over 65% of all Docker-based scale out operations run on Ubuntu.</p>
-      <p>Canonical works closely with Docker Inc. to deliver an integrated Commercially Supported (CS) Docker Engine offering on Ubuntu. This partnership provides customers with the fastest and easiest path for support of Ubuntu and Docker Engine in enterprise Docker operations.</p>
+      <p>Canonical works closely with Docker Inc. to deliver an integrated Enterprise Edition Docker Engine offering on Ubuntu. This partnership provides customers with the fastest and easiest path for support of Ubuntu and Docker Engine in enterprise Docker operations.</p>
       <p><a href="/containers/contact-us?product=docker">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
     </div>
     <div class="four-col last-col equal-height__item equal-height__align-vertically align-center">
@@ -64,7 +64,7 @@
       <p>Docker and Canonical&rsquo;s integrated support offering for Docker Engine running on Ubuntu provides a streamlined operations and support experience:</p>
       <ul class="list-ticks--compact">
         <li>Stable, maintained releases of Docker are published and updated by Docker as snap packages on Ubuntu, enabling direct access to the official Docker Engine for all Ubuntu users</li>
-        <li>Canonical provides Level 1 and Level 2 technical support for the CS Docker Engine and are backed by Docker Inc. for Level 3 support</li>
+        <li>Canonical provides Level 1 and Level 2 technical support for Docker Enterprise Edition and are backed by Docker Inc. for Level 3 support</li>
         <li>Canonical also ensures global availability of secure  Ubuntu images on Docker Hub</li>
       </ul>
       <p><a href="/containers/contact-us?product=docker">Talk to our container team&nbsp;&rsaquo;</a></p>
@@ -83,7 +83,7 @@
           <img class="p-testimonial__image--large" src="{{ ASSET_SERVER_URL }}8c4a1c18-d535298c-nick_stinemates_small.jpg" alt="" />
         </div>
         <div class="ten-col last-col">
-          <p class="p-testimonial__quote--large">Through our partnership, we provide users with more choice by bringing the agility, portability, and security benefits of the Docker CS engine to the larger Ubuntu community.</p>
+          <p class="p-testimonial__quote--large">Through our partnership, we provide users with more choice by bringing the agility, portability, and security benefits of the Docker Enterprise Edition to the larger Ubuntu community</p>
           <div class="p-testimonial__citation-wrap--large">
             <cite class="p-testimonial__citation--large">
               <img class="p-testimonial__logo" src="{{ ASSET_SERVER_URL }}b12d2f83-docker_logo_h.svg" alt="" /> Nick Stinemates, VP, Business Development & Technical Alliances at Docker, Inc</cite>

--- a/templates/containers/docker-ubuntu.html
+++ b/templates/containers/docker-ubuntu.html
@@ -21,7 +21,7 @@
       <h1>Docker Engine on Ubuntu</h1>
       <h2>Integrated support service with enterprise&nbsp;SLAs</h2>
       <p>Docker Engine is a lightweight container runtime with robust tooling that builds and runs your container. Over 65% of all Docker-based scale out operations run on Ubuntu.</p>
-      <p>Canonical works closely with Docker Inc. to deliver an integrated Enterprise Edition Docker Engine offering on Ubuntu. This partnership provides customers with the fastest and easiest path for support of Ubuntu and Docker Engine in enterprise Docker operations.</p>
+      <p>Canonical works closely with Docker Inc. to deliver an integrated Enterprise Edition Docker offering on Ubuntu. This partnership provides customers with the fastest and easiest path for support of Ubuntu and Docker Engine in enterprise Docker operations.</p>
       <p><a href="/containers/contact-us?product=docker">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
     </div>
     <div class="four-col last-col equal-height__item equal-height__align-vertically align-center">


### PR DESCRIPTION
## Done

Updated product name references on the docker page.

## QA

 - Go to `/containers/docker-ubuntu`
 - See that all refs to 'Commercially Supported' or 'CS' are now 'Enterprise Edition'