### PR TITLE
Remove self-service livepatch feature from /server/livepatch

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -30,7 +30,7 @@
     </div>
 </section>
 
-<div class="row no-border">
+<section class="row no-border">
     <div class="strip-inner-wrapper equal-height">
         <div class="four-col equal-height--vertical-divider__item clearfix">
             <div class="inline-small align-center">
@@ -68,42 +68,18 @@
                 <h3>Integrated service delivery</h3>
             </div>
             <p class="clear">
-                Apply kernel livepatches easily through the Landscape system
-                management tool or the CLI. The Canonical Livepatch Service is
-                only available with an Ubuntu Advantage subscription.
-            </p>
-        </div>
-    </div>
-</div>
-
-<section class="row strip-light row--kernal-livepatching">
-    <div class="strip-inner-wrapper">
-        <div class="six-col">
-            <h2>Kernel livepatching in Landscape</h2>
-            <p>
-                Apply livepatches straight through the GUI with the livepatch
-                feature for Landscape, available with an Ubuntu Advantage
-                subscription:
-            </p>
-            <ul class="list-ticks--compact">
-                <li>Manually apply Livepatch upgrades to specific computers</li>
-                <li>Automate Livepatch upgrades to maintain security compliance</li>
-                <li>Test Livepatches on a specific group of computers before rolling out to your entire&nbsp;system</li>
-            </ul>
-            <p>
-                <a href="/support">
-                    Learn more about Ubuntu Advantage&nbsp;&rsaquo;
-                </a>
+                Easily apply kernel livepatches through the CLI. The Canonical
+                Livepatch Service is available as part of Ubuntu Advantage
+                subscription.
             </p>
         </div>
     </div>
 </section>
 
-
 <section class="row strip-light no-border">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
-            <h2>How to enable the Canonical Livepatch Service in your CLI</h2>
+            <h2>How to enable the Canonical Livepatch Service</h2>
         </div>
         <div class="seven-col append-one">
             <ol class="list-stepped--spaced">


### PR DESCRIPTION
## Done
Remove self-service livepatch feature from /server/livepatch

## QA
- Pull code and run `./run`
- Go to http://0.0.0.0:8001/server/livepatch
- Check that the page looks ok
- Check the comments are complete in the copy doc

Copy doc: https://docs.google.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit#

## Screenshots
![10560527](https://cloud.githubusercontent.com/assets/1413534/24915413/f9e830ee-1ece-11e7-8f64-636865517a77.png)

