### PR TITLE
update /download/server/arm to vbt

### DIFF
--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -8,7 +8,9 @@
   .p-strip,
   .p-strip--grey,
   .p-strip--accent,
-  .p-strip--suru-accent {
+  .p-strip--suru-accent,
+  .p-strip--light,
+  .p-strip--dark {
     padding: 3.75rem 0;
 
     &.is-shallow {

--- a/templates/download/_nav_tertiary-v1.html
+++ b/templates/download/_nav_tertiary-v1.html
@@ -1,63 +1,63 @@
-<ul class="third-level-nav">
+<ul class="nav-secondary__menu p-inline-list">
   {% if level_2 == 'server' %}
-    <li><a {% if level_3 == 'arm' %} class="is-active"{% endif %}href="/download/server/arm">ARM</a></li>
-    <li><a {% if level_3 == 'power8' %} class="is-active"{% endif %}href="/download/server/power8">POWER8</a></li>
-    <li><a {% if level_3 == 'linuxone' %} class="is-active"{% endif %}href="/download/server/linuxone">LinuxONE</a></li>
-    <li><a {% if level_3 == 'provisioning' %} class="is-active"{% endif %}href="/download/server/provisioning">Provisioning</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'arm' %}is-active{% endif %}"href="/download/server/arm">ARM</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'power8' %}is-active{% endif %}"href="/download/server/power8">POWER8</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'linuxone' %}is-active{% endif %}"href="/download/server/linuxone">LinuxONE</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'provisioning' %}is-active{% endif %}"href="/download/server/provisioning">Provisioning</a></li>
   {% endif %}
   {% if level_2 == 'cloud' %}
-    <li><a {% if level_3 == 'conjure-up' %} class="is-active"{% endif %}href="/download/cloud/conjure-up">Conjure-up</a></li>
-    <li><a {% if level_3 == 'autopilot' %} class="is-active"{% endif %}href="/download/cloud/autopilot">Autopilot</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'conjure-up' %}is-active{% endif %}"href="/download/cloud/conjure-up">Conjure-up</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'autopilot' %}is-active{% endif %}"href="/download/cloud/autopilot">Autopilot</a></li>
   {% endif %}
   {% if level_3 == 'burn-a-dvd-on-macos' %}
-    <li><a class="is-active" href="/download/desktop/burn-a-dvd-on-macos">How to burn a DVD on macOS</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/burn-a-dvd-on-macos">How to burn a DVD on macOS</a></li>
   {% endif %}
   {% if level_3 == 'burn-a-dvd-on-ubuntu' %}
-    <li><a class="is-active" href="/download/desktop/burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu</a></li>
   {% endif %}
   {% if level_3 == 'burn-a-dvd-on-windows' %}
-    <li><a class="is-active" href="/download/desktop/burn-a-dvd-on-windows">How to burn a DVD on Windows</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/burn-a-dvd-on-windows">How to burn a DVD on Windows</a></li>
   {% endif %}
   {% if level_3 == 'create-a-usb-stick-on-macos' %}
-    <li><a class="is-active" href="/download/desktop/create-a-usb-stick-on-macos">Create a bootable USB stick on macOS</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/create-a-usb-stick-on-macos">Create a bootable USB stick on macOS</a></li>
   {% endif %}
   {% if level_3 == 'create-a-usb-stick-on-ubuntu' %}
-    <li><a class="is-active" href="/download/desktop/create-a-usb-stick-on-ubuntu">Create a bootable USB stick on Ubuntu</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/create-a-usb-stick-on-ubuntu">Create a bootable USB stick on Ubuntu</a></li>
   {% endif %}
   {% if level_3 == 'create-a-usb-stick-on-windows' %}
-    <li><a class="is-active" href="/download/desktop/create-a-usb-stick-on-windows">Create a bootable USB stick on Windows</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/create-a-usb-stick-on-windows">Create a bootable USB stick on Windows</a></li>
   {% endif %}
   {% if level_3 == 'install-desktop-latest' %}
-    <li><a class="is-active" href="/download/desktop/install-desktop-latest">Install Ubuntu 13.10</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/install-desktop-latest">Install Ubuntu 13.10</a></li>
   {% endif %}
   {% if level_3 == 'install-desktop-long-term-support' %}
-    <li><a class="is-active" href="/download/desktop/install-desktop-long-term-support">Install Ubuntu {{lts_release_full}}</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/install-desktop-long-term-support">Install Ubuntu {{lts_release_full}}</a></li>
   {% endif %}
   {% if level_3 == 'install-ubuntu-desktop' %}
-    <li><a class="is-active" href="/download/desktop/install-ubuntu-desktop">Installing Ubuntu Desktop</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/install-ubuntu-desktop">Installing Ubuntu Desktop</a></li>
   {% endif %}
   {% if level_3 == 'try-ubuntu-before-you-install' %}
