### PR TITLE
1621 download alternative downloads

### DIFF
--- a/static/sass/_v1_pattern_link.scss
+++ b/static/sass/_v1_pattern_link.scss
@@ -1,0 +1,12 @@
+@mixin ubuntu-p-link {
+  h1.p-link--external,
+  h2.p-link--external,
+  h3.p-link--external,
+  h4.p-link--external,
+  h5.p-link--external,
+  h6.p-link--external {
+    background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left center no-repeat;
+    background-size: 20px;
+    padding-left: 26px;
+  }
+}

--- a/static/sass/_v1_pattern_link.scss
+++ b/static/sass/_v1_pattern_link.scss
@@ -6,7 +6,7 @@
   h5,
   h6 {
     &.p-link--external {
-      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left #{(1rem / 3)} no-repeat;
+      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left #{(1em / 3)} no-repeat;
       background-size: $sp-medium;
       padding-left: $sp-large;
     }

--- a/static/sass/_v1_pattern_link.scss
+++ b/static/sass/_v1_pattern_link.scss
@@ -1,12 +1,14 @@
 @mixin ubuntu-p-link {
-  h1.p-link--external,
-  h2.p-link--external,
-  h3.p-link--external,
-  h4.p-link--external,
-  h5.p-link--external,
-  h6.p-link--external {
-    background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left center no-repeat;
-    background-size: 20px;
-    padding-left: 26px;
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &.p-link--external {
+      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left #{(1em / 2)} no-repeat;
+      background-size: $sp-medium;
+      padding-left: $sp-large;
+    }
   }
 }

--- a/static/sass/_v1_pattern_link.scss
+++ b/static/sass/_v1_pattern_link.scss
@@ -6,7 +6,7 @@
   h5,
   h6 {
     &.p-link--external {
-      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left #{(1em / 2)} no-repeat;
+      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left #{(1rem / 3)} no-repeat;
       background-size: $sp-medium;
       padding-left: $sp-large;
     }

--- a/static/sass/_v1_pattern_link.scss
+++ b/static/sass/_v1_pattern_link.scss
@@ -6,9 +6,9 @@
   h5,
   h6 {
     &.p-link--external {
-      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left #{(1em / 3)} no-repeat;
-      background-size: $sp-medium;
-      padding-left: $sp-large;
+      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left .2em no-repeat;
+      background-size: .85em;
+      padding-left: 1em;
     }
   }
 }

--- a/static/sass/_v1_pattern_lists.scss
+++ b/static/sass/_v1_pattern_lists.scss
@@ -12,6 +12,8 @@
   @include ubuntu-p-inline-list--small;
   @include ubuntu-p-inline-list-middot-small;
   @include ubuntu-p-is-ticked;
+  @include ubuntu-p-is-trisected;
+  @include ubuntu-p-is-quartered;
 }
 
 @mixin ubuntu-p-is-ticked {
@@ -114,6 +116,60 @@
       .last-item {
         &::after {
           content: '';
+        }
+      }
+    }
+  }
+}
+
+@mixin ubuntu-p-is-trisected {
+
+  [class*='p-list'] {
+
+    &.is-trisected {
+
+      @media (min-width: $breakpoint-medium) {
+        display: flex;
+        flex-wrap: wrap;
+
+        .p-list__item {
+          width: calc(33.33% - .5rem);
+          margin-right: .5rem;
+
+          &:nth-child(3n+3) {
+            margin-right: 0;
+          }
+
+          &:nth-last-child(0) {
+            border-bottom: 0;
+          }
+        }
+      }
+    }
+  }
+}
+
+@mixin ubuntu-p-is-quartered {
+
+  [class*='p-list'] {
+
+    &.is-quartered {
+
+      @media (min-width: $breakpoint-medium) {
+        display: flex;
+        flex-wrap: wrap;
+
+        .p-list__item {
+          width: calc(25% - .5rem);
+          margin-right: .5rem;
+
+          &:nth-child(4n+4) {
+            margin-right: 0;
+          }
+
+          &:nth-last-child(0) {
+            border-bottom: 0;
+          }
         }
       }
     }

--- a/static/sass/_v1_pattern_lists.scss
+++ b/static/sass/_v1_pattern_lists.scss
@@ -133,8 +133,8 @@
         flex-wrap: wrap;
 
         .p-list__item {
-          width: calc(33.33% - .5rem);
-          margin-right: .5rem;
+          width: calc(33.33% - .75rem);
+          margin-right: 1rem;
 
           &:nth-child(3n+3) {
             margin-right: 0;

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -20,6 +20,7 @@
 @import 'v1_pattern_notifications';
 @import 'v1_pattern_footer';
 @import 'v1_pattern_lists';
+@import 'v1_pattern_link';
 
 @include ubuntu-p-site-search;
 @include ubuntu-p-navigation;
@@ -27,6 +28,7 @@
 @include ubuntu-p-notification;
 @include ubuntu-p-footer;
 @include ubuntu-p-lists;
+@include ubuntu-p-link;
 
 // **************************
 // Bug fixes

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -15,7 +15,7 @@
       <h1>Alternative downloads</h1>
       <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older (and newer) releases. If you don&rsquo;t specifically require any of these installers, we recommend using our <a href="/download">default installers</a>.</p>
     </div>
-    <div class="col-5 u-vertically-center u-hidden--small">
+    <div class="col-5 u-vertically-center u-align--center u-hidden--small">
       <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" width="200" height="200" alt="" />
     </div>
   </div>

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -172,9 +172,9 @@
       <h2>Past releases and other flavours</h2>
       <p>Looking for an older release of Ubuntu? Whether you need an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
       <p><a class="p-link--external" href="http://releases.ubuntu.com/">Past releases</a></p>
-    </div><!-- /.col-8 -->
+    </div>
   </div>
-</div><!-- /.row -->
+</div>
 
 {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_more_info_enterprise" second_item="_download_all_installation" third_item="_download_helping_hands" %}
 

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -1,169 +1,181 @@
-{% extends "download/_base_download.html" %}
+{% extends "download/_base_download-v1.html" %}
 
 {% block title %}Alternative downloads{% endblock %}
 
 {% block meta_description %}Want to download via-bitTorrent links, get DVD images with more language packs, use the text-based alternate installer or find previous versions of Ubuntu?{% endblock %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Desktop" page_title="Alternative downloads"  %}
-</div><!-- /.strip-inner-wrapper -->
+{% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" subsection_title="Desktop" page_title="Alternative downloads"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="row equal-height">
-    <div class="strip-inner-wrapper">
-        <div class="seven-col equal-height__item">
-            <h1>Alternative downloads</h1>
-            <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older (and newer) releases. If you don&rsquo;t specifically require any of these installers, we recommend using our <a href="/download">default installers</a>.</p>
-        </div><!-- /.eight-col -->
-        <div class="five-col last-col equal-height__item equal-height__align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" width="200" height="200" alt="" class="priority-0" />
-        </div>
+<div class="p-strip is-deep is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>Alternative downloads</h1>
+      <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older (and newer) releases. If you don&rsquo;t specifically require any of these installers, we recommend using our <a href="/download">default installers</a>.</p>
     </div>
-</div>
-
-<div class="row">
-    <div class="strip-inner-wrapper">
-        <h2>Network installer</h2>
-        <div class="eight-col">
-            <p>The network installer lets you install Ubuntu over the network. This is useful, for example, if you have an old machine with a non-bootable CD-ROM or a computer that can&rsquo;t run the graphical interface-based installer, either because they don&rsquo;t meet the minimum requirements for the live CD/DVD or because they require extra configuration before  the graphical desktop can be used, or if you want to install Ubuntu on a large number of computers at once.</p>
-            <ul class="list-ticks--compact">
-                <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/{{latest_release}}/">Download the network installer for {{latest_release_full}}</a></li>
-                <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/16.04/">Download the network installer for 16.04 LTS</a></li>
-                <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
-            </ul>
-        </div><!-- /.eight-col -->
-    </div><!-- /.strip-inner-wrapper -->
-</div><!-- /.row -->
-
-<div class="row">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col append-four">
-            <h2>BitTorrent</h2>
-            <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>
-        </div>
-        <div class="four-col">
-            <h3 class="external--title"><span>Ubuntu {{latest_release}}</span></h3>
-            <ul class="no-bullets list">
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)&nbsp;&rsaquo;</a></li>
-            </ul>
-        </div><!-- /.four-col -->
-        <div class="four-col">
-            <h3 class="external--title"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
-            <ul class="no-bullets list">
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Server (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Server (32-bit)&nbsp;&rsaquo;</a></li>
-            </ul>
-        </div><!-- /.four-col -->
-        <div class="four-col last-col">
-            <h3 class="external--title"><span>Ubuntu 14.04.5 LTS</span></h3>
-            <ul class="no-bullets list">
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-amd64.iso.torrent">Ubuntu 14.04.5 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-i386.iso.torrent">Ubuntu 14.04.5 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso.torrent">Ubuntu 14.04.5 Server (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-i386.iso.torrent">Ubuntu 14.04.5 Server (32-bit)&nbsp;&rsaquo;</a></li>
-            </ul>
-        </div><!-- /.four-col -->
-    </div><!-- /.strip-inner-wrapper -->
-</div><!-- /.row -->
-
-<div class="row">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col append-four">
-            <h2>Other images</h2>
-            <p>For other versions of the Ubuntu installer please select your nearest mirror; however, we recommend you use  the <a href="/download">standard installer</a> as all other packages are available in Ubuntu Software Centre.</p>
-        </div>
-        <h3 class="external--title"><span>Select the nearest mirror</span></h3>
-        <ul class="twelve-col no-bullets list">
-            <li class="four-col"><a class="download-mirror" href="http://mirror.waia.asn.au/ubuntu-releases/">Australia &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland &rsaquo;</a></li>
-            <li class="four-col last-col"><a class="download-mirror" href="ftp://ftp.free.fr/mirrors/ftp.ubuntu.com/releases/">France &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://de.releases.ubuntu.com/">Germany &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://ftp.ntua.gr/pub/linux/ubuntu-releases-dvd">Greece &rsaquo;</a></li>
-            <li class="four-col last-col"><a class="download-mirror" href="http://ftp.heanet.ie/pub/ubuntu-cdimage/releases">Ireland &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://nl.archive.ubuntu.com/ubuntu-cdimages">Netherlands &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://mirror.yandex.ru/ubuntu-cdimage/releases">Russian Federation &rsaquo;</a></li>
-            <li class="four-col last-col"><a class="download-mirror" href="http://ubuntu.cica.es/releases/">Spain &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://ftp.acc.umu.se/mirror/cdimage.ubuntu.com/releases">Sweden &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://tw.archive.ubuntu.com/ubuntu-cd/">Taiwan &rsaquo;</a></li>
-            <li class="four-col"><a class="download-mirror" href="http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/releases">United Kingdom &rsaquo;</a></li>
-            <li class="four-col last-col"><a class="download-mirror" href="http://mirror.pnl.gov/releases/">United States &rsaquo;</a></li>
-        </ul>
-        <div class="twelve-col">
-            <p><a href="https://launchpad.net/ubuntu/+cdmirrors" class="external download-mirror">See all Ubuntu mirrors</a></p>
-        </div>
-    </div><!-- /.strip-inner-wrapper -->
-</div>
-
-<div class="row">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col append-four">
-            <h2 class="external--title">Past ARM releases</h2>
-            <p>Find older versions of Ubuntu for specific ARM platforms.</p>
-        </div>
-
-        <div class="twelve-col equal-height no-margin-bottom">
-            <div class="six-col box">
-                <ul class="inline-logos  not-for-small">
-                    <li class="inline-logos__item"><img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" alt="" width="150" /></li>
-                </ul>
-                <h3>Applied Micro X-Gene ARMv8</h3>
-                <ul class="no-bullets list">
-                    <li><a class="external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty/main/installer-arm64/current/images/generic/netboot/xgene/">14.04 LTS</a></li>
-                    <li><a class="external" href="https://wiki.ubuntu.com/ARM/Server/Install/Mustang">Installation instructions for the Mustang platform</a></li>
-                </ul>
-            </div>
-            <div class="six-col last-col box">
-                <ul class="inline-logos not-for-small">
-                    <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}f38c9ed1-hpe_pri_grn_pos_rgb.svg" alt="" width="150" /></li>
-                </ul>
-                <h3>HP Moonshot</h3>
-                <ul class="no-bullets list">
-                    <li><a class="external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty-updates/main/installer-armhf/current/images/keystone/netboot/">m800 ARMv7 netboot image (14.04 LTS)</a></li>
-                    <li><a class="external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty-updates/main/installer-arm64/current/images/generic/netboot/xgene/">m400 ARMv8 netboot image (14.04 LTS)</a></li>
-                    <li><a class="external" href="http://h20564.www2.hp.com/hpsc/doc/public/display?docId=c03933547">HP ProLiant Moonshot user guide</a></li>
-                </ul>
-            </div>
-            <div class="six-col box">
-                <ul class="inline-logos not-for-small">
-                    <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}4fc650f0-Marvell_Logo.svg" alt="" width="150" /></li>
-                </ul>
-                <h3>Marvell Armada XP</h3>
-                <ul class="no-bullets list">
-                    <li><a class="external" href="http://ports.ubuntu.com/ubuntu-ports/dists/precise-updates/main/installer-armhf/current/images/armadaxp/netboot">12.04 LTS</a></li>
-                    <li><a class="external" href="https://wiki.ubuntu.com/ARM/Server/Install/ArmadaXP">Installation instructions for Armada XP-based systems</a></li>
-                </ul>
-            </div>
-            <div class="six-col last-col box">
-                <ul class="inline-logos not-for-small">
-                    <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}43b35b55-logo-cavium.png" alt="" width="150" /></li>
-                </ul>
-                <h3>Cavium Thunder 48 and 96 core ARMv8</h3>
-                <ul class="no-bullets list">
-                    <li><a class="external" href="http://cavium.com/ThunderX_ARM_Processors.html">Cavium ThunderX product details </a></li>
-                    <li><a class="external" href="http://www.cavium.com/ContactCavium.htm">14.04 LTS Tech Preview available directly from Cavium</a></li>
-                </ul>
-            </div>
-        </div>
+    <div class="col-5 u-vertically-center u-hidden--small">
+      <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" width="200" height="200" alt="" />
     </div>
+  </div>
 </div>
 
-<div class="row no-border">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h2>Past releases and other flavours</h2>
-            <p>Looking for an older release of Ubuntu? Whether you need an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
-            <p><a class="external download-pastreleases" href="http://releases.ubuntu.com/">Past releases</a></p>
-        </div><!-- /.eight-col -->
-    </div><!-- /.strip-inner-wrapper -->
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Network installer</h2>
+      <p>The network installer lets you install Ubuntu over the network. This is useful, for example, if you have an old machine with a non-bootable CD-ROM or a computer that can&rsquo;t run the graphical interface-based installer, either because they don&rsquo;t meet the minimum requirements for the live CD/DVD or because they require extra configuration before  the graphical desktop can be used, or if you want to install Ubuntu on a large number of computers at once.</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked"><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/{{latest_release}}/">Download the network installer for {{latest_release_full}}</a></li>
+        <li class="p-list__item is-ticked"><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/16.04/">Download the network installer for 16.04 LTS</a></li>
+        <li class="p-list__item is-ticked"><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>BitTorrent</h2>
+      <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-4">
+      <h3 class="p-link--external"><span>Ubuntu {{latest_release}}</span></h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)&nbsp;&rsaquo;</a></li>
+      </ul>
+    </div>
+    <div class="col-4">
+      <h3 class="p-link--external"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Server (64-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Server (32-bit)&nbsp;&rsaquo;</a></li>
+      </ul>
+    </div>
+    <div class="col-4">
+      <h3 class="p-link--external"><span>Ubuntu 14.04.5 LTS</span></h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-amd64.iso.torrent">Ubuntu 14.04.5 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-i386.iso.torrent">Ubuntu 14.04.5 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso.torrent">Ubuntu 14.04.5 Server (64-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-i386.iso.torrent">Ubuntu 14.04.5 Server (32-bit)&nbsp;&rsaquo;</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Other images</h2>
+      <p>For other versions of the Ubuntu installer please select your nearest mirror; however, we recommend you use  the <a href="/download">standard installer</a> as all other packages are available in Ubuntu Software Centre.</p>
+      <h3 class="p-link--external"><span>Select the nearest mirror</span></h3>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <ul class="p-list--divided is-trisected">
+        <li class="p-list__item"><a  href="http://mirror.waia.asn.au/ubuntu-releases/">Australia &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland &rsaquo;</a></li>
+        <li class="p-list__item"><a href="ftp://ftp.free.fr/mirrors/ftp.ubuntu.com/releases/">France &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://de.releases.ubuntu.com/">Germany &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://ftp.ntua.gr/pub/linux/ubuntu-releases-dvd">Greece &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://ftp.heanet.ie/pub/ubuntu-cdimage/releases">Ireland &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://nl.archive.ubuntu.com/ubuntu-cdimages">Netherlands &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://mirror.yandex.ru/ubuntu-cdimage/releases">Russian Federation &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://ubuntu.cica.es/releases/">Spain &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://ftp.acc.umu.se/mirror/cdimage.ubuntu.com/releases">Sweden &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://tw.archive.ubuntu.com/ubuntu-cd/">Taiwan &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/releases">United Kingdom &rsaquo;</a></li>
+        <li class="p-list__item"><a href="http://mirror.pnl.gov/releases/">United States &rsaquo;</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p><a href="https://launchpad.net/ubuntu/+cdmirrors" class="p-link--external">See all Ubuntu mirrors</a></p>
+    </div>
+  </div>
+</div>
+</div>
+
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Past ARM releases</h2>
+      <p>Find older versions of Ubuntu for specific ARM platforms.</p>
+    </div>
+  </div>
+
+  <div class="row u-equal-height u-no-margin--bottom">
+    <div class="col-6 p-card">
+      <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+        <img src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" alt="" width="150" />
+      </div>
+      <h3 class="p-card__title">Applied Micro X-Gene ARMv8</h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty/main/installer-arm64/current/images/generic/netboot/xgene/">14.04 LTS</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://wiki.ubuntu.com/ARM/Server/Install/Mustang">Installation instructions for the Mustang platform</a></li>
+      </ul>
+    </div>
+    <div class="col-6 p-card">
+      <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+        <img src="{{ ASSET_SERVER_URL }}f38c9ed1-hpe_pri_grn_pos_rgb.svg" alt="" width="150" />
+      </div>
+      <h3 class="p-card__title">HP Moonshot</h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty-updates/main/installer-armhf/current/images/keystone/netboot/">m800 ARMv7 netboot image (14.04 LTS)</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty-updates/main/installer-arm64/current/images/generic/netboot/xgene/">m400 ARMv8 netboot image (14.04 LTS)</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="http://h20564.www2.hp.com/hpsc/doc/public/display?docId=c03933547">HP ProLiant Moonshot user guide</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+        <img src="{{ ASSET_SERVER_URL }}4fc650f0-Marvell_Logo.svg" alt="" width="150" />
+      </div>
+      <h3 class="p-card__title">Marvell Armada XP</h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/precise-updates/main/installer-armhf/current/images/armadaxp/netboot">12.04 LTS</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://wiki.ubuntu.com/ARM/Server/Install/ArmadaXP">Installation instructions for Armada XP-based systems</a></li>
+      </ul>
+    </div>
+    <div class="col-6 p-card">
+      <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+        <img src="{{ ASSET_SERVER_URL }}43b35b55-logo-cavium.png" alt="" width="150" />
+      </div>
+      <h3 class="p-card__title">Cavium Thunder 48 and 96 core ARMv8</h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item"><a class="p-link--external" href="http://cavium.com/ThunderX_ARM_Processors.html">Cavium ThunderX product details </a></li>
+        <li class="p-list__item"><a class="p-link--external" href="http://www.cavium.com/ContactCavium.htm">14.04 LTS Tech Preview available directly from Cavium</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Past releases and other flavours</h2>
+      <p>Looking for an older release of Ubuntu? Whether you need an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
+      <p><a class="p-link--external" href="http://releases.ubuntu.com/">Past releases</a></p>
+    </div><!-- /.col-8 -->
+  </div>
 </div><!-- /.row -->
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_more_info_enterprise" second_item="_download_all_installation" third_item="_download_helping_hands" %}
+{% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_more_info_enterprise" second_item="_download_all_installation" third_item="_download_helping_hands" %}
 
 {% endblock content %}

--- a/templates/shared-v1/contextual_footers/_cloud_install_openstack.html
+++ b/templates/shared-v1/contextual_footers/_cloud_install_openstack.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Installing OpenStack yourself</h3>
   <p>If you prefer a manual setup of the latest OpenStack version, you can follow the instructions in our OpenStack operations guide.</p>
-  <p><a href="https://help.ubuntu.com/lts/clouddocs/installer/" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud installer on help.u.c', 'eventLabel' : 'Installing OpenStack yourself', 'eventValue' : undefined });">Read the instructions</a></p>
+  <p><a href="https://help.ubuntu.com/lts/clouddocs/installer/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud installer on help.u.c', 'eventLabel' : 'Installing OpenStack yourself', 'eventValue' : undefined });">Read the instructions</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_cloud_juju.html
+++ b/templates/shared-v1/contextual_footers/_cloud_juju.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Experience Juju</h3>
   <p>Try our demo and see how easy it can be to manage services in the cloud.</p>
-  <p><a href="https://demo.jujucharms.com/" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'jujucharms demo', 'eventLabel' : 'Experience Juju', 'eventValue' : undefined });">Try the Juju demo</a></p>
+  <p><a href="https://demo.jujucharms.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'jujucharms demo', 'eventLabel' : 'Experience Juju', 'eventValue' : undefined });">Try the Juju demo</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_cloud_juju_charm_store.html
+++ b/templates/shared-v1/contextual_footers/_cloud_juju_charm_store.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Browse the Charm Store</h3>
   <p>Charms are scripts that can be written in any language to deploy and configure services.</p>
-  <p><a href="https://jujucharms.com/store" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'jujucharms', 'eventLabel' : 'Browse the Charm Store', 'eventValue' : undefined });">Find out more at jujucharms.com</a></p>
+  <p><a href="https://jujucharms.com/store" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'jujucharms', 'eventLabel' : 'Browse the Charm Store', 'eventValue' : undefined });">Find out more at jujucharms.com</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_cloud_lxd.html
+++ b/templates/shared-v1/contextual_footers/_cloud_lxd.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Try LXD for real, now</h3>
   <p>Get 30 minutes free access to a system with live LXD containers.</p>
