### PR TITLE
Fix missing chevron after first breadcrumb link

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -200,6 +200,21 @@
 
       .p-breadcrumbs__link {
         color: $color-mid-dark;
+
+        @media (min-width: $breakpoint-medium) {
+          + .second-level-nav {
+            position: relative;
+
+            &::before {
+              content: '\203A';
+              font-weight: 400;
+              color: $color-mid-dark;
+              left: -$sp-x-small;
+              position: absolute;
+              top: 0;
+            }
+          }
+        }
       }
     }
 
@@ -280,6 +295,10 @@
       display: inline-block;
       padding-left: 0;
       margin-bottom: 0;
+
+      @media (max-width: $breakpoint-medium - 1) {
+        width: 100%;
+      }
     }
 
     .second-level-nav & {


### PR DESCRIPTION
## Done

Fix missing chevron after first breadcrumb link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about/about-ubuntu](http://0.0.0.0:8001/about/about-ubuntu)
- Check nav on resolutions greater than 768px
- Ensure that there is a chevron after first breadcrumb link

Expected:
<img width="375" alt="screen shot 2017-05-25 at 15 34 20" src="https://cloud.githubusercontent.com/assets/505570/26454677/ae452f4e-415f-11e7-8029-6e344ce8e08e.png">

## Issue / Card

Fixes #1740 

## Demo

[http://www.ubuntu.com-1740-missing-chevron.demo.haus](http://www.ubuntu.com-1740-missing-chevron.demo.haus)