### PR TITLE
update /download/server to vbt

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -133,7 +133,7 @@
           border-bottom: 1px solid $color-mid-light;
           width: 100%;
           display: inline-block;
-          padding: $sp-x-small $sp-x-small $sp-x-small $sp-small;
+          padding: $sp-x-small;
           margin-bottom: $sp-x-small;
           color: $color-dark;
         }
@@ -284,6 +284,8 @@
 
     .second-level-nav & {
       border-bottom: 0;
+      padding-top: 0;
+      padding-bottom: 0;
     }
   }
 
@@ -295,7 +297,7 @@
 
     @media (max-width: $breakpoint-medium - 1) {
       .p-inline-list__item {
-        padding: .75rem 1rem;
+        padding: 0 $sp-x-small;
       }
     }
 

--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -318,11 +318,14 @@
 
   /// XXX adding > on nav
   .second-level-nav::before {
-    content: '\203A';
-    display: inline-block;
-    height: 1rem;
-    margin-left: -.5rem;
-    position: absolute;
-    width: 1rem;
+
+    @media (min-width: $breakpoint-medium + 1) {
+      content: '\203A';
+      display: inline-block;
+      height: 1rem;
+      margin-left: -.5rem;
+      position: absolute;
+      width: 1rem;
+    }
   }
 }

--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -317,15 +317,14 @@
   }
 
   /// XXX adding > on nav
-  .second-level-nav::before {
+  ul.p-breadcrumbs >li > a:first-of-type::after {
 
     @media (min-width: $breakpoint-medium + 1) {
-      content: '\203A';
-      display: inline-block;
-      height: 1rem;
-      margin-left: -.5rem;
+      color: $color-mid-dark;
+      content: '\00a0\00a0\203A';
+      font-weight: 400;
+      font-size: 1rem;
       position: absolute;
-      width: 1rem;
     }
   }
 }

--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -315,4 +315,14 @@
       }
     }
   }
+
+  /// XXX adding > on nav
+  .second-level-nav::before {
+    content: '\203A';
+    display: inline-block;
+    height: 1rem;
+    margin-left: -.5rem;
+    position: absolute;
+    width: 1rem;
+  }
 }

--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -2,6 +2,7 @@
   @include ubuntu-p-strip-modifiers;
   @include ubuntu-p-strip--grey;
   @include ubuntu-p-strip--accent;
+  @include ubuntu-p-strip-white;
 }
 
 @mixin ubuntu-p-strip-modifiers {
@@ -38,6 +39,12 @@
 @mixin ubuntu-p-strip--grey {
   .p-strip--grey {
     background-color: $color-light;
+  }
+}
+
+@mixin ubuntu-p-strip-white {
+  .p-strip--white {
+    background-color: $color-x-light;
   }
 }
 

--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -2,7 +2,6 @@
   @include ubuntu-p-strip-modifiers;
   @include ubuntu-p-strip--grey;
   @include ubuntu-p-strip--accent;
-  @include ubuntu-p-strip-white;
 }
 
 @mixin ubuntu-p-strip-modifiers {
@@ -39,12 +38,6 @@
 @mixin ubuntu-p-strip--grey {
   .p-strip--grey {
     background-color: $color-light;
-  }
-}
-
-@mixin ubuntu-p-strip-white {
-  .p-strip--white {
-    background-color: $color-x-light;
   }
 }
 

--- a/templates/download/_nav_tertiary-v1.html
+++ b/templates/download/_nav_tertiary-v1.html
@@ -1,4 +1,4 @@
-<ul class="nav-secondary__menu p-inline-list">
+<ul class="nav-tertiary__menu p-inline-list">
   {% if level_2 == 'server' %}
     <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'arm' %}is-active{% endif %}"href="/download/server/arm">ARM</a></li>
     <li class="p-inline-list__item"><a class="p-inline-list__link {% if level_3 == 'power8' %}is-active{% endif %}"href="/download/server/power8">POWER8</a></li>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -41,137 +41,131 @@
         <div class="col-4">
           <p class="p-card__content">
             <a class="p-button--brand is-wide" href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
-            <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
-          </div>
+          <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
         </div>
       </div>
     </div>
   </div>
+</div>
 
