### PR TITLE
Remove self-service livepatch feature from /download/server

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -56,35 +56,7 @@
             </p>
         </div>
         <div class="equal-height">
-            <div class="four-col box">
-                <h3>
-                    Securely patch your kernels without rebooting with the
-                    Canonical livepatch service
-                </h3>
-                <p>
-                    Apply livepatches straight through the GUI with the livepatch
-                    feature for Landscape, available with an Ubuntu Advantage
-                    subscription:
-                </p>
-                <ul class="list">
-                    <li>
-                        Manually apply Livepatch upgrades to specific computers
-                    </li>
-                    <li>
-                        Automate Livepatch upgrades to maintain security compliance
-                    </li>
-                    <li>
-                        Test Livepatches on a specific group of computers before
-                        rolling out to your entire system
-                    </li>
-                </ul>
-                <p>
-                    <a href="/server/livepatch">
-                        Learn more about the Canonical livepatch service&nbsp;&rsaquo;
-                    </a>
-                </p>
-            </div>
-            <div class="four-col box">
+            <div class="six-col box">
                 <h3>Server management with Landscape</h3>
                 <ul class="list">
                     <li>
@@ -106,7 +78,7 @@
                     </a>
                 </p>
             </div>
-            <div class="four-col last-col box">
+            <div class="six-col last-col box">
                 <h3>Server provisioning with MAAS</h3>
                 <ul class="list">
                     <li>


### PR DESCRIPTION
## Done
Remove self-service livepatch feature from /download/server

## QA
- Pull code and run `./run`
- Go to http://0.0.0.0:8001/download/server
- Check that the page looks ok
- Check the comments are complete in the copy doc

Copy doc: https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit?pli=1

## Screenshots
![10560586](https://cloud.githubusercontent.com/assets/1413534/24917268/8b42feb6-1ed4-11e7-8590-32ffd2c15f64.png)

