### PR TITLE
Fix form buttons on /legal to use Vanilla buttons

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -97,3 +97,17 @@ html {
 .p-button--neutral.is-compact {
   padding: $sp-x-small $sp-small;
 }
+
+// brand submit buttons bg override
+// https://github.com/vanilla-framework/vanilla-framework/issues/1080
+
+.p-button--brand[type=submit]{
+  background-color: $color-brand;
+  border-color: $color-brand;
+
+  &:hover,
+  &:active {
+    background-color: darken($color-brand, 10%);
+    border-color: darken($color-brand, 10%);
+  }
+}

--- a/templates/legal/contributors/submit.html
+++ b/templates/legal/contributors/submit.html
@@ -627,7 +627,7 @@
                       </div>
                     </li>
                     <li class="actions">
-                      <input type="submit" class="primaryAction" id="submit-" name="tfa_submitAction" value="I agree">
+                      <input type="submit" class="p-button--brand" id="submit-" name="tfa_submitAction" value="I agree">
                       <input type="hidden" value="237277" name="tfa_dbFormId" id="tfa_dbFormId">
                       <input type="hidden" value="" name="tfa_dbResponseId" id="tfa_dbResponseId">
                       <input type="hidden" value="d00afcc394fd0912b8a3895b593d43ef" name="tfa_dbControl" id="tfa_dbControl">

--- a/templates/legal/terms-and-policies/confidentiality-agreement.html
+++ b/templates/legal/terms-and-policies/confidentiality-agreement.html
@@ -7,47 +7,48 @@
 
 <link href="https://www.tfaforms.com/css/form.css" rel="stylesheet" type="text/css" />
 <script>
-    wFORMS.behaviors.prefill.skip = false;
+  wFORMS.behaviors.prefill.skip = false;
 </script>
 <style type="text/css" media="screen">
-.supportInfo {
-  display: none;
-}
+  .supportInfo {
+    display: none;
+  }
 
-.offstate-b {
-  display: none;
-}
+  .offstate-b {
+    display: none;
+  }
 
-div.error, div.ok {
-    margin:20px 50px;
-    text-align:center;
+  div.error,
+  div.ok {
+    margin: 20px 50px;
+    text-align: center;
     padding: 0;
-}
+  }
 
-div.error p, div.ok p {
+  div.error p,
+  div.ok p {
     margin: 10px;
-}
+  }
 
-.wForm textarea {
+  .wForm textarea {
     width: 100%;
-}
+  }
 
-div.error {
+  div.error {
     background: #FCC;
     color: #200;
     border: 1px solid #D77;
-}
+  }
 
-div.ok {
+  div.ok {
     background: #DFD;
     color: #020;
     border: 1px solid #0A0;
-}
+  }
 
-form label.reqMark {
-  color: #333;
-}
-
+  form label.reqMark {
+    color: #333;
+  }
 </style>
 <script>
   /* make jslint happy */
@@ -57,30 +58,31 @@ form label.reqMark {
   // Use this in a FormAssembly code block to add a string to a field's class (that's how standard validations work)
   // this allows form developer to add validations not permitted by FormAssembly's UI.
 
-  function custom_validation(id, class_info)
-  {
-    base2.DOM.Element.addEventListener(document,'DOMContentLoaded',
-    function()
-    {
-      try {document.getElementById(id).className += " " + class_info;}
-      catch(err)
-      {
-        throw new Error("Custom validation could not be applied to field " + id);
-      }
-    },
-    false);
+  function custom_validation(id, class_info) {
+    base2.DOM.Element.addEventListener(document, 'DOMContentLoaded',
+      function() {
+        try {
+          document.getElementById(id).className += " " + class_info;
+        } catch (err) {
+          throw new Error("Custom validation could not be applied to field " + id);
+        }
+      },
+      false);
   }
 
   // validate-length validates string does not exceed given number of chars
 
-  wFORMS.behaviors.validation.rules.isUnderLimit   = { selector: ".validate-length", check: 'isUnderLimit' };
+  wFORMS.behaviors.validation.rules.isUnderLimit = {
+    selector: ".validate-length",
+    check: 'isUnderLimit'
+  };
   wFORMS.behaviors.validation.messages.isUnderLimit = "This text is too long.";
 
   wFORMS.behaviors.validation.instance.prototype.isUnderLimit = function(element, value) {
     var pattern = new RegExp(/validate-length (\d*)/i);
     var matches = element.className.match(pattern);
 
-    if(matches && matches[1]) {
+    if (matches && matches[1]) {
       return (value.length <= matches[1]);
     }
     return true;
@@ -92,7 +94,10 @@ form label.reqMark {
   // we just check for exactly 12 digits, and each digit may be optionally followed by a dash
   // so dashes are essentially ignored
 
-  wFORMS.behaviors.validation.rules.isAWSAccountNumber = { selector: ".validate-awsaccountnumber", check: 'validateAWSAccountNumber' };
+  wFORMS.behaviors.validation.rules.isAWSAccountNumber = {
+    selector: ".validate-awsaccountnumber",
+    check: 'validateAWSAccountNumber'
+  };
   wFORMS.behaviors.validation.messages.isAWSAccountNumber = "Not a valid Amazon AWS Account number (expected format '1234-5678-0987')";
 
   wFORMS.behaviors.validation.instance.prototype.validateAWSAccountNumber = function(element, value) {
@@ -500,7 +505,7 @@ form label.reqMark {
                     </li>
                     <li class="p-list__item">
                       <div class="actions" id="tfa_0-A">
-                        <input type="submit" class="primaryAction" value="I agree">
+                        <input type="submit" class="p-button--brand" value="I agree">
                       </div>
                       <div style="clear:both"></div>
                       <input type="hidden" value="353675" name="tfa_dbFormId" id="tfa_dbFormId">


### PR DESCRIPTION
## Done

Fix form buttons on /legal to use Vanilla buttons

## QA

- Check code override and see issue has been raised upstream
- Buttons on the following pages should use Vanilla Brand button style:

[http://www.ubuntu.com-1750-form-buttons.demo.haus/legal/terms-and-policies/confidentiality-agreement](http://www.ubuntu.com-1750-form-buttons.demo.haus/legal/terms-and-policies/confidentiality-agreement)
[http://www.ubuntu.com-1750-form-buttons.demo.haus/legal/contributors/submit](http://www.ubuntu.com-1750-form-buttons.demo.haus/legal/contributors/submit)


## Issue / Card

Fixes #1750 