-  <p><a href="https://linuxcontainers.org/lxd/try-it/" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'LXD', 'eventLabel' : 'Try LXD for real, now', 'eventValue' : undefined });">Try LXD</a></p>
+  <p><a href="https://linuxcontainers.org/lxd/try-it/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'LXD', 'eventLabel' : 'Try LXD for real, now', 'eventValue' : undefined });">Try LXD</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_cloud_maas.html
+++ b/templates/shared-v1/contextual_footers/_cloud_maas.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Install MAAS</h3>
   <p>Metal as a Service (MAAS) brings the language of the cloud to physical servers.</p>
-  <p><a href="https://maas.io/get-started" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS.io', 'eventLabel' : 'Install MAAS', 'eventValue' : undefined });">Find out more at maas.io</a></p>
+  <p><a href="https://maas.io/get-started" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS.io', 'eventLabel' : 'Install MAAS', 'eventValue' : undefined });">Find out more at maas.io</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_containers_juju.html
+++ b/templates/shared-v1/contextual_footers/_containers_juju.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Juju for container management</h3>
   <p>Juju makes it easy to deploy container management solutions by provisioning, installing and configuring all the systems in the cluster.</p>
-  <a href="https://jujucharms.com/containers" title="Juju solutions for container management" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Juju charms containers', 'eventLabel' : 'Read more', 'eventValue' : undefined });">Read more about Juju and containers</a>
+  <a href="https://jujucharms.com/containers" title="Juju solutions for container management" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Juju charms containers', 'eventLabel' : 'Read more', 'eventValue' : undefined });">Read more about Juju and containers</a>
 </div>

