### PR TITLE
Contextual footer top border should only be 3px

### DIFF
--- a/static/sass/_v1_pattern_footer.scss
+++ b/static/sass/_v1_pattern_footer.scss
@@ -214,6 +214,6 @@
 
   // contextual footer
   .contextual-footer {
-    border-top: .875rem solid $color-brand;
+    border-top: 3px solid $color-brand;
   }
 }


### PR DESCRIPTION
## Done

Contextual footer top border should only be 3px

## QA

- Pull code
- Go to /about
- Check that top orange border on contextual footer is only 3px
