### PR TITLE
Reduce space betwix downloads

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -51,14 +51,10 @@
                     <ul class="no-bullets">
                         <li><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></li>
                     </ul>
-                </div><!-- /.four-col -->
-            </div><!-- /.box -->
-        </div><!-- /.twelve-col -->
-    </div><!-- /.strip-inner-wrapper -->
-</div><!-- /.row -->
-
-<div class="row row-grey">
-    <div class="strip-inner-wrapper">
+                </div>
+            </div>
+        </div>
+        
         <div class="twelve-col no-margin-bottom">
             <div class="box box-highlight clearfix equal-height--vertical-divider">
                 <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">


### PR DESCRIPTION
## Done

Reduce space between 16.04 and 17.04 downloads

## QA

- Pull code and run ./run
- Go to http://localhost:8001/download/desktop
- Make sure the gap is less

## Issue / Card

Card: https://trello.com/c/T0MbiYht

## Screenshots

### Bad as per live
![screen shot 2017-04-11 at 14 59 49](https://cloud.githubusercontent.com/assets/2152/24913183/420df766-1ec8-11e7-9895-0adbd5a6e314.png)

### Good as per this fix
![screen shot 2017-04-11 at 14 59 14](https://cloud.githubusercontent.com/assets/2152/24913194/49346ca0-1ec8-11e7-9ea9-fb2166714a70.png)


