### PR TITLE
add  ‘and Ubuntu 14.04 LTS’ to /server/livepatch

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -41,7 +41,7 @@
             </div>
             <p class="clear">
                 The Canonical Livepatch Service lets you apply kernel fixes in
-                seconds, without restarting your Ubuntu 16.04 LTS system.
+                seconds, without restarting your Ubuntu 16.04 LTS and Ubuntu 14.04 LTS systems.
                 Fewer reboots means improved service availability.
             </p>
         </div>
@@ -56,7 +56,7 @@
                 Finding a downtime window to address security vulnerabilities
                 can be challenging. The Canonical Livepatch Service applies
                 Linux kernel patches without rebooting, keeping your Ubuntu
-                16.04 LTS systems secure and compliant.
+                16.04 LTS and Ubuntu 14.04 LTS systems secure and compliant.
             </p>
         </div>
         <div class="four-col equal-height--vertical-divider__item clearfix last-col">


### PR DESCRIPTION
## Done

* add  ‘and Ubuntu 14.04 LTS’ to /server/livepatch
* updated the [copy doc](https://docs.google.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/server/livepatch)
- [demo](http://www.ubuntu.com-livepatch-1404-update.demo.haus/server/livepatch)

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/26485136/adf3240e-41ed-11e7-9600-893c4f777865.png)