--- a/templates/shared-v1/contextual_footers/_core_contribute.html
+++ b/templates/shared-v1/contextual_footers/_core_contribute.html
@@ -1,6 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Contribute</h3>
   <p>Add to Ubuntu Core.</p>
-  <p><a href="http://snapcraft.io/docs/build-snaps/your-first-snap" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'snapcraft.io/docs/build-snaps/your-first-snap', 'eventLabel' : 'Contribute to Ubuntu Core', 'eventValue' : undefined });">Learn how to create a snap</a></p>
-  <p><a href="https://github.com/snapcore/snapd" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'github.com/snapcore/snapd', 'eventLabel' : 'Contribute to Ubuntu Core', 'eventValue' : undefined });">Check out the project on GitHub</a></p>
+  <p><a href="http://snapcraft.io/docs/build-snaps/your-first-snap" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'snapcraft.io/docs/build-snaps/your-first-snap', 'eventLabel' : 'Contribute to Ubuntu Core', 'eventValue' : undefined });">Learn how to create a snap</a></p>
+  <p><a href="https://github.com/snapcore/snapd" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'github.com/snapcore/snapd', 'eventLabel' : 'Contribute to Ubuntu Core', 'eventValue' : undefined });">Check out the project on GitHub</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_core_learn_more.html
+++ b/templates/shared-v1/contextual_footers/_core_learn_more.html
@@ -1,6 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Learn more</h3>
   <p>You can start your Ubuntu Core journey by either reading or asking.</p>
