### PR TITLE
Remove testimonial on plans and pricing page

### DIFF
--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -138,25 +138,6 @@
     </div>
 </section>
 
-<section class="row">
-    <div class="strip-inner-wrapper">
-        <h2 class="muted-heading">
-            What people are saying about Ubuntu Advantage
-        </h2>
-        <div class="ten-col prepend-two">
-            <blockquote class="pull-quote">
-                <p>
-                    <span>&ldquo;</span>
-                    Great 10/10 experience, and a very helpful Ubuntu
-                    technician.
-                    <span>&rdquo;</span>
-                </p>
-                <p><cite>AT&amp;T</cite></p>
-            </blockquote>
-        </div>
-    </div>
-</section>
-
 <section class="row row-get-started strip-light">
     <div class="strip-inner-wrapper">
         <h2>Ubuntu on public clouds</h2>


### PR DESCRIPTION
## Done
Remove testimonial on plans and pricing page

## QA
- Pull this branch and run `./run`
- Go to http://local host:8001/cloud/plans-and-pricing
- Check the testimonial had been removed
- Check the sections follow ok