### PR TITLE
update /desktop/snappy contextual footer

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -179,6 +179,6 @@
   </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

* updated footer to default from the [footer copy doc](https://docs.google.com/document/d/1kq0SPv-PAIfL9nHGxgNDpHhr5OplE2iNaZZiqG4RT48/edit#)
* updated the page’s [copy doc](https://docs.google.com/document/d/19EIGiQ4FLfWVQczBgAqj5lIcWGnM0GmVGWggFIXcHt0/edit#)

## QA

1. open /desktop/snappy
2. see the footer is the default desktop one

## Issue / Card

Fixes #1540

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/25217587/644603b8-259f-11e7-912e-f8bcb627a0c1.png)

