### PR TITLE
Landscape self service takeunder on the homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -121,7 +121,7 @@
 <section class="row row-featured strip no-border">
   <div class="strip-inner-wrapper equal-height">
     {% include "takeovers/takeunders/_iot-02-2017.html" %}
-    {% include "takeovers/takeunders/_maas-webinar.html" %}
+    {% include "takeovers/takeunders/_landscape-self-service.html" %}
   </div>
 </section>
 

--- a/templates/takeovers/takeunders/_landscape-self-service.html
+++ b/templates/takeovers/takeunders/_landscape-self-service.html
@@ -21,7 +21,7 @@
   <div class="four-col last-col align-center not-for-small">
     <img class="featured__image featured--right__image not-for-small"
       src="{{ ASSET_SERVER_URL }}58b386e6-landscape-logo.svg"
-      width="200"
+      width="145"
       alt="" />
   </div>
 </div>

--- a/templates/takeovers/takeunders/_landscape-self-service.html
+++ b/templates/takeovers/takeunders/_landscape-self-service.html
@@ -1,0 +1,27 @@
+<div class="featured--right equal-height__item">
+  <div class="six-col prepend-one append-one no-margin-bottom">
+    <h2 class="featured--right__title">
+      <a class="featured__content"
+        href="https://landscape.canonical.com/try-landscape"
+        onclick="dataLayer.push({
+          'event' : 'GAEvent',
+          'eventCategory' : 'Homepage Link',
+          'eventAction' : 'Landscape self service takeunder',
+          'eventLabel' : 'New Landscape SaaS with $100 free credit',
+          'eventValue' : undefined
+        });">
+        New Landscape SaaS with &dollar;100 free credit&nbsp;&rsaquo;
+      </a>
+    </h2>
+    <p class="featured__content">
+      Try Landscape, our system management tool, for only &dollar;0.01 per
+      machine per hour.
+    </p>
+  </div>
+  <div class="four-col last-col align-center not-for-small">
+    <img class="featured__image featured--right__image not-for-small"
+      src="{{ ASSET_SERVER_URL }}58b386e6-landscape-logo.svg"
+      width="200"
+      alt="" />
+  </div>
+</div>


### PR DESCRIPTION
## Done
Added the landscape self-service take under on the homepage.

## QA

- Pull the code and run `./run`
- Go to http://0.0.0.0:8001/
- Scroll to the take under section
- Check the copy and link is the same as the copy doc
- Check the image is the same as in the card

## Issue / Card
Card: https://trello.com/c/bLhpkZ1y
Copy doc: https://docs.google.com/document/d/1rWY_bADnxZOWe-JStjP9cjsrn6f3Nmdq4Hs_sJDMsDU/edit

## Screenshots
![10559963](https://cloud.githubusercontent.com/assets/1413534/24903489/7dbd016c-1ea5-11e7-98af-4ea174f299cb.png)

