### PR TITLE
fix misplaced /div on /core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -56,7 +56,7 @@
   </div>
 </div>
 
-<div class="p-strip--grey is-deep" style="padding-bottom: 0;">
+<div class="p-strip--grey is-deep u-no-padding--bottom">
   <div class="row">
     <div class="u-equal-height">
       <div class="col-6">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -56,7 +56,6 @@
   </div>
 </div>
 
-
 <div class="p-strip--grey is-deep" style="padding-bottom: 0;">
   <div class="row">
     <div class="u-equal-height">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -32,40 +32,41 @@
     <div class="col-10">
       <h2>Ubuntu powers the next wave of smart IoT</h2>
     </div>
+  </div>
 
-    <div class="row  p-divider">
-      <div class="col-4 p-divider__block">
-        <img src="{{ ASSET_SERVER_URL }}2def20f4-iot_digital_signage_overview.jpg?w=300" class="row--verticals__logo" alt="" />
-        <h3>Digital signage</h3>
-        <p>With a small footprint and full OpenGL with reliable updates, Ubuntu Core provides a perfect platform for millions of digital signs.</p>
-        <p><a href="/internet-of-things/digital-signage">Digital signage on Ubuntu&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-4 p-divider__block">
-        <img src="{{ ASSET_SERVER_URL }}1e37ff95-iot_overview_robotics.jpg?w=300" class="row--verticals__logo" alt="" />
-        <h3>Robotics</h3>
-        <p>With full support for ROS in Snapcraft, it&rsquo;s easy to enable apps on robots and drones, creating new ecosystems and business models.</p>
-        <p><a href="/internet-of-things/robotics">Robots and drones, rocking Ubuntu Core&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-4 p-divider__block">
-        <img src="{{ ASSET_SERVER_URL }}3e480882-iot_gateways_product_image.jpg?w=300" class="row--verticals__logo" alt="" />
-        <h3>Edge Gateways</h3>
-        <p>Rich networking and protocol support make Ubuntu Core the perfect choice for your industrial gateways.</p>
-        <p><a href="/internet-of-things/gateways">IoT gateways on Ubuntu&nbsp;&rsaquo;</a></p>
-      </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <img src="{{ ASSET_SERVER_URL }}2def20f4-iot_digital_signage_overview.jpg?w=300" class="row--verticals__logo" alt="" />
+      <h3>Digital signage</h3>
+      <p>With a small footprint and full OpenGL with reliable updates, Ubuntu Core provides a perfect platform for millions of digital signs.</p>
+      <p><a href="/internet-of-things/digital-signage">Digital signage on Ubuntu&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <img src="{{ ASSET_SERVER_URL }}1e37ff95-iot_overview_robotics.jpg?w=300" class="row--verticals__logo" alt="" />
+      <h3>Robotics</h3>
+      <p>With full support for ROS in Snapcraft, it&rsquo;s easy to enable apps on robots and drones, creating new ecosystems and business models.</p>
+      <p><a href="/internet-of-things/robotics">Robots and drones, rocking Ubuntu Core&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <img src="{{ ASSET_SERVER_URL }}3e480882-iot_gateways_product_image.jpg?w=300" class="row--verticals__logo" alt="" />
+      <h3>Edge Gateways</h3>
+      <p>Rich networking and protocol support make Ubuntu Core the perfect choice for your industrial gateways.</p>
+      <p><a href="/internet-of-things/gateways">IoT gateways on Ubuntu&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>
+
 
 <div class="p-strip--grey is-deep" style="padding-bottom: 0;">
   <div class="row">
     <div class="u-equal-height">
       <div class="col-6">
-      <h2>Why use Ubuntu Core?</h2>
-      <p>Ubuntu Core uses the same kernel, libraries and system software as classic Ubuntu. You can develop snaps on your Ubuntu PC just like any other application. The difference is that it&rsquo;s been built for the Internet of Things.</p>
-    </div>
+        <h2>Why use Ubuntu Core?</h2>
+        <p>Ubuntu Core uses the same kernel, libraries and system software as classic Ubuntu. You can develop snaps on your Ubuntu PC just like any other application. The difference is that it&rsquo;s been built for the Internet of Things.</p>
+      </div>
       <div class="col-6 u-vertically-center u-align--center">
-      <img src="{{ ASSET_SERVER_URL }}5051e6e5-core_logo.svg" alt="" width="300" />
-    </div>
+        <img src="{{ ASSET_SERVER_URL }}5051e6e5-core_logo.svg" alt="" width="300" />
+      </div>
     </div>
   </div>
 </div>
@@ -198,6 +199,7 @@
     </div>
   </div>
 </div>
+
 {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

* noticed a odd missing /div on live on /core

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/core)
- [demo](http://www.ubuntu.com-fix-core-powers-section.demo.haus/core)

