### PR TITLE
Remove border-top on p-breadcrumbs on large screens

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -69,7 +69,7 @@
 
   .nav-secondary {
 
-    @media (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large){
        border-top: 1px solid $color-mid-light;
     }
 


### PR DESCRIPTION
## Done

Remove border-top on p-breadcrumbs on large screens

## QA

- Pull code
- Run `./run serve`
- Check that border-top on secondary nav disappears in large screens

## Issue / Card

Related #1741