-  <div class="p-strip--light is-shallow is-bordered">
-    <div class="row">
-      <div class="col-8">
-        <h2>Your next steps with Ubuntu Server</h2>
-        <p>Use Ubuntu&rsquo;s tools to help you provision and manage your servers</p>
-        </div>
-      </div>
-
-      <div class="row u-equal-height">
-        <div class="col-6 p-card">
-          <h3>Server management with Landscape</h3>
-          <ul class="p-list--divided">
-            <li class="p-list__item">
-              Landscape is the leading management tool to deploy, monitor
-              and manage your Ubuntu servers
-            </li>
-            <li class="p-list__item">
-              It features Autopilot, the fastest way to build an
-              OpenStack cloud
-            </li>
-            <li class="p-list__item">
-              Landscape is also available as part of Ubuntu Advantage,
-              Canonical&rsquo;s world-class support service
-            </li>
-          </ul>
-          <p><a href="https://landscape.canonical.com/"><span class="p-link--external">Get Landscape</span></a></p>
-        </div>
-        <div class="col-6 p-card">
-          <h3>Server provisioning with MAAS</h3>
-          <ul class="p-list--divided">
-            <li class="p-list__item">
-              Metal as a Service (MAAS) offers cloud style provisioning
-              for physical servers
-            </li>
-            <li class="p-list__item">
-              Designed for building data centres with complex networks
-            </li>
-            <li class="p-list__item">
-              Supports Windows, Ubuntu, CentOS, RHEL and SUSE
-            </li>
-          </ul>
-          <p><a href="https://maas.io/"><span class="p-link--external">Get MAAS</span></a></p>
-        </div>
-      </div>
+<div class="p-strip--light is-shallow is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Your next steps with Ubuntu Server</h2>
+      <p>Use Ubuntu&rsquo;s tools to help you provision and manage your servers</p>
     </div>
   </div>
 
-  <div class="p-strip--white is-bordered is-shallow">
-    <div class="row">
-      <div class="col-12">
-        <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>
-        <ul class="p-list is-split">
-          <li class="p-list__item is-ticked">Supported for five years by Canonical</li>
-          <li class="p-list__item is-ticked">ZFS support for LXD OpenStack hosts</li>
-          <li class="p-list__item is-ticked">Nova LXD driver &ndash; deploy OpenStack instances as system containers, dramatically increasing per-node density</li>
-          <li class="p-list__item is-ticked">Juju OpenStack bundle &ndash; automated deployment of OpenStack into LXD system containers</li>
-          <li class="p-list__item is-ticked">Certified by Microsoft to host Windows Server 2012 and Windows Server 2008 R2 as guests, under its Server Virtualisation Validation Program (SVVP)</li>
-          <li class="p-list__item is-ticked">Updated to the Mitaka release, including automated installation, queuing/notification and the integration of database-as-a-service</li>
-          <li class="p-list__item is-ticked">OpenStack software, Juju, MAAS, LXD on IBM LinuxONE mainframe</li>
-        </ul>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3>Server management with Landscape</h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Landscape is the leading management tool to deploy, monitor and manage your Ubuntu servers
+        </li>
+        <li class="p-list__item">
+          It features Autopilot, the fastest way to build an OpenStack cloud
+        </li>
+        <li class="p-list__item">
+          Landscape is also available as part of Ubuntu Advantage, Canonical&rsquo;s world-class support service
+        </li>
+      </ul>
+      <p><a href="https://landscape.canonical.com/"><span class="p-link--external">Get Landscape</span></a></p>
+    </div>
+    <div class="col-6 p-card">
+      <h3>Server provisioning with MAAS</h3>
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Metal as a Service (MAAS) offers cloud style provisioning for physical servers
+        </li>
+        <li class="p-list__item">
+          Designed for building data centres with complex networks
+        </li>
+        <li class="p-list__item">
+          Supports Windows, Ubuntu, CentOS, RHEL and SUSE
+        </li>
+      </ul>
+      <p><a href="https://maas.io/"><span class="p-link--external">Get MAAS</span></a></p>
+    </div>
+  </div>
+</div>
+</div>
+
+<div class="p-strip--white is-bordered is-shallow">
+  <div class="row">
+    <div class="col-12">
+      <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Supported for five years by Canonical</li>
+        <li class="p-list__item is-ticked">ZFS support for LXD OpenStack hosts</li>
+        <li class="p-list__item is-ticked">Nova LXD driver &ndash; deploy OpenStack instances as system containers, dramatically increasing per-node density</li>
+        <li class="p-list__item is-ticked">Juju OpenStack bundle &ndash; automated deployment of OpenStack into LXD system containers</li>
+        <li class="p-list__item is-ticked">Certified by Microsoft to host Windows Server 2012 and Windows Server 2008 R2 as guests, under its Server Virtualisation Validation Program (SVVP)</li>
+        <li class="p-list__item is-ticked">Updated to the Mitaka release, including automated installation, queuing/notification and the integration of database-as-a-service</li>
+        <li class="p-list__item is-ticked">OpenStack software, Juju, MAAS, LXD on IBM LinuxONE mainframe</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip--light is-shallow">
+  <div class="row">
+    <div class="col-10">
+      <h2>Alternative architectures</h2>
     </div>
   </div>
 
-  <div class="p-strip--light is-shallow">
-    <div class="row">
-      <div class="col-10">
-        <h2>Alternative architectures</h2>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">Ubuntu Server for ARM</h3>
+      <p class="p-card__content">Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
+      <p class="p-card__content"><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">Ubuntu for POWER8</h3>
+      <p class="p-card__content">Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
+      <p class="p-card__content"><a href="/download/server/power8">Get Ubuntu for POWER8&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">Ubuntu for IBM LinuxONE</h3>
+      <p class="p-card__content">IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
+      <p class="p-card__content"><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</div>
 
