### PR TITLE
Change ‘download’ to ‘downloads’

### DIFF
--- a/static/css/section/_footer.scss
+++ b/static/css/section/_footer.scss
@@ -640,7 +640,7 @@ footer.global {
 
             &::after {
               content: "|";
-              padding: 0 .5em;
+              padding: 0 .45em;
               font-size: .6666em;
             }
 

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="Alternative downloads"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Alternative downloads"  %}
 </div><!-- /.strip-inner-wrapper -->
 {% endblock second_level_nav_items %}
 

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -10,7 +10,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Cloud" page_title="Autopilot"  %}
+  {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Cloud" page_title="Autopilot"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/cloud/conjure-up.html
+++ b/templates/download/cloud/conjure-up.html
@@ -10,7 +10,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Cloud" page_title="Conjure-up"  %}
+  {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Cloud" page_title="Conjure-up"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Cloud" tertiary="true"  %}
+  {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" page_title="Cloud" tertiary="true"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/burn-a-dvd-on-macos.html
+++ b/templates/download/desktop/burn-a-dvd-on-macos.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="How to burn a DVD on macOS"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="How to burn a DVD on macOS"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/burn-a-dvd-on-ubuntu.html
+++ b/templates/download/desktop/burn-a-dvd-on-ubuntu.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="How to burn a DVD on Ubuntu"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="How to burn a DVD on Ubuntu"  %}
 </div><!-- /.strip-inner-wrapper -->
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/burn-a-dvd-on-windows.html
+++ b/templates/download/desktop/burn-a-dvd-on-windows.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="How to burn a DVD on Windows"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="How to burn a DVD on Windows"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="Contribute"  %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Contribute"  %}
     </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/create-a-usb-stick-on-macos.html
+++ b/templates/download/desktop/create-a-usb-stick-on-macos.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="How to create a bootable USB stick on macOS"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="How to create a bootable USB stick on macOS"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/create-a-usb-stick-on-ubuntu.html
+++ b/templates/download/desktop/create-a-usb-stick-on-ubuntu.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="How to create a bootable USB stick on Ubuntu"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="How to create a bootable USB stick on Ubuntu"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/create-a-usb-stick-on-windows.html
+++ b/templates/download/desktop/create-a-usb-stick-on-windows.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="How to create a bootable USB stick on Windows"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="How to create a bootable USB stick on Windows"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Desktop"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" page_title="Desktop"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/install-ubuntu-desktop.html
+++ b/templates/download/desktop/install-ubuntu-desktop.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="Install Ubuntu {{lts_release_full}}"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Install Ubuntu {{lts_release_full}}"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -12,7 +12,7 @@ Thank you for your contribution
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="Thank you"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Thank you"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/try-ubuntu-before-you-install.html
+++ b/templates/download/desktop/try-ubuntu-before-you-install.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="Try Ubuntu before you install it"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Try Ubuntu before you install it"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/desktop/upgrade.html
+++ b/templates/download/desktop/upgrade.html
@@ -4,7 +4,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="Upgrade" tertiary="true" %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Upgrade" tertiary="true" %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/how-to-verify.html
+++ b/templates/download/how-to-verify.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
   <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="Alternative downloads"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Alternative downloads"  %}
   </div><!-- /.strip-inner-wrapper -->
 {% endblock second_level_nav_items %}
 

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -7,7 +7,7 @@
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Overview"  %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" page_title="Overview"  %}
     </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -4,7 +4,7 @@
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="ARM" %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="ARM" %}
     </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Server" tertiary="true"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" page_title="Server" tertiary="true"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/install-ubuntu-server.html
+++ b/templates/download/server/install-ubuntu-server.html
@@ -6,7 +6,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="Installing Ubuntu Server"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="Installing Ubuntu Server"  %}
 </div><!-- /.strip-inner-wrapper -->
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/linuxone-signup-thank-you.html
+++ b/templates/download/server/linuxone-signup-thank-you.html
@@ -4,7 +4,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="Thank you"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="Thank you"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -8,7 +8,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="LinuxONE"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="LinuxONE"  %}
 </div><!-- /.strip-inner-wrapper -->
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -9,7 +9,7 @@
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="POWER8" %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="POWER8" %}
     </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -9,7 +9,7 @@
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="Provisioning" %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="Provisioning" %}
     </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -7,7 +7,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="Thank you"  %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="Thank you"  %}
 </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -8,7 +8,7 @@ Thanks for downloading Ubuntu Server
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="Thank you"  %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="Thank you"  %}
     </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -8,7 +8,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Ubuntu flavours" page_title="Ubuntu flavours"  %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Ubuntu flavours" page_title="Ubuntu flavours"  %}
     </div><!-- /.strip-inner-wrapper -->
 {% endblock second_level_nav_items %}
 

--- a/templates/download/ubuntu-kylin.html
+++ b/templates/download/ubuntu-kylin.html
@@ -5,7 +5,7 @@
 
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Desktop" page_title="zh-CN" %}
+        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="zh-CN" %}
     </div>
 {% endblock second_level_nav_items %}
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -111,7 +111,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               <li><a{% if level_1 == 'support' %} class="active"{% endif %} href="/support">Support</a>
                 {% include "support/_nav_secondary.html" with promo="true" %}
               </li>
-              <li><a{% if level_1 == 'download' %} class="active"{% endif %} href="/download">Download</a>
+              <li><a{% if level_1 == 'download' %} class="active"{% endif %} href="/download">Downloads</a>
                 {% include "download/_nav_secondary.html" with promo="true" %}
               </li>
             </ul>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -37,7 +37,7 @@
     <div class="nav-wrapper">
       <div class="footer-b inline-lists">
         <ul class="clearfix">
-          <li><h2><a href="/download">Download</a></h2>
+          <li><h2><a href="/download">Downloads</a></h2>
             {% include "download/_nav_secondary.html" %}
           </li>
           <li><h2><a href="/about">About</a></h2>


### PR DESCRIPTION
## Done

Change ‘download’ to ‘downloads’
Reduced padding on footer links in order to fit downloads

## QA

Run ./run to get the site running. Check all instances of ‘download’ has been changed (not the url) check that /downloads redirects to /download (this already existed)

## Issue / Card

Card: https://trello.com/c/sSVqEEKT