### PR TITLE
Increase vertical alignment of nav items

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -65,7 +65,7 @@
   .nav-secondary {
     &__row {
       @media (min-width: $breakpoint-medium) {
-        padding: 0 $sp-x-small;
+        padding: 0 $sp-small;
       }
     }
   }
@@ -169,7 +169,7 @@
 
     @media (min-width: $breakpoint-large) {
       &__row {
-        padding: 0 $sp-x-small;
+        padding: 0 $sp-small;
       }
     }
 

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -42,6 +42,10 @@
 // https://github.com/vanilla-framework/vanilla-framework/issues/1037
 .p-navigation__logo {
   margin: .65rem;
+
+  @media (min-width: $breakpoint-medium) {
+    padding-left: .4rem;
+  }
 }
 
 // at exactly $breakpoint-medium, there is not a clean switch between mobile/desktop nav styles


### PR DESCRIPTION
## Done

Increase vertical alignment of nav items.

Note: The global nav does not align exactly just above the tablet breakpoint and it feels wrong to override it here to do so. 

Given there are three disparate moving parts to the navigation header as a whole, I don't think it feasible nor practical to get them to exactly align at all varying breakpoints in the 'medium' viewports.

They should, however, line up nicely when the site max width is reached.

<img width="273" alt="screen shot 2017-05-09 at 14 07 42" src="https://cloud.githubusercontent.com/assets/505570/25852343/f34fe7ce-34c0-11e7-9da7-e9da9b063f22.png">


## QA

- Pull code
- Run `./run serve`
- Navigate to [http://0.0.0.0:8001/about](http://0.0.0.0:8001/about)
- Check alignment of navigation

## Issue / Card

Related #1698 