### PR TITLE
Remove margin from breadcrumbs.

### DIFF
--- a/templates/templates/_nav_breadcrumb-v1.html
+++ b/templates/templates/_nav_breadcrumb-v1.html
@@ -1,5 +1,5 @@
 <div class="row nav-secondary__row">
-  <div class="col-12">
+  <div class="col-12 u-no-margin--bottom">
     <ul class="p-breadcrumbs">
       {% if level_2 and not level_3 and not tertiary %}
         <li class="p-breadcrumbs__item"><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>


### PR DESCRIPTION
## Done

Remove the bottom margin from the breadcrumbs at small screens.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support/esm](http://0.0.0.0:8001/support/esm))
- Check all viewports but see that small screen no longer has the gap visible on the [live website](https://www.ubuntu.com/support/esm).


## Issue / Card

Fixes #1797 

[Demo](http://www.ubuntu.com-vbt-breadcrumb-margin.demo.haus/support/esm)