### PR TITLE
Remove Unity 8 preview from /desktop/ubuntu-kylin

### DIFF
--- a/templates/desktop/ubuntu-kylin.html
+++ b/templates/desktop/ubuntu-kylin.html
@@ -171,7 +171,7 @@
 </section>
 
 
-<section class="row strip-light">
+<section class="row strip-light no-border">
     <div class="strip-inner-wrapper">
          <div class="six-col">
             <h3>Kingsoft WPS Office</h3>
@@ -182,19 +182,6 @@
          </div>
     </div>
  </section>
-
-<section class="row equal-height no-border strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="five-col equal-height__item equal-height__align-vertically priority-0">
-            <img src="{{ ASSET_SERVER_URL }}1097135a-image-unity8.svg" alt="" width="299" height="213" />
-        </div>
-        <div class="seven-col equal-height__item last-col">
-            <h3>Unity 8 preview</h3>
-            <p>Ubuntu Kylin {{lts_release_full}} offers an optional preview of Unity 8, the next generation Ubuntu user interface. To download the preview, search for unity8-desktop-session-mir in the Ubuntu Software Centre.</p>
-            <p>Please note that it uses the current version of Mir, the new graphics platform being developed by the Ubuntu community. Mir only works with open-source graphics drivers at present.</p>
-        </div>
-    </div>
-</section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_kylin_download" second_item="_desktop_kylin_learn_more" third_item="_desktop_further_reading" %}
 


### PR DESCRIPTION
## Done

Remove Unity 8 preview from /desktop/ubuntu-kylin

## QA

- Pull code and run ./run
- Go to: http://localhost:8001/desktop/ubuntu-kylin
- Check that the Unity 8 preview section has gone a per copy doc

### Design QA

Go to https://www.ubuntu.com/desktop/ubuntu-kylin and note the final section 'Unity 8 preview’ then pop over to http://www.ubuntu.com-1704-desktop-unity.demo.haus/desktop/ubuntu-kylin and note that the section has been removed 

## Issue / Card

Card: https://trello.com/c/5421cMFB
Doc: https://docs.google.com/a/canonical.com/document/d/1eJVoek0vT_vT4vy1Quw0NaBqm1fR9K2Dw8korIT2pKc/edit?disco=AAAABIz1RwE