-  <p><a href="http://docs.ubuntu.com/core" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'docs.ubuntu.com/core', 'eventLabel' : 'Ubuntu Core Docs', 'eventValue' : undefined });">Read the docs</a></p>
-  <p><a href="http://askubuntu.com/search?q=snap" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ask.ubuntu.com', 'eventLabel' : 'ask.ubuntu.com', 'eventValue' : undefined });">Visit ask.ubuntu.com</a></p>
+  <p><a href="http://docs.ubuntu.com/core" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'docs.ubuntu.com/core', 'eventLabel' : 'Ubuntu Core Docs', 'eventValue' : undefined });">Read the docs</a></p>
+  <p><a href="http://askubuntu.com/search?q=snap" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ask.ubuntu.com', 'eventLabel' : 'ask.ubuntu.com', 'eventValue' : undefined });">Visit ask.ubuntu.com</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_desktop_buy_preinstalled.html
+++ b/templates/shared-v1/contextual_footers/_desktop_buy_preinstalled.html
@@ -2,5 +2,5 @@
   <img src="{{ ASSET_SERVER_URL }}652813be-footer-laptop.png" alt="Laptop" />
   <h3 class="p-heading--four">Buy it pre-installed</h3>
   <p>Ubuntu is available on a huge range of devices from the world&rsquo;s largest hardware manufacturers including Dell, HP and Lenovo.</p>
