### PR TITLE
Tweak layout of hero section of /legal/contributors

### DIFF
--- a/templates/legal/contributors/index.html
+++ b/templates/legal/contributors/index.html
@@ -7,9 +7,9 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="p-strip">
+<div class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
-    <div class="col-8 suffix-1">
+    <div class="col-8">
       <h1>Canonical contributor licence&nbsp;agreement</h1>
       <p>At Canonical, we manage a lot of <a class="p-link--external" href="http://www.canonical.com/projects/directory">open source projects</a> and we&rsquo;re required to have agreements with everyone who takes part in them. It&rsquo;s the easiest way
         for you to give us permission to use your contributions. In effect, you&rsquo;re giving us a licence, but you still own the copyright &mdash; so you retain the right to modify your code and use it in other projects. </p>


### PR DESCRIPTION
## Done

Made /legal/contributors hero have the same style as /legal hero

## QA

- Pull code
- Run `./run serve`
- Check that [legal/contributors](http://0.0.0.0:8001/legal/contributors) looks like [/legal](http://0.0.0.0:8001/legal)

## Issue / Card

Related #1761 