### PR TITLE
Remove bottom orange keyline on search input

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -6,12 +6,12 @@
 
   .p-navigation {
     margin-bottom: 0;
-    border-bottom: 1px solid $color-light;
     font-size: .875rem;
     font-weight: 400;
 
     @media (max-width: $breakpoint-medium) {
       font-weight: 300;
+      border-bottom: 1px solid $color-light;
     }
 
     &__logo {
@@ -63,6 +63,11 @@
   // .nav-secondary override
 
   .nav-secondary {
+
+    @media (min-width: $breakpoint-medium) {
+       border-top: 1px solid $color-mid-light;
+    }
+
     &__row {
       @media (min-width: $breakpoint-medium) {
         padding: 0 $sp-x-small;


### PR DESCRIPTION
## Done

Remove bottom orange keyline on search input

## QA

- Pull code
- Run `./run serve`
- Go to [http://0.0.0.0:8001/about](http://0.0.0.0:8001/about)
- Reduce screen width to 900px
- Clock search icon
- Verify there's no longer an orange keyline under the search input

## Issue / Card

Related #1689 