### PR TITLE
added small and medium fonts for maas pricing

### DIFF
--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -160,18 +160,34 @@
 
     .pricing {
       &__title {
-        font-size: 1.75em;
+        font-size: 1.25em;
         margin-bottom: 12px;
+
+        @media only screen and (min-width: $breakpoint-medium) {
+          font-size: 1.5em;
+        }
+
+        @media only screen and (min-width: $breakpoint-large) {
+          font-size: 1.75em;
+        }
       }
 
       &__cost {
-        font-size: 1.75em;
+        font-size: 1.25em;
         text-align: left;
         color: #333;
         font-weight: 300;
         border-top: 1px solid #d2d2d2;
         padding-top: 12px;
         margin-top: 12px;
+
+        @media only screen and (min-width: $breakpoint-medium) {
+          font-size: 1.5em;
+        }
+
+        @media only screen and (min-width: $breakpoint-large) {
+          font-size: 1.75em;
+        }
       }
 
       &__unit {


### PR DESCRIPTION
## Done

* added font sizes for S/M

## QA

1. go to /server/maas
2. look at the pricing table
3. see that the fonts drop for small and medium screens

## Issue / Card

Fixes #1456

## Screenshots

small

![image](https://cloud.githubusercontent.com/assets/441217/24586091/3c3d21ec-1791-11e7-8a3a-63241f078fa7.png)

medium

![image](https://cloud.githubusercontent.com/assets/441217/24586096/51a60cba-1791-11e7-8533-8d71cab7022d.png)
