### PR TITLE
Revert to default cloud takeover

### DIFF
--- a/static/sass/section/_homepage.scss
+++ b/static/sass/section/_homepage.scss
@@ -669,7 +669,8 @@ $shark: #181c21; // http://chir.ag/projects/name-that-color/#181C21
 
 // ============================ Takeovers ============================
 // cloud default, don not remove
-body.homepage-cloud-default {
+body.homepage-cloud-default,
+body.homepage-cloud-default--2 {
   @media only screen and (min-width : $breakpoint-medium) {
     h1 {
       padding-top: 90px;
@@ -686,7 +687,16 @@ body.homepage-cloud-default {
       padding-top: 105px;
     }
   } // @media only screen and (min-width : $breakpoint-large)
-} // body.homepage-cloud-default
+
+  
+} 
+
+// Override for the A/B test
+  body.homepage-cloud-default--2 {
+    .strip.no-border {
+      border-bottom: 1px dotted $warm-grey !important;
+    }
+  }// body.homepage-cloud-default
 
 body.homepage-bootstack-generic {
   header.banner {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block takeover_body_class %}homepage-1704{% endblock takeover_body_class %}
+{% block takeover_body_class %}homepage-cloud-default{% endblock takeover_body_class %}
 
 {% block head_extra %}
   <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
@@ -8,7 +8,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_1704_takeover.html" %}
+{% include "takeovers/_cloud_default.html" %}
 
 {% get_rss_feed "https://insights.ubuntu.com/tag/spotlight/feed" limit=1 as spotlight_feed %}
 

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block takeover_body_class %}homepage-1704{% endblock takeover_body_class %}
+{% block takeover_body_class %}homepage-cloud-default--2{% endblock takeover_body_class %}
 
 {% block head_extra %}
   <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
@@ -8,7 +8,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_1704_takeover.html" %}
+{% include "takeovers/_cloud_default.html" %}
 
 {% get_rss_feed "https://insights.ubuntu.com/tag/spotlight/feed" limit=1 as spotlight_feed %}
 


### PR DESCRIPTION
## Done
Reverted the takeover to the default cloud one. Fix up some styling for the index2 homepage.

## QA
- Pull code and run `./run`
- Go to http://0.0.0.0:8001/
- Check that the home page takeover looks and works ok

## Screenshots
![the leading operating system for pcs iot devices servers and the cloud - ubuntu](https://cloud.githubusercontent.com/assets/1413534/25451842/6ccd1622-2abb-11e7-9047-c9580b7b44f8.png)
