### PR TITLE
Edit report a bug link

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -74,7 +74,7 @@
         <nav>
           <ul class="p-inline-list--middot-small u-no-margin--bottom">
             <li class="p-inline-list__item"><a class="p-link--soft" accesskey="8" href="/legal">Legal information</a></li>
-            <li class="p-inline-list__item"><a class="p-link--soft" href="https://github.com/canonical-websites/www.ubuntu.com/issues" id="report-a-bug">Report a bug on this site</a></li>
+            <li class="p-inline-list__item"><a class="p-link--soft" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a></li>
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
## Done

Edit report bug link, currently it’s:

https://github.com/canonical-websites/www.ubuntu.com/issues

should be:

https://github.com/canonical-websites/www.ubuntu.com/issues/new

## QA

run ./run to get started

Check that the link works and that the referring page is added to the issue content as was intended