### PR TITLE
add caveat of Ubuntu Advantage or Landscape seats for on-prem

### DIFF
--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -244,7 +244,7 @@
     <div class="strip-inner-wrapper">
         <div class="ten-col">
             <h2>Landscape on-premises server</h2>
-            <p>If you&rsquo;d prefer a server on premises running behind your firewall, Landscape can be installed on private hardware. This is functionally identical to the SaaS, but you control the hardware.</p>
+            <p>If you&rsquo;d prefer a server on premises running behind your firewall, Landscape can be installed on private hardware. This is functionally identical to the SaaS, but you control the hardware. Requires all the desktop, servers or nodes it manages to have either a Ubuntu Advantage or Landscape seat.</p>
             <table class="audience-enterprise ua-table">
                 <thead>
                     <tr>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -244,7 +244,7 @@
     <div class="strip-inner-wrapper">
         <div class="ten-col">
             <h2>Landscape on-premises server</h2>
-            <p>If you&rsquo;d prefer a server on premises running behind your firewall, Landscape can be installed on private hardware. This is functionally identical to the SaaS, but you control the hardware. Requires all the desktop, servers or nodes it manages to have either a Ubuntu Advantage or Landscape seat.</p>
+            <p>If you&rsquo;d prefer a server on premises running behind your firewall, Landscape can be installed on private hardware. This is functionally identical to the SaaS, but you control the hardware. Requires all the desktop, servers and nodes it manages to have either an Ubuntu Advantage or Landscape seat.</p>
             <table class="audience-enterprise ua-table">
                 <thead>
                     <tr>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -244,7 +244,7 @@
     <div class="strip-inner-wrapper">
         <div class="ten-col">
             <h2>Landscape on-premises server</h2>
-            <p>If you&rsquo;d prefer a server on premises running behind your firewall, Landscape can be installed on private hardware. This is functionally identical to the SaaS, but you control the hardware. Requires all the desktop, servers and nodes it manages to have either an Ubuntu Advantage or Landscape seat.</p>
+            <p>If you&rsquo;d prefer a server on premises running behind your firewall, Landscape can be installed on private hardware. This is functionally identical to the SaaS, but you control the hardware. Requires all the desktops, servers and nodes it manages to have either an Ubuntu Advantage or Landscape seat.</p>
             <table class="audience-enterprise ua-table">
                 <thead>
                     <tr>


### PR DESCRIPTION
## Done

* added caveat to the /support/plans-and-pricing page for Landscape On-Premises server
* updated the copy doc

## QA

1. go to /support/plans-and-pricing
2. compare the Landscape text with the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/24623607/e656033c-18a0-11e7-8ba4-28d78a023ad5.png)
