### PR TITLE
Add p-card to sidebar on /legal/ubuntu-advantage/service-description

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -130,7 +130,7 @@
     </ol>
   </div>
 
-  <div class="box col-4 not-for-small">
+  <div class="col-4 not-for-small p-card">
     <h3>Contents</h3>
     <ol class="nested-counter">
       <li class="nested-counter__item"><a href="#service-description-overview">Overview&nbsp;&rsaquo;</a></li>


### PR DESCRIPTION
## Done

Add `.p-card` to sidebar on /legal/ubuntu-advantage/service-description

## QA

- Pull code
- Run `./run serve`
- Check [http://0.0.0.0:8001/legal/ubuntu-advantage/service-description
](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description
) has .p-card in sidebar as live

## Issue / Card

Fixes #1754 