### PR TITLE
Correct incorrect rogue html entities

### DIFF
--- a/templates/legal/short-terms/2015-09-09.html
+++ b/templates/legal/short-terms/2015-09-09.html
@@ -134,7 +134,7 @@
         <h2>9. Term and termination</h2>
         <ol class="p-list">
           <li class="p-list__item"><span class="number">9.1</span> This Agreement will come into force on the Effective Date and will continue until the end of the Services Term unless terminated earlier under this Clause 9.</li>
-          <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement
+          <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rsquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement
             will automatically terminate.</li>
           <li class="p-list__item"><span class="number">9.3</span> Either party may terminate this Agreement immediately by written notice if the other party:
             <ol class="p-list">
@@ -144,7 +144,7 @@
             </ol>
           </li>
           <li class="p-list__item"><span class="number">9.4</span>Canonical may terminate this Agreement for convenience upon giving 90 days prior notice to Customer.</li>
-          <li class="p-list__item"><span class="number">9.5</span>On expiration or termination this Agreement for any reason, Canonical&rquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise
+          <li class="p-list__item"><span class="number">9.5</span>On expiration or termination this Agreement for any reason, Canonical&rsquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise
             agreed. On termination other than by Canonical for convenience in accordance with Clause 9.4, Customer will immediately pay all outstanding Fees applicable to this Agreement including Fees that would otherwise have been payable with respect
             to the full Agreement term. On termination of this Agreement by Canonical for convenience in accordance with Clause 9.4, Canonical will provide Customer with a pro rata refund of any prepaid Fees for the remaining unexpired portion of the
             Services Term.</li>

--- a/templates/legal/short-terms/2016-05-20.html
+++ b/templates/legal/short-terms/2016-05-20.html
@@ -135,7 +135,7 @@
         <h2>9. Term and termination</h2>
         <ol class="p-list">
           <li class="p-list__item"><span class="number">9.1</span> This Agreement will come into force on the Effective Date and will continue until the end of the Services Term unless terminated earlier under this Clause 9.</li>
-          <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement
+          <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rsquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement
             will automatically terminate.</li>
           <li class="p-list__item"><span class="number">9.3</span> Either party may terminate this Agreement immediately by written notice if the other party:
             <ol class="p-list">
@@ -145,7 +145,7 @@
             </ol>
           </li>
           <li class="p-list__item"><span class="number">9.4</span>Canonical may terminate this Agreement for convenience upon giving 90 days prior notice to Customer.</li>
-          <li class="p-list__item"><span class="number">9.5</span>On expiration or termination this Agreement for any reason, Canonical&rquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise
+          <li class="p-list__item"><span class="number">9.5</span>On expiration or termination this Agreement for any reason, Canonical&rsquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise
             agreed. On termination other than by Canonical for convenience in accordance with Clause 9.4, Customer will immediately pay all outstanding Fees applicable to this Agreement including Fees that would otherwise have been payable with respect
             to the full Agreement term. On termination of this Agreement by Canonical for convenience in accordance with Clause 9.4, Canonical will provide Customer with a pro rata refund of any prepaid Fees for the remaining unexpired portion of the
             Services Term.</li>

--- a/templates/legal/short-terms/index.html
+++ b/templates/legal/short-terms/index.html
@@ -137,7 +137,7 @@
         <h2>9. Term and termination</h2>
         <ol class="p-list">
           <li class="p-list__item"><span class="number">9.1</span> This Agreement will come into force on the Effective Date and will continue until the end of the Services Term unless terminated earlier under this Clause 9.</li>
-          <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement
+          <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rsquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement
             will automatically terminate.</li>
           <li class="p-list__item"><span class="number">9.3</span> Either party may terminate this Agreement immediately by written notice if the other party:
             <ol class="p-list">
@@ -147,7 +147,7 @@
             </ol>
           </li>
           <li class="p-list__item"><span class="number">9.4</span> Canonical may terminate this Agreement for convenience upon giving 90 days prior notice to Customer.</li>
-          <li class="p-list__item"><span class="number">9.5</span> On expiration or termination this Agreement for any reason, Canonical&rquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise
+          <li class="p-list__item"><span class="number">9.5</span> On expiration or termination this Agreement for any reason, Canonical&rsquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise
             agreed. On termination other than by Canonical for convenience in accordance with Clause 9.4, Customer will immediately pay all outstanding Fees applicable to this Agreement including Fees that would otherwise have been payable with respect
             to the full Agreement term. On termination of this Agreement by Canonical for convenience in accordance with Clause 9.4, Canonical will provide Customer with a pro rata refund of any prepaid Fees for the remaining unexpired portion of the
             Services Term.</li>


### PR DESCRIPTION
## Done

Correct incorrect rogue html entities - `&rsquo;` not `&rquo;`

## QA

- Check code
- View in situ at /legal/short-terms

## Issue / Card

Fixes #1759