-    <li><a class="is-active" href="/download/desktop/try-ubuntu-before-you-install">Try Ubuntu before you install</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/try-ubuntu-before-you-install">Try Ubuntu before you install</a></li>
   {% endif %}
   {% if level_3 == 'install-ubuntu-server' %}
-    <li><a class="is-active" href="/download/server/install-ubuntu-server">Installing Ubuntu Server</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/server/install-ubuntu-server">Installing Ubuntu Server</a></li>
   {% endif %}
   {% if level_3 == 'cloud-archive-instructions' %}
-    <li><a class="is-active" href="/download/cloud/cloud-archive-instructions">Cloud archive instructions</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/cloud/cloud-archive-instructions">Cloud archive instructions</a></li>
   {% endif %}
   {% if level_3 == 'upgrade' %}
-    <li><a class="is-active" href="/download/desktop/upgrade">Upgrade</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/upgrade">Upgrade</a></li>
   {% endif %}
   {% if level_3 == 'thank-you' %}
-    <li><a class="is-active" href="/download/{{ level_2 }}/thank-you">Thank you</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/{{ level_2 }}/thank-you">Thank you</a></li>
   {% endif %}
   {% if level_2 == 'alternative-downloads' %}
-    <li><a class="is-active" href="/download/alternative-downloads">Alternative Downloads</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/alternative-downloads">Alternative Downloads</a></li>
   {% endif %}
   {% if level_3 == 'ubuntu-kylin' or level_3 == 'ubuntu-kylin-zh-CN' %}
-    <li><a class="is-active" href="/download/desktop/ubuntu-kylin">Ubuntu Kylin</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/ubuntu-kylin">Ubuntu Kylin</a></li>
   {% endif %}
   {% if level_3 == 'contribute' %}
-    <li><a class="is-active" href="/download/desktop/contribute">Contribute</a></li>
+    <li class="p-inline-list__item"><a class="p-inline-list__link class="is-active" href="/download/desktop/contribute">Contribute</a></li>
   {% endif %}
 </ul>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -7,7 +7,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="p-strip is-deep">
+<div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-8">
       <h1>Ubuntu Server for ARM</h1>
@@ -31,14 +31,14 @@
   </div>
 </div>
 
-<div class="p-strip--light is-deep">
+<div class="p-strip--light is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-8">
       <h3>Containers, databases, web and more</h3>
       <p>Ubuntu Server for ARM includes everything you are looking for in a server operating system, including:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">The LXD container hypervisor, giving you instant access to isolated, secured environments running with bare-metal performance</li>
-        <li class="p-list__item is-ticked">Application container technology based on Docker and Kubernetes, including FAN-based networking.</li>
+        <li class="p-list__item is-ticked">Application container technology based on Docker and Kubernetes, including FAN-based networking</li>
         <li class="p-list__item is-ticked">SQL and NoSQL databases including CouchDB, MySQL, PostgreSQL, Redis and sqlite</li>
         <li class="p-list__item is-ticked">A wide collection of Web technologies, from HTTP servers to frameworks including Apache, Django, memcached, nginx, Wordpress and varnish</li>
       </ul>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -1,71 +1,68 @@
-{% extends "download/_base_download.html" %}
+{% extends "download/_base_download-v1.html" %}
 
 {% block title %}Ubuntu for ARM | Download{% endblock %}
 
 {% block second_level_nav_items %}
-    <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Server" page_title="ARM" %}
-    </div>
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" subsection_title="Server" page_title="ARM" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="row row-grey">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h1>Ubuntu Server for ARM</h1>
-            <p>Ubuntu {{lts_release_full_with_point}} includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
-            <p>Develop and test using over 50,000 software packages and runtimes &mdash; including Go, Java, Javascript, PHP, Python and Ruby &mdash; and deploy at scale using our complete scale-out management suite including MAAS and Juju. Ubuntu delivers server-grade performance on ARM, while fully retaining the reliable and familiar Ubuntu experience.</p>
-        </div>
-        <div class="twelve-col box box-highlight">
-            <div class="twelve-col no-margin-bottom equal-height--vertical-divider">
-                <div class="equal-height--vertical-divider__item six-col">
-                    <h3>Ubuntu Server</h3>
-                    <p>This is the iso image of the Ubuntu Server installer.</p>
-                    <p><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
-                    <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
-                </div>
-                <div class="equal-height--vertical-divider__item six-col last-col">
-                    <h3>Ubuntu netboot</h3>
-                    <p>This installer lets you install Ubuntu over the network.</p>
-                    <p><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
-                    <p><a href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images&nbsp;&rsaquo;</a></p>
-                </div>
-            </div>
-        </div>
-    </div><!-- /.strip-inner-wrapper -->
-</div><!-- /.row -->
-<div class="row">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="eight-col no-margin-bottom equal-height__item">
-            <h3>Containers, databases, web and more</h3>
-            <p>Ubuntu Server for ARM includes everything you are looking for in a server operating system, including:</p>
-            <ul class="list-ticks--compact">
-                <li>The LXD container hypervisor, giving you instant access to isolated, secured environments running with bare-metal performance</li>
-                <li>Application container technology based on Docker and Kubernetes, including FAN-based networking.</li>
-                <li>SQL and NoSQL databases including CouchDB, MySQL, PostgreSQL, Redis and sqlite</li>
-                <li>A wide collection of Web technologies, from HTTP servers to frameworks including Apache, Django, memcached, nginx, Wordpress and varnish</li>
-            </ul>
-        </div>
-        <div class="four-col last-col no-margin-bottom not-for-small equal-height__item equal-height__align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}c3499461-picto-server-warmgrey.svg" alt="" width="200" height="200" />
-        </div>
-    </div><!-- /.strip-inner-wrapper -->
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu Server for ARM</h1>
+      <p>Ubuntu {{lts_release_full_with_point}} includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
+      <p>Develop and test using over 50,000 software packages and runtimes &mdash; including Go, Java, Javascript, PHP, Python and Ruby &mdash; and deploy at scale using our complete scale-out management suite including MAAS and Juju. Ubuntu delivers server-grade performance on ARM, while fully retaining the reliable and familiar Ubuntu experience.</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card--highlighted is-divided">
+      <h3 class="p-card__title">Ubuntu Server</h3>
+      <p class="p-card__content">This is the iso image of the Ubuntu Server installer.</p>
+      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="p-button--brand is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
+      <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 p-card--highlighted is-divided">
+      <h3 class="p-card__title">Ubuntu netboot</h3>
+      <p class="p-card__content">This installer lets you install Ubuntu over the network.</p>
+      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}" class="p-button--brand is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
+      <p><a href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
 </div>
 
