### PR TITLE
Footer secondary nav

### DIFF
--- a/static/sass/_v1_pattern_footer.scss
+++ b/static/sass/_v1_pattern_footer.scss
@@ -163,12 +163,11 @@
           border-top: 1px solid $color-mid-light;
           color: $color-dark;
           display: block;
-          font-size: .867rem;
+          font-size: .8125rem;
           padding: $sp-small $sp-small $sp-small $sp-medium;
 
           @media only screen and (min-width: $breakpoint-medium) {
             border: 0;
-            font-size: .8125rem;
             padding: 0 0 $sp-x-small;;
           }
         }


### PR DESCRIPTION
## Done

Secondary nav items had font sizes that didn't work with the new base font size, corrected it.

## QA

Check the footer nav in all viewports, especially the dropped-down secondary nav in small viewport.