### PR TITLE
Add Systems management tool section to support plans and pricing

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -26,7 +26,7 @@ body {
 .heading-6 {
   &--headline {
     margin-bottom: 2rem;
-    
+
     @media only screen and (min-width : $breakpoint-medium) {
       margin-bottom: 3.75rem;
     }
@@ -126,6 +126,20 @@ body {
   &.row-cool-grey {
     background-color: $cool-grey;
     color: $white;
+  }
+
+  &.row-system-management {
+    @media only screen and (min-width: $breakpoint-medium) {
+      background-image: url('#{$asset-server-url}fe2cdde9-features-graph.png');
+      background-position: 158% 45px;
+      background-repeat: no-repeat;
+      background-size: 56%;
+    }
+
+    @media only screen and (min-width: $breakpoint-large) {
+      background-position: right -45% top 60px;
+      background-size: 60%;
+    }
   }
 }
 

--- a/templates/shared/_systems_management_tool.html
+++ b/templates/shared/_systems_management_tool.html
@@ -1,0 +1,38 @@
+<section class="row row-grey row-system-management">
+    <div class="strip-inner-wrapper">
+        <div class="seven-col">
+            <h2>Systems management tool: Landscape</h2>
+            <p>
+                Reduce your team's efforts on day-to-day management with
+                Landscape, the most cost-effective tool to support and monitor
+                large and growing networks of desktops, servers and clouds.
+            </p>
+            <p>Take control of your infrastructure with:</p>
+            <ul class="list-ticks--compact">
+                <li>
+                    Automated updates and managed physical, virtual and
+                    cloud-based systems from a single interface
+                </li>
+                <li>
+                    Fully automated deployment of our reference architecture
+                    OpenStack cloud with
+                    <a href="/cloud/openstack/autopilot">Autopilot</a>
+                </li>
+                <li>Monitored and managed machines at scale</li>
+                <li class="last-item">Maintained security and compliance</li>
+                <li>Controlled inventory</li>
+                <li>Integration with current systems</li>
+                <li>Install, upgrade or downdate packages</li>
+                <li>Role-based access</li>
+                <li class="last-item">Canonical livepatch service</li>
+            </ul>
+            <p>
+                <a class="external"
+                    href="https://landscape.canonical.com/"
+                    alt="Learn more about Landscape">
+                    Learn more about Landscape
+                </a>
+            </p>
+        </div>
+    </div>
+</section>

--- a/templates/shared/_systems_management_tool.html
+++ b/templates/shared/_systems_management_tool.html
@@ -28,8 +28,7 @@
             </ul>
             <p>
                 <a class="external"
-                    href="https://landscape.canonical.com/"
-                    alt="Learn more about Landscape">
+                    href="https://landscape.canonical.com/">
                     Learn more about Landscape
                 </a>
             </p>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -25,6 +25,8 @@
     </div>
 </div><!-- /row-hero -->
 
+{% include "shared/_systems_management_tool.html" %}
+
 <div class="row row-grey row-pricing" id="ua">
     <div class="strip-inner-wrapper">
         <div class="eight-col">
@@ -62,15 +64,24 @@
     </div>
 </div><!-- /ua -->
 
-<div class="row row-white no-border no-padding-bottom" id="ubuntu-advantage-for-cloud">
+<div class="row row-white no-border no-padding-bottom"
+    id="ubuntu-advantage-for-cloud">
     <div class="strip-inner-wrapper">
         <div class="seven-col product-intro no-margin-bottom">
             <h2>Ubuntu Advantage for clouds</h2>
-            <p>Ubuntu Advantage offers support and management tools to keep your business productive in the cloud.</p>
-            <p><a href="/cloud/plans-and-pricing">Learn more&nbsp;&rsaquo;</a></p>
+            <p>
+                Ubuntu Advantage offers support service and management tools
+                to keep your business productive in the cloud.
+            </p>
+            <p>
+                <a href="/cloud/plans-and-pricing">
+                    Learn more&nbsp;&rsaquo;
+                </a>
+            </p>
         </div>
         <div class="prepend-two two-col text-center priority-0">
-            <img src="{{ ASSET_SERVER_URL }}dfd42685-picto-cloud-darkaubergine.svg" alt="" />
+            <img src="{{ ASSET_SERVER_URL }}dfd42685-picto-cloud-darkaubergine.svg"
+                alt="" />
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Done
Add Systems management tool section to support plans and pricing

## QA
- Pull code and run `./run`
- Go to http://localhost:8001/support/plans-and-pricing
- Check that the copy matches te copy doc

Copy doc: https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit?pli=1#heading=h.9q52wbh3nkil

## Screenshots
![10553372](https://cloud.githubusercontent.com/assets/1413534/24715417/1d94e2a4-1a23-11e7-9ca1-f9c5d0a8e758.png)

