### PR TITLE
Use new docker image

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -65,7 +65,7 @@ yarn install
 Then you can use the built in scripts to build or watch the Sass:
 
 ``` bash
-npm build  # Build the Sass to CSS then exit
+npm run build  # Build the Sass to CSS then exit
 npm run watch  # Dynamically watch for Sass changes and build CSS
 # or
 yarn run build  # Build the Sass to CSS then exit

--- a/run
+++ b/run
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Define the versions of the two docker images
-django_image="ubuntudesign/django:v1.2.0-candidate"
+django_image="ubuntudesign/django:v1.2.0"
 yarn_image="ubuntudesign/yarn:v0.1.0"
 
 # Usage instructions

--- a/run
+++ b/run
@@ -123,6 +123,7 @@ docker_run() {
   docker run  \
     --user $(id -u):$(id -g)  `# Use the current user inside container`  \
     ${env_file}               `# Pass environment variables into the container, if file exists`  \
+    --rm                      `# Tidy up by deleting the container when it stops`  \
     --volume `pwd`:`pwd`      `# Mirror current directory inside container`  \
     --workdir `pwd`           `# Set current directory to the image's work directory`  \
     ${tty}                    `# Attach a pseudo-terminal, if relevant`  \
@@ -169,7 +170,7 @@ case $run_command in
         $yarn_image run watch     `# Use the image for node version 7`
     fi
 
-    docker_django runserver 0.0.0.0:${PORT}
+    docker_django
   ;;
   "watch")
     yarn_install

--- a/run
+++ b/run
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Define the versions of the two docker images
-django_image="ubuntudesign/django-app:v1.1.0"
+django_image="ubuntudesign/django:v1.2.0-candidate"
 yarn_image="ubuntudesign/yarn:v0.1.0"
 
 # Usage instructions


### PR DESCRIPTION
This will do a better job of detecting whether a database is needed.

I was having a problem with the old method - for some reason my django
container thought there was a service available called `db`, so it was
trying to connect to the database, and it was breaking Django. This
solves that.

QA
--

Check `./run` still works.