### PR TITLE
Remove self-service livepatch feature from /cloud/plans-and-pricing

### DIFF
--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -33,7 +33,6 @@
             <ul class="list-ticks--compact">
                 <li>Management at scale</li>
                 <li>Deploy or rollback security updates</li>
-                <li>Live patching</li>
                 <li>Compliance reports</li>
                 <li>Role-based access</li>
                 <li>Informative monitoring</li>
@@ -135,6 +134,25 @@
         </div>
         <div class="five-col text-center last-col">
             <img src="{{ ASSET_SERVER_URL }}3ba54a27-picto-contact-midaubergine.svg" width="200" alt="" />
+        </div>
+    </div>
+</section>
+
+<section class="row">
+    <div class="strip-inner-wrapper">
+        <h2 class="muted-heading">
+            What people are saying about Ubuntu Advantage
+        </h2>
+        <div class="ten-col prepend-two">
+            <blockquote class="pull-quote">
+                <p>
+                    <span>&ldquo;</span>
+                    Great 10/10 experience, and a very helpful Ubuntu
+                    technician.
+                    <span>&rdquo;</span>
+                </p>
+                <p><cite>AT&amp;T</cite></p>
+            </blockquote>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done
Remove self-service livepatch feature from /cloud/plans-and-pricing

## QA
- Pull code and run `./run`
- Go to http://0.0.0.0:8001/cloud/plans-and-pricing
- Check that the page looks ok
- Check the comments are complete in the copy doc

Copy doc: https://docs.google.com/document/d/1yZ7wClcmxGCqMyyyBJLO66Z3YlpT-4soWLFmJ6uXeMM/edit?pli=1#

## Screenshots
![10560555](https://cloud.githubusercontent.com/assets/1413534/24916301/ad9ec114-1ed1-11e7-8d33-7e447a42bcc6.png)

