### PR TITLE
Increase padding around items in primary nav

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -47,15 +47,11 @@
       }
 
       @media (min-width: $breakpoint-medium) {
-        padding: $sp-medium $sp-x-small;
+        padding: $sp-medium $sp-small;
 
         &:hover {
           background-color: $color-brand-light;
         }
-      }
-
-      @media (min-width: $breakpoint-large) {
-        padding: $sp-medium $sp-small;
       }
     }
   }


### PR DESCRIPTION
## Done

Now text size of primary nav has been reduced, we can increase the left/right padding of each link item on medium screens and remove large screen override

## QA

- Pull code
- Check /about
- Make sure nav doesn't break while changing screen resolution

## Issue / Card

Related #1698