-  <p><a href="http://partners.ubuntu.com/partner-programmes/retail" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'partners.u.c - retail', 'eventLabel' : 'Buy it pre-installed', 'eventValue' : undefined });">Find out more about our retail partners</a></p>
+  <p><a href="http://partners.ubuntu.com/partner-programmes/retail" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'partners.u.c - retail', 'eventLabel' : 'Buy it pre-installed', 'eventValue' : undefined });">Find out more about our retail partners</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_desktop_developer_community.html
+++ b/templates/shared-v1/contextual_footers/_desktop_developer_community.html
@@ -3,11 +3,11 @@
   <h3 class="p-heading--four">Join our community </h3>
   <p>Share ideas, write code, and get advice and help from our large, active community of IT professionals.</p>
   <ul class="p-list">
-    <li><a href="https://askubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="external">Ask Ubuntu</a></li>
-    <li><a href="https://community.ubuntu.com/contribute/support/mailinglists/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'mailing lists', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="external">Mailing lists</a></li>
+    <li><a href="https://askubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="p-link--external">Ask Ubuntu</a></li>
+    <li><a href="https://community.ubuntu.com/contribute/support/mailinglists/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'mailing lists', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="p-link--external">Mailing lists</a></li>
   </ul>
   <ul class="p-list">
