### PR TITLE
Ensure secondary level nav aligns on S screen

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -265,23 +265,23 @@
 
     @media (max-width: $breakpoint-medium - 1) {
       .p-inline-list__item {
-        padding: .5rem;
+        padding: $sp-x-small;
       }
     }
 
     @media (min-width: $breakpoint-medium) {
-      margin-left: 1.5rem;
+      margin-left: $sp-large;
       display: inline-block;
 
       .p-inline-list__item {
-        margin-right: .75rem;
+        margin-right: $sp-small;
       }
     }
 
     @media (min-width: $breakpoint-large) {
 
       .p-inline-list__item {
-        margin-right: 1.5rem;
+        margin-right: $sp-large;
       }
     }
   }

--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -249,6 +249,7 @@
       display: inline-block;
       padding-left: 0;
       margin-bottom: 0;
+      margin-left: .125rem;
     }
 
     .second-level-nav & {
@@ -264,7 +265,7 @@
 
     @media (max-width: $breakpoint-medium - 1) {
       .p-inline-list__item {
-        padding: .75rem 1rem;
+        padding: .5rem;
       }
     }
 


### PR DESCRIPTION
## Done

Ensure secondary level nav aligns on S screen

## QA

- Pull code
- Run `./run serve`
- Go to [http://0.0.0.0:8001/about/about-ubuntu](http://0.0.0.0:8001/about/about-ubuntu)
- Reduce screen width to 400px
- Verify that secondary level nav items align

## Screenshots

Expected:

<img width="335" alt="screen shot 2017-05-15 at 16 31 19" src="https://cloud.githubusercontent.com/assets/505570/26065687/9d9714bc-398c-11e7-8e76-cd4478e2a2ee.png">

## Issue / Card

Fixes #1765 




