### PR TITLE
Remove edubuntu flavour from alternative flavours

### DIFF
--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -35,17 +35,6 @@ full Ubuntu archive for packages and updates.{% endblock %}
         <ul class="grid-list twelve-col no-bullets no-margin-bottom">
           <li class="grid-list__item four-col">
             <div class="one-col ">
-                <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}c0c81698-Edubuntu_logo.svg" alt="Edubuntu icon">
-            </div>
-            <div class="three-col last-col">
-                <h3><a class="external" href="https://www.edubuntu.org/">Edubuntu</a></h3>
-                <p>Edubuntu includes applications and games appropriate for
-                children, and enables a teacher to setup a complete classroom
-                quickly and easily.</p>
-            </div>
-          </li>
-          <li class="grid-list__item four-col">
-            <div class="one-col ">
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}267e8693-Kubuntu_logo.svg" alt="Kubuntu icon">
             </div>
             <div class="three-col last-col">
@@ -54,7 +43,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 good-looking system for home and office use.</p>
             </div>
           </li>
-          <li class="grid-list__item four-col last-col">
+          <li class="grid-list__item four-col">
             <div class="one-col ">
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}600c73c4-Lubuntu.svg" alt="Lubuntu icon">
             </div>
@@ -65,8 +54,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 running on low-spec hardware.</p>
             </div>
           </li>
-
-          <li class="grid-list__item four-col">
+          <li class="grid-list__item four-col last-col">
             <div class="one-col ">
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}2a8f9030-mythbuntu.svg" alt="Mythbuntu icon">
             </div>
@@ -74,6 +62,15 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 <h3><a class="external" href="http://www.mythbuntu.org/">Mythbuntu</a></h3>
                 <p>Mythbuntu is a standalone MythTV based PVR system. It can be
                 a standalone system or integrated with an existing MythTV network.</p>
+            </div>
+          </li>
+          <li class="grid-list__item four-col">
+            <div class="one-col ">
+                <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}49e647f4-budgie-remix-logo-medium.svg" alt="Budgie icon">
+            </div>
+            <div class="three-col last-col">
+                <h3><a class="external" href="https://ubuntubudgie.org/">Ubuntu Budgie</a></h3>
+                <p>Ubuntu Budgie provides the Budgie desktop environment which focuses on simplicity and elegance. It provides a traditional desktop metaphor based interface utilising a customisable panel based menu driven system.</p>
             </div>
           </li>
           <li class="grid-list__item four-col">
@@ -98,7 +95,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
             </div>
           </li>
 
-          <li class="grid-list__item four-col">
+          <li class="grid-list__item last-row four-col">
             <div class="one-col ">
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}b89d0c93-mate.svg" alt="Ubuntu MATE icon">
             </div>
@@ -109,7 +106,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 Ubuntu's default desktop until October 2010.</p>
             </div>
           </li>
-          <li class="grid-list__item four-col">
+          <li class="grid-list__item last-row four-col">
             <div class="one-col ">
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}4a512076-ubuntustudio.svg" alt="Ubuntu Studio icon">
             </div>
@@ -120,7 +117,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 professional.</p>
             </div>
           </li>
-          <li class="grid-list__item four-col last-col">
+          <li class="grid-list__item last-row four-col last-col">
             <div class="one-col ">
                 <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}36e8f12b-Xubuntu_logo.svg" alt="Xbuntu icon">
             </div>
@@ -128,17 +125,6 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 <h3><a class="external" href="https://xubuntu.org/">Xubuntu</a></h3>
                 <p>Xubuntu is an elegant and easy to use operating system. Xubuntu comes with Xfce, which is a stable, light and configurable desktop environment.</p>
             </div>
-          </li>
-          <li class="grid-list__item four-col last-row">
-            <div class="one-col ">
-                <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}49e647f4-budgie-remix-logo-medium.svg" alt="Budgie icon">
-            </div>
-            <div class="three-col last-col">
-                <h3><a class="external" href="https://ubuntubudgie.org/">Ubuntu Budgie</a></h3>
-                <p>Ubuntu Budgie provides the Budgie desktop environment which focuses on simplicity and elegance. It provides a traditional desktop metaphor based interface utilising a customisable panel based menu driven system.</p>
-            </div>
-          </li>
-          <li class="grid-list__item four-col">
           </li>
         </ul>
         </div><!-- /.twelve-col -->


### PR DESCRIPTION
## Done

Remove edubuntu flavour from alternative flavours

## QA

- Pull code and run ./run
- Go to http://localhost:8001/download/ubuntu-flavours
- Check that edubuntu has been removed and that the list is now in alphabetical order

The will get design sign off on 1704-dev

## Issue / Card

Card: https://trello.com/c/XgvM9qly
