### PR TITLE
Aligned text left in cookie bar.

### DIFF
--- a/static/sass/_v1_pattern_notifications.scss
+++ b/static/sass/_v1_pattern_notifications.scss
@@ -21,6 +21,7 @@
     }
 
     &__content {
+      text-align: left;
       margin-bottom: 0;
       padding-right: $sp-large;
     }


### PR DESCRIPTION
## Done

Left-aligned the text in the cookie bar.

## QA

See that the cookie bar has left-aligned text.

Note: Add `state('open');` to `scratch-v1.js` to force display of the cookie bar.