### PR TITLE
Add missing ‘of’ to /legal copy

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -338,7 +338,7 @@
 
       <h3 id="ua-server">Ubuntu Advantage Server</h3>
 
-      <p>The scope each particular offering (Essential, Standard, or Advanced) is defined below. The following items are not covered under any Ubuntu Advantage Server offerings.</p>
+      <p>The scope of each particular offering (Essential, Standard, or Advanced) is defined below. The following items are not covered under any Ubuntu Advantage Server offerings.</p>
 
       <ul>
         <li class="p-list__item">Ceph</li>


### PR DESCRIPTION
## Done

This was something copy stakeholder missed and only flagged to me after /legal went live. 

- Add missing ‘of’ to /legal copy

## QA

Check code 