-    <li><a href="https://insights.ubuntu.com" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'insights.u.c', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="external">Ubuntu Insights</a></li>
-    <li><a href="https://ubuntuforums.org/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntuforums.org', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="external">Ubuntu Forums</a></li>
+    <li><a href="https://insights.ubuntu.com" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'insights.u.c', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="p-link--external">Ubuntu Insights</a></li>
+    <li><a href="https://ubuntuforums.org/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntuforums.org', 'eventLabel' : 'Join our community', 'eventValue' : undefined });" class="p-link--external">Ubuntu Forums</a></li>
   </ul>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_cloud_askubuntu_autopilot.html
+++ b/templates/shared-v1/contextual_footers/_download_cloud_askubuntu_autopilot.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ask Ubuntu</h3>
   <p>Do you have any questions or feedback about setting up OpenStack Autopilot?</p>
-  <p><a href="https://askubuntu.com/questions/ask?tags=landscape+openstack-autopilot" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu for autopilot help', 'eventLabel' : 'Ask Ubuntu', 'eventValue' : undefined });">Talk to us on Ask Ubuntu</a></p>
+  <p><a href="https://askubuntu.com/questions/ask?tags=landscape+openstack-autopilot" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu for autopilot help', 'eventLabel' : 'Ask Ubuntu', 'eventValue' : undefined });">Talk to us on Ask Ubuntu</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_desktop_guide.html
+++ b/templates/shared-v1/contextual_footers/_download_desktop_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ubuntu desktop guide</h3>
   <p>Read the official Ubuntu desktop documentation.</p>
-  <p><a class="external" href="https://help.ubuntu.com/stable/ubuntu-help" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c', 'eventLabel' : 'Ubuntu desktop guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
+  <p><a class="p-link--external" href="https://help.ubuntu.com/stable/ubuntu-help" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c', 'eventLabel' : 'Ubuntu desktop guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_documentation.html
+++ b/templates/shared-v1/contextual_footers/_download_documentation.html
@@ -1,10 +1,10 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Detailed documentation</h3>
-  <p><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation/UbuntuServerGuide" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c server guide', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server Guide</a></p>
+  <p><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation/UbuntuServerGuide" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c server guide', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server Guide</a></p>
 
-  <p><a href="https://help.ubuntu.com/" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c latest', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{latest_release_full}} documentation</a></p>
+  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c latest', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{latest_release_full}} documentation</a></p>
 
-  <p><a href="https://help.ubuntu.com/" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
+  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
 
   <p><a href="/download/how-to-verify" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'how to verify', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Verify your download&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_enterprise_support.html
