### PR TITLE
Extend the SVG to PNG to include all IE versions

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -12,9 +12,10 @@ if (!core) { var core = {}; }
 
 core.svgFallback = function() {
 	if (typeof Modernizr === "object") {
-		if (!Modernizr.svg || !Modernizr.backgroundsize) {
+        var isIE = window.navigator.userAgent.indexOf("MSIE ");
+        if (!Modernizr.svg || !Modernizr.backgroundsize || isIE !== -1) {
 			var svgs = document.querySelectorAll("img[src$='.svg']")
-            svgs.each(function(node) {
+            svgs.forEach(function(node) {
                 var src = node.src;
                 if (src.indexOf('assets.ubuntu.com/v1/') > -1) {
 					// Support for the newer asset server


### PR DESCRIPTION
## Done
Added an IE check to the SVG to PNG javascript snippet. Swapped `each` for `forEach` as we have polyfilled that function.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site on Browser stack at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/))
- Check that all images are converted to png's and scale nicelly

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/72
