### PR TITLE
Remove inset shadow from search input

### DIFF
--- a/static/sass/_v1_pattern_site_search.scss
+++ b/static/sass/_v1_pattern_site_search.scss
@@ -56,6 +56,7 @@
     &__input[type='search'] {
       background: $color-light;
       border: 0;
+      box-shadow: none;
     }
 
     &__button {


### PR DESCRIPTION
## Done

Remove inset shadow from search input

## QA

- Pull code
- Run `./run serve`
- Verify that search input box does not have a box shadow

## Issue / Card

#1689 