-    <div class="row u-equal-height">
-      <div class="col-4 p-card">
-        <h3 class="p-card__title">Ubuntu Server for ARM</h3>
-        <p class="p-card__content">Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
-        <p class="p-card__content"><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-4 p-card">
-        <h3 class="p-card__title">Ubuntu for POWER8</h3>
-        <p class="p-card__content">Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
-        <p class="p-card__content"><a href="/download/server/power8">Get Ubuntu for POWER8&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-4 p-card">
-        <h3 class="p-card__title">Ubuntu for IBM LinuxONE</h3>
-        <p class="p-card__content">IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
-        <p class="p-card__content"><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
-      </div>
+<div class="p-strip--light is-shallow">
+  <div class="row">
+    <div class="col-10">
+      <h2>Get the version you need</h2>
     </div>
   </div>
 
-  <div class="p-strip--light is-shallow">
-    <div class="row">
-      <div class="col-10">
-        <h2>Get the version you need</h2>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-4 p-divider__block">
+      {% include "download/shared/_buy_a_usb-v1.html" %}
     </div>
 
-    <div class="row u-equal-height">
-        <div class="col-4 p-divider__block">
-          {% include "download/shared/_buy_a_usb-v1.html" %}
-        </div>
-
-        <div class="col-4 p-divider__block">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" alt="download icon" src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" />
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" alt="download icon" src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" />
           <h3 class="p-heading-icon__title">Find alternative downloads</h3>
         </div>
-        </div>
-          <p>Ubuntu is available via BitTorrent links and  regional mirrors. You can also use the network installer.</p>
-          <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
-        </div>
+      </div>
+      <p>Ubuntu is available via BitTorrent links and regional mirrors. You can also use the network installer.</p>
+      <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
+    </div>
 
-        <div class="col-4 p-divider__block">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" alt="server icon" src="{{ ASSET_SERVER_URL }}c3499461-picto-server-warmgrey.svg" />
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" alt="server icon" src="{{ ASSET_SERVER_URL }}c3499461-picto-server-warmgrey.svg" />
           <h3 class="p-heading-icon__title">Download a previous release</h3>
         </div>
-        </div>
-          <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
-          <p><a href="http://releases.ubuntu.com" class="p-link--external">Previous releases</a></p>
-        </div>
       </div>
+      <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
+      <p><a href="http://releases.ubuntu.com" class="p-link--external">Previous releases</a></p>
     </div>
   </div>
 </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -3,7 +3,7 @@
 {% block extra_body_class %}download-server-home{% endblock %}
 
 {% block second_level_nav_items %}
-{% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" page_title="Server" tertiary="true"  %}
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" page_title="Server" tertiary="true"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -89,7 +89,6 @@
     </div>
   </div>
 </div>
-</div>
 
 <div class="p-strip--white is-bordered is-shallow">
   <div class="row">

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -15,9 +15,9 @@
   </div>
 
   <div class="row">
-    <div class="col-12 p-card--highlighted p-divider">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
-      <div class="u-equal-height">
+      <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The Long Term Support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
@@ -31,9 +31,9 @@
   </div>
 
   <div class="row">
-    <div class="col-12 p-card--highlighted p-divider">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu Server {{latest_release}}</h2>
-      <div class="u-equal-height">
+      <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months of security and maintenance updates.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{latest_release}} release notes</a></p>
@@ -41,133 +41,133 @@
         <div class="col-4">
           <p class="p-card__content">
             <a class="p-button--brand is-wide" href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
