### PR TITLE
Used left and right as a simpler solution to the cookie bar margins

### DIFF
--- a/static/sass/_v1_pattern_notifications.scss
+++ b/static/sass/_v1_pattern_notifications.scss
@@ -8,9 +8,10 @@
     @include vf-notifications-default;
 
     bottom: 0;
+    left: $sp-small;
+    right: $sp-small;
     position: fixed;
-    text-align: left;
-    width: 100%;
+    width: auto;
     z-index: 2;
 
     @media (min-width: $breakpoint-large) {


### PR DESCRIPTION
## Done

Positioned the cookie bar to give a margin at small and medium screens.

## QA

 - Add `state('open');` as line 6 in scratch-v1.js
 - `./run`
 - See the beauty of the cookie bar at all viewports 
