### PR TITLE
Move ./run to use host yarn cache folder

### DIFF
--- a/run
+++ b/run
@@ -28,6 +28,7 @@ Commands
 - yarn <args>: Run yarn
 - django <args>: Run ./manage.py <args>
 - clean: Remove all images and containers, any installed dependencies and the .docker-project file
+- clean-cache: Empty cache files, which are saved between projects (eg, yarn)
 
 Persistent options
 ---
@@ -61,6 +62,9 @@ if grep -q '^docker:' /etc/group && ! groups | grep -q '\bdocker\b'; then
     exit 1
 fi
 
+# Check if yarn is locally installed
+command -v yarn >/dev/null 2>&1 && LOCAL_YARN_INSTALLED=1 || LOCAL_YARN_INSTALLED=0
+
 # Generate the project name
 if [[ -f ".docker-project" ]]; then
   project=$(cat .docker-project)
@@ -78,23 +82,14 @@ if [ -f .env ]; then
     export $(cat .env | grep -v ^\# | xargs)
 fi
 
-# Bind yarn cache to host folder if available
-yarn_cache_host=""
+# Bind yarn cache to named volume or local yarn cache if available
+yarn_cache_host="yarn_cache"
 yarn_cache_docker="/home/shared/.cache/yarn/"
-if type yarn 2>/dev/null; then
-  # Get correct location from installed yarn
+# If yarn is installed, use its local cache directory
+if LOCAL_YARN_INSTALLED; then
   yarn_cache_host=`yarn cache dir`
-else
-  case "$(uname -s)" in
-    "Darwin")
-      yarn_cache_host="${HOME}/Library/Caches/"
-    ;;
-    "Linux")
-      yarn_cache_host="${HOME}/.cache/yarn/"
-    ;;
-  esac
+  mkdir -p ${yarn_cache_host}
 fi
-mkdir -p ${yarn_cache_host}
 yarn_cache_arg="--volume ${yarn_cache_host}:${yarn_cache_docker}"
 
 # Optional arguments
@@ -170,6 +165,15 @@ yarn_install () {
   docker_run $yarn_image install
 }
 
+clean_cache () {
+  # Clean yarn cache volume
+  docker volume rm yarn_cache
+  if LOCAL_YARN_INSTALLED; then
+    yarn clean
+    mkdir -p ${yarn_cache_host}
+  fi
+}
+
 
 # Do the real business
 run_command=${1:-}
@@ -209,6 +213,9 @@ case $run_command in
   "clean")
     rm -rf node_modules .docker-project
     docker volume rm --force ${project}-dependencies
+  ;;
+  "clean-cache")
+    clean_cache $@
   ;;
   "django") docker_django $@ ;;
   "yarn") docker_yarn $@ ;;

--- a/run
+++ b/run
@@ -63,7 +63,7 @@ if grep -q '^docker:' /etc/group && ! groups | grep -q '\bdocker\b'; then
 fi
 
 # Check if yarn is locally installed
-command -v yarn >/dev/null 2>&1 && LOCAL_YARN_INSTALLED=1 || LOCAL_YARN_INSTALLED=0
+command -v yarn >/dev/null 2>&1 && LOCAL_YARN_INSTALLED=true || LOCAL_YARN_INSTALLED=false
 
 # Generate the project name
 if [[ -f ".docker-project" ]]; then
@@ -76,6 +76,7 @@ fi
 # Defaults
 PORT=8000
 DJANGO_DEBUG=true
+OPT_CACHE_CLEAN_FORCE=false
 
 # Read current environment variables
 if [ -f .env ]; then
@@ -86,7 +87,7 @@ fi
 yarn_cache_host="yarn_cache"
 yarn_cache_docker="/home/shared/.cache/yarn/"
 # If yarn is installed, use its local cache directory
-if LOCAL_YARN_INSTALLED; then
+if [ "$LOCAL_YARN_INSTALLED" = true ]; then
   yarn_cache_host=`yarn cache dir`
   mkdir -p ${yarn_cache_host}
 fi