-          <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
+            <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
-<div class="p-strip--light is-shallow is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Your next steps with Ubuntu Server</h2>
-      <p>Use Ubuntu&rsquo;s tools to help you provision and manage your servers</p>
-    </div>
-  </div>
-
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <h3>Server management with Landscape</h3>
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          Landscape is the leading management tool to deploy, monitor and manage your Ubuntu servers
-        </li>
-        <li class="p-list__item">
-          It features Autopilot, the fastest way to build an OpenStack cloud
-        </li>
-        <li class="p-list__item">
-          Landscape is also available as part of Ubuntu Advantage, Canonical&rsquo;s world-class support service
-        </li>
-      </ul>
-      <p><a href="https://landscape.canonical.com/"><span class="p-link--external">Get Landscape</span></a></p>
-    </div>
-    <div class="col-6 p-card">
-      <h3>Server provisioning with MAAS</h3>
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          Metal as a Service (MAAS) offers cloud style provisioning for physical servers
-        </li>
-        <li class="p-list__item">
-          Designed for building data centres with complex networks
-        </li>
-        <li class="p-list__item">
-          Supports Windows, Ubuntu, CentOS, RHEL and SUSE
-        </li>
-      </ul>
-      <p><a href="https://maas.io/"><span class="p-link--external">Get MAAS</span></a></p>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip is-bordered is-shallow">
-  <div class="row">
-    <div class="col-12">
-      <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>
-      <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">Supported for five years by Canonical</li>
-        <li class="p-list__item is-ticked">ZFS support for LXD OpenStack hosts</li>
-        <li class="p-list__item is-ticked">Nova LXD driver &ndash; deploy OpenStack instances as system containers, dramatically increasing per-node density</li>
-        <li class="p-list__item is-ticked">Juju OpenStack bundle &ndash; automated deployment of OpenStack into LXD system containers</li>
-        <li class="p-list__item is-ticked">Certified by Microsoft to host Windows Server 2012 and Windows Server 2008 R2 as guests, under its Server Virtualisation Validation Program (SVVP)</li>
-        <li class="p-list__item is-ticked">Updated to the Mitaka release, including automated installation, queuing/notification and the integration of database-as-a-service</li>
-        <li class="p-list__item is-ticked">OpenStack software, Juju, MAAS, LXD on IBM LinuxONE mainframe</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip--light is-shallow">
-  <div class="row">
-    <div class="col-10">
-      <h2>Alternative architectures</h2>
-    </div>
-  </div>
-
-  <div class="row u-equal-height">
-    <div class="col-4 p-card">
-      <h3 class="p-card__title">Ubuntu Server for ARM</h3>
-      <p class="p-card__content">Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
-      <p class="p-card__content"><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-card">
-      <h3 class="p-card__title">Ubuntu for POWER8</h3>
-      <p class="p-card__content">Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
-      <p class="p-card__content"><a href="/download/server/power8">Get Ubuntu for POWER8&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-card">
-      <h3 class="p-card__title">Ubuntu for IBM LinuxONE</h3>
-      <p class="p-card__content">IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
-      <p class="p-card__content"><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip--light is-shallow">
-  <div class="row">
-    <div class="col-10">
-      <h2>Get the version you need</h2>
-    </div>
-  </div>
-
-  <div class="row u-equal-height">
-    <div class="col-4 p-divider__block">
-      {% include "download/shared/_buy_a_usb-v1.html" %}
-    </div>
-
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" alt="download icon" src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" />
-          <h3 class="p-heading-icon__title">Find alternative downloads</h3>
-        </div>
+  <div class="p-strip--light is-shallow is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2>Your next steps with Ubuntu Server</h2>
+        <p>Use Ubuntu&rsquo;s tools to help you provision and manage your servers</p>
       </div>
-      <p>Ubuntu is available via BitTorrent links and regional mirrors. You can also use the network installer.</p>
-      <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
     </div>
 
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" alt="server icon" src="{{ ASSET_SERVER_URL }}c3499461-picto-server-warmgrey.svg" />
-          <h3 class="p-heading-icon__title">Download a previous release</h3>
-        </div>
+    <div class="row u-equal-height">
+      <div class="col-6 p-card">
+        <h3>Server management with Landscape</h3>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            Landscape is the leading management tool to deploy, monitor and manage your Ubuntu servers
+          </li>
+          <li class="p-list__item">
+            It features Autopilot, the fastest way to build an OpenStack cloud
+          </li>
+          <li class="p-list__item">
+            Landscape is also available as part of Ubuntu Advantage, Canonical&rsquo;s world-class support service
+          </li>
+        </ul>
+        <p><a href="https://landscape.canonical.com/"><span class="p-link--external">Get Landscape</span></a></p>
       </div>
-      <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
-      <p><a href="http://releases.ubuntu.com" class="p-link--external">Previous releases</a></p>
+      <div class="col-6 p-card">
+        <h3>Server provisioning with MAAS</h3>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            Metal as a Service (MAAS) offers cloud style provisioning for physical servers
+          </li>
+          <li class="p-list__item">
+            Designed for building data centres with complex networks
+          </li>
+          <li class="p-list__item">
+            Supports Windows, Ubuntu, CentOS, RHEL and SUSE
+          </li>
+        </ul>
+        <p><a href="https://maas.io/"><span class="p-link--external">Get MAAS</span></a></p>
+      </div>
     </div>
   </div>
