### PR TITLE
Small screen footer top padding removal.

### DIFF
--- a/static/sass/_v1_pattern_footer.scss
+++ b/static/sass/_v1_pattern_footer.scss
@@ -13,8 +13,12 @@
   .p-footer {
     border: 0;
     box-shadow: 0 4px 4px -4px $color-shadow inset;
-    padding: $sp-xx-large 0;
+    padding: 0 0 $sp-xx-large 0;
     margin-bottom: 0;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      padding: $sp-xx-large 0;
+    }
 
     @media only screen and (max-width: $breakpoint-medium) {
       &__nav-col {


### PR DESCRIPTION
## Done

Removed the top padding of the footer on smallest viewport.

## QA

Check `/about` at all viewports and check that there's no top padding on the footer (above the back to top link) on small screens.

Demo: http://www.ubuntu.com-footer-top-margin.demo.haus/about