### PR TITLE
Temporary inclusion of latest vanilla inline-images pattern with a proposed addition for logos as used on ubuntu.com

### DIFF
--- a/static/sass/_v1_pattern_inline-images.scss
+++ b/static/sass/_v1_pattern_inline-images.scss
@@ -1,0 +1,62 @@
+// XXX temporary copied code from master branch of Vanilla-framwork until
+// This can be removed when https://github.com/canonical-websites/www.ubuntu.com/issues/1824 is complete
+// Image grid to showcase group of images
+@mixin vf-p-inline-images {
+  .p-inline-images {
+    @extend %clearfix;
+    display: block;
+    list-style: none; // if list is used as wrapper
+    text-align: center;
+
+    &__item {
+      display: inline-block;
+      margin: $sp-x-large;
+      max-width: 6rem;
+      text-align: center;
+      vertical-align: middle;
+      width: 100%;
+
+      @media (min-width: $breakpoint-medium) {
+        margin: $sp-xxx-large;
+        max-width: 11.25rem;
+      }
+
+      * {
+        width: 100%;
+      }
+    }
+
+    @include deprecate('2.0.0', 'Use .p-inline-images__item instead') {
+      &__img {
+        display: inline-block;
+        margin: $sp-x-large;
+        max-width: 6rem;
+        text-align: center;
+        vertical-align: middle;
+        width: 100%;
+
+        @media (min-width: $breakpoint-medium) {
+          margin: $sp-xxx-large;
+          max-width: 11.25rem;
+        }
+      }
+    }
+  }
+}
+
+// XXX Extension of the inline images to add logo support
+// This should be proposed up to vanilla-brochure-theme once approved
+@mixin ubuntu-p-inline-images {
+  @include vf-p-inline-images;
+
+  .p-inline-images__logo {
+    max-height: $sp-xxx-large;
+    max-width: 7rem;
+    width: auto;
+
+    @media only screen and (min-width : $breakpoint-medium) {
+      max-height: 5.5rem;
+      max-width: 9rem;
+    }
+  }
+}

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -22,6 +22,7 @@
 @import 'v1_pattern_lists';
 @import 'v1_pattern_link';
 @import 'v1_contribution';
+@import 'v1_pattern_inline-images';
 
 @include ubuntu-p-site-search;
 @include ubuntu-p-navigation;
@@ -31,6 +32,7 @@
 @include ubuntu-p-lists;
 @include ubuntu-p-link;
 @include ubuntu-p-contribute;
+@include ubuntu-p-inline-images;
 
 // **************************
 // Bug fixes


### PR DESCRIPTION
## Done

Temporary inclusion of upstream version of the inline-images pattern from vanilla-framework until the [vanilla brochure theme is updated]() to include it.

## QA

- Check out this feature branch
- Use the pattern somewhere on a v1 page. Any page in the /about section will do. [Example implementation](https://pastebin.canonical.com/189061/).
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/))
- Check that the list renders well in all viewports

Design review can be completed when the first page to use this pattern is landed.

## Issue / Card

Fixes #1826 

