### PR TITLE
Add Livepatch in Landscape section on livepatch page

### DIFF
--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -125,6 +125,21 @@
         padding: 20px 0;
       }
     }
+
+    .row-kernal-livepatching {
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        background-image: url('#{$asset-server-url}4d62c90a-applying-Livepatches.png?W=600');
+        background-position: 158% 45px;
+        background-repeat: no-repeat;
+        background-size: 56%;
+      }
+
+      @media only screen and (min-width: $breakpoint-large) {
+        background-position: right -100px center;
+        background-size: 40%;
+      }
+    }
   }
   // @subsection /server/maas
   &.server-maas {

--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -126,7 +126,7 @@
       }
     }
 
-    .row-kernal-livepatching {
+    .row--kernal-livepatching {
 
       @media only screen and (min-width: $breakpoint-medium) {
         background-image: url('#{$asset-server-url}4d62c90a-applying-Livepatches.png?W=600');

--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -76,7 +76,7 @@
     </div>
 </div>
 
-<section class="row strip-light row-kernal-livepatching">
+<section class="row strip-light row--kernal-livepatching">
     <div class="strip-inner-wrapper">
         <div class="six-col">
             <h2>Kernel livepatching in Landscape</h2>

--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -19,7 +19,12 @@
         </div>
         <div class="left six-col">
             <h2>Apply critical kernel patches without rebooting.</h2>
-            <p>Want to apply critical kernel security fixes without rebooting your system? The Canonical Livepatch Service for Ubuntu 16.04 LTS reduces planned or unplanned downtime while maintaining compliance and security.</p>
+            <p>
+              Want to apply critical kernel security fixes without rebooting
+              your system? The Canonical Livepatch Service for Ubuntu 16.04 LTS
+              and Ubuntu 14.04 LTS reduces planned or unplanned downtime while
+              maintaining compliance and security.
+            </p>
             <p><a class="button--primary" href="/livepatch">Sign up</a></p>
         </div>
     </div>
@@ -35,7 +40,11 @@
             <div class="no-margin-bottom">
                 <h3>Maximise service availability</h3>
             </div>
-            <p class="clear">Mission-critical workloads, such as enterprise databases, virtual/cloud hosts or infrastructure services, can&rsquo;t afford downtime. The Canonical Livepatch Service lets you apply kernel fixes in seconds, without restarting your Ubuntu 16.04 LTS system. Fewer reboots means improved service availability.</p>
+            <p class="clear">
+                The Canonical Livepatch Service lets you apply kernel fixes in
+                seconds, without restarting your Ubuntu 16.04 LTS system.
+                Fewer reboots means improved service availability.
+            </p>
         </div>
         <div class="four-col equal-height--vertical-divider__item clearfix">
             <div class="inline-small align-center">
@@ -44,8 +53,12 @@
             <div class="no-margin-bottom">
                 <h3>Maintain security and compliance</h3>
             </div>
-            <p class="clear">When a security loophole is identified in the Linux kernel, patching is the only way to reduce your exposure from malicious attack.</p>
-            <p>But finding a downtime window to address security vulnerabilities can be challenging. The Canonical Livepatch Service applies Linux kernel patches without rebooting, keeping your Ubuntu 16.04 LTS systems secure and compliant.</p>
+            <p class="clear">
+                Finding a downtime window to address security vulnerabilities
+                can be challenging. The Canonical Livepatch Service applies
+                Linux kernel patches without rebooting, keeping your Ubuntu
+                16.04 LTS systems secure and compliant.
+            </p>
         </div>
         <div class="four-col equal-height--vertical-divider__item clearfix last-col">
             <div class="inline-small align-center">
@@ -54,15 +67,49 @@
             <div class="no-margin-bottom">
                 <h3>Integrated service delivery</h3>
             </div>
-            <p class="clear">The Canonical Livepatch Service is available with an Ubuntu Advantage subscription. For existing customers introducing the Canonical Livepatch Service into your existing administrative processes is simple.</p>
+            <p class="clear">
+                Apply kernel livepatches easily through the Landscape system
+                management tool or the CLI. The Canonical Livepatch Service is
+                only available with an Ubuntu Advantage subscription.
+            </p>
         </div>
     </div>
 </div>
 
+<section class="row strip-light">
+    <div class="strip-inner-wrapper">
+        <div class="eight-col">
+            <h2>Kernel livepatching in Landscape</h2>
+            <p>
+                Apply livepatches straight through the GUI with the livepatch
+                feature for Landscape, available with an Ubuntu Advantage
+                subscription:
+            </p>
+        </div>
+        <div class="four-col append-one">
+            <ul class="list-ticks--compact">
+                <li>Manually apply Livepatch upgrades to specific computers</li>
+                <li>Automate Livepatch upgrades to maintain security compliance</li>
+                <li>Test Livepatches on a specific group of computers before rolling out to your entire&nbsp;system</li>
+            </ul>
+            <p>
+                <a href="/support">
+                    Learn more about Ubuntu Advantage&nbsp;&rsaquo;
+                </a>
+            </p>
+        </div>
+        <div class="seven-col last-col">
+            <img src="{{ ASSET_SERVER_URL }}4d62c90a-applying-Livepatches.png"
+                alt="Landscape admin splashscreen" />
+        </div>
+    </div>
+</section>
+
+
 <section class="row strip-light no-border">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
-            <h2>How to enable the Canonical Livepatch&nbsp;Service</h2>
+            <h2>How to enable the Canonical Livepatch Service in your CLI</h2>
         </div>
         <div class="seven-col append-one">
             <ol class="list-stepped--spaced">

--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -76,17 +76,15 @@
     </div>
 </div>
 
-<section class="row strip-light">
+<section class="row strip-light row-kernal-livepatching">
     <div class="strip-inner-wrapper">
-        <div class="eight-col">
+        <div class="six-col">
             <h2>Kernel livepatching in Landscape</h2>
             <p>
                 Apply livepatches straight through the GUI with the livepatch
                 feature for Landscape, available with an Ubuntu Advantage
                 subscription:
             </p>
-        </div>
-        <div class="four-col append-one">
             <ul class="list-ticks--compact">
                 <li>Manually apply Livepatch upgrades to specific computers</li>
                 <li>Automate Livepatch upgrades to maintain security compliance</li>
@@ -97,10 +95,6 @@
                     Learn more about Ubuntu Advantage&nbsp;&rsaquo;
                 </a>
             </p>
-        </div>
-        <div class="seven-col last-col">
-            <img src="{{ ASSET_SERVER_URL }}4d62c90a-applying-Livepatches.png"
-                alt="Landscape admin splashscreen" />
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done
Updated some copy and added "Kernel livepatching in Landscape" section.

## QA
- Pull code and run `./run`
- Go to http://localhost:8001/server/livepatch
- Check the copy matches the copy doc

Copy doc: https://docs.google.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit#

## Screenshots
![10553252](https://cloud.githubusercontent.com/assets/1413534/24710706/db887036-1a15-11e7-9017-43e023cc1ecf.png)