@@ -113,6 +114,15 @@ module_volumes=()
 
 while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     key="$1"
+    case $run_command in
+      "clean-cache")
+          case $key in
+              -f|--force)
+                  OPT_CACHE_CLEAN_FORCE=true
+              ;;
+          esac
+      ;;
+    esac
 
     case $key in
         -p|--port)
@@ -127,7 +137,6 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
         ;;
         --no-debug) DJANGO_DEBUG=false ;;
         -h|--help) echo "$USAGE"; exit ;;
-        *) invalid ;;
     esac
     shift
 done
@@ -171,10 +180,16 @@ yarn_install () {
 
 clean_cache () {
   # Clean yarn cache volume
-  docker volume rm yarn_cache
-  if LOCAL_YARN_INSTALLED; then
-    yarn clean
-    mkdir -p ${yarn_cache_host}
+  echo "Deleting yarn_cache Docker volume..."
+  docker volume rm yarn_cache 2>/dev/null || echo "No volume found"
+  if [ $LOCAL_YARN_INSTALLED = true ]; then
+    if [ $OPT_CACHE_CLEAN_FORCE = true ]; then
+      yarn cache clean
+    else
+      echo "#"
+      echo "# Yarn is locally installed, use --force to clean your local cache"
+      echo "#"
+    fi
   fi
 }
 

--- a/run
+++ b/run
@@ -105,6 +105,10 @@ invalid() {
     exit 1
 }
 
+# Find current run command
+run_command=${1:-}
+if [[ -n "${run_command}" ]]; then shift; fi
+
 module_volumes=()
 
 while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
@@ -176,9 +180,6 @@ clean_cache () {
 
 
 # Do the real business
-run_command=${1:-}
-if [[ -n "${run_command}" ]]; then shift; fi
-
 case $run_command in
   ""|"start")
     yarn_install

--- a/run
+++ b/run
@@ -78,6 +78,25 @@ if [ -f .env ]; then
     export $(cat .env | grep -v ^\# | xargs)
 fi
 
+# Bind yarn cache to host folder if available
+yarn_cache_host=""
+yarn_cache_docker="/home/shared/.cache/yarn/"
+if type yarn 2>/dev/null; then
+  # Get correct location from installed yarn
+  yarn_cache_host=`yarn cache dir`
+else
+  case "$(uname -s)" in
+    "Darwin")
+      yarn_cache_host="${HOME}/Library/Caches/"
+    ;;
+    "Linux")
+      yarn_cache_host="${HOME}/.cache/yarn/"
+    ;;
+  esac
+fi
+mkdir -p ${yarn_cache_host}
+yarn_cache_arg="--volume ${yarn_cache_host}:${yarn_cache_docker}"
+
 # Optional arguments
 # ==
 #  --port {port} - The local port to run the web service on
@@ -141,8 +160,9 @@ docker_django () {
 docker_yarn () {
   # Run "yarn" from the "node" image
   docker_run  \
+    ${yarn_cache_arg} \
     ${module_volumes[@]+"${module_volumes[@]}"}  `# Add any override modules as volumes`  \
-    $yarn_image $@               `# Use the image for node version 7`
+    $yarn_image $@              `# Use the image for node version 7`
 }
 
 yarn_install () {
@@ -194,4 +214,3 @@ case $run_command in
   "yarn") docker_yarn $@ ;;
   *) invalid ;;
 esac
-


### PR DESCRIPTION
This mounts the host yarn cache into the docker image, so it can share the cache and keep everything wonderfully fast!

## QA
 - Install yarn on your computer - `npm install -g yarn`
 - `yarn install`
 - Delete node_modules
 - `./run yarn install` - should be fast using cache, with no errors
 - Delete node_modules again
 - `yarn install` - no errors


This needs reviews from someone on Linux and on OSX
