### PR TITLE
add compact button style for use in the footer

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -85,3 +85,9 @@ html {
     font-size: $font-base-size;
   }
 }
+
+/// XXX Compact button style
+/// This should be considered for inclusion in vanilla-framework
+.p-button--neutral.is-compact {
+  padding: $sp-x-small $sp-small;
+}

--- a/templates/templates/footer-v1.html
+++ b/templates/templates/footer-v1.html
@@ -86,9 +86,9 @@
         <nav>
           <ul class="p-inline-list">
             <li class="u-hidden--small p-inline-list__item">
-              <a class="p-button--neutral" href="/about/contact-us"><small>Contact us</small></a>
+              <a class="p-button--neutral is-compact" href="/about/contact-us"><small>Contact us</small></a>
             </li>
-            <li class="u-hidden--medium u-hidden--large p-inline-list__item">
+            <li class="u-hidden--medium is-compact u-hidden--large p-inline-list__item">
               <a class="p-link--soft" href="/about/contact-us"><small>Contact us</small></a>
             </li>
             <li class="p-inline-list__item">


### PR DESCRIPTION
## Done

Added a compact button state class for use in the footer

## QA

Go to `/about` and see the compact button style in action in "contact us"

Issue: #1705 