### PR TITLE
1581 server hyperscale

### DIFF
--- a/static/sass/_v1_pattern_pull_quotes.scss
+++ b/static/sass/_v1_pattern_pull_quotes.scss
@@ -1,0 +1,9 @@
+@mixin ubuntu-p-pull-quote {
+
+  .p-pull-quote--accent {
+    @extend .p-pull-quote;
+    > p {
+      color: $color-x-light;
+    }
+  }
+}

--- a/static/sass/_v1_pattern_pull_quotes.scss
+++ b/static/sass/_v1_pattern_pull_quotes.scss
@@ -5,5 +5,13 @@
     > p {
       color: $color-x-light;
     }
+
+    > p:last-of-type::after,
+    > p:last-of-type::after,
+    > p:first-of-type::before,
+    > p:first-of-type::before
+     {
+        color: $color-brand;
+      }
   }
 }

--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -2,7 +2,7 @@
   @include ubuntu-p-strip-modifiers;
   @include ubuntu-p-strip--grey;
   @include ubuntu-p-strip--accent;
-  @include ubuntu-p-strip--white;
+  @include ubuntu-p-strip--x-light;
 }
 
 @mixin ubuntu-p-strip-modifiers {
@@ -12,7 +12,7 @@
   .p-strip--suru-accent,
   .p-strip--light,
   .p-strip--dark,
-  .p-strip--white {
+  .p-strip--x-light {
     padding: 3.75rem 0;
 
     &.is-shallow {
@@ -65,8 +65,8 @@
   }
 }
 
-@mixin ubuntu-p-strip--white {
-  .p-strip--white {
+@mixin ubuntu-p-strip--x-light {
+  .p-strip--x-light {
     @include strip;
     background-color: $color-x-light;
   }

--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -2,6 +2,7 @@
   @include ubuntu-p-strip-modifiers;
   @include ubuntu-p-strip--grey;
   @include ubuntu-p-strip--accent;
+  @include ubuntu-p-strip--white;
 }
 
 @mixin ubuntu-p-strip-modifiers {
@@ -10,7 +11,8 @@
   .p-strip--accent,
   .p-strip--suru-accent,
   .p-strip--light,
-  .p-strip--dark {
+  .p-strip--dark,
+  .p-strip--white {
     padding: 3.75rem 0;
 
     &.is-shallow {
@@ -60,5 +62,12 @@
       background-repeat: no-repeat;
       background-size: cover;
     }
+  }
+}
+
+@mixin ubuntu-p-strip--white {
+  .p-strip--white {
+    @include strip;
+    background-color: $color-x-light;
   }
 }

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -26,6 +26,7 @@
 @import 'v1_pattern_inline-images';
 @import 'v1_patterns_testimonials';
 @import 'v1_pattern_hero';
+@import 'v1_pattern_pull_quotes';
 
 @include ubuntu-p-site-search;
 @include ubuntu-p-navigation;
@@ -39,6 +40,7 @@
 @include ubuntu-p-inline-images;
 @include ubuntu-p-testimonials;
 @include ubuntu-p-hero;
+@include ubuntu-p-pull-quote;
 
 // **************************
 // Bug fixes

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -208,7 +208,7 @@
 </div>
 
 
-<div class="p-strip--white is-deep is-bordered">
+<div class="p-strip--x-light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
       <h2 class="p-heading--muted u-align--center">A selection of our hardware partners</h2>
@@ -225,7 +225,7 @@
   </div>
 </div>
 
-<div class="p-strip--white is-deep">
+<div class="p-strip--x-light is-deep">
   <div class="row">
     <div class="col-12">
       <h2 class="p-heading--muted u-align--center">A selection of our software partners</h2>

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -1,225 +1,247 @@
-
-{% extends "server/base_server.html" %}
-
+{% extends "server/base_server-v1.html" %}
 {% block title %}Ubuntu Server and hyperscale | Server{% endblock %}
 {% block meta_description %}Unlock the promise of new extreme low-energy server technology{% endblock %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="Server" page_title="Hyperscale"  %}
-</div>
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Server" page_title="Hyperscale"  %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero clearfix strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="left eight-col">
-            <h1>Ubuntu leads in hyperscale</h1>
-            <p>Ubuntu is the hyperscale OS, natively powering scale-out workloads on a new wave of low-cost, ultra-dense hardware based on x86 and ARM processors.</p>
-            <p><a class="button--primary" href="/download/server">Download Ubuntu Server</a></p>
-            <p class="no-margin"><a href="/download/arm">Download Ubuntu for ARM &nbsp;&rsaquo;</a></p>
-        </div>
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu leads in hyperscale</h1>
+      <p>Ubuntu is the hyperscale OS, natively powering scale-out workloads on a new wave of low-cost, ultra-dense hardware based on x86 and ARM processors.</p>
+      <p><a class="p-button--brand" href="/download/server">Download Ubuntu Server</a></p>
+      <p><a href="/download/arm">Download Ubuntu for ARM &nbsp;&rsaquo;</a></p>
     </div>
-</section>
+  </div>
+</div>
 
-<section class="row welcome-hyperscale">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="six-col equal-height__item">
-            <h2>Welcome to hyperscale, the future of the datacentre</h2>
-            <p>Computing in the 21st century will be done at an unprecedented scale, connecting people across the continents to a vast network of business, social and entertainment services.</p>
-            <p>Providing compute capacity at that magnitude is today&rsquo;s top infrastructure challenge. That challenge is being taken on by a new wave of ultra-dense hardware, combined with software designed to natively scale out.</p>
-            <p>Tomorrow&rsquo;s servers will be built upon multiple architectures, including Intel x86 and ARM, and will be connected into datacentre-wide clusters via flexible, high-speed fabrics. At the heart of these clusters lies Ubuntu Server, the OS leading the cloud computing revolution.</p>
-        </div>
-        <div class="six-col last-col not-for-small equal-height__item equal-height__align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}ab812f69-image-server-hyperscale.svg" alt="" />
-        </div>
+<div class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6">
+        <h2>Welcome to hyperscale, the future of the datacentre</h2>
+        <p>Computing in the 21st century will be done at an unprecedented scale, connecting people across the continents to a vast network of business, social and entertainment services.</p>
+        <p>Providing compute capacity at that magnitude is today&rsquo;s top infrastructure challenge. That challenge is being taken on by a new wave of ultra-dense hardware, combined with software designed to natively scale out.</p>
+        <p>Tomorrow&rsquo;s servers will be built upon multiple architectures, including Intel x86 and ARM, and will be connected into datacentre-wide clusters via flexible, high-speed fabrics. At the heart of these clusters lies Ubuntu Server, the OS leading the cloud computing revolution.</p>
+      </div>
+      <div class="col-5 prefix-1 u-align--center u-vertically-center u-hidden--small">
+        <img src="{{ ASSET_SERVER_URL }}ab812f69-image-server-hyperscale.svg" alt="" />
+      </div>
     </div>
-</section>
+  </div>
+</div>
 
-<section class="row">
-    <div class="strip-inner-wrapper">
-        <h2>Ubuntu Server for hyperscale</h2>
-        <div class="six-col">
-            <p>Ubuntu Server embraces the scale-out philosophy and comes out of the box with tools that make deploying a complex network of services as easy as drawing up a diagram and pressing &ldquo;go&rdquo;.</p>
-        </div>
-        <div class="six-col last-col">
-            <p>Ubuntu works seamlessly across x86 and ARM. And it comes with all the leading open source and commercial workloads built in, including Apache Hadoop, Inktank Ceph, 10gen MongoDB and many others.</p>
-        </div>
-        <h3>Here&rsquo;s why Ubuntu is the best answer to the scale-out challenge:</h3>
-        <div class="combined-list">
-            <ul class="six-col list-ticks--canonical">
-                <li><strong>Scale-out at the core</strong>: Ubuntu Server supports the scale-out compute model and provides tools which make it simple to manage the entire cluster.</li>
-                <li><strong>No end-user licence fee</strong>: Ubuntu is offered free to end-users. Adding 100 more nodes shouldn&rsquo;t require you to pay another 100 times for the OS!</li>
-                <li class="last-item"><strong>Partners</strong>: Canonical has a global program with SoC vendors and OEMs to ensure that platforms are enabled and certified to run Ubuntu.</li>
-            </ul>
-            <ul class="six-col last-col list-ticks--canonical">
-                <li><strong>Seamless platform support</strong>: Ubuntu Server runs exactly the same on every enabled architecture, be it x86, ARM or PowerPC; with the same applications and tools.</li>
-                <li><strong>Commercially supported</strong>: Canonical backs its free OS commitment with Ubuntu Advantage including commercial support, systems management and access to top experts.</li>
-            </ul>
-        </div>
-        <div class="six-col">
-            <p><a href="/server/management">Find out more about server management&nbsp;&rsaquo;</a></p>
-        </div>
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Ubuntu Server for hyperscale</h2>
     </div>
-</section>
-
-<section class="row">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col">
-            <blockquote class="pull-quote">
-                <p><span>&ldquo;</span>A new wave of workloads demand breakthrough efficiencies in density, energy, and operational costs which can be scaled to a customer&rsquo;s IT environment&nbsp;<span>&rdquo;</span></p>
-                <p><cite>Paul Santeler, VP &amp; GM, Hyperscale Business Unit, HP</cite></p>
-            </blockquote>
-        </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Ubuntu Server embraces the scale-out philosophy and comes out of the box with tools that make deploying a complex network of services as easy as drawing up a diagram and pressing &ldquo;go&rdquo;.</p>
     </div>
-</section>
-
-<section class="row strip-light">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="equal-height__item seven-col">
-            <h2>Canonical&rsquo;s long-term commitment</h2>
-            <p>Canonical&rsquo;s first investment in hyperscale dates back to 2008. We invested early in at scale management tools like Landscape and Juju, supporting the management of machines and services at scale through enterprise-class automation.</p>
-            <p>Canonical is also a pioneer with ARM Servers, building the first commercial general-purpose ARM Linux OS in 2007 and the first ARM-based Server OS in 2009. We founded Linaro along with ARM in 2010.</p>
-            <p>Ubuntu now runs on every significant ARM platform deployed in the datacentre, including the recently-announced Baidu storage cluster.</p>
-        </div>
-        <div class="five-col last-col equal-height__item equal-height__align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}c74f59b7-picto-reducecosts-warmgrey.svg" width="199" height="199" class="priority-0" alt="" />
-        </div>
+    <div class="col-6">
+      <p>Ubuntu works seamlessly across x86 and ARM. And it comes with all the leading open source and commercial workloads built in, including Apache Hadoop, Inktank Ceph, 10gen MongoDB and many others.</p>
     </div>
-</section>
-
-<section class="row no-border">
-    <div class="strip-inner-wrapper equal-height--vertical-divider">
-        <div class="twelve-col">
-            <h2 class="twelve-col">The complete solution for hyperscale</h2>
-            <div class="equal-height--vertical-divider__item six-col">
-                <h3>Workload-level orchestration with Juju</h3>
-                <p>Canonical&rsquo;s Juju framework goes beyond traditional orchestration systems to create a new paradigm in workload deployment.</p>
-                <p>Juju decouples services deployed onto the cluster from the nodes running them, and makes the deployment of the individual service easy.</p>
-                <p>Juju also supports deployment to cloud services like Amazon EC2 and Rackspace Cloud, and includes charms for open source workloads and key server ISV products.</p>
-                <p><a href="/cloud/orchestration/juju">Get more details on Juju here&nbsp;&rsaquo;</a></p>
-            </div>
-            <div class="equal-height--vertical-divider__item six-col last-col">
-                <h3>Bare-metal provisioning with MAAS</h3>
-                <p>With their unique architecture, hyperscale servers need to be provisioned through scalable automation. Canonical&rsquo;s Metal as a Service (MAAS) addresses the problem of deploying hundreds of OS instances to a cluster of nodes:</p>
-                <p>MAAS provides a flexible mechanism to automatically detect, provision and configure individual nodes with Ubuntu server without any complex or manual configuration </p>
-                <p><a href="/cloud/orchestration/maas">Learn more about MAAS&nbsp;&rsaquo;</a></p>
-            </div>
-        </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <h3>Here&rsquo;s why Ubuntu is the best answer to the scale-out challenge:</h3>
+      <ul class="p-list--divided is-split">
+        <li class="p-list__item is-ticked"><strong>Scale-out at the core</strong>: Ubuntu Server supports the scale-out compute model and provides tools which make it simple to manage the entire cluster.</li>
+        <li class="p-list__item is-ticked"><strong>No end-user licence fee</strong>: Ubuntu is offered free to end-users. Adding 100 more nodes shouldn&rsquo;t require you to pay another 100 times for the OS!</li>
+        <li class="p-list__item is-ticked"><strong>Partners</strong>: Canonical has a global program with SoC vendors and OEMs to ensure that platforms are enabled and certified to run Ubuntu.</li>
+        <li class="p-list__item is-ticked"><strong>Seamless platform support</strong>: Ubuntu Server runs exactly the same on every enabled architecture, be it x86, ARM or PowerPC; with the same applications and tools.</li>
+        <li class="p-list__item is-ticked"><strong>Commercially supported</strong>: Canonical backs its free OS commitment with Ubuntu Advantage including commercial support, systems management and access to top experts.</li>
+      </ul>
+      <p><a href="/server/management">Find out more about server management&nbsp;&rsaquo;</a></p>
     </div>
+  </div>
+</div>
 
-    <div class="strip-inner-wrapper equal-height">
-        <div class="box box-highlight four-col ">
-            <h3>Deployment-time workload acceleration</h3>
-            <p>Hyperscale systems with Juju and MAAS can provide nodes optimised to specific applications, including crypto, vector compute and transcoding.  </p>
-        </div>
-        <div class="box box-highlight four-col">
-            <h3>Landscape</h3>
-            <p>Ubuntu&rsquo;s systems management tool supports management of ARM devices on equal footing alongside your x86 infrastructure.</p>
-        </div>
-        <div class="box box-highlight four-col last-col ">
-            <h3>x86 and ARM support</h3>
-            <p>With Ubuntu, general-purpose hyperscale clusters may be deployed with a combination of Xeon or Opteron-class x86, low-power x86 and ARM nodes. </p>
-        </div>
+<div class="p-strip--accent is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <blockquote class="p-pull-quote--accent">
+        <p>A new wave of workloads demand breakthrough efficiencies in density, energy, and operational costs which can be scaled to a customer&rsquo;s IT environment</p>
+        <cite class="p-pull-quote__citation">Paul Santeler, VP &amp; GM, Hyperscale Business Unit, HP</cite>
+      </blockquote>
     </div>
-</section>
+  </div>
+</div>
 
-<section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h2>Your roadmap for hyperscale success</h2>
-            <p>Canonical offers a range of services tailored to the needs of SoC and OEM partners as well as end users deploying hyperscale clusters.</p>
-        </div>
-        <div class="twelve-col equal-height--vertical-divider">
-            <div class="equal-height--vertical-divider__item four-col">
-                <h3>SoC partners</h3>
-                <p>Canonical offers hardware enablement services to ensure that new System On Chip (SoC) silicon is tightly integrated and tuned with Ubuntu, and a certification program to give OEMs and end users the highest level of confidence that the complete system, including chip, enclosure and OS work together in the most optimal way. </p>
-            </div>
-            <div class="equal-height--vertical-divider__item four-col">
-                <h3>OEM and product developers</h3>
-                <p>Canonical offers a range of engineering services to all companies within the value chain developing boards, sub-systems, appliances and complete server suites to ensure that systems are fully certified to meet the rigorous demands of the hyperscale datacentre.</p>
-            </div>
-            <div class="equal-height--vertical-divider__item four-col last-col">
-                <h3>End users</h3>
-                <p>Canonical, together with OEM and ODM partners, delivers critical support and services to ensure customers can realise the full benefits of hyperscale technology.</p>
-            </div>
-        </div>
-        <div class="eight-col append-four">
-            <p><a href="/server/contact-us">Contact us about hyperscale&nbsp;&rsaquo;</a></p>
-        </div>
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-7">
+        <h2>Canonical&rsquo;s long-term commitment</h2>
+        <p>Canonical&rsquo;s first investment in hyperscale dates back to 2008. We invested early in at scale management tools like Landscape and Juju, supporting the management of machines and services at scale through enterprise-class automation.</p>
+        <p>Canonical is also a pioneer with ARM Servers, building the first commercial general-purpose ARM Linux OS in 2007 and the first ARM-based Server OS in 2009. We founded Linaro along with ARM in 2010.</p>
+        <p>Ubuntu now runs on every significant ARM platform deployed in the datacentre, including the recently-announced Baidu storage cluster.</p>
+      </div>
+      <div class="col-5 u-align--center u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}c74f59b7-picto-reducecosts-warmgrey.svg" width="199" height="199" class="u-hidden--small" alt="" />
+      </div>
     </div>
-</section>
+  </div>
+</div>
 
-<section class="row">
-    <div class="strip-inner-wrapper equal-height">
-        <h2>Hyperscale partners</h2>
-        <ul class="partner-list no-bullets">
-            <li class="six-col box">
-                <div class="partner-logo text-center">
-                    <img src="{{ ASSET_SERVER_URL }}cd5c35a3-partners-logo-hp.png" width="94" height="94" alt="" />
-                </div>
-                <p>Canonical has been involved in the development of Moonshot, HP&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
-                <p><a href="http://partners.ubuntu.com/hp" class="external">Learn more</a></p>
-            </li>
-            <li class="box six-col last-col">
-                <div class="partner-logo text-center">
-                    <img src="{{ ASSET_SERVER_URL }}388b97f3-partners-logo-arm.png" width="150" height="45" alt="ARM logo" />
-                </div>
-                <p>ARM and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
-                <p><a href="http://partners.ubuntu.com/arm" class="external">Learn more</a></p>
-            </li>
-            <li class="box six-col">
-                <div class="partner-logo text-center">
-                    <img src="{{ ASSET_SERVER_URL }}d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium logo" />
-                </div>
-                <p>Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
-                <p><a href="http://www.cavium.com">Learn more&nbsp;&rsaquo;</a></p>
-            </li>
-            <li class="box six-col last-col">
-                <div class="partner-logo text-center">
-                    <img src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation logo" />
-                </div>
-                <p>Applied Micro Circuits Corporation is a global leader in computing and connectivity solutions for next-generation cloud infrastructure and data centers. AppliedMicro delivers silicon solutions that dramatically lower total cost of ownership.</p>
-                <p><a href="https://www.apm.com/products/data-center/x-gene-family/" class="external">Learn more</a></p>
-            </li>
-        </ul>
+<div class="p-strip--light is-deep"  style="padding-bottom: 2rem;">
+  <div class="row">
+    <div class="col-12">
+      <h2>The complete solution for hyperscale</h2>
     </div>
-</section>
+  </div>
 
-<section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col">
-            <h2 class="muted-heading">A selection of our hardware partners</h2>
-            <ul id="hardware-partners" class="inline-logos no-margin dynamic-logos">
-              {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" limit=10 as hardware_partners %}
-              {% for partner in hardware_partners %}
-                <li class="inline-logos__item">
-                  <img class="inline-logos__image" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-                </li>
-              {% endfor %}
-            </ul>
-            <p class="align-center"><a href="https://certification.ubuntu.com">View all certified hardware&nbsp;&rsaquo;</a></p>
+  <div class="row p-divider">
+    <div class="col-6 p-divider__block">
+      <h3 class="p-heading--four">Workload-level orchestration with Juju</h3>
+      <p>Canonical&rsquo;s Juju framework goes beyond traditional orchestration systems to create a new paradigm in workload deployment.</p>
+      <p>Juju decouples services deployed onto the cluster from the nodes running them, and makes the deployment of the individual service easy.</p>
+      <p>Juju also supports deployment to cloud services like Amazon EC2 and Rackspace Cloud, and includes charms for open source workloads and key server ISV products.</p>
+      <p><a href="/cloud/orchestration/juju">Get more details on Juju here&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 p-divider__block">
+      <h3 class="p-heading--four">Bare-metal provisioning with MAAS</h3>
+      <p>With their unique architecture, hyperscale servers need to be provisioned through scalable automation. Canonical&rsquo;s Metal as a Service (MAAS) addresses the problem of deploying hundreds of OS instances to a cluster of nodes:</p>
+      <p>MAAS provides a flexible mechanism to automatically detect, provision and configure individual nodes with Ubuntu server without any complex or manual configuration </p>
+      <p><a href="/cloud/orchestration/maas">Learn more about MAAS&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip--light is-deep is-bordered" style="padding-top: 2rem;">
+  <div class="row">
+    <div class="u-equal-height  u-vertically-spaced">
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Deployment-time workload acceleration</h3>
+        <p class="p-card__content">Hyperscale systems with Juju and MAAS can provide nodes optimised to specific applications, including crypto, vector compute and transcoding.  </p>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">Landscape</h3>
+        <p class="p-card__content">Ubuntu&rsquo;s systems management tool supports management of ARM devices on equal footing alongside your x86 infrastructure.</p>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">x86 and ARM support</h3>
+        <p class="p-card__content">With Ubuntu, general-purpose hyperscale clusters may be deployed with a combination of Xeon or Opteron-class x86, low-power x86 and ARM nodes. </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Your roadmap for hyperscale success</h2>
+      <p>Canonical offers a range of services tailored to the needs of SoC and OEM partners as well as end users deploying hyperscale clusters.</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 p-divider">
+      <div class="col-4 p-divider__block">
+        <h3>SoC partners</h3>
+        <p>Canonical offers hardware enablement services to ensure that new System On Chip (SoC) silicon is tightly integrated and tuned with Ubuntu, and a certification program to give OEMs and end users the highest level of confidence that the complete system, including chip, enclosure and OS work together in the most optimal way. </p>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h3>OEM and product developers</h3>
+        <p>Canonical offers a range of engineering services to all companies within the value chain developing boards, sub-systems, appliances and complete server suites to ensure that systems are fully certified to meet the rigorous demands of the hyperscale datacentre.</p>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h3>End users</h3>
+        <p>Canonical, together with OEM and ODM partners, delivers critical support and services to ensure customers can realise the full benefits of hyperscale technology.</p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8 suffix-4">
+      <p><a href="/server/contact-us">Contact us about hyperscale&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Hyperscale partners</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 p-card">
+        <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+          <img src="{{ ASSET_SERVER_URL }}cd5c35a3-partners-logo-hp.png" width="94" height="94" alt="" />
         </div>
-    </div>
-</section>
-
-<section class="row no-border strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col">
-            <h2 class="muted-heading">A selection of our software partners</h2>
-            <ul id="software-partners" class="inline-logos no-margin dynamic-logos">
-              {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=OpenStack&service-offered=softwarecontent-publisher" limit=10 as software_partners %}
-              {% for partner in software_partners %}
-                <li class="inline-logos__item">
-                  <img class="inline-logos__image" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-                </li>
-              {% endfor %}
-            </ul>
-            <p class="align-center"><a href="/partners/certified-software">View all certified software&nbsp;&rsaquo;</a></p>
+        <p class="p-card__content">Canonical has been involved in the development of Moonshot, HP&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
+        <p class="p-card__content"><a href="http://partners.ubuntu.com/hp" class="external">Learn more</a></p>
+      </div>
+      <div class="col-6 p-card">
+        <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+          <img src="{{ ASSET_SERVER_URL }}388b97f3-partners-logo-arm.png" width="150" height="45" alt="ARM logo" />
         </div>
+        <p class="p-card__content">ARM and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
+        <p class="p-card__content"><a href="http://partners.ubuntu.com/arm" class="external">Learn more</a></p>
+      </div>
     </div>
-</section>
+  </div>
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 p-card">
+        <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+          <img src="{{ ASSET_SERVER_URL }}d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium logo" />
+        </div>
+        <p class="p-card__content">Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
+        <p class="p-card__content"><a href="http://www.cavium.com">Learn more&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-6 p-card">
+        <div class="u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+          <img src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation logo" />
+        </div>
+        <p class="p-card__content">Applied Micro Circuits Corporation is a global leader in computing and connectivity solutions for next-generation cloud infrastructure and data centers. AppliedMicro delivers silicon solutions that dramatically lower total cost of ownership.</p>
+        <p class="p-card__content"><a class="p-link--external" href="https://www.apm.com/products/data-center/x-gene-family/">Learn more</a></p>
+      </div>
+    </div>
+  </div>
+</div>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
+
+<div class="p-strip--white is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">A selection of our hardware partners</h2>
+      <ul class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" limit=10 as hardware_partners %}
+        {% for partner in hardware_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a class="p-link--external" href="https://certification.ubuntu.com">View all certified hardware partners</a></p>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip--white is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">A selection of our software partners</h2>
+      <ul class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=OpenStack&service-offered=softwarecontent-publisher" limit=10 as software_partners %}
+        {% for partner in software_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a class="p-link--external" href="/partners/certified-software">View all certified software partners</a></p>
+    </div>
+  </div>
+</div>
+
+{% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
 
 {% endblock content %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -34,7 +34,7 @@
   </div>
 </div>
 
-<div class="p-strip is-deep is-bordered">
+<div class="p-strip is-deep">
   <div class="row">
     <div class="col-12">
       <h2>Ubuntu Server for hyperscale</h2>
@@ -63,7 +63,7 @@
   </div>
 </div>
 
-<div class="p-strip--accent is-deep is-bordered">
+<div class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-12">
       <blockquote class="p-pull-quote--accent">
@@ -225,7 +225,7 @@
   </div>
 </div>
 
-<div class="p-strip--white is-deep is-bordered">
+<div class="p-strip--white is-deep">
   <div class="row">
     <div class="col-12">
       <h2 class="p-heading--muted u-align--center">A selection of our software partners</h2>


### PR DESCRIPTION
## Done

* update /server/hyperscape to vbt
* added .p-strip—white for logo clouds
* added .p-pull-quote—accent for sitting on a p-strip—accent

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/server/hyperscale)
- compart to the [design](https://www.dropbox.com/work/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/3.%20Server?preview=server-hyperscale.png) and [demo](http://www.ubuntu.com-1581-server-hyperscale.demo.haus/server/hyperscale)


## Issue / Card

Fixes #1581
