### PR TITLE
update snapcraft social links on /desktop/snappy

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -173,7 +173,7 @@
     <div class="wrapper">
       <div class="eight-col">
         <h2>Creating a snap is easy!</h2>
-        <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps to the world. Read how to <a class="external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a> or on the <a class="external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>
+        <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps to the world. Read how to <a class="external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a> and on the <a class="external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>
       </div>
     </div>
   </div>

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -173,7 +173,7 @@
     <div class="wrapper">
       <div class="eight-col">
         <h2>Creating a snap is easy!</h2>
-        <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps to the world. Read how to <a class="external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on the <a class="external" href="https://webchat.freenode.net/?channels=snappy">#snappy channel on Freenode</a> or on the <a class="external" href="https://lists.ubuntu.com/mailman/listinfo/snapcraft">snapcraft mailing list</a>.</p>
+        <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps to the world. Read how to <a class="external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a> or on the <a class="external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

* updated the social links on /desktop/snappy to point to Rocket Chat and the new discourse forum
* updated the [copy doc](https://docs.google.com/document/d/19EIGiQ4FLfWVQczBgAqj5lIcWGnM0GmVGWggFIXcHt0/edit)

## QA

1. go to http://0.0.0.0:8001/desktop/snappy
2. see the updated ‘Creating a snap is easy!’ section with links to Rocket Chat and the forum
3. test the links

## Issue / Card

Fixes #1573

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/26024725/9b6857e6-37cf-11e7-8d17-a92f682bcb59.png)
