### PR TITLE
update download-thank-you-linuxone to vbt

### DIFF
--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -8,7 +8,9 @@
   .p-strip,
   .p-strip--grey,
   .p-strip--accent,
-  .p-strip--suru-accent {
+  .p-strip--suru-accent,
+  .p-strip--light,
+  .p-strip--dark {
     padding: 3.75rem 0;
 
     &.is-shallow {

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -103,6 +103,8 @@ html {
 /// XXX Brand button color fix
 /// .p-button--brand is blue when visited
 .p-button--brand {
+  color: $color-x-light;
+
   &:link,
   &:visited,
   &:active,

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -102,7 +102,7 @@ html {
 
 /// XXX Brand button color fix
 /// .p-button--brand is blue when visited
-a.p-button--brand {
+.p-button--brand {
   &:link,
   &:visited,
   &:active,

--- a/templates/download/_nav_tertiary-v1.html
+++ b/templates/download/_nav_tertiary-v1.html
@@ -1,63 +1,63 @@
-<ul class="third-level-nav">
+<ul class="nav-secondary__menu p-inline-list">
   {% if level_2 == 'server' %}
-    <li><a {% if level_3 == 'arm' %} class="is-active"{% endif %}href="/download/server/arm">ARM</a></li>
-    <li><a {% if level_3 == 'power8' %} class="is-active"{% endif %}href="/download/server/power8">POWER8</a></li>
-    <li><a {% if level_3 == 'linuxone' %} class="is-active"{% endif %}href="/download/server/linuxone">LinuxONE</a></li>
-    <li><a {% if level_3 == 'provisioning' %} class="is-active"{% endif %}href="/download/server/provisioning">Provisioning</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'arm' %}is-active{% endif %}"href="/download/server/arm">ARM</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'power8' %}is-active{% endif %}"href="/download/server/power8">POWER8</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'linuxone' %}is-active{% endif %}"href="/download/server/linuxone">LinuxONE</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'provisioning' %}is-active{% endif %}"href="/download/server/provisioning">Provisioning</a></li>
   {% endif %}
   {% if level_2 == 'cloud' %}
-    <li><a {% if level_3 == 'conjure-up' %} class="is-active"{% endif %}href="/download/cloud/conjure-up">Conjure-up</a></li>
-    <li><a {% if level_3 == 'autopilot' %} class="is-active"{% endif %}href="/download/cloud/autopilot">Autopilot</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'conjure-up' %}is-active{% endif %}"href="/download/cloud/conjure-up">Conjure-up</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'autopilot' %}is-active{% endif %}"href="/download/cloud/autopilot">Autopilot</a></li>
   {% endif %}
   {% if level_3 == 'burn-a-dvd-on-macos' %}
-    <li><a class="is-active" href="/download/desktop/burn-a-dvd-on-macos">How to burn a DVD on macOS</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/burn-a-dvd-on-macos">How to burn a DVD on macOS</a></li>
   {% endif %}
   {% if level_3 == 'burn-a-dvd-on-ubuntu' %}
-    <li><a class="is-active" href="/download/desktop/burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu</a></li>
   {% endif %}
   {% if level_3 == 'burn-a-dvd-on-windows' %}
-    <li><a class="is-active" href="/download/desktop/burn-a-dvd-on-windows">How to burn a DVD on Windows</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/burn-a-dvd-on-windows">How to burn a DVD on Windows</a></li>
   {% endif %}
   {% if level_3 == 'create-a-usb-stick-on-macos' %}
-    <li><a class="is-active" href="/download/desktop/create-a-usb-stick-on-macos">Create a bootable USB stick on macOS</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/create-a-usb-stick-on-macos">Create a bootable USB stick on macOS</a></li>
   {% endif %}
   {% if level_3 == 'create-a-usb-stick-on-ubuntu' %}
-    <li><a class="is-active" href="/download/desktop/create-a-usb-stick-on-ubuntu">Create a bootable USB stick on Ubuntu</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/create-a-usb-stick-on-ubuntu">Create a bootable USB stick on Ubuntu</a></li>
   {% endif %}
   {% if level_3 == 'create-a-usb-stick-on-windows' %}
-    <li><a class="is-active" href="/download/desktop/create-a-usb-stick-on-windows">Create a bootable USB stick on Windows</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/create-a-usb-stick-on-windows">Create a bootable USB stick on Windows</a></li>
   {% endif %}
   {% if level_3 == 'install-desktop-latest' %}
-    <li><a class="is-active" href="/download/desktop/install-desktop-latest">Install Ubuntu 13.10</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/install-desktop-latest">Install Ubuntu 13.10</a></li>
   {% endif %}
   {% if level_3 == 'install-desktop-long-term-support' %}
-    <li><a class="is-active" href="/download/desktop/install-desktop-long-term-support">Install Ubuntu {{lts_release_full}}</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/install-desktop-long-term-support">Install Ubuntu {{lts_release_full}}</a></li>
   {% endif %}
   {% if level_3 == 'install-ubuntu-desktop' %}
-    <li><a class="is-active" href="/download/desktop/install-ubuntu-desktop">Installing Ubuntu Desktop</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/install-ubuntu-desktop">Installing Ubuntu Desktop</a></li>
   {% endif %}
   {% if level_3 == 'try-ubuntu-before-you-install' %}
-    <li><a class="is-active" href="/download/desktop/try-ubuntu-before-you-install">Try Ubuntu before you install</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/try-ubuntu-before-you-install">Try Ubuntu before you install</a></li>
   {% endif %}
   {% if level_3 == 'install-ubuntu-server' %}
-    <li><a class="is-active" href="/download/server/install-ubuntu-server">Installing Ubuntu Server</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/server/install-ubuntu-server">Installing Ubuntu Server</a></li>
   {% endif %}
   {% if level_3 == 'cloud-archive-instructions' %}
-    <li><a class="is-active" href="/download/cloud/cloud-archive-instructions">Cloud archive instructions</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/cloud/cloud-archive-instructions">Cloud archive instructions</a></li>
   {% endif %}
   {% if level_3 == 'upgrade' %}
-    <li><a class="is-active" href="/download/desktop/upgrade">Upgrade</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/upgrade">Upgrade</a></li>
   {% endif %}
   {% if level_3 == 'thank-you' %}
-    <li><a class="is-active" href="/download/{{ level_2 }}/thank-you">Thank you</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/{{ level_2 }}/thank-you">Thank you</a></li>
   {% endif %}
   {% if level_2 == 'alternative-downloads' %}
-    <li><a class="is-active" href="/download/alternative-downloads">Alternative Downloads</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/alternative-downloads">Alternative Downloads</a></li>
   {% endif %}
   {% if level_3 == 'ubuntu-kylin' or level_3 == 'ubuntu-kylin-zh-CN' %}
-    <li><a class="is-active" href="/download/desktop/ubuntu-kylin">Ubuntu Kylin</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/ubuntu-kylin">Ubuntu Kylin</a></li>
   {% endif %}
   {% if level_3 == 'contribute' %}
-    <li><a class="is-active" href="/download/desktop/contribute">Contribute</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/contribute">Contribute</a></li>
   {% endif %}
 </ul>

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -127,7 +127,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
             <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
-            <h3>Forrester Research eBook</h3>
+            <h3 class="p-heading-icon__title">Forrester Research eBook</h3>
           </div>
         </div>
         <p>Get more from the cloud with the right platform approach.</p>
@@ -137,7 +137,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
             <img class="p-heading-icon__img" alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
-            <h3>IDC Analyst White Paper</h3>
+            <h3 class="p-heading-icon__title">IDC Analyst White Paper</h3>
           </div>
         </div>
         <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
@@ -147,7 +147,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
             <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
-            <h3>IBM Systems Magazine Webinar</h3>
+            <h3 class="p-heading-icon__title">IBM Systems Magazine Webinar</h3>
           </div>
         </div>
         <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -26,7 +26,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
       <p>For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us +44 (0) 207 630 2406 or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
     </div>
     <div class="col-6 p-card">
-      <h2  class="p-card__title">Purchase Ubuntu Advantage</h2>
+      <h2 class="p-card__title">Purchase Ubuntu Advantage</h2>
       <p class="p-card__content">As you move into a production environment you need to purchase Ubuntu Advantage for your server. Complete this form and someone from Canonical sales will get in touch.</p>
 
       <!-- MARKETO FORM -->
@@ -36,29 +36,29 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
         <fieldset>
           <ul class="p-list">
-            <li  class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel " >First name: <span>*</span></label>
-              <input required  id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired" >
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel ">First name: <span>*</span></label>
+              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
-            <li  class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel " >Last name: <span>*</span></label>
-              <input required  id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired" >
+            <li class="mktFormReq mktField p-list__item">
+              <label for="LastName" class="mktoLabel ">Last name: <span>*</span></label>
+              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
-            <li  class="mktFormReq mktField p-list__item">
-              <label for="Company" class="mktoLabel " >Company name: <span>*</span></label>
-              <input required  id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired" >
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Company" class="mktoLabel ">Company name: <span>*</span></label>
+              <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
-            <li  class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel " >Email address: <span>*</span></label>
-              <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" >
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Email" class="mktoLabel ">Email address: <span>*</span></label>
+              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
             </li>
-            <li  class="mktFormReq mktField p-list__item">
-              <label for="Phone" class="mktoLabel " >Phone number: <span>*</span></label>
-              <input required  id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" >
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Phone" class="mktoLabel ">Phone number: <span>*</span></label>
+              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
             </li>
-            <li  class="mktField p-list__item">
-              <label for="NumUbuntuServers__c" class="mktoLabel " >Number of drawers you are purchasing support for:</label>
-              <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField " ><option value="">Select...</option>
+            <li class="mktField p-list__item">
+              <label for="NumUbuntuServers__c" class="mktoLabel ">Number of drawers you are purchasing support for:</label>
+              <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField "><option value="">Select...</option>
                 <option value="zBC12" disabled>zBC12</option>
                 <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
                 <option value="zEC12" disabled>zEC12</option>
@@ -73,32 +73,34 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
                 <option value="Z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
                 <option value="Z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
                 <option value="Z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option></select>
-              </li>
-              <li  class="mktField p-list__item">
-                <label for="Comments_from_Contact__c" class="mktoLabel " >Serial number(s)</label>
-                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000" ></textarea>
-              </li>
-              <li  class="mktField p-list__item">
-                <label for="purchaseordernumber" class="mktoLabel " >Purchase order number:</label>
-                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField  " >
-              </li>
-              <li  class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox"> <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
-              </li>
-
-              <li  class="mktField p-list__item">
-                <input name="Optin_cloud_nuture" id="Optin_cloud_nuture" type="checkbox" value="yes" class="mktoField"> <label for="Optin_cloud_nuture" class="mktoLabel " >I would like to receive eBooks and White Papers by Canonical.</label>
-              </li>
-              <li>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
-              <li  class="mktField p-list__item">
-                <p></p><button type="submit" class="mktoButton p-button--brand is-wide">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value=""></p>
-              </li>
-            </ul>
-          </fieldset>
-          <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
-          <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
-        </form>
-        <script>
+            </li>
+            <li class="mktField p-list__item">
+              <label for="Comments_from_Contact__c" class="mktoLabel ">Serial number(s)</label>
+              <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000"></textarea>
+            </li>
+            <li class="mktField p-list__item">
+              <label for="purchaseordernumber" class="mktoLabel ">Purchase order number:</label>
+              <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField  ">
+            </li>
+            <li class="mktField p-list__item">
+              <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox"> <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
+            </li>
+            <li class="mktField p-list__item">
+              <input name="Optin_cloud_nuture" id="Optin_cloud_nuture" type="checkbox" value="yes" class="mktoField"> <label for="Optin_cloud_nuture" class="mktoLabel ">I would like to receive eBooks and White Papers by Canonical.</label>
+            </li>
+            <li>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
+            <li class="mktField p-list__item">
+              <button type="submit" class="mktoButton p-button--brand is-wide">Submit</button><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
+                name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
+              <input
+                type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+            </li>
+          </ul>
+        </fieldset>
+        <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+        <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+      </form>
+      <script>
         $("#mktoForm_1400").validate({
           errorElement: "span",
           errorClass: "mktFormMsg mktError",
@@ -106,57 +108,58 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
           onclick: false,
           onblur: false
         });
-        $(function(){$("#comments").hide()});
-        $('#Ubuntu_User__c').on('change',function(){
+        $(function() {
+          $("#comments").hide()
+        });
+        $('#Ubuntu_User__c').on('change', function() {
           var selection = $(this).val();
-          if(selection == 'Commercially only') {
+          if (selection == 'Commercially only') {
             $('#comments').show();
           } else {
             $('#comments').hide();
           }
         });
-        </script>
-        <!-- /MARKETO FORM -->
-      </div>
+      </script>
+      <!-- /MARKETO FORM -->
     </div>
   </div>
+</div>
 
-  <div class="p-strip is-shallow">
-    <div class="row p-divider">
-      <div class="col-4 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
-            <h3 class="p-heading-icon__title">Forrester Research eBook</h3>
-          </div>
+<div class="p-strip is-shallow">
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
+          <h3 class="p-heading-icon__title">Forrester Research eBook</h3>
         </div>
-        <p>Get more from the cloud with the right platform approach.</p>
-        <p><a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html"  class="p-link--external">Download eBook</a></p>
       </div>
-      <div class="col-4 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
-            <h3 class="p-heading-icon__title">IDC Analyst White Paper</h3>
-          </div>
+      <p>Get more from the cloud with the right platform approach.</p>
+      <p><a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html" class="p-link--external">Download eBook</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
+          <h3 class="p-heading-icon__title">IDC Analyst White Paper</h3>
         </div>
-        <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
-        <p><a href="http://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW" class="p-link--external">Download whitepaper</a></p>
       </div>
-      <div class="col-4 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
-            <h3 class="p-heading-icon__title">IBM Systems Magazine Webinar</h3>
-          </div>
+      <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
+      <p><a href="http://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW" class="p-link--external">Download whitepaper</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
+          <h3 class="p-heading-icon__title">IBM Systems Magazine Webinar</h3>
         </div>
-        <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>
-        <p><a href="https://ibmsystemsmag.webex.com/ibmsystemsmag/lsr.php?RCID=8a447682b6dd0bffe57723fc5238d202" class="p-link--external">Watch webinar on-demand</a></p>
       </div>
+      <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>
+      <p><a href="https://ibmsystemsmag.webex.com/ibmsystemsmag/lsr.php?RCID=8a447682b6dd0bffe57723fc5238d202" class="p-link--external">Watch webinar on-demand</a></p>
     </div>
   </div>
+</div>
 
+{% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
 
-  {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
-
-  {% endblock content %}
+{% endblock content %}

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -1,16 +1,16 @@
 {% extends "download/_base_download-v1.html" %}
 
 {% block title %}
-  Thanks for downloading Ubuntu for LinuxONE and z Systems
+Thanks for downloading Ubuntu for LinuxONE and z Systems
 {% endblock %}
 {% block extra_body_class %}download-thankyou{% endblock %}
 
 {% block second_level_nav_items %}
-    {% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" subsection_title="Server" page_title="Thank you"  %}
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" subsection_title="Server" page_title="Thank you"  %}
 {% endblock second_level_nav_items %}
 
 {% block head_extra %}
-<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-s390x.iso">
+  <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-s390x.iso">
 {% endblock %}
 
 {% block content %}
@@ -91,7 +91,7 @@
               </li>
               <li>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
               <li  class="mktField p-list__item">
-                <button type="submit" class="mktoButton p-button--brand is-wide">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+                <p></p><button type="submit" class="mktoButton p-button--brand is-wide">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value=""></p>
               </li>
             </ul>
           </fieldset>
@@ -122,28 +122,34 @@
   </div>
 
   <div class="p-strip is-shallow">
-    <div class="row u-equal-height">
-      <div class="col-4 p-card--highlighted">
-        <div class="u-align--center" style="margin: 1rem 0;">
-          <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
+    <div class="row p-divider">
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
+            <h3>Forrester Research eBook</h3>
+          </div>
         </div>
-        <h3>Forrester Research eBook</h3>
         <p>Get more from the cloud with the right platform approach.</p>
         <p><a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html"  class="p-link--external">Download eBook</a></p>
       </div>
-      <div class="col-4 p-card--highlighted">
-        <div class="u-align--center" style="margin: 1rem 0;">
-          <img alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
+            <h3>IDC Analyst White Paper</h3>
+          </div>
         </div>
-        <h3>IDC Analyst White Paper</h3>
         <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
         <p><a href="http://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW" class="p-link--external">Download whitepaper</a></p>
       </div>
-      <div class="col-4 p-card--highlighted">
-        <div class="u-align--center" style="margin: 1rem 0;">
-          <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
+            <h3>IBM Systems Magazine Webinar</h3>
+          </div>
         </div>
-        <h3>IBM Systems Magazine Webinar</h3>
         <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>
         <p><a href="https://ibmsystemsmag.webex.com/ibmsystemsmag/lsr.php?RCID=8a447682b6dd0bffe57723fc5238d202" class="p-link--external">Watch webinar on-demand</a></p>
       </div>

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -1,14 +1,12 @@
-{% extends "download/_base_download.html" %}
+{% extends "download/_base_download-v1.html" %}
 
 {% block title %}
-Thanks for downloading Ubuntu for LinuxONE and z Systems
+  Thanks for downloading Ubuntu for LinuxONE and z Systems
 {% endblock %}
 {% block extra_body_class %}download-thankyou{% endblock %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="Thank you"  %}
-</div>
+    {% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" subsection_title="Server" page_title="Thank you"  %}
 {% endblock second_level_nav_items %}
 
 {% block head_extra %}
@@ -17,143 +15,142 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
 
 {% block content %}
 
-<div class="row row-hero no-border">
-    <div class="strip-inner-wrapper">
-        <div class="six-col">
-            <h1>Thanks for downloading Ubuntu for LinuxONE and z&nbsp;Systems</h1>
-            <p>Thank you for downloading Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems. Your ISO download should start automatically.</p>
-            <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/xenial/release ">visit the download page</a>.</p>
-            <p>Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
-            <p>Your use of Ubuntu on z Systems and LinuxONE in production constitutes <a href="https://www.ubuntu.com/legal/short-terms">acceptance of these terms</a>.</p>
-            <p>For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us +44 (0) 207 630 2406 or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
-        </div>
-        <div class="six-col last-col box">
-            <h2>Purchase Ubuntu Advantage</h2>
-            <p>As you move into a production environment you need to purchase Ubuntu Advantage for your server. Complete this form and someone from Canonical sales will get in touch.</p>
-
-            <!-- MARKETO FORM -->
-            <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
-            <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
-            
-            <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
-                <fieldset>
-                    <ul class="no-bullets">
-                        <li  class="mktFormReq mktField">
-                            <label for="FirstName" class="mktoLabel " >First name: <span>*</span></label>
-                            <input required  id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired" >
-                        </li>
-                        <li  class="mktFormReq mktField">
-                            <label for="LastName" class="mktoLabel " >Last name: <span>*</span></label>
-                            <input required  id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired" >
-                        </li>
-                        <li  class="mktFormReq mktField">
-                            <label for="Company" class="mktoLabel " >Company name: <span>*</span></label>
-                            <input required  id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired" >
-                        </li>
-                        <li  class="mktFormReq mktField">
-                            <label for="Email" class="mktoLabel " >Email address: <span>*</span></label>
-                            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" >
-                        </li>
-                        <li  class="mktFormReq mktField">
-                            <label for="Phone" class="mktoLabel " >Phone number: <span>*</span></label>
-                            <input required  id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" >
-                        </li>
-                        <li  class="mktField">
-                            <label for="NumUbuntuServers__c" class="mktoLabel " >Number of drawers you are purchasing support for:</label>
-                            <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField " ><option value="">Select...</option>
-                                <option value="zBC12" disabled>zBC12</option>
-                                <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
-                                <option value="zEC12" disabled>zEC12</option>
-                                <option value="zEC12 - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
-                                <option value="zEC12 - 2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
-                                <option value="zEC12 - 3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
-                                <option value="zEC12 - 4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
-                                <option value="Z13s/Rockhopper" disabled> Z13s/Rockhopper</option>
-                                <option value="Z13s/Rockhopper - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
-                                <option value="Z13/Emperor" disabled>Z13/Emperor</option>
-                                <option value="Z13/Emperor - 1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
-                                <option value="Z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
-                                <option value="Z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
-                                <option value="Z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option></select>
-                            </li>
-                            <li  class="mktField">
-                                <label for="Comments_from_Contact__c" class="mktoLabel " >Serial number(s)</label>
-                                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000" ></textarea>
-                            </li>
-                            <li  class="mktField">
-                                <label for="purchaseordernumber" class="mktoLabel " >Purchase order number:</label>
-                                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField  " >
-                            </li>
-                            <li  class="mktField">
-                                <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
-                                <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
-                            </li>
-
-                            <li  class="mktField">
-                                <input name="Optin_cloud_nuture" id="Optin_cloud_nuture" type="checkbox" value="yes" class="mktoField">                                <label for="Optin_cloud_nuture" class="mktoLabel " >I would like to receive eBooks and White Papers by Canonical.</label>
-                            </li>
-                            <li>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
-                            <li  class="mktField">
-                                <button type="submit" class="mktoButton">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
-                            </li>
-                        </ul>
-                    </fieldset>
-                    <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
-                    <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
-                </form>
-                <script>
-                $("#mktoForm_1400").validate({
-                    errorElement: "span",
-                    errorClass: "mktFormMsg mktError",
-                    onkeyup: false,
-                    onclick: false,
-                    onblur: false
-                });
-                $(function(){$("#comments").hide()});
-                $('#Ubuntu_User__c').on('change',function(){
-                    var selection = $(this).val();
-                    if(selection == 'Commercially only') {
-                        $('#comments').show();
-                    } else {
-                        $('#comments').hide();
-                    }
-                });
-                </script>
-                <!-- /MARKETO FORM -->
-            </div>
-        </div>
+<div class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h1>Thanks for downloading Ubuntu for LinuxONE and z&nbsp;Systems</h1>
+      <p>Thank you for downloading Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems. Your ISO download should start automatically.</p>
+      <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/xenial/release ">visit the download page</a>.</p>
+      <p>Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
+      <p>Your use of Ubuntu on z Systems and LinuxONE in production constitutes <a href="https://www.ubuntu.com/legal/short-terms">acceptance of these terms</a>.</p>
+      <p>For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us +44 (0) 207 630 2406 or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
     </div>
-    <div class="row row-grey no-border">
-        <div class="strip-inner-wrapper">
-            <div class="twelve-col no-margin-bottom equal-height">
-                <div class="four-col support box box-highlight equal-height__item">
-                    <div class="align-center four-col">
-                        <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
-                    </div>
-                    <h3>Forrester Research eBook</h3>
-                    <p>Get more from the cloud with the right platform approach.</p>
-                    <p><a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html"  class="external">Download eBook</a></p>
-                </div>
-                <div class="four-col one box box-highlight equal-height__item">
-                    <div class="align-center four-col">
-                        <img alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
-                    </div>
-                    <h3>IDC Analyst White Paper</h3>
-                    <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
-                    <p><a href="http://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW" class="external">Download whitepaper</a></p>
-                </div>
-                <div class="four-col ask last-col box box-highlight equal-height__item">
-                    <div class="align-center four-col">
-                        <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
-                    </div>
-                    <h3>IBM Systems Magazine Webinar</h3>
-                    <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>
-                    <p><a href="https://ibmsystemsmag.webex.com/ibmsystemsmag/lsr.php?RCID=8a447682b6dd0bffe57723fc5238d202" class="external">Watch webinar on-demand</a></p>
-                </div>
-            </div><!-- /.row .row-box -->
-        </div><!-- /.strip-inner-wrapper -->
-    </div><!-- /.row .row-grey -->
+    <div class="col-6 p-card">
+      <h2  class="p-card__title">Purchase Ubuntu Advantage</h2>
+      <p class="p-card__content">As you move into a production environment you need to purchase Ubuntu Advantage for your server. Complete this form and someone from Canonical sales will get in touch.</p>
 
-    {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+      <!-- MARKETO FORM -->
+      <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
 
-    {% endblock content %}
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
+        <fieldset>
+          <ul class="p-list">
+            <li  class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel " >First name: <span>*</span></label>
+              <input required  id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired" >
+            </li>
+            <li  class="mktFormReq mktField p-list__item">
+              <label for="LastName" class="mktoLabel " >Last name: <span>*</span></label>
+              <input required  id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired" >
+            </li>
+            <li  class="mktFormReq mktField p-list__item">
+              <label for="Company" class="mktoLabel " >Company name: <span>*</span></label>
+              <input required  id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired" >
+            </li>
+            <li  class="mktFormReq mktField p-list__item">
+              <label for="Email" class="mktoLabel " >Email address: <span>*</span></label>
+              <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" >
+            </li>
+            <li  class="mktFormReq mktField p-list__item">
+              <label for="Phone" class="mktoLabel " >Phone number: <span>*</span></label>
+              <input required  id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" >
+            </li>
+            <li  class="mktField p-list__item">
+              <label for="NumUbuntuServers__c" class="mktoLabel " >Number of drawers you are purchasing support for:</label>
+              <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField " ><option value="">Select...</option>
+                <option value="zBC12" disabled>zBC12</option>
+                <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
+                <option value="zEC12" disabled>zEC12</option>
+                <option value="zEC12 - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                <option value="zEC12 - 2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
+                <option value="zEC12 - 3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
+                <option value="zEC12 - 4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
+                <option value="Z13s/Rockhopper" disabled> Z13s/Rockhopper</option>
+                <option value="Z13s/Rockhopper - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                <option value="Z13/Emperor" disabled>Z13/Emperor</option>
+                <option value="Z13/Emperor - 1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
+                <option value="Z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
+                <option value="Z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
+                <option value="Z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option></select>
+              </li>
+              <li  class="mktField p-list__item">
+                <label for="Comments_from_Contact__c" class="mktoLabel " >Serial number(s)</label>
+                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000" ></textarea>
+              </li>
+              <li  class="mktField p-list__item">
+                <label for="purchaseordernumber" class="mktoLabel " >Purchase order number:</label>
+                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField  " >
+              </li>
+              <li  class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox"> <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
+              </li>
+
+              <li  class="mktField p-list__item">
+                <input name="Optin_cloud_nuture" id="Optin_cloud_nuture" type="checkbox" value="yes" class="mktoField"> <label for="Optin_cloud_nuture" class="mktoLabel " >I would like to receive eBooks and White Papers by Canonical.</label>
+              </li>
+              <li>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
+              <li  class="mktField p-list__item">
+                <button type="submit" class="mktoButton p-button--brand is-wide">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+              </li>
+            </ul>
+          </fieldset>
+          <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+          <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+        </form>
+        <script>
+        $("#mktoForm_1400").validate({
+          errorElement: "span",
+          errorClass: "mktFormMsg mktError",
+          onkeyup: false,
+          onclick: false,
+          onblur: false
+        });
+        $(function(){$("#comments").hide()});
+        $('#Ubuntu_User__c').on('change',function(){
+          var selection = $(this).val();
+          if(selection == 'Commercially only') {
+            $('#comments').show();
+          } else {
+            $('#comments').hide();
+          }
+        });
+        </script>
+        <!-- /MARKETO FORM -->
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-shallow">
+    <div class="row u-equal-height">
+      <div class="col-4 p-card--highlighted">
+        <div class="u-align--center" style="margin: 1rem 0;">
+          <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
+        </div>
+        <h3>Forrester Research eBook</h3>
+        <p>Get more from the cloud with the right platform approach.</p>
+        <p><a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html"  class="p-link--external">Download eBook</a></p>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <div class="u-align--center" style="margin: 1rem 0;">
+          <img alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
+        </div>
+        <h3>IDC Analyst White Paper</h3>
+        <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
+        <p><a href="http://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW" class="p-link--external">Download whitepaper</a></p>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <div class="u-align--center" style="margin: 1rem 0;">
+          <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
+        </div>
+        <h3>IBM Systems Magazine Webinar</h3>
+        <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>
+        <p><a href="https://ibmsystemsmag.webex.com/ibmsystemsmag/lsr.php?RCID=8a447682b6dd0bffe57723fc5238d202" class="p-link--external">Watch webinar on-demand</a></p>
+      </div>
+    </div>
+  </div>
+
+
+  {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+
+  {% endblock content %}


### PR DESCRIPTION
## Done

* updated /download/server/thank-you-linuxone to vbt
* extened strip to have .is-deep and .is-bordered for --light and --dark strips

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/download/server/thank-you-linuxone)
- compare to the [design](https://www.dropbox.com/search/work?path=%2F00_web_team%2F_ubuntu.com%2Fnew+projects%2Fvanilla+update%2Fpatterns+inventory&preview=download-server-linuxone-thank-you.png&qsid=27984850060468009768774727364561&query=linuxone) and the [demo](http://www.ubuntu.com-1645-download-thank-you-linuxone.demo.haus/download/server/thank-you-linuxone)


## Issue / Card

Fixes #1645 
