### PR TITLE
Reduce top spacing in breadcrumb link

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -104,7 +104,7 @@
           width: 100%;
           display: inline-block;
           padding: $sp-x-small;
-          margin-bottom: $sp-medium;
+          margin-bottom: $sp-x-small;
           color: $color-dark;
         }
       }


### PR DESCRIPTION
## Done

Reduce top spacing in breadcrumb link

## QA

- Pull code
- Run `./run serve`
- Go to [http://0.0.0.0:8001/about](http://0.0.0.0:8001/about)
- Reduce screen resolution to 400px
- Verify that spacing in breadcrumb link is equal - https://cl.ly/1d020M211a0f

## Issue / Card

Related #1693 