### PR TITLE
Footer font size

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -103,8 +103,11 @@
 
     &__menu {
       display: inline-block;
-      margin-left: $sp-large;
       position: relative;
+
+      @media (min-width: $breakpoint-medium) {
+        margin-left: $sp-large;
+      }
     }
 
     // large screen view
@@ -225,7 +228,7 @@
 
     @media (min-width: $breakpoint-large) {
       margin-left: 2.5rem;
-      
+
       .p-inline-list__item {
         margin-right: 1.5rem;
       }

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -73,3 +73,15 @@
       min-width: 55px;
   }
 }
+
+
+/// XXX Base font size is set to 16px across all viewports
+/// This is a change to be made upstream in vanilla-framework
+/// Issue: https://github.com/vanilla-framework/vanilla-framework/issues/1053
+html {
+  font-size: $font-base-size;
+
+  @media screen and (min-width: $breakpoint-medium) {
+    font-size: $font-base-size;
+  }
+}


### PR DESCRIPTION
## Done

 - Set font size to be the same across viewports - using `$font-base-size`
 - Removed left padding from the secondary nav that breaks at small screen

## QA

View `/about` on all viewports. See that the footer text is always 13px.

A local fix until the upstream [vanilla-framework issue](https://github.com/vanilla-framework/vanilla-framework/issues/1053) is resolved

Partial fix for #1709 