### PR TITLE
update /server/maas pricing to be inline with maas.io

### DIFF
--- a/templates/server/maas.html
+++ b/templates/server/maas.html
@@ -211,7 +211,7 @@
       <p class="pricing__cost">Free</p>
       <div class="pricing__detail">
         <ul class="list-ticks--compact">
-          <li>Ubuntu, CentOS, custom images</li>
+          <li>Ubuntu, CentOS</li>
         </ul>
         <p><a href="/download/server/provisioning">Get started&nbsp;&rsaquo;</a></p>
       </div>
@@ -224,6 +224,7 @@
         <ul class="list-ticks--compact">
           <li>All operating systems</li>
           <li>9 to 5 support on weekdays (US and Europe only)</li>
+          <li>Custom images</li>
         </ul>
         <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
       </div>
@@ -236,6 +237,7 @@
         <ul class="list-ticks--compact">
           <li>All operating systems</li>
           <li>24/7 support</li>
+          <li>Custom images</li>
         </ul>
         <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
       </div>

--- a/templates/server/maas.html
+++ b/templates/server/maas.html
@@ -211,7 +211,7 @@
       <p class="pricing__cost">Free</p>
       <div class="pricing__detail">
         <ul class="list-ticks--compact">
-          <li>Ubuntu, CentOS</li>
+          <li>Ubuntu and CentOS</li>
         </ul>
         <p><a href="/download/server/provisioning">Get started&nbsp;&rsaquo;</a></p>
       </div>


### PR DESCRIPTION
## Done

* updated bullets on /server/maas pricing section to be in line with maas.io

## QA

1. go to /server/maas and see that the bullets match the [copy doc](https://docs.google.com/document/d/1IrlcBMrX_TDrRC8U1_QSbEOEJ55pGY7nnCd-nfZfiXM/edit)

## Issue / Card

Relates to [maas bug 104](https://github.com/canonical-websites/maas.io/pull/104)

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/24662650/9b9d890c-194d-11e7-81db-790d8f70eb0c.png)
