### PR TITLE
update /download pages html for p-divided changes

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -21,14 +21,14 @@
         <div class="col-6 p-divider__block">
           <p class="p-heading--five">Single machine</p>
           <h2>Try OpenStack on a single&nbsp;machine</h2>
-          <p class="p-card__content">Conjure-up is an ideal tool for people who want to build an OpenStack cloud on a single machine using LXD containers.</p>
-          <p class="p-card__content"><a href="/download/cloud/conjure-up">Try conjure-up on single machine&nbsp;&rsaquo;</a></p>
+          <p class="p-card__content">Conjure-up is an ideal tool for people who want to build an OpenStack cloud on a single machine using LXD containers. This will let you see what a production setup will look like.</p>
+          <p class="p-card__content"><a class="p-button--brand is-wide" href="/download/cloud/conjure-up">Try conjure-up on single machine&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-6">
           <p class="p-heading--five">Cluster</p>
           <h2>Build your own production&nbsp;cloud</h2>
           <p class="p-card__content">Canonical&rsquo;s OpenStack Autopilot handles every aspect of your production cloud across multiple physical machines through installation, expansion and everyday operations.</p>
-          <p class="p-card__content"><a href="/download/cloud/autopilot">Build a production cloud with Autopilot&nbsp;&rsaquo;</a></p>
+          <p class="p-card__content"><a class="p-button--brand is-wide" href="/download/cloud/autopilot">Build a production cloud with Autopilot&nbsp;&rsaquo;</a></p>
         </div>
       </div>
     </div>

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -22,13 +22,13 @@
           <p class="p-heading--five">Single machine</p>
           <h2>Try OpenStack on a single&nbsp;machine</h2>
           <p class="p-card__content">Conjure-up is an ideal tool for people who want to build an OpenStack cloud on a single machine using LXD containers. This will let you see what a production setup will look like.</p>
-          <p class="p-card__content"><a class="p-button--brand is-wide" href="/download/cloud/conjure-up">Try conjure-up on single machine&nbsp;&rsaquo;</a></p>
+          <p class="p-card__content"><a class="p-button--brand is-wide" href="/download/cloud/conjure-up">Try conjure-up on single machine</a></p>
         </div>
         <div class="col-6">
           <p class="p-heading--five">Cluster</p>
           <h2>Build your own production&nbsp;cloud</h2>
           <p class="p-card__content">Canonical&rsquo;s OpenStack Autopilot handles every aspect of your production cloud across multiple physical machines through installation, expansion and everyday operations.</p>
-          <p class="p-card__content"><a class="p-button--brand is-wide" href="/download/cloud/autopilot">Build a production cloud with Autopilot&nbsp;&rsaquo;</a></p>
+          <p class="p-card__content"><a class="p-button--brand is-wide" href="/download/cloud/autopilot">Build a production cloud with Autopilot</a></p>
         </div>
       </div>
     </div>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -14,9 +14,9 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-12 p-card--highlighted p-divider">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu {{lts_release_full_with_point}}</h2>
-      <div class="u-equal-height">
+      <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">Download the latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, guaranteed.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{lts_release_full}} release notes</a></p>
@@ -47,9 +47,9 @@
   </div>
 
   <div class="row">
-    <div class="col-12 p-card--highlighted p-divider">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu {{latest_release}}</h2>
-      <div class="u-equal-height">
+      <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months of security and maintenance updates.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{latest_release}} release notes</a></p>

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -17,9 +17,9 @@
   </div>
 
   <div class="row">
-    <div class="col-12 p-card--highlighted p-divider">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu Server {{lts_release_full}}</h2>
-      <div class="u-equal-height">
+      <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">IBM LinuxONE and z&nbsp;Systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, security and resiliency. Ubuntu {{lts_release_full}}  was released for general availability (GA) in April and can now be downloaded by all IBM LinuxOne and z Systems customers.</p>
           <p class="p-card__content">Ubuntu {{lts_release_full}} for IBM LinuxONE and z&nbsp;Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>

--- a/templates/download/ubuntu-kylin.html
+++ b/templates/download/ubuntu-kylin.html
@@ -14,9 +14,9 @@
   </div>
 
   <div class="row">
-    <div class="col-12 p-card--highlighted p-divider">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu Kylin {{lts_release_full_with_point}}</h2>
-      <div class="u-equal-height">
+      <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">Download the long-term support edition of Ubuntu Kylin {{lts_release_full_with_point}} ISO image file. To install Ubuntu Kylin, burn the image file on a DVD or create a bootable USB disk.</p>
         </div>
@@ -31,9 +31,9 @@
 
 
   <div class="row">
-    <div class="col-12 p-card--highlighted p-divider">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu Kylin {{latest_release}}</h2>
-      <div class="u-equal-height">
+      <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">Download the latest version, Ubuntu Kylin {{latest_release}} as an ISO image file. To install Ubuntu Kylin, burn the image file onto a DVD or create a bootable USB disk.</p>
         </div>


### PR DESCRIPTION
## Done

* update html for p-divided changes
* also added buttons to /download/cloud

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
  - [desktop](http://www.ubuntu.com-fix-download-p-divided.demo.haus/download/desktop)
  - [cloud](http://www.ubuntu.com-fix-download-p-divided.demo.haus/download/cloud)
  - [server linuxone](http://www.ubuntu.com-fix-download-p-divided.demo.haus/download/server/linuxone)
  - [kylin](http://www.ubuntu.com-fix-download-p-divided.demo.haus/download/ubuntu-kylin)

