### PR TITLE
Give back to top link the same padding as other small screen footer links.

### DIFF
--- a/static/sass/_v1_pattern_footer.scss
+++ b/static/sass/_v1_pattern_footer.scss
@@ -139,7 +139,7 @@
       display: block;
       left: auto;
       margin-bottom: -1px;
-      padding: $sp-medium 0 $sp-medium $sp-x-large;
+      padding: $sp-small 0 $sp-small $sp-x-large;
       position: relative;
       z-index: 2;
 


### PR DESCRIPTION
## Done

Gave the back to top link in the footer at small screens the same padding as other footer links.

## QA

Look at the footer in small screen on `/about`