+++ b/templates/shared-v1/contextual_footers/_download_enterprise_support.html
@@ -1,6 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Professional support for Ubuntu</h3>
   <p>Get professional support for Ubuntu from Canonical. We help organisations around the world to manage their Ubuntu cloud, server and desktop deployments.</p>
-  <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Buy Ubuntu Advantage</span></a></p>
+  <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="p-link--external">Buy Ubuntu Advantage</span></a></p>
   <p><a href="/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu Advantage page', 'eventLabel' : 'Enterprise support', 'eventValue' : undefined });">Find out more&nbsp;›</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_helping_hands.html
+++ b/templates/shared-v1/contextual_footers/_download_helping_hands.html
@@ -2,8 +2,8 @@
   <h3 class="p-heading--four">Helping hands</h3>
   <p>If you get stuck, help is always at hand.</p>
   <ul class="p-list">
-      <li><a class="external" href="https://askubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu.com', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ask Ubuntu</a></li>
-      <li><a class="external" href="https://ubuntuforums.org/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntuforums', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ubuntu Forums</a></li>
-      <li><a class="external" href="https://wiki.ubuntu.com/IRC/ChannelList" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c IRC channel list', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">IRC-based support</a></li>
+      <li><a class="p-link--external" href="https://askubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu.com', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ask Ubuntu</a></li>
+      <li><a class="p-link--external" href="https://ubuntuforums.org/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntuforums', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ubuntu Forums</a></li>
+      <li><a class="p-link--external" href="https://wiki.ubuntu.com/IRC/ChannelList" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c IRC channel list', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">IRC-based support</a></li>
   </ul>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_kylin_bittorrent.html
+++ b/templates/shared-v1/contextual_footers/_download_kylin_bittorrent.html
@@ -2,7 +2,7 @@
   <h3 class="p-heading--four">BitTorrent</h3>
   <p>If you prefer, you can download Ubuntu Kylin {{lts_release_full}} via a torrent.</p>
   <ul class="p-list">
-      <li><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{ lts_release }}/release/ubuntukylin-{{ lts_release }}-desktop-amd64.iso.torrent" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : '64 bit kylin torrent', 'eventLabel' : 'BitTorrent', 'eventValue' : undefined });">64-bit torrent</a></li>
-      <li><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{ lts_release }}/release/ubuntukylin-{{ lts_release }}-desktop-i386.iso.torrent" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : '32 bit kylin torrent', 'eventLabel' : 'BitTorrent', 'eventValue' : undefined });">32-bit torrent</a></li>
+      <li><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{ lts_release }}/release/ubuntukylin-{{ lts_release }}-desktop-amd64.iso.torrent" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : '64 bit kylin torrent', 'eventLabel' : 'BitTorrent', 'eventValue' : undefined });">64-bit torrent</a></li>
+      <li><a href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{ lts_release }}/release/ubuntukylin-{{ lts_release }}-desktop-i386.iso.torrent" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : '32 bit kylin torrent', 'eventLabel' : 'BitTorrent', 'eventValue' : undefined });">32-bit torrent</a></li>
   </ul>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_kylin_community.html
+++ b/templates/shared-v1/contextual_footers/_download_kylin_community.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">The community is here to help</h3>
   <p>To learn more about Ubuntu Kylin or get help on installing or using it.</p>
-  <p><a href="http://www.ubuntukylin.com" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntukylin.com', 'eventLabel' : 'The community is here to help', 'eventValue' : undefined });">Visit ubuntukylin.com</a></p>
+  <p><a href="http://www.ubuntukylin.com" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntukylin.com', 'eventLabel' : 'The community is here to help', 'eventValue' : undefined });">Visit ubuntukylin.com</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_server_arm_guide.html
+++ b/templates/shared-v1/contextual_footers/_download_server_arm_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Installation guides</h3>
   <p>For help with installing Ubuntu on an ARM-based platform, check out our step-by-step installation guides.</p>
-  <p><a class="external" href="https://wiki.ubuntu.com/ARM/Server/Install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c', 'eventLabel' : 'ARM install guide', 'eventValue' : undefined });">ARM guides</a></p>
+  <p><a class="p-link--external" href="https://wiki.ubuntu.com/ARM/Server/Install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c', 'eventLabel' : 'ARM install guide', 'eventValue' : undefined });">ARM guides</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_download_server_guide.html
+++ b/templates/shared-v1/contextual_footers/_download_server_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ubuntu Server guide</h3>
   <p>Read the official Ubuntu Server documentation.</p>
-  <p><a class="external" href="https://help.ubuntu.com/lts/serverguide/index.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c server guide', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
+  <p><a class="p-link--external" href="https://help.ubuntu.com/lts/serverguide/index.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c server guide', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_iot_developers.html
+++ b/templates/shared-v1/contextual_footers/_iot_developers.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Want to learn more about developing with Ubuntu Core?</h3>
   <p>Learn how to build or port apps for the next generation of Ubuntu.</p>
