### PR TITLE
Add ./run detach option, with bonus namespacing and cleaning

### DIFF
--- a/run
+++ b/run
@@ -184,6 +184,7 @@ yarn_install () {
   # Install yarn dependencies, without module overrides
   docker_run \
     --name ${container_name} \
+    --volume ${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-yarn-cache}:/home/shared/.cache/yarn/  `# Bind yarn cache to volume` \
     ${yarn_image} install
 }
 

--- a/run
+++ b/run
@@ -120,6 +120,15 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     shift
 done
 
+kill_docker_container() {
+  container_name="${1}"
+  # Kill any previously running containers
+  if docker ps | grep -q ${container_name}; then
+    echo "Killing previous container:"
+    docker kill ${container_name} || true
+  fi
+}
+
 docker_run() {
   # The standard set of "docker run" arguments
 
@@ -138,12 +147,7 @@ docker_run() {
 
 docker_django () {
   container_name="${project}-django"
-
-  # Kill any previously running containers
-  if docker ps | grep -q ${container_name}; then
-    echo "Killing previous container:"
-    docker kill ${container_name} || true
-  fi
+  kill_docker_container "${container_name}"
 
   # Run Django using the docker image
   docker_run  \
@@ -157,12 +161,7 @@ docker_django () {
 
 docker_yarn () {
   container_name="${project}-yarn"
-
-  # Kill any previously running containers
-  if docker ps | grep -q ${container_name}; then
-    echo "Killing previous container:"
-    docker kill ${container_name} || true
-  fi
+  kill_docker_container "${container_name}"
 
   # Run "yarn" from the "node" image
   docker_run  \
@@ -174,12 +173,7 @@ docker_yarn () {
 
 yarn_install () {
   container_name="${project}-yarn-install"
-
-  # Kill any previously running containers
-  if docker ps | grep -q ${container_name}; then
-    echo "Killing previous container:"
-    docker kill ${container_name} || true
-  fi
+  kill_docker_container "${container_name}"
 
   # Install yarn dependencies, without module overrides
   docker_run \
@@ -211,7 +205,7 @@ case $run_command in
     # Run watch command in the background
     if [[ ${1:-} == "--watch" ]] || [[ ${1:-} == "-w" ]]; then
       container_name="${project}-yarn-$(date +'%s')"
-      trap 'docker kill ${container_name}' EXIT
+      kill_docker_container "${container_name}"
       docker_run  \
         --name ${container_name}  `# Name the unit so it can be killed` \
         --detach                  `# Run in the background` \

--- a/run
+++ b/run
@@ -13,6 +13,7 @@ USAGE="Usage
   $ ./run \\
     [-p|--port NUM]          # Specify local port for server \\
     [-m|--node-module PATH]  # A path to a local node module to use instead of the installed dependencies \\
+    [-d|--detach]            # Detach container to the backgorund \\
     [--no-debug]             # Turn off Django's DEBUG setting \\
     [COMMAND]                # Optionally provide a command to run
 
@@ -73,6 +74,7 @@ else
 fi
 
 # Defaults
+DETACH=''
 PORT=8000
 DJANGO_DEBUG=true
 
@@ -100,6 +102,7 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     key="$1"
 
     case $key in
+        -d|--detach) DETACH='--detach' ;;
         -p|--port)
             if [ -z "${2:-}" ]; then invalid; fi
             PORT="$2"
@@ -134,25 +137,54 @@ docker_run() {
 }
 
 docker_django () {
+  container_name="${project}-django"
+
+  # Kill any previously running containers
+  if docker ps | grep -q ${container_name}; then
+    echo "Killing previous container:"
+    docker kill ${container_name} || true
+  fi
+
   # Run Django using the docker image
   docker_run  \
+    --name ${container_name} \
     --volume ${project}-dependencies:/usr/local/lib/python2.7/site-packages  `# Store dependencies in a docker volume`  \
     --publish ${PORT}:${PORT}  `# Export the server port`  \
     --env PORT=${PORT}  `# Set the port correctly`  \
+    ${DETACH} `# Detach from session if flag is set`  \
     $django_image $@  `# Run the django image`
 }
 
 docker_yarn () {
+  container_name="${project}-yarn"
+
+  # Kill any previously running containers
+  if docker ps | grep -q ${container_name}; then
+    echo "Killing previous container:"
+    docker kill ${container_name} || true
+  fi
+
   # Run "yarn" from the "node" image
   docker_run  \
+    --name ${container_name} \
     --volume ${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-yarn-cache}:/home/shared/.cache/yarn/  `# Bind yarn cache to volume` \
     ${module_volumes[@]+"${module_volumes[@]}"}  `# Add any override modules as volumes`  \
     $yarn_image $@              `# Use the image for node version 7`
 }
 
 yarn_install () {
+  container_name="${project}-yarn-install"
+
+  # Kill any previously running containers
+  if docker ps | grep -q ${container_name}; then
+    echo "Killing previous container:"
+    docker kill ${container_name} || true
+  fi
+
   # Install yarn dependencies, without module overrides
-  docker_run $yarn_image install
+  docker_run \
+    --name ${container_name} \
+    ${yarn_image} install
 }
 
 clean_cache () {
@@ -177,7 +209,7 @@ case $run_command in
 
     # Run watch command in the background
     if [[ ${1:-} == "--watch" ]] || [[ ${1:-} == "-w" ]]; then
-      container_name="yarn-$(date +'%s')"
+      container_name="${project}-yarn-$(date +'%s')"
       trap 'docker kill ${container_name}' EXIT
       docker_run  \
         --name ${container_name}  `# Name the unit so it can be killed` \
@@ -202,6 +234,10 @@ case $run_command in
     docker_django test
   ;;
   "clean")
+    running_containers="$(docker ps -aq --filter name=${project})"
+    if [ -n "${running_containers}" ]; then
+      docker rm --force $running_containers
+    fi
     rm -rf node_modules .docker-project
     docker volume rm --force ${project}-dependencies
   ;;
@@ -212,4 +248,3 @@ case $run_command in
   "yarn") docker_yarn $@ ;;
   *) invalid ;;
 esac
-

--- a/run
+++ b/run
@@ -204,12 +204,13 @@ case $run_command in
 
     # Run watch command in the background
     if [[ ${1:-} == "--watch" ]] || [[ ${1:-} == "-w" ]]; then
-      container_name="${project}-yarn-$(date +'%s')"
+      container_name="${project}-yarn-watch"
       kill_docker_container "${container_name}"
       docker_run  \
         --name ${container_name}  `# Name the unit so it can be killed` \
         --detach                  `# Run in the background` \
         $yarn_image run watch     `# Use the image for node version 7`
+      trap "kill_docker_container '${container_name}'" EXIT INT TERM
     fi
 
     docker_django

--- a/run
+++ b/run
@@ -210,7 +210,7 @@ case $run_command in
         --name ${container_name}  `# Name the unit so it can be killed` \
         --detach                  `# Run in the background` \
         $yarn_image run watch     `# Use the image for node version 7`
-      trap "kill_docker_container '${container_name}'" EXIT INT TERM
+      trap "kill_docker_container '${container_name}'" EXIT
     fi
 
     docker_django

--- a/run
+++ b/run
@@ -120,12 +120,12 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     shift
 done
 
-kill_docker_container() {
+rm_docker_container() {
   container_name="${1}"
   # Kill any previously running containers
-  if docker ps | grep -q ${container_name}; then
-    echo "Killing previous container:"
-    docker kill ${container_name} || true
+  if docker ps --all | grep -q ${container_name}; then
+    echo "Removing container:"
+    docker rm --force ${container_name} || true
   fi
 }
 
@@ -147,7 +147,7 @@ docker_run() {
 
 docker_django () {
   container_name="${project}-django"
-  kill_docker_container "${container_name}"
+  rm_docker_container "${container_name}"
 
   # Run Django using the docker image
   docker_run  \
@@ -161,7 +161,7 @@ docker_django () {
 
 docker_yarn () {
   container_name="${project}-yarn"
-  kill_docker_container "${container_name}"
+  rm_docker_container "${container_name}"
 
   # Run "yarn" from the "node" image
   docker_run  \
@@ -173,7 +173,7 @@ docker_yarn () {
 
 yarn_install () {
   container_name="${project}-yarn-install"
-  kill_docker_container "${container_name}"
+  rm_docker_container "${container_name}"
 
   # Install yarn dependencies, without module overrides
   docker_run \
@@ -205,12 +205,12 @@ case $run_command in
     # Run watch command in the background
     if [[ ${1:-} == "--watch" ]] || [[ ${1:-} == "-w" ]]; then
       container_name="${project}-yarn-watch"
-      kill_docker_container "${container_name}"
+      rm_docker_container "${container_name}"
       docker_run  \
         --name ${container_name}  `# Name the unit so it can be killed` \
         --detach                  `# Run in the background` \
         $yarn_image run watch     `# Use the image for node version 7`
-      trap "kill_docker_container '${container_name}'" EXIT
+      trap "rm_docker_container '${container_name}'" EXIT
     fi
 
     docker_django

--- a/run
+++ b/run
@@ -230,9 +230,9 @@ case $run_command in
     docker_django test
   ;;
   "clean")
-    running_containers="$(docker ps -aq --filter name=${project})"
-    if [ -n "${running_containers}" ]; then
-      docker rm --force $running_containers
+    project_containers="$(docker ps -aq --filter name=${project})"
+    if [ -n "${project_containers}" ]; then
+      docker rm --force $project_containers
     fi
     rm -rf node_modules .docker-project
     docker volume rm --force ${project}-dependencies


### PR DESCRIPTION
## Done

- Added `./run --detach` to run in background
- Namespaced all of the containers, for easy management
- `./run clean` now cleans all said namespaced containers
- Also, added yarn cache volume to yarn_install

## QA

- `./run` should work fine
- `./run --detach` should run in background. Can test with `docker ps`
- `./run` should kill background process and run as normal
- Running `./run --detach` should be killed and cleaned when running `./run clean`
