### PR TITLE
Add landscape section to the cloud plans and pricing page

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -726,6 +726,24 @@
     }
   }
 
+  // @subsection /cloud/plans-and-pricing
+  &.cloud-plans-and-pricing {
+    .row-ubuntu-advantage-promo {
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        background-image: url('#{$asset-server-url}65274d19-landscape-screenshot.png?W=600');
+        background-position: 158% 45px;
+        background-repeat: no-repeat;
+        background-size: 56%;
+      }
+
+      @media only screen and (min-width: $breakpoint-large) {
+        background-position: right -100px top 40px;
+        background-size: 40%;
+      }
+    }
+  }
+
   // @subsection /cloud/training
   &.cloud-training  {
 

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -9,14 +9,12 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero strip-light">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="seven-col equal-height__item">
+<section class="row row-hero strip-dark">
+    <div class="strip-inner-wrapper">
+        <div class="six-col">
             <h1>Plans and pricing</h1>
-            <p class="intro six-col">Ubuntu OpenStack offers the best economics of any commercially supported OpenStack solution. Canonical offers everything you need from fully managed clouds to training and support. We aim to be as easy and economical as possible to work with and that includes flexible pricing.</p>
-        </div>
-        <div class="five-col last-col align-center equal-height__item equal-height__align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}d8e144cc-picto-reducecosts-midaubergine.svg" width="220" alt="" />
+            <p class="intro">Ubuntu OpenStack offers the best economics of any commercially supported OpenStack solution.</p>
+            <p>Canonical offers everything you need from fully managed clouds to training and support. We aim to be as easy and economical as possible to work with and that includes flexible pricing.</p>
         </div>
     </div>
 </section>
@@ -160,32 +158,36 @@
               <thead>
                 <tr>
                   <th scope="col">&nbsp;</th>
-                  <th scope="col">Price</th>
+                  <th scope="col" colspan="2">Price</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
                   <th rowspan="1" scope="row"><a href="/server/maas">MAAS</a></th>
-                  <td>FREE</td>
+                  <td colspan="2">FREE</td>
                 </tr>
                 <tr>
                   <th rowspan="1" scope="row"><a href="/cloud/juju">Juju</a></th>
-                  <td>FREE</td>
+                  <td colspan="2">FREE</td>
                 </tr>
                 <tr>
                   <th rowspan="1" scope="row"><a href="/cloud/openstack">Ubuntu OpenStack</a></th>
-                  <td>FREE</td>
+                  <td colspan="2">FREE</td>
                 </tr>
                 <tr>
-                  <th rowspan="1" scope="row"><a href="/support">Landscape</a></th>
-                  <td>
-                      Free up to ten machines <br />
-                      or <br />
-                      $0.01 per machine hour (SaaS) <br />
-                      or <br />
-                      sold as part of Ubuntu Advantage (SaaS or on-premises)
+                  <th rowspan="2" scope="row"><a href="/support">Landscape</a></th>
+                  <td width="50%">
+                      <h6 class="no-margin-bottom">SaaS</h6>
+                      <p>$0.01 per machine hour</p>
+                  </td>
+                  <td width="50%">
+                      <h6 class="no-margin-bottom">On-premises</h6>
+                      <p>Free up to ten machines</p>
                   </td>
                 </tr>
+                <tr>
+                    <td colspan="2">Or comes as part of <a href="/support/plans-and-pricing">Ubuntu Advantage</a> subscription</td>
+                <tr>
               </tbody>
             </table>
         </div>

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -21,6 +21,30 @@
     </div>
 </section>
 
+<section class="row strip-light row-ubuntu-advantage-promo">
+    <div class="strip-inner-wrapper">
+        <div class="eight-col">
+            <h2>Landscape: Server management</h2>
+            <p>
+                Landscape allows you to manage thousands of Ubuntu machines as
+                easily as one, making the administration of Ubuntu desktops,
+                servers and cloud instances more cost-effective. It&rsquo;s
+                easy to set up, easy to use and it requires no special
+                hardware. It features:
+            </p>
+            <ul class="list-ticks--compact">
+                <li>Management at scale</li>
+                <li>Deploy or rollback security updates</li>
+                <li>Live patching</li>
+                <li>Compliance reports</li>
+                <li>Role-based access</li>
+                <li>Informative monitoring</li>
+            </ul>
+            <p><a href="https://landscape.canonical.com/">Learn more about Landscape&nbsp;&rsaquo;</a></p>
+        </div>
+    </div>
+</section>
+
 <section class="row no-border no-padding-bottom strip-light">
     <div class="strip-inner-wrapper">
         <div class="eight-col no-margin-bottom">
@@ -65,7 +89,7 @@
         <div class="ten-col">
         {% include "shared/_ubuntu_advantage_cloud_service_provider.html" %}
         </div>
-        
+
         <div class="eight-col">
             <p><a href="/management/contact-us">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
         </div>
@@ -154,7 +178,13 @@
                 </tr>
                 <tr>
                   <th rowspan="1" scope="row"><a href="/support">Landscape</a></th>
-                  <td>Sold as part of Ubuntu Advantage</td>
+                  <td>
+                      Free up to ten machines <br />
+                      or <br />
+                      $0.01 per machine hour (SaaS) <br />
+                      or <br />
+                      sold as part of Ubuntu Advantage (SaaS or on-premises)
+                  </td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## Done
Updated the /cloud/plans-and-pricing page with a new Landscape section and update the pricing at the bottom.

## QA
- Pull down code
- Run `./run`
- Go to http://localhost:8001/cloud/plans-and-pricing
- Check the Landscape section matches the copy doc
- Check the pricing table at the bottom matches the copy doc

## Screenshots
![10552767](https://cloud.githubusercontent.com/assets/1413534/24701058/00febf5c-19f1-11e7-9875-eb213ab32391.png)

## Details
Copy doc https://docs.google.com/document/d/1yZ7wClcmxGCqMyyyBJLO66Z3YlpT-4soWLFmJ6uXeMM/edit?pli=1#

