### PR TITLE
Reduce strip--deep on sm screens

### DIFF
--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -8,7 +8,11 @@
     }
 
     &.is-deep {
-      padding: 6.25rem 0;
+      padding: 2.5rem 0;
+
+      @media (min-width: $breakpoint-medium) {
+        padding: 6.25rem 0;
+      }
     }
 
     &.is-bordered {


### PR DESCRIPTION
## Done

Reduce `.p-strip--deep` padding on sm screens to 40px

## QA

- Pull code
- Run `./run serve`
- Navigate to /about
- Reduce screen size to less than 768px
- Verify hero strip top/bottom padding reduces to 40px

## Issue / Card

Related #1681
