### PR TITLE
1704 downloads updates

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -23,7 +23,7 @@
             <div class="box box-highlight clearfix equal-height--vertical-divider">
                 <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                     <h2>Ubuntu {{lts_release_full_with_point}}</h2>
-                    <p>Download the latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support – which means five years of free security and maintenance updates, guaranteed.</p>
+                    <p>Download the latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, guaranteed.</p>
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu {{lts_release_full}} release notes</a></p>
 
                     <p>Recommended system requirements:</p>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -20,7 +20,7 @@
             <div class="box box-highlight clearfix equal-height--vertical-divider">
                 <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                     <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
-                    <p>The Long Term Support version of Ubuntu Server, including the {{openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
+                    <p>The Long Term Support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
@@ -34,7 +34,7 @@
             <div class="box box-highlight clearfix equal-height--vertical-divider">
                 <div class="eight-col no-margin-bottom equal-height--vertical-divider__item">
                     <h2>Ubuntu Server {{latest_release}}</h2>
-                    <p>The latest version of Ubuntu Server, including the Newton release of OpenStack and nine months of security and maintenance updates.</p>
+                    <p>The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months of security and maintenance updates.</p>
                     <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{latest_release}} release notes</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -53,7 +53,7 @@
         <div class="four-col equal-height--vertical-divider__item clearfix last-col">
             <h3>Ubuntu {{latest_release_full}} for IBM POWER8</h3>
             <p>
-                The Ubuntu {{latest_release_full}} standard release builds on top of Ubuntu {{lts_release_full}}, further enabling rapid innovation for POWER8. It includes support for new POWER8 LC models, while continuing to improve performance and availability with enhanced CAPI Flash support.
+                The Ubuntu {{latest_release_full}} standard release builds on top of Ubuntu {{lts_release_full}}, further enabling rapid innovation for POWER8.
             </p>
         </div>
     </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ZestyZapus" latest_release="17.04" latest_release_full='17.04' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.2" lts_release_full='16.04 LTS' lts_release_with_point="16.04.2" lts_release_full_with_point='16.04.2 <abbr title="long-term support">LTS</abbr>' openstack_version="Mitaka" %}
+{% with latest_release_name="ZestyZapus" latest_release="17.04" latest_release_full='17.04' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.2" lts_release_full='16.04 LTS' lts_release_with_point="16.04.2" lts_release_full_with_point='16.04.2 <abbr title="long-term support">LTS</abbr>' lts_openstack_version="Mitaka" latest_openstack_version="Ocata" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="YakketyYak" latest_release="16.10" latest_release_full='16.10' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.2" lts_release_full='16.04 LTS' lts_release_with_point="16.04.2" lts_release_full_with_point='16.04.2 <abbr title="long-term support">LTS</abbr>' openstack_version="Mitaka" %}
+{% with latest_release_name="ZestyZapus" latest_release="17.04" latest_release_full='17.04' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.2" lts_release_full='16.04 LTS' lts_release_with_point="16.04.2" lts_release_full_with_point='16.04.2 <abbr title="long-term support">LTS</abbr>' openstack_version="Mitaka" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

Update downloads desktop overview, server overview and server/power8 as per copy doc updates

## QA

- Pull code
- Run ./run
- Go to 
  - http://localhost:8001/download/desktop
  - http://localhost:8001/download/server
  - http://localhost:8001/server/power8.html
  - http://localhost:8001/download/ubuntu-kylin
  - http://localhost:8001/download/server/power8
- Check that the pages match the copy docs

No actual code changes to download/ubuntu-kylin but the latest release section updates from the variable changes.

I’ve made the same changes to templates/base.html in PR https://github.com/canonical-websites/www.ubuntu.com/pull/1489 

No design review needed for this branch as it’s going into the 1704-dev feature branch to be design approved there

## Issue / Card

Card: https://trello.com/c/2XVwL0Fy

### Docs

- /download/ubuntu-kylin - https://docs.google.com/document/d/1rbyD8r8t8PVAczVm2MTrLEB7RQPUQO6amfYuetGJP3Y/edit#
- /download/desktop - https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit 
- /download/server - https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit#
- /download/server/power8 https://docs.google.com/document/d/1e-vav_b54KlKsi92w3rDu9J14O0gpp8yAanEAIImlE8/edit
 