-</div>
+
+  <div class="p-strip is-bordered is-shallow">
+    <div class="row">
+      <div class="col-12">
+        <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>
+        <ul class="p-list is-split">
+          <li class="p-list__item is-ticked">Supported for five years by Canonical</li>
+          <li class="p-list__item is-ticked">ZFS support for LXD OpenStack hosts</li>
+          <li class="p-list__item is-ticked">Nova LXD driver &ndash; deploy OpenStack instances as system containers, dramatically increasing per-node density</li>
+          <li class="p-list__item is-ticked">Juju OpenStack bundle &ndash; automated deployment of OpenStack into LXD system containers</li>
+          <li class="p-list__item is-ticked">Certified by Microsoft to host Windows Server 2012 and Windows Server 2008 R2 as guests, under its Server Virtualisation Validation Program (SVVP)</li>
+          <li class="p-list__item is-ticked">Updated to the Mitaka release, including automated installation, queuing/notification and the integration of database-as-a-service</li>
+          <li class="p-list__item is-ticked">OpenStack software, Juju, MAAS, LXD on IBM LinuxONE mainframe</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-10">
+        <h2>Alternative architectures</h2>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Ubuntu Server for ARM</h3>
+        <p class="p-card__content">Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
+        <p class="p-card__content"><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Ubuntu for POWER8</h3>
+        <p class="p-card__content">Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
+        <p class="p-card__content"><a href="/download/server/power8">Get Ubuntu for POWER8&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Ubuntu for IBM LinuxONE</h3>
+        <p class="p-card__content">IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
+        <p class="p-card__content"><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-10">
+        <h2>Get the version you need</h2>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="col-4 p-divider__block">
+        {% include "download/shared/_buy_a_usb-v1.html" %}
+      </div>
+
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" alt="download icon" src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" />
+            <h3 class="p-heading-icon__title">Find alternative downloads</h3>
+          </div>
+        </div>
+        <p>Ubuntu is available via BitTorrent links and regional mirrors. You can also use the network installer.</p>
+        <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
+      </div>
+
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" alt="server icon" src="{{ ASSET_SERVER_URL }}c3499461-picto-server-warmgrey.svg" />
+            <h3 class="p-heading-icon__title">Download a previous release</h3>
+          </div>
+        </div>
+        <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
+        <p><a href="http://releases.ubuntu.com" class="p-link--external">Previous releases</a></p>
+      </div>
+    </div>
+  </div>
 
   {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
 

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -1,192 +1,180 @@
-{% extends "download/_base_download.html" %}
-
+{% extends "download/_base_download-v1.html" %}
 {% block title %}Download Ubuntu Server | Download{% endblock %}
-
 {% block extra_body_class %}download-server-home{% endblock %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" page_title="Server" tertiary="true"  %}
-</div>
+{% include "templates/_nav_breadcrumb-v1.html" with div_title="Downloads" page_title="Server" tertiary="true"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-grey row-hero">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col append-four">
-            <h1>Download Ubuntu Server</h1>
-        </div>
-        <div class="twelve-col no-margin-bottom">
-            <div class="box box-highlight clearfix equal-height--vertical-divider">
-                <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
-                    <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
-                    <p>The Long Term Support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
-                    <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
-                </div>
-                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
-                    <p><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a></p>
-                    <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
-                </div>
-            </div>
-        </div>
-
-        <div class="twelve-col no-margin-bottom">
-            <div class="box box-highlight clearfix equal-height--vertical-divider">
-                <div class="eight-col no-margin-bottom equal-height--vertical-divider__item">
-                    <h2>Ubuntu Server {{latest_release}}</h2>
-                    <p>The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months of security and maintenance updates.</p>
-                    <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{latest_release}} release notes</a></p>
-                </div>
-                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
-                    <p><a href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
-                    <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
-                </div>
-            </div>
-        </div>
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-10">
+      <h1>Download Ubuntu Server</h1>
     </div>
-</section>
+  </div>
 
-<section class="row no-border">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h2>Your next steps with Ubuntu Server</h2>
-            <p>
-                Use Ubuntu&rsquo;s tools to help you provision and manage
-                your servers
-            </p>
+  <div class="row">
+    <div class="col-12 p-card--highlighted p-divider">
+      <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
+      <div class="u-equal-height">
+        <div class="col-8 p-divider__block">
+          <p class="p-card__content">The Long Term Support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
         </div>
-        <div class="equal-height">
-            <div class="six-col box">
-                <h3>Server management with Landscape</h3>
-                <ul class="list">
-                    <li>
-                        Landscape is the leading management tool to deploy, monitor
-                        and manage your Ubuntu servers
-                    </li>
-                    <li>
-                        It features Autopilot, the fastest way to build an
-                        OpenStack cloud
-                    </li>
-                    <li>
-                        Landscape is also available as part of Ubuntu Advantage,
-                        Canonical&rsquo;s world-class support service
-                    </li>
-                </ul>
-                <p>
-                    <a href="https://landscape.canonical.com/">
-                        <span class="external">Get Landscape</span>
-                    </a>
-                </p>
-            </div>
-            <div class="six-col last-col box">
-                <h3>Server provisioning with MAAS</h3>
-                <ul class="list">
-                    <li>
-                        Metal as a Service (MAAS) offers cloud style provisioning
-                        for physical servers
-                    </li>
-                    <li>
-                        Designed for building data centres with complex networks
-                    </li>
-                    <li>
-                        Supports Windows, Ubuntu, CentOS, RHEL and SUSE
-                    </li>
-                </ul>
-                <p>
-                    <a href="https://maas.io/">
-                        <span class="external">Get MAAS</span>
-                    </a>
-                </p>
-            </div>
+        <div class="col-4">
+          <p class="p-card__content"><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="p-button--brand is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a></p>
+          <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
         </div>
+      </div>
     </div>
-</section>
+  </div>
 
-<section class="row strip-light no-border">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>
+  <div class="row">
+    <div class="col-12 p-card--highlighted p-divider">
+      <h2>Ubuntu Server {{latest_release}}</h2>
+      <div class="u-equal-height">
+        <div class="col-8 p-divider__block">
+          <p class="p-card__content">The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months of security and maintenance updates.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{latest_release}} release notes</a></p>
         </div>
-        <div class="combined-list">
-            <ul class="six-col list-ticks--compact">
-                <li>Supported for five years by Canonical</li>
-                <li>
-                    Updated to the Mitaka release, including automated
-                    installation, queuing/notification and the integration
-                    of database-as-a-service
-                </li>
-                <li>
-                    Nova LXD driver &ndash; deploy OpenStack instances as
-                    system containers, dramatically increasing per-node
-                    density
-                </li>
-                <li>
-                    Juju OpenStack bundle &ndash; automated deployment of
-                    OpenStack into LXD system containers
-                </li>
-            </ul>
-            <ul class="six-col last-col list-ticks--compact">
-                <li>ZFS support for LXD OpenStack hosts</li>
-                <li>
-                    Certified by Microsoft to host Windows Server 2012 and
-                    Windows Server 2008 R2 as guests, under its Server
-                    Virtualisation Validation Program (SVVP)
-                </li>
-                <li>
-                    OpenStack software, Juju, MAAS, LXD on IBM LinuxONE
-                    mainframe
-                </li>
-            </ul>
+        <div class="col-4">
+          <p class="p-card__content">
+            <a class="p-button--brand is-wide" href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
+            <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
+          </div>
         </div>
+      </div>
     </div>
-</section>
+  </div>
 
-<section class="row row-grey">
-    <div class="strip-inner-wrapper">
-        <h2 class="twelve-col">Alternative architectures</h2>
-        <div class="equal-height">
-            <div class="four-col box">
-                <h3>Ubuntu Server for ARM</h3>
-                <p>Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
-                <p><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
-            </div>
-            <div class="four-col box">
-                <h3>Ubuntu for POWER8</h3>
-                <p>Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
-                <p><a href="/download/server/power8">Get Ubuntu for POWER8&nbsp;&rsaquo;</a></p>
-            </div>
-            <div class="four-col box last-col">
-                <h3>Ubuntu for IBM LinuxONE</h3>
-                <p>IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
-                <p><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
-            </div>
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-8">
+        <h2>Your next steps with Ubuntu Server</h2>
+        <p>Use Ubuntu&rsquo;s tools to help you provision and manage your servers</p>
         </div>
-    </div>
-</section>
+      </div>
 
-<section class="row no-border">
-    <div class="strip-inner-wrapper">
-        <h2 class="twelve-col">Get the version you need</h2>
-        <div class="twelve-col">
-            <div class="equal-height equal-height--vertical-divider">
-                <div class="four-col equal-height--vertical-divider__item">
-                    {% include "download/shared/_buy_a_usb.html" %}
-                </div>
-                <div class="four-col equal-height--vertical-divider__item">
-                    <h3 class="header--download">Find alternative downloads</h3>
-                    <p>Ubuntu is available via BitTorrent links and  regional mirrors. You can also use the network installer.</p>
-                    <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
-                </div>
-                <div class="four-col equal-height--vertical-divider__item last-col">
-                    <h3 class="header--server">Download a previous release</h3>
-                    <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
-                    <p><a href="http://releases.ubuntu.com" class="external">Previous releases</a></p>
-                </div>
-            </div>
+      <div class="row u-equal-height">
+        <div class="col-6 p-card">
+          <h3>Server management with Landscape</h3>
+          <ul class="p-list--divided">
+            <li class="p-list__item">
+              Landscape is the leading management tool to deploy, monitor
+              and manage your Ubuntu servers
+            </li>
+            <li class="p-list__item">
+              It features Autopilot, the fastest way to build an
+              OpenStack cloud
+            </li>
+            <li class="p-list__item">
+              Landscape is also available as part of Ubuntu Advantage,
+              Canonical&rsquo;s world-class support service
+            </li>
+          </ul>
+          <p><a href="https://landscape.canonical.com/"><span class="p-link--external">Get Landscape</span></a></p>
         </div>
+        <div class="col-6 p-card">
+          <h3>Server provisioning with MAAS</h3>
+          <ul class="p-list--divided">
+            <li class="p-list__item">
+              Metal as a Service (MAAS) offers cloud style provisioning
+              for physical servers
+            </li>
+            <li class="p-list__item">
+              Designed for building data centres with complex networks
+            </li>
+            <li class="p-list__item">
+              Supports Windows, Ubuntu, CentOS, RHEL and SUSE
+            </li>
+          </ul>
+          <p><a href="https://maas.io/"><span class="p-link--external">Get MAAS</span></a></p>
+        </div>
+      </div>
     </div>
-</section>
+  </div>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+  <div class="p-strip--white is-shallow">
+    <div class="row">
+      <div class="col-12">
+        <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>
+        <ul class="p-list is-split">
+          <li class="p-list__item is-ticked">Supported for five years by Canonical</li>
+          <li class="p-list__item is-ticked">ZFS support for LXD OpenStack hosts</li>
+          <li class="p-list__item is-ticked">Nova LXD driver &ndash; deploy OpenStack instances as system containers, dramatically increasing per-node density</li>
+          <li class="p-list__item is-ticked">Juju OpenStack bundle &ndash; automated deployment of OpenStack into LXD system containers</li>
+          <li class="p-list__item is-ticked">Certified by Microsoft to host Windows Server 2012 and Windows Server 2008 R2 as guests, under its Server Virtualisation Validation Program (SVVP)</li>
+          <li class="p-list__item is-ticked">Updated to the Mitaka release, including automated installation, queuing/notification and the integration of database-as-a-service</li>
+          <li class="p-list__item is-ticked">OpenStack software, Juju, MAAS, LXD on IBM LinuxONE mainframe</li>
+        </ul>
+      </div>
+    </div>
+  </div>
 
-{% endblock content %}
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-10">
+        <h2>Alternative architectures</h2>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Ubuntu Server for ARM</h3>
+        <p class="p-card__content">Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
+        <p class="p-card__content"><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Ubuntu for POWER8</h3>
+        <p class="p-card__content">Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
+        <p class="p-card__content"><a href="/download/server/power8">Get Ubuntu for POWER8&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Ubuntu for IBM LinuxONE</h3>
+        <p class="p-card__content">IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
+        <p class="p-card__content"><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-10">
+        <h2>Get the version you need</h2>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+        <div class="col-4 p-divider__block">
+          {% include "download/shared/_buy_a_usb-v1.html" %}
+        </div>
+
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon">
+            <div class="p-heading-icon__header">
+              <img class="p-heading-icon__img" alt="download icon" src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" />
+          <h3 class="p-heading-icon__title">Find alternative downloads</h3>
+        </div>
+        </div>
+          <p>Ubuntu is available via BitTorrent links and  regional mirrors. You can also use the network installer.</p>
+          <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
+        </div>
+
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon">
+            <div class="p-heading-icon__header">
+              <img class="p-heading-icon__img" alt="server icon" src="{{ ASSET_SERVER_URL }}c3499461-picto-server-warmgrey.svg" />
+          <h3 class="p-heading-icon__title">Download a previous release</h3>
+        </div>
+        </div>
+          <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
+          <p><a href="http://releases.ubuntu.com" class="p-link--external">Previous releases</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+
+  {% endblock content %}

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -90,7 +90,7 @@
   </div>
 </div>
 
-<div class="p-strip--white is-bordered is-shallow">
+<div class="p-strip is-bordered is-shallow">
   <div class="row">
     <div class="col-12">
       <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -3,7 +3,7 @@
 {% block extra_body_class %}download-server-home{% endblock %}
 
 {% block second_level_nav_items %}
-{% include "templates/_nav_breadcrumb-v1.html" with div_title="Downloads" page_title="Server" tertiary="true"  %}
+{% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" page_title="Server" tertiary="true"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
@@ -48,7 +48,7 @@
     </div>
   </div>
 
-  <div class="p-strip--light is-shallow">
+  <div class="p-strip--light is-shallow is-bordered">
     <div class="row">
       <div class="col-8">
         <h2>Your next steps with Ubuntu Server</h2>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -7,7 +7,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="p-strip is-deep">
+<div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-10">
       <h1>Download Ubuntu Server</h1>
@@ -95,7 +95,7 @@
     </div>
   </div>
 
-  <div class="p-strip--white is-shallow">
+  <div class="p-strip--white is-bordered is-shallow">
     <div class="row">
       <div class="col-12">
         <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -174,6 +174,7 @@
       </div>
     </div>
   </div>
+</div>
 
   {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
 

--- a/templates/download/shared/_buy_a_usb-v1.html
+++ b/templates/download/shared/_buy_a_usb-v1.html
@@ -1,8 +1,8 @@
-<div class="p-heading-icon">
-  <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" alt="dvd icon" src="{{ ASSET_SERVER_URL }}a9ed9a5c-picto-cddvd-warmgrey.svg" />
-    <h3 class="p-heading-icon__title">Buy a {{lts_release_full}} USB stick</h3>
+  <div class="p-heading-icon">
+    <div class="p-heading-icon__header">
+      <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}a9ed9a5c-picto-cddvd-warmgrey.svg" alt="dvd icon" />
+      <h3 class="p-heading-icon__title">Buy a {{lts_release_full}} USB stick</h3>
+    </div>
   </div>
-</div>
-<p>Ubuntu {{lts_release_full}} is available for purchase on USB stick, from the online Ubuntu shop.</p>
-<p><a href="https://shop.canonical.com/index.php?cPath=17">Buy now&nbsp;&rsaquo;</a></p>
+  <p>Ubuntu {{lts_release_full}} is available for purchase on USB stick, from the online Ubuntu shop.</p>
+  <p><a class="p-link--external" href="https://shop.canonical.com/index.php?cPath=17">Buy now</a></p>

--- a/templates/download/shared/_buy_a_usb-v1.html
+++ b/templates/download/shared/_buy_a_usb-v1.html
@@ -1,0 +1,8 @@
+<div class="p-heading-icon">
+  <div class="p-heading-icon__header">
+    <img class="p-heading-icon__img" alt="dvd icon" src="{{ ASSET_SERVER_URL }}a9ed9a5c-picto-cddvd-warmgrey.svg" />
+    <h3 class="p-heading-icon__title">Buy a {{lts_release_full}} USB stick</h3>
+  </div>
+</div>
+<p>Ubuntu {{lts_release_full}} is available for purchase on USB stick, from the online Ubuntu shop.</p>
+<p><a href="https://shop.canonical.com/index.php?cPath=17">Buy now&nbsp;&rsaquo;</a></p>

--- a/templates/templates/_nav_breadcrumb-v1.html
+++ b/templates/templates/_nav_breadcrumb-v1.html
@@ -2,21 +2,23 @@
   <div class="col-12 u-no-margin--bottom">
     <ul class="p-breadcrumbs">
       {% if level_2 and not level_3 and not tertiary %}
-        <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
+        <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a></li>
       {% else %}
         {% if level_3 %}
           <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
-          <ul class="second-level-nav">
-            <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}/{{ level_2 }}">{{ subsection_title }}</a></li>
-          </ul>
+            <ul class="second-level-nav">
+              <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}/{{ level_2 }}">{{ subsection_title }}</a></li>
+            </ul>
+          </li>
         {% else %}
           {% if level_2 %}
             <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
