### PR TITLE
Make active links in breadcrumbs orange

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -129,6 +129,10 @@
 
       a {
         color: $color-dark;
+
+        &.is-active {
+          color: $color-brand;
+        }
       }
 
       .p-breadcrumbs__link {
@@ -225,7 +229,7 @@
 
     @media (min-width: $breakpoint-large) {
       margin-left: 2.5rem;
-      
+
       .p-inline-list__item {
         margin-right: 1.5rem;
       }


### PR DESCRIPTION
## Done

Make active links in breadcrumbs orange

## QA

- Run `./run serve`
- Navigate to `/about/about-ubuntu/our-philosophy`
- Check that '_Philosophy_' in the breadcrumbs is colored orange

## Issue / Card

Fixes #1691