### PR TITLE
Remove self-service livepatch feature from /support

### DIFF
--- a/templates/shared/_systems_management_tool.html
+++ b/templates/shared/_systems_management_tool.html
@@ -9,34 +9,30 @@
                 large and growing networks of&nbsp;desktops, servers and clouds.
             </p>
             <p>Take control of your infrastructure with:</p>
-        </div>
-        <div class="combined-list">
-            <ul class="six-col list-ticks--compact">
-                <li>
-                    Automated updates and managed physical, virtual and
-                    cloud-based systems from a single interface
-                </li>
-                <li>Monitored and managed machines at scale</li>
-                <li>Controlled inventory</li>
-                <li>Integration with current systems</li>
-                <li class="last-item">Maintained security and compliance</li>
-            </ul>
-            <ul class="six-col last-col list-ticks--compact">
-                <li>
-                    Fully automated deployment of our reference architecture
-                    OpenStack cloud with
-                    <a href="/cloud/openstack/autopilot">Autopilot</a>
-                </li>
-                <li>Install, upgrade or downdate packages</li>
-                <li>Role-based access</li>
-                <li class="last-item">Canonical livepatch service</li>
-            </ul>
-            <p>
-                <a class="external"
-                    href="https://landscape.canonical.com/">
-                    Learn more about Landscape
-                </a>
-            </p>
-        </div>
+              <ul class="list-ticks--compact">
+                  <li>
+                      Automated updates and managed physical, virtual and
+                      cloud-based systems from a single interface
+                  </li>
+                  <li>Monitored and managed machines at scale</li>
+                  <li>Controlled inventory</li>
+                  <li>Integration with current systems</li>
+                  <li>Maintained security and compliance</li>
+                  <li>
+                      Fully automated deployment of our reference architecture
+                      OpenStack cloud with
+                      <a href="/cloud/openstack/autopilot">Autopilot</a>
+                  </li>
+                  <li>Install, upgrade or downdate packages</li>
+                  <li>Role-based access</li>
+                  <li class="last-item">Canonical livepatch service</li>
+              </ul>
+              <p>
+                  <a class="external"
+                      href="https://landscape.canonical.com/">
+                      Learn more about Landscape
+                  </a>
+              </p>
+          </div>
     </div>
 </section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -134,17 +134,7 @@
 
 {% include "shared/_systems_management_tool.html" %}
 
-<section class="row row-white">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h2>The Canonical Livepatch Service</h2>
-            <p>Available to all Ubuntu Advantage customers, the Canonical Livepatch Service enables you to apply critical kernel security fixes to your Ubuntu 16.04 LTS system without rebooting, and it reduces planned or unplanned downtime while maintaining compliance and security.</p>
-            <p><a href="/server/livepatch">Learn more about the Canonical Livepatch Service&nbsp;&rsaquo;</a></p>
-        </div>
-    </div>
-</section>
-
-<section id="community-support" class="row row-grey no-border">
+<section id="community-support" class="row strip-light no-border">
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h2>Community support</h2>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -95,6 +95,8 @@
     </div>
 </section>
 
+{% include "shared/_systems_management_tool.html" %}
+
 <section class="row row-white">
     <div class="strip-inner-wrapper">
         <div class="ten-col push-one align-center">
@@ -131,8 +133,6 @@
         </div>
     </div>
 </section>
-
-{% include "shared/_systems_management_tool.html" %}
 
 <section id="community-support" class="row strip-light no-border">
     <div class="strip-inner-wrapper">


### PR DESCRIPTION
## Done
Remove self-service livepatch feature from /support

## QA
- Pull code and run `./run`
- Go to http://0.0.0.0:8001/support
- Check that the page looks ok
- Check the comments are complete in the copy doc

Copy doc: https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit?pli=1#

## Screenshots
![10560571](https://cloud.githubusercontent.com/assets/1413534/24916819/327b95b4-1ed3-11e7-8206-af8eedeb67ad.png)