-            <ul class="second-level-nav">
-              <li class="p-breadcrumbs__item"><a class="is-active p-breadcrumbs__link" href="/{{ level_1 }}/{{ level_2 }}">{{ page_title }}</a></li>
-            </ul>
+              <ul class="second-level-nav">
+                <li class="p-breadcrumbs__item"><a class="is-active p-breadcrumbs__link" href="/{{ level_1 }}/{{ level_2 }}">{{ page_title }}</a></li>
+              </ul>
+            </li>
           {% else %}
-            <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
+            <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a></li>
           {% endif %}
         {% endif %}
       {% endif %}
@@ -40,9 +42,6 @@
         {% include secondary with icon="true" %}
         {% endwith %}
       {% endif %}
-      </li>
-      </ul>
-      </li>
     {% endif %}
     </ul>
   </div>

--- a/templates/templates/_nav_breadcrumb-v1.html
+++ b/templates/templates/_nav_breadcrumb-v1.html
@@ -2,7 +2,7 @@
   <div class="col-12 u-no-margin--bottom">
     <ul class="p-breadcrumbs">
       {% if level_2 and not level_3 and not tertiary %}
-        <li class="p-breadcrumbs__item"><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
+        <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
       {% else %}
         {% if level_3 %}
           <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
@@ -16,7 +16,7 @@
               <li class="p-breadcrumbs__item"><a class="is-active p-breadcrumbs__link" href="/{{ level_1 }}/{{ level_2 }}">{{ page_title }}</a></li>
             </ul>
           {% else %}
-            <li class="p-breadcrumbs__item"><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
+            <li class="p-breadcrumbs__item"><a class="p-breadcrumbs__link" href="/{{ level_1 }}">{{ section_title }}</a>
           {% endif %}
         {% endif %}
       {% endif %}


### PR DESCRIPTION
## Done

* update /download/server to vbt
* added p-strip—white, but I assume it was added in another PR? and what is the difference with .p-strip--light?
* fixed the ‘LTS’ abbreviation - and will do again in /download/desktop
* fixed the text-decoration on LTS in another PR
* the 'Ubuntu Server 16.04.1 LTS for OpenStack' section was new... so I changed the strip colors, but needs looking at

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:  [page](http://0.0.0.0:8001/download/server)
- compare to the [design](https://www.dropbox.com/search/work?path=%2F00_web_team%2F_ubuntu.com%2Fnew+projects%2Fvanilla+update%2Fpatterns+inventory&preview=download-server.png&qsid=01007770716940212773576207606415&query=download-server) and [demo](http://www.ubuntu.com-1638-download-server.demo.haus/download/server)

## Issue / Card

Fixes #1638

