### PR TITLE
Update the title of the default cloud takeover

### DIFF
--- a/templates/takeovers/_cloud_default.html
+++ b/templates/takeovers/_cloud_default.html
@@ -1,7 +1,7 @@
 <section class="row strip no-border row-popular-cloud">
     <div class="strip-inner-wrapper">
         <div class="five-col append-one">
-            <h1>Ubuntu Cloud</h1>
+            <h1>No. 1 in the cloud</h1>
             <div class="six-col text-center for-mobile">
                 <img alt="Ubuntu Cloud" src="{{ ASSET_SERVER_URL }}475bdf5b-image-cloud.svg" />
             </div>


### PR DESCRIPTION
## Done
Update the title of the result cloud takeover

## QA
- Pull code and run `./run`
- Check the homepage has the correct title

## Details
Comment: https://github.com/canonical-websites/www.ubuntu.com/pull/1667#issuecomment-297680643

## Done

[List of work items including drive-bys]

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
