### PR TITLE
Fix the --port option for ./run

### DIFF
--- a/run
+++ b/run
@@ -135,6 +135,7 @@ docker_django () {
   docker_run  \
     --volume ${project}-dependencies:/usr/local/lib/python2.7/site-packages  `# Store dependencies in a docker volume`  \
     --publish ${PORT}:${PORT}  `# Export the server port`  \
+    --env PORT=${PORT}  `# Set the port correctly`  \
     $django_image $@  `# Run the django image`
 }
 


### PR DESCRIPTION
Fix the --port option for ./run

Fixes #1464 

QA
---

``` bash
./run --port 8765
# or
./run -p 8765
```

Check things work.
