### PR TITLE
change contribution slider from desktop from convergence

### DIFF
--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -26,16 +26,16 @@
 
         <form class="nine-col contribute box box-highlight clearfix" id="contributions-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
             <fieldset class="contribute__options noscript">
-                <section id="ubuntu-mobile">
-                    <label for="amount-mobile">
-                        <p class="title"><strong>Ubuntu for personal and mobile computing</strong></p>
-                        <p class="contribute__description">I want convergence now!</p>
+                <section id="ubuntu-desktop">
+                    <label for="amount-desktop">
+                        <p class="title"><strong>Ubuntu Desktop</strong></p>
+                        <p class="contribute__description">Make the desktop even more amazing.</p>
                     </label>
 
                     <div class="contribute__option-amount">
                         <span class="contribute__option-currency">$</span>
-                        <input type="number" min="0" max="125" id="amount-mobile" name="amount_1" value="3" tabindex="1" class="contribute__option-value">
-                        <input type="hidden" name="item_name_1" value="Ubuntu for personal and mobile computing">
+                        <input type="number" min="0" max="125" id="amount-desktop" name="amount_1" value="3" tabindex="1" class="contribute__option-value">
+                        <input type="hidden" name="item_name_1" value="Ubuntu Desktop">
                     </div>
                 </section>
                 <section id="ubuntu-for-cloud">


### PR DESCRIPTION
## Done

* updated the [copy doc](https://docs.google.com/document/d/1Q4ghGy-4iVvsmg2gwHhd0novCGm7Ww0Osz1WB-p_fSI/edit)
* updated the convergence slider

## QA

1. go to /download/desktop/contribute
2. see the first option is how Ubuntu Desktop
3. see that the google analytics are correct
![image](https://cloud.githubusercontent.com/assets/441217/24964093/37596f46-1f98-11e7-8056-acfe3405d0d0.png)


## Issue / Card

Fixes #1511 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/24964106/3f143fea-1f98-11e7-8dbb-bdb69df5d1ac.png)

