### PR TITLE
Tweak hero layout in /legal/ubuntu-advantage

### DIFF
--- a/templates/legal/ubuntu-advantage/index.html
+++ b/templates/legal/ubuntu-advantage/index.html
@@ -21,7 +21,9 @@
       </div>
     </div>
   </div>
+</div>
 
+<div class="p-strip">
   <div class="row">
     <div class="u-equal-height">
       <div class="col-6 p-card">


### PR DESCRIPTION
## Done

Ensure that hero in `/legal/ubuntu-advantage` matches `/legal/terms-and-policies`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site in your web browser at: [http://0.0.0.0:8001/]([](http://0.0.0.0:8001/))
- Verify that hero in `/legal/ubuntu-advantage` matches `/legal/terms-and-policies`


## Issue / Card

Fixes #1752 