-<div class="row row-white no-border">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="four-col text-center not-for-small equal-height__item equal-height__align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}b5352dc1-logo-arm.svg" alt="" width="200" height="200" />
-        </div>
-        <div class="eight-col last-col equal-height__item">
-            <h3>Commercially supported and ready to deploy today</h3>
-            <p>Pair your ARM server deployment with enterprise-grade 24x7 support with Ubuntu Advantage to get the SLA-backed  assurance that you are fully covered by our system and architecture experts &mdash; no matter what comes up.</p>
-            <p>Built for cutting-edge hardware, from the HP Moonshot range to standard form-factor certified systems, Ubuntu and ARM Server provide truly compelling economics for cloud-scale deployment.</p>
-            <p><a href="/server/contact-us">Contact us about your ARM server plans&nbsp;&rsaquo;</a></p>
-        </div><!-- /.twelve-col -->
-    </div><!-- /.strip-inner-wrapper -->
-</div><!-- /.row -->
+<div class="p-strip--light is-deep">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h3>Containers, databases, web and more</h3>
+      <p>Ubuntu Server for ARM includes everything you are looking for in a server operating system, including:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">The LXD container hypervisor, giving you instant access to isolated, secured environments running with bare-metal performance</li>
+        <li class="p-list__item is-ticked">Application container technology based on Docker and Kubernetes, including FAN-based networking.</li>
+        <li class="p-list__item is-ticked">SQL and NoSQL databases including CouchDB, MySQL, PostgreSQL, Redis and sqlite</li>
+        <li class="p-list__item is-ticked">A wide collection of Web technologies, from HTTP servers to frameworks including Apache, Django, memcached, nginx, Wordpress and varnish</li>
+      </ul>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hidden--small">
+      <img src="{{ ASSET_SERVER_URL }}c3499461-picto-server-warmgrey.svg" alt="" width="200" height="200" />
+    </div>
+  </div>
+</div>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_arm_guide" second_item="_download_enterprise_support" third_item="_download_helping_hands" %}
+<div class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-4 u-align--center u-vertically-center u-hidden--small">
+      <img src="{{ ASSET_SERVER_URL }}b5352dc1-logo-arm.svg" alt="" width="200" height="200" />
+    </div>
+    <div class="col-8">
+      <h3>Commercially supported and ready to deploy today</h3>
+      <p>Pair your ARM server deployment with enterprise-grade 24x7 support with Ubuntu Advantage to get the SLA-backed  assurance that you are fully covered by our system and architecture experts &mdash; no matter what comes up.</p>
+      <p>Built for cutting-edge hardware, from the HP Moonshot range to standard form-factor certified systems, Ubuntu and ARM Server provide truly compelling economics for cloud-scale deployment.</p>
+      <p><a href="/server/contact-us">Contact us about your ARM server plans&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</div>
+
+{% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_server_arm_guide" second_item="_download_enterprise_support" third_item="_download_helping_hands" %}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

* converted /download/server/arm to vbt

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/download/server/arm)
- compare to the [design](https://www.dropbox.com/search/work?path=%2F00_web_team%2F_ubuntu.com%2Fnew+projects%2Fvanilla+update%2Fpatterns+inventory&preview=download-server-arm.png&qsid=27984850060468009768774727364561&query=linuxone) and the [demo](http://www.ubuntu.com-1639-download-server-arm.demo.haus/download/server/arm)

## Issue / Card

Fixes #1639 