-  <p><a href="https://developer.ubuntu.com/en/snappy/" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'dev.u.c/snappy', 'eventLabel' : 'Develop with Ubuntu core', 'eventValue' : undefined });">Visit our developer site</a></p>
+  <p><a href="https://developer.ubuntu.com/en/snappy/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'dev.u.c/snappy', 'eventLabel' : 'Develop with Ubuntu core', 'eventValue' : undefined });">Visit our developer site</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_iot_for_developers.html
+++ b/templates/shared-v1/contextual_footers/_iot_for_developers.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">For developers</h3>
   <p>Ubuntu Core delivers security, reliable updates and much more.</p>
-  <p><a href="http://developer.ubuntu.com/en/snappy/?utm_campaign=Device_FY17_IOT&utm_medium=iotthankyoupage&utm_source=ubuntuwebsite&utm_content=seedeveloperinformation" class="external">Learn about Ubuntu Core for developers</a></p>
+  <p><a href="http://developer.ubuntu.com/en/snappy/?utm_campaign=Device_FY17_IOT&utm_medium=iotthankyoupage&utm_source=ubuntuwebsite&utm_content=seedeveloperinformation" class="p-link--external">Learn about Ubuntu Core for developers</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_iot_webinars.html
+++ b/templates/shared-v1/contextual_footers/_iot_webinars.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Upcoming webinars</h3>
   <p>Learn from leaders in the digital signage space, how they’re innovating and using Ubuntu.</p>
-  <p><a href="https://www.brighttalk.com/webcast/6793/211999?utm_source=UbuntuSites&amp;utm_medium=DSpage&amp;utm_campaign=211999" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'brighttalk', 'eventLabel' : 'Upcoming webinars', 'eventValue' : undefined });">Sign up for our next webinar</a></p>
+  <p><a href="https://www.brighttalk.com/webcast/6793/211999?utm_source=UbuntuSites&amp;utm_medium=DSpage&amp;utm_campaign=211999" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'brighttalk', 'eventLabel' : 'Upcoming webinars', 'eventValue' : undefined });">Sign up for our next webinar</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_maas-faq.html
+++ b/templates/shared-v1/contextual_footers/_maas-faq.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">MAAS FAQ</h3>
   <p>Top 10 questions about MAAS. Your guide to MAAS, bare-metal provisioning, and more.</p>
-  <p><a href="http://insights.ubuntu.com/2013/08/29/top-10-questions-about-maas/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS page', 'eventLabel' : 'Download MAAS datasheet', 'eventValue' : undefined });" class="external">Download MAAS datasheet</a></p>
+  <p><a href="http://insights.ubuntu.com/2013/08/29/top-10-questions-about-maas/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS page', 'eventLabel' : 'Download MAAS datasheet', 'eventValue' : undefined });" class="p-link--external">Download MAAS datasheet</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_server_contact_us.html
+++ b/templates/shared-v1/contextual_footers/_server_contact_us.html
@@ -1,6 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ubuntu Advantage for business</h3>
   <p>Get professional support {% if level_2 == 'management' %}with Ubuntu Advantage{% else %}for Ubuntu Server{% endif %} from Canonical.</p>
-  <p><a href="https://buy.ubuntu.com" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'Ubuntu Advantage store', 'eventValue' : undefined });"><span class="external">Visit the store</span></a></p>
+  <p><a href="https://buy.ubuntu.com" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'Ubuntu Advantage store', 'eventValue' : undefined });"><span class="p-link--external">Visit the store</span></a></p>
   <p><a href="/server/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'For business', 'eventValue' : undefined });">Get in touch&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_support-image.html
+++ b/templates/shared-v1/contextual_footers/_support-image.html
@@ -2,6 +2,6 @@
   <img src="{{ ASSET_SERVER_URL }}9f035e4a-picto-support-orange.svg" alt="Pictogram pictogram" />
   <h3 class="p-heading--four">Professional support for Ubuntu</h3>
   <p>Get professional support from Canonical to manage your Ubuntu desktop, cloud and server deployments.</p>
-  <p><a href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Buy Ubuntu Advantage', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });" class="external">Buy Ubuntu Advantage</a></p>
+  <p><a href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Buy Ubuntu Advantage', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });" class="p-link--external">Buy Ubuntu Advantage</a></p>
   <p><a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu support', 'eventLabel' : 'Find out more', 'eventValue' : undefined });">Find out more&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_support.html
+++ b/templates/shared-v1/contextual_footers/_support.html
@@ -1,6 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Professional support for Ubuntu</h3>
   <p>Get professional support from Canonical to manage your Ubuntu desktop, cloud and server deployments.</p>
-  <p><a href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Buy Ubuntu Advantage', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });" class="external">Buy Ubuntu Advantage</a></p>
+  <p><a href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Buy Ubuntu Advantage', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });" class="p-link--external">Buy Ubuntu Advantage</a></p>
   <p><a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu support', 'eventLabel' : 'Find out more', 'eventValue' : undefined });">Find out more&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

* updated alternative downloads - http://0.0.0.0:8001/download/alternative-downloads
* fixed contextual footers to use p-link--external, instead of external and added equal height to each section so the dividers look even

## QA

- Check out this feature branch or the [demo](http://www.ubuntu.com-1621-download-alternative-downloads.demo.haus/download/alternative-downloads)
- Run the site using the command `./run serve`
- look at the above page and see if it looks ok
- fixed external link class and made equal heights

## Issue / Card

Fixes #1621 

