### PR TITLE
Remove custom images from MAAS

### DIFF
--- a/templates/server/maas.html
+++ b/templates/server/maas.html
@@ -224,7 +224,6 @@
         <ul class="list-ticks--compact">
           <li>All operating systems</li>
           <li>9 to 5 support on weekdays (US and Europe only)</li>
-          <li>Custom images</li>
         </ul>
         <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
       </div>
@@ -237,7 +236,6 @@
         <ul class="list-ticks--compact">
           <li>All operating systems</li>
           <li>24/7 support</li>
-          <li>Custom images</li>
         </ul>
         <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
       </div>


### PR DESCRIPTION
## Done
Removed custom images from MAAS page

## QA
- Pull code
- Run `./run`
- Go to http://localhost:8001/server/maas
- Check that Custom images have been removed
