### PR TITLE
Remove mobile contextual footers

### DIFF
--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -153,6 +153,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with  first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with  first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
 
 {% endblock content %}

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -91,6 +91,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
 
 {% endblock content %}

--- a/templates/desktop/government.html
+++ b/templates/desktop/government.html
@@ -92,7 +92,7 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
 
 {% endblock content %}
 {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -142,6 +142,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_download" second_item="_desktop_newsletter_signup--image" third_item="_desktop_for_china" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_download" second_item="_support-image" third_item="_desktop_for_china" %}
 
 {% endblock content %}

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -139,6 +139,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_devices_newsletter_signup" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
 
 {% endblock content %}

--- a/templates/shared/contextual_footers/_mobile_developer.html
+++ b/templates/shared/contextual_footers/_mobile_developer.html
@@ -1,3 +1,0 @@
-<h3 class="contextual-footer__title">Explore our developer site</h3>
-<p class="contextual-footer__text">Whether you&rsquo;re a mobile app developer, a web developer or a software engineer, Ubuntu is the ideal development platform. </p>
-<p class="contextual-footer__text"><a href="https://developer.ubuntu.com/en/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'developer website', 'eventLabel' : 'Now available', 'eventValue' : undefined });" class="external">Find everything you need to start developing for Ubuntu</a></p>

--- a/templates/shared/contextual_footers/_mobile_further_reading.html
+++ b/templates/shared/contextual_footers/_mobile_further_reading.html
@@ -1,2 +1,0 @@
-<h3 class="contextual-footer__title">Further reading</h3>
-{% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/group/phone-and-tablet/feed" %}

--- a/templates/shared/contextual_footers/_mobile_partners_developers.html
+++ b/templates/shared/contextual_footers/_mobile_partners_developers.html
@@ -1,4 +1,0 @@
-<h3 class="contextual-footer__title">A new opportunity</h3>
-<p class="contextual-footer__text">Mobile carriers, device makers and developers: start building your Ubuntu Mobile experiences today.</p>
-<p class="contextual-footer__text"><a href="/mobile/partners" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'mobile partners page', 'eventLabel' : 'New opportunity', 'eventValue' : undefined });">For carriers and OEMs</a></p>
-<p class="contextual-footer__text"><a href="/mobile/developers" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'mobile developers page', 'eventLabel' : 'New opportunity', 'eventValue' : undefined });">For mobile developers</a></p>

--- a/templates/shared/contextual_footers/_phone_available.html
+++ b/templates/shared/contextual_footers/_phone_available.html
@@ -1,3 +1,0 @@
-<h3 class="contextual-footer__title">Now available</h3>
-<p class="contextual-footer__text">Buy an Ubuntu phone directly from our partners, such as BQ and Snapdeal.</p>
-<p class="contextual-footer__text"><a href="/phone/devices" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'phone devices page', 'eventLabel' : 'Now available', 'eventValue' : undefined });">Learn more about our devices&nbsp;&rsaquo;</a></p>

--- a/templates/shared/contextual_footers/_phone_further_reading.html
+++ b/templates/shared/contextual_footers/_phone_further_reading.html
@@ -1,2 +1,0 @@
-<h3 class="contextual-footer__title">Further reading</h3>
-{% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/group/phone-and-tablet/feed" %}

--- a/templates/shared/contextual_footers/_phone_partners_developers.html
+++ b/templates/shared/contextual_footers/_phone_partners_developers.html
@@ -1,4 +1,0 @@
-<h3 class="contextual-footer__title">A new opportunity</h3>
-<p class="contextual-footer__text">Mobile carriers, handset makers and developers: start building your Ubuntu mobile experiences today.</p>
-<p class="contextual-footer__text"><a href="/phone/partners" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'phone partners page', 'eventLabel' : 'New opportunity', 'eventValue' : undefined });">For carriers and OEMs</a></p>
-<p class="contextual-footer__text"><a href="/phone/developers" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'phone developers page', 'eventLabel' : 'New opportunity', 'eventValue' : undefined });">For mobile developers</a></p>

--- a/templates/shared/contextual_footers/_support-image.html
+++ b/templates/shared/contextual_footers/_support-image.html
@@ -1,0 +1,5 @@
+<img class="contextual-footer__image--centered" src="{{ ASSET_SERVER_URL }}9f035e4a-picto-support-orange.svg" alt="Pictogram pictogram" />
+<h3 class="contextual-footer__title">Professional support for Ubuntu</h3>
+<p class="contextual-footer__text">Get professional support from Canonical to manage your Ubuntu desktop, cloud and server deployments.</p>
+<p class="contextual-footer__text"><a href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Buy Ubuntu Advantage', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });" class="external">Buy Ubuntu Advantage</a></p>
+<p class="contextual-footer__text"><a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu support', 'eventLabel' : 'Find out more', 'eventValue' : undefined });">Find out more&nbsp;&rsaquo;</a></p>

--- a/templates/shared/contextual_footers/_support.html
+++ b/templates/shared/contextual_footers/_support.html
@@ -1,0 +1,4 @@
+<h3 class="contextual-footer__title">Professional support for Ubuntu</h3>
+<p class="contextual-footer__text">Get professional support from Canonical to manage your Ubuntu desktop, cloud and server deployments.</p>
+<p class="contextual-footer__text"><a href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Buy Ubuntu Advantage', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });" class="external">Buy Ubuntu Advantage</a></p>
+<p class="contextual-footer__text"><a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu support', 'eventLabel' : 'Find out more', 'eventValue' : undefined });">Find out more&nbsp;&rsaquo;</a></p>

--- a/templates/shared/contextual_footers/_tablet_available.html
+++ b/templates/shared/contextual_footers/_tablet_available.html
@@ -1,3 +1,0 @@
-<h3 class="contextual-footer__title">Ubuntu tablets available for sale</h3>
-<p class="contextual-footer__text">The world&rsquo;s first Ubuntu Tablet is available to buy, direct from the manufacturer, BQ.</p>
-<p class="contextual-footer__text"><a href="/tablet/devices" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'tablet devices page', 'eventLabel' : 'tablets for sale', 'eventValue' : undefined });">Buy now&nbsp;&rsaquo;</a></p>

--- a/templates/shared/contextual_footers/_tablet_developers.html
+++ b/templates/shared/contextual_footers/_tablet_developers.html
@@ -1,3 +1,0 @@
-<h3 class="contextual-footer__title">Want to learn more about developing with Ubuntu Core?</h3>
-<p class="contextual-footer__text">Learn how to build or port apps for the next generation of Ubuntu.</p>
-<p class="contextual-footer__text"><a class="external" href="https://developer.ubuntu.com/snappy/start" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'dev.u.c snappy page', 'eventLabel' : 'Develope Ubuntu core', 'eventValue' : undefined });">Try snappy Ubuntu Core</a></p>

--- a/templates/shared/contextual_footers/_tablet_further_reading.html
+++ b/templates/shared/contextual_footers/_tablet_further_reading.html
@@ -1,3 +1,0 @@
-<h3 class="contextual-footer__title">Further reading</h3>
-{% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/group/phone-and-tablet/feed" articles=5 %}
-</div>


### PR DESCRIPTION
## Done

Removed contextual footers for mobile and replaced them with support contextual footers in two variants (with or without an image)

## QA

Check all the pages in the /desktop section have support, not devices newsletter, contextual footers.

Demo: http://www.ubuntu.com-remove-mobile-contextual-footers.demo.haus/desktop
