### PR TITLE
Remove small-screen-specific styling for the footer inline list

### DIFF
--- a/static/sass/_v1_pattern_footer.scss
+++ b/static/sass/_v1_pattern_footer.scss
@@ -190,14 +190,6 @@
     a:hover {
       color: currentColor;
     }
-
-    .p-inline-list__item {
-      display: block;
-
-      @media only screen and (min-width: $breakpoint-medium) {
-        display: inline-block;
-      }
-    }
   }
 
   // social icons in footer

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -92,4 +92,5 @@ html {
 /// This should be considered for inclusion in vanilla-framework
 .p-button--neutral.is-compact {
   padding: $sp-x-small $sp-small;
+  width: auto;
 }

--- a/templates/templates/footer-v1.html
+++ b/templates/templates/footer-v1.html
@@ -85,11 +85,8 @@
       <div class="col-7">
         <nav>
           <ul class="p-inline-list">
-            <li class="u-hidden--small p-inline-list__item">
+            <li class="p-inline-list__item">
               <a class="p-button--neutral is-compact" href="/about/contact-us"><small>Contact us</small></a>
-            </li>
-            <li class="u-hidden--medium is-compact u-hidden--large p-inline-list__item">
-              <a class="p-link--soft" href="/about/contact-us"><small>Contact us</small></a>
             </li>
             <li class="p-inline-list__item">
               <a class="p-link--soft" href="/about"><small>About us</small></a>


### PR DESCRIPTION
## Done

Made the link list in the footer ("Contact us" etc.) look the same on all viewports. This required updated the compact variant of button to stop it being 100% at mobile.

## QA

Check the footer of `/about` page in all viewports.
