### PR TITLE
Make sure secondary nav items don’t break onto two lines

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -69,6 +69,10 @@
 
   .nav-secondary {
 
+    .p-inline-list__link {
+      display: inline-block;
+    }
+
     @media (min-width: $breakpoint-medium) {
        border-top: 1px solid $color-mid-light;
     }


### PR DESCRIPTION
## Done

Make sure secondary nav items don’t break onto two lines

## QA

- Pull code
- Run `./run serve`
- Go to [http://0.0.0.0:8001/legal/terms-and-policies](http://0.0.0.0:8001/legal/terms-and-policies)
- Verify that secondary nav items don't break onto two lines when screen width is reduced


## Issue / Card

Fixes #1748 

## Screenshots

Expected: 

<img width="796" alt="screen shot 2017-05-12 at 16 42 14" src="https://cloud.githubusercontent.com/assets/505570/26005773/01a1877e-3732-11e7-8fac-6cfd4c1a8781.png">
