### PR TITLE
Remove device newsletter

### DIFF
--- a/static/css/section/_contextual_footer.scss
+++ b/static/css/section/_contextual_footer.scss
@@ -28,6 +28,7 @@
   @media only screen and (min-width: $breakpoint-medium) {
     border-radius: 0;
     margin: 0;
+    padding: 0 0 30px;
   }
 
   &:after {

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -153,6 +153,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with  first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with  first_item="_desktop_contact_us" second_item="_desktop_buy_preinstalled" third_item="_desktop_further_reading" %}
 
 {% endblock content %}

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -91,6 +91,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_desktop_buy_preinstalled" third_item="_desktop_further_reading" %}
 
 {% endblock content %}

--- a/templates/desktop/government.html
+++ b/templates/desktop/government.html
@@ -92,7 +92,7 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_desktop_buy_preinstalled" third_item="_desktop_further_reading" %}
 
 {% endblock content %}
 {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -142,6 +142,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_download" second_item="_desktop_newsletter_signup--image" third_item="_desktop_for_china" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_download" second_item="_desktop_buy_preinstalled" third_item="_desktop_for_china" %}
 
 {% endblock content %}

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -139,6 +139,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_desktop_buy_preinstalled" third_item="_desktop_further_reading" %}
 
 {% endblock content %}

--- a/templates/mobile/developers.html
+++ b/templates/mobile/developers.html
@@ -126,6 +126,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_mobile_developer" second_item="_devices_newsletter_signup" third_item="_mobile_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_mobile_developer" second_item="_mobile_further_reading" %}
 
 {% endblock content %}

--- a/templates/mobile/devices.html
+++ b/templates/mobile/devices.html
@@ -178,6 +178,6 @@ Ubuntu smartphone, Ubuntu smartphones, smartphone Ubuntu, Ubuntu phone, Ubuntu p
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_phone_partners_developers" second_item="_devices_newsletter_signup" third_item="_phone_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_phone_partners_developers" second_item="_phone_further_reading" %}
 
 {% endblock content %}

--- a/templates/mobile/features.html
+++ b/templates/mobile/features.html
@@ -173,6 +173,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_mobile_partners_developers" second_item="_devices_newsletter_signup" third_item="_mobile_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_mobile_partners_developers" second_item="_phone_further_reading" %}
 
 {% endblock content %}

--- a/templates/mobile/index.html
+++ b/templates/mobile/index.html
@@ -122,7 +122,7 @@ Ubuntu phone, Ubuntu tablet, convergence, mobile, IoT, devices, Linux phone, Lin
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_phone_partners_developers" second_item="_devices_newsletter_signup" third_item="_phone_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_phone_partners_developers" second_item="_phone_further_reading" %}
 
 {% include "shared/_device_animation.html" %}
 

--- a/templates/mobile/partners.html
+++ b/templates/mobile/partners.html
@@ -114,6 +114,6 @@ Ubuntu tablet, Ubuntu for tablets, Ubuntu Edition, Ubuntu, tablet Ubuntu, lightw
     </div>
  </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_mobile_partners_developers" second_item="_devices_newsletter_signup" third_item="_phone_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_mobile_partners_developers" second_item="_phone_further_reading" %}
 
 {% endblock content %}

--- a/templates/shared/contextual_footers/_contextual_footer.html
+++ b/templates/shared/contextual_footers/_contextual_footer.html
@@ -1,18 +1,21 @@
-<!-- contextual-footer -->
 <div class="contextual-footer clearfix">
     <hr class="contextual-footer__hort-divider" />
     <div class="strip-inner-wrapper">
         <div class="twelve-col contextual-footer__content-container equal-height--vertical-divider no-margin-bottom">
-            <div class="equal-height--vertical-divider__item four-col contextual-footer__feature--first {{ first_item_class|default:''}}">
-                {% with "shared/contextual_footers/"|add:first_item|add:".html" as item_file %} {% include item_file %} {% endwith %}
-            </div>
-            <div class="equal-height--vertical-divider__item four-col contextual-footer__feature {{ second_item_class|default:''}}">
-                {% with "shared/contextual_footers/"|add:second_item|add:".html" as item_file %} {% include item_file %} {% endwith %}
-            </div>
-            <div class="equal-height--vertical-divider__item four-col contextual-footer__feature {{ third_item_class|default:''}} last-col">
-                {% with "shared/contextual_footers/"|add:third_item|add:".html" as item_file %} {% include item_file %} {% endwith %}
-            </div>
+            {% if first_item %}
+                <div class="equal-height--vertical-divider__item{% if not third_item %} six-col{% else %} four-col{% endif %} contextual-footer__feature--first {{ first_item_class|default:''}}">
+                    {% with "shared/contextual_footers/"|add:first_item|add:".html" as item_file %} {% include item_file %} {% endwith %}
+                </div>
+            {% endif %}
+            {% if second_item %}
+                <div class="equal-height--vertical-divider__item{% if not third_item %} six-col last-col{% else %} four-col{% endif %} contextual-footer__feature {{ second_item_class|default:''}}">
+                    {% with "shared/contextual_footers/"|add:second_item|add:".html" as item_file %} {% include item_file %} {% endwith %}
+                </div>{% endif %}
+            {% if third_item %}
+                <div class="equal-height--vertical-divider__item four-col contextual-footer__feature {{ third_item_class|default:''}} last-col">
+                    {% with "shared/contextual_footers/"|add:third_item|add:".html" as item_file %} {% include item_file %} {% endwith %}
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>
-<!-- /#context-footer -->


### PR DESCRIPTION
## Done

Remove device newsletter from desktop and mobile pages
Add footer extra logic to enable only two columns in contextual footer

## QA

- Pull code and run ./run
- Go to: 
  - http://localhost:8001/desktop
  - http://localhost:8001/desktop/education
  - http://localhost:8001/desktop/enterprise
  - http://localhost:8001/desktop/government
  - http://localhost:8001/desktop/partners
  - http://localhost:8001/mobile
  - http://localhost:8001/mobile/features
  - http://localhost:8001/mobile/devices
  - http://localhost:8001/mobile/partners
  - http://localhost:8001/mobile/developers
- Check that there is no device newsletter sign up form
- The mobile section only has two columns now which indicates that the new contextual footer logic works
- Demo available here: www.ubuntu.com-remove-device-newsletter.demo.haus

## Issue / Card

Card: https://trello.com/c/fC8ojCPd