### PR TITLE
Add Landscape row to cloud overview page

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -264,7 +264,7 @@
             <p>
                 Landscape allows you to manage thousands of Ubuntu machines as
                 easily as one, making the administration of Ubuntu desktops,
-                servers and cloud instances more cost-effective. It&rsquo;s
+                servers and cloud instances more cost-effective.<br />It&rsquo;s
                 easy to set up, easy to use and it requires no special
                 hardware. It features:
             </p>

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -256,6 +256,37 @@
     </div>
 </section>
 
+<section class="row strip-dark">
+    <div class="strip-inner-wrapper">
+        <div class="eight-col">
+            <h2>Landscape</h2>
+            <h3>Server management</h3>
+            <p>
+                Landscape allows you to manage thousands of Ubuntu machines as
+                easily as one, making the administration of Ubuntu desktops,
+                servers and cloud instances more cost-effective. It&rsquo;s
+                easy to set up, easy to use and it requires no special
+                hardware. It features:
+            </p>
+            <ul class="four-col list-ticks--compact">
+                <li>Management at scale</li>
+                <li>Deploy or rollback security updates</li>
+                <li>Live patching</li>
+            </ul>
+            <ul class="four-col last-col list-ticks--compact">
+                <li>Compliance reports</li>
+                <li>Role-based access</li>
+                <li>Informative monitoring</li>
+            </ul>
+            <p>
+                <a href="https://landscape.canonical.com/" class="external">
+                    Learn more about Landscape
+                </a>
+            </p>
+        </div>
+    </div>
+</section>
+
 <section class="row no-border">
     <div class="strip-inner-wrapper">
         <div class="eight-col">

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -237,7 +237,7 @@
     </div>
 </section>
 
-<section class="row row-maas row-grey">
+<section class="row row-maas row-grey no-border">
     <div class="strip-inner-wrapper">
         <div class="six-col">
             <h2>MAAS is Metal as a Service</h2>
@@ -268,16 +268,18 @@
                 easy to set up, easy to use and it requires no special
                 hardware. It features:
             </p>
-            <ul class="four-col list-ticks--compact">
-                <li>Management at scale</li>
-                <li>Deploy or rollback security updates</li>
-                <li>Live patching</li>
-            </ul>
-            <ul class="four-col last-col list-ticks--compact">
-                <li>Compliance reports</li>
-                <li>Role-based access</li>
-                <li>Informative monitoring</li>
-            </ul>
+            <div class="combined-list">
+              <ul class="four-col list-ticks--compact">
+                  <li>Management at scale</li>
+                  <li>Deploy or rollback security updates</li>
+                  <li>Live patching</li>
+              </ul>
+              <ul class="four-col last-col list-ticks--compact">
+                  <li>Compliance reports</li>
+                  <li>Role-based access</li>
+                  <li>Informative monitoring</li>
+              </ul>
+            </div>
             <p>
                 <a href="https://landscape.canonical.com/" class="external">
                     Learn more about Landscape


### PR DESCRIPTION
## Done
Added a landscape section to the cloud overview page.

## QA
- Pull code
- Run `./run`
- Go to http://localhost:8001/cloud
- Check that the landscape section matches to copy doc
- The image was removed by design

## Screenshots
![10552787](https://cloud.githubusercontent.com/assets/1413534/24701640/1173058a-19f3-11e7-9193-ffef14b5f954.png)

## Details
Copy doc: https://drive.google.com/open?id=1mQjVXDcoP8ChOzRdmuI55BdXhbURD53qBNc2bgJhfhg
