### PR TITLE
Temporary addition of a muted heading style

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -168,3 +168,11 @@ fieldset {
     margin-top: $sp-large;
   }
 }
+
+// XXX Muted heading theme
+// https://github.com/vanilla-framework/vanilla-brochure-theme/issues/66
+.p-heading--muted {
+  color: $color-dark;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
## Done
Temporary addition of a muted heading style
This will be added to vanilla-brochure-theme soon and can be removed then.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/))
- Edit a page using the v1 vanilla styling to have a heading with class "p-heading--muted"
- Check the heading at all viewports.