### PR TITLE
1612 /download/cloud/autopilot to vbt

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -219,11 +219,15 @@ body.has-background {
 
 /// XXX fix nested bullets to use default styles
 ul.p-list  ul.p-list {
-  list-style-type: disc;
+  list-style-type: circle;
 
   ul.p-list {
-    list-style-type: circle;
+    list-style-type: disc;
   }
+}
+
+.p-list-step__content ul.p-list {
+  list-style-type: disc;
 }
 
 /// XXX fix two-digit padding in .p-list-step__bullet

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -216,3 +216,17 @@ body.has-background {
     background-image: url(#{$assets-path}f8a323a7-image-background-paper.png);
   }
 }
+
+/// XXX fix nested bullets to use default styles
+ul.p-list  ul.p-list {
+  list-style-type: disc;
+
+  ul.p-list {
+    list-style-type: circle;
+  }
+}
+
+/// XXX fix two-digit padding in .p-list-step__bullet
+.p-list-step__bullet {
+  padding: .65rem .4rem;
+}

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -1,269 +1,257 @@
-{% extends "download/_base_download.html" %}
-
+{% extends "download/_base_download-v1.html" %}
 {% block title %}Build OpenStack with Autopilot | Download{% endblock %}
-
 {% block meta_description %}Whether you’re building your own OpenStack cloud, want a hosted private cloud or want to use Ubuntu in the public cloud, we offer all the training, software, tools, services and support you need.{% endblock %}
-
 {% block extra_body_class %}download-cloud-autopilot{% endblock %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Downloads" subsection_title="Cloud" page_title="Autopilot"  %}
-</div>
+{% include "templates/_nav_breadcrumb-v1.html" with section_title="Downloads" subsection_title="Cloud" page_title="Autopilot"  %}
 {% endblock second_level_nav_items %}
 
-
 {% block content %}
-
-<section class="row row-grey no-border">
-  <div class="strip-inner-wrapper">
-    <div class="eight-col">
+<div class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="col-10">
       <h1>Get a production cloud with OpenStack Autopilot</h1>
     </div>
-    <div class="box box-highlight clearfix equal-height--vertical-divider">
-      <div class="equal-height--vertical-divider__item six-col">
-        <h2>OpenStack Autopilot</h2>
-        <p>Canonical&rsquo;s OpenStack Autopilot handles every aspect of your production cloud across multiple physical machines through installation, expansion and everyday operations.</p>
+  </div>
+  <div class="row">
+    <div class="p-card--highlighted">
+      <div class="u-equal-height p-divider">
+        <div class="col-6 p-divider__block">
+          <h2>OpenStack Autopilot</h2>
+          <p>Canonical&rsquo;s OpenStack Autopilot handles every aspect of your production cloud across multiple physical machines through installation, expansion and everyday operations.</p>
+        </div>
+        <div class="col-6 p-divider__block">
+          <h3>Requirements</h3>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">A minimum of 6 machines with the following roles:
+              <ul class="p-list">
+                <li class="p-list__item is-ticked">1 machine for the MAAS server</li>
+                <li class="p-list__item is-ticked">1 machine for the Juju controller</li>
+                <li class="p-list__item is-ticked">1 machine for the OpenStack Autopilot</li>
+                <li class="p-list__item is-ticked">3 or more machines for the cloud (6 or more if you want HA):
+                  <ul class="p-list">
+                    <li class="p-list__item is-ticked">At least one must have 2 NICs</li>
+                    <li class="p-list__item is-ticked">At least 3 must have 2 disks</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+            <li class="p-list__item is-ticked">A dedicated switch to create a private cloud LAN</li>
+            <li class="p-list__item is-ticked">Internet access through a router on that LAN</li>
+          </ul>
+        </div>
       </div>
-      <div class="equal-height--vertical-divider__item six-col last-col no-margin-bottom download-button">
-        <h3>Requirements</h3>
-        <ul class="list-ticks--compact">
-          <li>A minimum of 6 machines with the following roles:
-            <ul class="list-ticks--compact">
-              <li>1 machine for the MAAS server</li>
-              <li>1 machine for the Juju controller</li>
-              <li>1 machine for the OpenStack Autopilot</li>
-              <li>3 or more machines for the cloud (6 or more if you want HA):
-                <ul class="list-ticks--compact">
-                  <li>At least one must have 2 NICs</li>
-                  <li>At least 3 must have 2 disks</li>
+    </div>
+  </div>
+</div>
+
+{% include "download/shared/_get_ebook-v1.html"%}
+
+<div class="p-strip--light is-deep is-bordered" id="instructions">
+  <div class="row">
+    <div class="col-12">
+      <h2>Installation instructions</h2>
+
+      <ol class="p-stepped-list--detailed">
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">1</span>Set up your hardware</h3>
+          <div class="p-list-step__content">
+            <p><a href="http://releases.ubuntu.com/16.04/" class="p-link--external">Install Ubuntu Server 16.04 LTS</a> on the machine designated to be the MAAS server.</p>
+            <p>You need to setup a private network with all machines plugged in and enough IP addresses available for all physical and virtual machines you plan to run. This network must not have a DHCP server: MAAS will fill in that role.</p>
+            <p>For the simplest topology, connect the second NIC of the dual-nic machine(s) to the same network.</p>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Install MAAS</h3>
+          <div class="p-list-step__content">
+            <p>To install MAAS, start off on your Ubuntu Server 16.04 LTS machine and  type the command below following the step-by-step instructions:</p>
+            <p class="p-code-snippet">
+              <input class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
+              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+            </p>
+            <p class="p-code-snippet">
+              <input class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
+              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+            </p>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Create your admin credentials and optionally import your SSH key by typing:</li>
+            </ul>
+            <p class="p-code-snippet">
+              <input class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
+              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+            </p>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Login to the MAAS UI at http://&lt;maas.ip&gt;/MAAS/</li>
+              <li class="p-list__item is-ticked">Fill in the details on the welcome page and import images for Ubuntu 14.04 LTS and 16.04 LTS. Importing images may take a while, but you can click &ldquo;continue&rdquo; as soon as it&rsquo;s started</li>
+              <li class="p-list__item is-ticked">If you haven&rsquo;t imported your SSH key before, now is your chance to import one from Launchpad, GitHub or you can also upload it directly</li>
+            </ul>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Configure the MAAS subnet and&nbsp;DHCP</h3>
+          <div class="p-list-step__content">
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Go to the &ldquo;Subnets&rdquo; tab and click on your subnet. Verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are filled in and update as necessary</li>
+              <li class="p-list__item is-ticked">Go back (or click on &ldquo;subnets&rdquo; again) and this time click on the &ldquo;untagged&rdquo; VLAN. Select &ldquo;Provide dhcp&rdquo; in the &ldquo;Take action&rdquo; button  and select a suitable Dynamic range. To start with, count one IP per NIC connected to the network</li>
+            </ul>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Verify image syncing</h3>
+          <div class="p-list-step__content">
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. This is the process started earlier, and depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced</li>
+            </ul>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Register your hardware with MAAS</h3>
+          <div class="p-list-step__content">
+            <p>Now you need to enlist and commission machines:</p>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Ensure all machines are set to PXE boot, if possible disable all other boot options, including local disk, in the BIOS</li>
+              <li class="p-list__item is-ticked">Power the machines on. They will all appear in the &ldquo;Nodes&rdquo; tab of MAAS after a while</li>
+              <li class="p-list__item is-ticked">Edit each machine, filling in the power type and other parameters, if they are not correct already</li>
+              <li class="p-list__item is-ticked">Select all the machines and, using the &ldquo;Take action&rdquo; dropdown, &ldquo;Commission&rdquo; them</li>
+              <li class="p-list__item is-ticked">Wait until all machines have a &ldquo;Ready&rdquo; status</li>
+              <li class="p-list__item is-ticked">Verify the networking by going to the details page for the node(s) that have multiple NICs and check that the second NIC (the non-PXE one):
+                <ul class="p-list">
+                  <li class="p-list__item is-ticked">Is connected to the subnet</li>
+                  <li class="p-list__item is-ticked">Has the &ldquo;IP address&rdquo; field set to &ldquo;unconfigured&rdquo;</li>
                 </ul>
               </li>
+              <li class="p-list__item is-ticked">The first NIC should be the same except the IP address field will be set to &ldquo;Auto assign&rdquo;</li>
             </ul>
-          </li>
-          <li>A dedicated switch to create a private cloud LAN</li>
-          <li>Internet access through a router on that LAN</li>
-        </ul>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Launch OpenStack Autopilot</h3>
+          <div class="p-list-step__content">
+            <p>Setup Landscape and launch the OpenStack Autopilot with the following commands:</p>
+            <p class="p-code-snippet">
+              <input class="p-code-snippet__input" value="snap install conjure-up --classic" readonly="readonly">
+              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+            </p>
+            <p class="p-code-snippet">
+              <input class="p-code-snippet__input" value="conjure-up --bootstrap-to &lt;hostname&gt;" readonly="readonly">
+              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+            </p>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Replace &lt;hostname&gt; above with the hostname of the machine that was selected for the Juju controller role. Do not add the domain name to it</li>
+              <li class="p-list__item is-ticked">
+                <p>Select &ldquo;Landscape&rdquo;</p>
+                <a href="{{ ASSET_SERVER_URL }}24390fd2-1_select_landscape.png">
+                  <img src="{{ ASSET_SERVER_URL }}24390fd2-1_select_landscape.png?w=424" alt="Select landscape" />
+                </a>
+              </li>
+              <li class="p-list__item is-ticked">
+                <p>Select &ldquo;maas&rdquo; as the cloud type</p>
+              </li>
+              <li class="p-list__item is-ticked">Fill in your:
+                <ul class="p-list">
+                  <li class="p-list__item is-ticked">MAAS server IP</li>
+                  <li class="p-list__item is-ticked">MAAS user API key &mdash; found in your user&rsquo;s settings in the MAAS user interface (top-right corner)</li>
+                </ul>
+                <a href="{{ ASSET_SERVER_URL }}4e155f7e-3_maas_ip_api_key.png">
+                  <img src="{{ ASSET_SERVER_URL }}4e155f7e-3_maas_ip_api_key.png?w=424" alt="Set IP and API key" />
+                </a>
+              </li>
+              <li class="p-list__item is-ticked">
+                <p>The next page will show you the list of applications that make up a Landscape deployment. In the case of Landscape, all applications will be deployed to one machine only using LXD containers. If you want to select which machine that will be, you can click on the &ldquo;Architect&rdquo; button of any application. Otherwise, click on &ldquo;Deploy&rdquo; on the bottom right</p>
+                <a href="{{ ASSET_SERVER_URL }}ab5505f6-4_list_of_applications.png">
+                  <img src="{{ ASSET_SERVER_URL }}ab5505f6-4_list_of_applications.png?w=424" alt="Applications list" />
+                </a>
+              </li>
+              <li class="p-list__item is-ticked">
+                <p>When everything is installed, you will be asked to provide details about the Landscape administrator to be created: name, email and password</p>
+              </li>
+              <li class="p-list__item is-ticked">
+                <p>Finally, a summary will be displayed with a link for you to access Landscape and begin your Openstack deployment. Open that link to access Landscape</p>
+                <a href="{{ ASSET_SERVER_URL }}12db1ed7-8_summary.png">
+                  <img src="{{ ASSET_SERVER_URL }}12db1ed7-8_summary.png?w=424" alt="Set IP and API key" />
+                </a>
+              </li>
+              <li class="p-list__item is-ticked">
+                <p>Login with your Admin Email and Password</p>
+              </li>
+            </ul>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">7</span>Review your checklist</h3>
+          <div class="p-list-step__content">
+            <p>At the bottom of the setup page there is a checklist with the status of all of your resources. These should all be green, if it isn’t follow the instructions to resolve.</p>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">8</span>Choose your OpenStack components</h3>
+          <div class="p-list-step__content">
+            <img src="{{ ASSET_SERVER_URL }}32a02c50-install-openstack-with-autopilot-step8.png" alt="" />
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">9</span>Select the hardware on which to deploy the cloud</h3>
+          <div class="p-list-step__content">
+            <img src="{{ ASSET_SERVER_URL }}30c17ac2-install-openstack-with-autopilot-step9.png" alt="" />
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">10</span>Select &ldquo;Install&rdquo; to start building your cloud</h3>
+          <div class="p-list-step__content">
+            <img src="{{ ASSET_SERVER_URL }}77bc020b-Installing+region+1++++table+++Progress.png" alt="" />
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">11</span>Create an OpenStack account to access your Horizon dashboard</h3>
+          <div class="p-list-step__content">
+            <img src="{{ ASSET_SERVER_URL }}19a76480-while-you-wait.png" alt="" /><br/><br/><br/>
+          </div>
+        </li>
+
+        <li class="p-list-step__item col-12">
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">12</span>Monitor your region and scale out</h3>
+          <div class="p-list-step__content">
+            <img src="{{ ASSET_SERVER_URL }}7405e963-install-openstack-with-autopilot-step12.png" alt="" />
+          </div>
+        </li>
+      </ol>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-4 u-align--center u-hidden--small u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="200" alt="" />
+      </div>
+      <div class="col-7 prefix-1 u-vertically-center">
+        <div class="row">
+          <div class="col-12">
+            <h2>Need more help?</h2>
+            <p>Let our cloud experts help you take the next step.</p>
+            <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
+            <p>Already a Landscape Dedicated Server customer? Upgrading is simple, see the instructions in the <a href="https://help.landscape.canonical.com/LDS/ReleaseNotes" class="p-link--external">release notes</a>.</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</section>
+</div>
 
-{% include "download/shared/_get_ebook.html"%}
-
-<section id="instructions" class="row row-install-autopilot">
-  <div class="strip-inner-wrapper">
-    <h2>Installation instructions</h2>
-    <ol class="list-stepped--spaced download-help">
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Set up your hardware</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <p><a href="http://releases.ubuntu.com/16.04/" class="external">Install Ubuntu Server 16.04 LTS</a> on the machine designated to be the MAAS server.</p>
-          <p>You need to setup a private network with all machines plugged in and enough IP addresses available for all physical and virtual machines you plan to run. This network must not have a DHCP server: MAAS will fill in that role.</p>
-          <p>For the simplest topology, connect the second NIC of the dual-nic machine(s) to the same network.</p>
-        </div>
-      </li>
-
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Install MAAS</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <p>To install MAAS, start off on your Ubuntu Server 16.04 LTS machine and  type the command below following the step-by-step instructions:</p>
-          <p class="command-line">
-            <input class="command-line__input" value="sudo apt update" readonly="readonly">
-            <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-          </p>
-          <p class="command-line">
-            <input class="command-line__input" value="sudo apt install maas" readonly="readonly">
-            <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-          </p>
-          <ul>
-            <li>Create your admin credentials and optionally import your SSH key by typing:</li>
-          </ul>
-          <p class="command-line">
-            <input class="command-line__input" value="sudo maas createadmin" readonly="readonly">
-            <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-          </p>
-          <ul>
-            <li>Login to the MAAS UI at <code>http://&lt;maas.ip&gt;/MAAS/</code></li>
-            <li>Fill in the details on the welcome page and import images for Ubuntu 14.04 LTS and 16.04 LTS. Importing images may take a while, but you can click &ldquo;continue&rdquo; as soon as it&rsquo;s started</li>
-            <li>If you haven&rsquo;t imported your SSH key before, now is your chance to import one from Launchpad, GitHub or you can also upload it directly</li>
-          </ul>
-        </div>
-      </li>
-
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Configure the MAAS subnet and&nbsp;DHCP</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <ul>
-            <li>Go to the &ldquo;Subnets&rdquo; tab and click on your subnet. Verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are filled in and update as necessary</li>
-            <li>Go back (or click on &ldquo;subnets&rdquo; again) and this time click on the &ldquo;untagged&rdquo; VLAN. Select &ldquo;Provide dhcp&rdquo; in the &ldquo;Take action&rdquo; button  and select a suitable Dynamic range. To start with, count one IP per NIC connected to the network</li>
-          </ul>
-        </div>
-      </li>
-
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Verify image syncing</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <ul>
-            <li>Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. This is the process started earlier, and depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced</li>
-          </ul>
-        </div>
-      </li>
-
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Register your hardware with MAAS</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <p>Now you need to enlist and commission machines:</p>
-          <ul>
-            <li>Ensure all machines are set to PXE boot, if possible disable all other boot options, including local disk, in the BIOS</li>
-            <li>Power the machines on. They will all appear in the &ldquo;Nodes&rdquo; tab of MAAS after a while</li>
-            <li>Edit each machine, filling in the power type and other parameters, if they are not correct already</li>
-            <li>Select all the machines and, using the &ldquo;Take action&rdquo; dropdown, &ldquo;Commission&rdquo; them</li>
-            <li>Wait until all machines have a &ldquo;Ready&rdquo; status</li>
-            <li>Verify the networking by going to the details page for the node(s) that have multiple NICs and check that the second NIC (the non-PXE one):
-              <ul>
-                <li>Is connected to the subnet</li>
-                <li>Has the &ldquo;IP address&rdquo; field set to &ldquo;unconfigured&rdquo;</li>
-              </ul>
-            </li>
-            <li>The first NIC should be the same except the IP address field will be set to &ldquo;Auto assign&rdquo;</li>
-          </ul>
-        </div>
-      </li>
-
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Launch OpenStack Autopilot</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <p>Setup Landscape and launch the OpenStack Autopilot with the following commands:</p>
-          <p class="command-line">
-            <input class="command-line__input" value="snap install conjure-up --classic" readonly="readonly">
-            <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-          </p>
-          <p class="command-line">
-            <input class="command-line__input" value="conjure-up --bootstrap-to &lt;hostname&gt;" readonly="readonly">
-            <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-          </p>
-          <ul>
-            <li>Replace &lt;hostname&gt; above with the hostname of the machine that was selected for the Juju controller role. Do not add the domain name to it</li>
-            <li>
-              <p>Select &ldquo;Landscape&rdquo;</p>
-              <a href="{{ ASSET_SERVER_URL }}24390fd2-1_select_landscape.png">
-                <img src="{{ ASSET_SERVER_URL }}24390fd2-1_select_landscape.png?w=424" alt="Select landscape" />
-              </a>
-            </li>
-            <li>
-              <p>Select &ldquo;maas&rdquo; as the cloud type</p>
-            </li>
-            <li>Fill in your:
-              <ul>
-                <li>MAAS server IP</li>
-                <li>MAAS user API key &mdash; found in your user&rsquo;s settings in the MAAS user interface (top-right corner)</li>
-              </ul>
-              <a href="{{ ASSET_SERVER_URL }}4e155f7e-3_maas_ip_api_key.png">
-                <img src="{{ ASSET_SERVER_URL }}4e155f7e-3_maas_ip_api_key.png?w=424" alt="Set IP and API key" />
-              </a>
-            </li>
-            <li>
-              <p>The next page will show you the list of applications that make up a Landscape deployment. In the case of Landscape, all applications will be deployed to one machine only using LXD containers. If you want to select which machine that will be, you can click on the &ldquo;Architect&rdquo; button of any application. Otherwise, click on &ldquo;Deploy&rdquo; on the bottom right</p>
-              <a href="{{ ASSET_SERVER_URL }}ab5505f6-4_list_of_applications.png">
-                <img src="{{ ASSET_SERVER_URL }}ab5505f6-4_list_of_applications.png?w=424" alt="Applications list" />
-              </a>
-            </li>
-            <li>
-              <p>When everything is installed, you will be asked to provide details about the Landscape administrator to be created: name, email and password</p>
-            </li>
-            <li>
-              <p>Finally, a summary will be displayed with a link for you to access Landscape and begin your Openstack deployment. Open that link to access Landscape</p>
-              <a href="{{ ASSET_SERVER_URL }}12db1ed7-8_summary.png">
-                <img src="{{ ASSET_SERVER_URL }}12db1ed7-8_summary.png?w=424" alt="Set IP and API key" />
-              </a>
-            </li>
-            <li>
-              <p>Login with your Admin Email and Password</p>
-            </li>
-          </ul>
-        </div>
-      </li>
-
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Review your checklist</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <p>At the bottom of the setup page there is a checklist with the status of all of your resources. These should all be green, if it isn’t follow the instructions to resolve.</p>
-        </div>
-      </li>
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Choose your OpenStack components</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <img src="{{ ASSET_SERVER_URL }}32a02c50-install-openstack-with-autopilot-step8.png" alt="" />
-        </div>
-      </li>
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Select the hardware on which to deploy the cloud</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <img src="{{ ASSET_SERVER_URL }}30c17ac2-install-openstack-with-autopilot-step9.png" alt="" />
-        </div>
-      </li>
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Select &ldquo;Install&rdquo; to start building your cloud</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <img src="{{ ASSET_SERVER_URL }}77bc020b-Installing+region+1++++table+++Progress.png" alt="" />
-        </div>
-      </li>
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Create an OpenStack account to access your Horizon dashboard</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <img src="{{ ASSET_SERVER_URL }}19a76480-while-you-wait.png" alt="" /><br/><br/><br/>
-        </div>
-      </li>
-      <li class="list-stepped__item">
-        <div class="five-col">
-          <h3 class="list-stepped__title">Monitor your region and scale out</h3>
-        </div>
-        <div class="seven-col last-col list-stepped__box right">
-          <img src="{{ ASSET_SERVER_URL }}7405e963-install-openstack-with-autopilot-step12.png" alt="" />
-        </div>
-      </li>
-    </ol>
-  </div>
-</section>
-
-<section class="row row-white no-border">
-  <div class="strip-inner-wrapper equal-height">
-    <div class="four-col align-center not-for-small equal-height__item equal-height__align-vertically">
-      <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="200" alt="" />
-    </div>
-    <div class="seven-col prepend-one last-col equal-height__item equal-height__align-vertically">
-      <h2>Need more help?</h2>
-      <p>Let our cloud experts help you take the next step.</p>
-      <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
-      <p>Already a Landscape Dedicated Server customer? Upgrading is simple, see the instructions in the <a href="https://help.landscape.canonical.com/LDS/ReleaseNotes" class="external">release notes</a>.</p>
-    </div>
-  </div>
-</section>
-
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_cloud_bootstack" second_item="_download_cloud_buy_landscape" third_item="_download_documentation" %}
+{% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_download_cloud_bootstack" second_item="_download_cloud_buy_landscape" third_item="_download_documentation" %}
 
 
 {% endblock content %}

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -8,7 +8,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="p-strip--light is-deep is-bordered">
+<div class="p-strip--light is-deep">
   <div class="row">
     <div class="col-10">
       <h1>Get a production cloud with OpenStack Autopilot</h1>
@@ -26,13 +26,13 @@
           <ul class="p-list">
             <li class="p-list__item is-ticked">A minimum of 6 machines with the following roles:
               <ul class="p-list">
-                <li class="p-list__item is-ticked">1 machine for the MAAS server</li>
-                <li class="p-list__item is-ticked">1 machine for the Juju controller</li>
-                <li class="p-list__item is-ticked">1 machine for the OpenStack Autopilot</li>
-                <li class="p-list__item is-ticked">3 or more machines for the cloud (6 or more if you want HA):
+                <li class="p-list__item">1 machine for the MAAS server</li>
+                <li class="p-list__item">1 machine for the Juju controller</li>
+                <li class="p-list__item">1 machine for the OpenStack Autopilot</li>
+                <li class="p-list__item">3 or more machines for the cloud (6 or more if you want HA):
                   <ul class="p-list">
-                    <li class="p-list__item is-ticked">At least one must have 2 NICs</li>
-                    <li class="p-list__item is-ticked">At least 3 must have 2 disks</li>
+                    <li class="p-list__item">At least one must have 2 NICs</li>
+                    <li class="p-list__item">At least 3 must have 2 disks</li>
                   </ul>
                 </li>
               </ul>
@@ -84,9 +84,9 @@
               <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
             </p>
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Login to the MAAS UI at http://&lt;maas.ip&gt;/MAAS/</li>
-              <li class="p-list__item is-ticked">Fill in the details on the welcome page and import images for Ubuntu 14.04 LTS and 16.04 LTS. Importing images may take a while, but you can click &ldquo;continue&rdquo; as soon as it&rsquo;s started</li>
-              <li class="p-list__item is-ticked">If you haven&rsquo;t imported your SSH key before, now is your chance to import one from Launchpad, GitHub or you can also upload it directly</li>
+              <li class="p-list__item">Login to the MAAS UI at http://&lt;maas.ip&gt;/MAAS/</li>
+              <li class="p-list__item">Fill in the details on the welcome page and import images for Ubuntu 14.04 LTS and 16.04 LTS. Importing images may take a while, but you can click &ldquo;continue&rdquo; as soon as it&rsquo;s started</li>
+              <li class="p-list__item">If you haven&rsquo;t imported your SSH key before, now is your chance to import one from Launchpad, GitHub or you can also upload it directly</li>
             </ul>
           </div>
         </li>
@@ -95,8 +95,8 @@
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Configure the MAAS subnet and&nbsp;DHCP</h3>
           <div class="p-list-step__content">
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Go to the &ldquo;Subnets&rdquo; tab and click on your subnet. Verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are filled in and update as necessary</li>
-              <li class="p-list__item is-ticked">Go back (or click on &ldquo;subnets&rdquo; again) and this time click on the &ldquo;untagged&rdquo; VLAN. Select &ldquo;Provide dhcp&rdquo; in the &ldquo;Take action&rdquo; button  and select a suitable Dynamic range. To start with, count one IP per NIC connected to the network</li>
+              <li class="p-list__item">Go to the &ldquo;Subnets&rdquo; tab and click on your subnet. Verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are filled in and update as necessary</li>
+              <li class="p-list__item">Go back (or click on &ldquo;subnets&rdquo; again) and this time click on the &ldquo;untagged&rdquo; VLAN. Select &ldquo;Provide dhcp&rdquo; in the &ldquo;Take action&rdquo; button  and select a suitable Dynamic range. To start with, count one IP per NIC connected to the network</li>
             </ul>
           </div>
         </li>
@@ -105,7 +105,7 @@
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Verify image syncing</h3>
           <div class="p-list-step__content">
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. This is the process started earlier, and depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced</li>
+              <li class="p-list__item">Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. This is the process started earlier, and depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced</li>
             </ul>
           </div>
         </li>
@@ -115,18 +115,18 @@
           <div class="p-list-step__content">
             <p>Now you need to enlist and commission machines:</p>
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Ensure all machines are set to PXE boot, if possible disable all other boot options, including local disk, in the BIOS</li>
-              <li class="p-list__item is-ticked">Power the machines on. They will all appear in the &ldquo;Nodes&rdquo; tab of MAAS after a while</li>
-              <li class="p-list__item is-ticked">Edit each machine, filling in the power type and other parameters, if they are not correct already</li>
-              <li class="p-list__item is-ticked">Select all the machines and, using the &ldquo;Take action&rdquo; dropdown, &ldquo;Commission&rdquo; them</li>
-              <li class="p-list__item is-ticked">Wait until all machines have a &ldquo;Ready&rdquo; status</li>
-              <li class="p-list__item is-ticked">Verify the networking by going to the details page for the node(s) that have multiple NICs and check that the second NIC (the non-PXE one):
+              <li class="p-list__item">Ensure all machines are set to PXE boot, if possible disable all other boot options, including local disk, in the BIOS</li>
+              <li class="p-list__item">Power the machines on. They will all appear in the &ldquo;Nodes&rdquo; tab of MAAS after a while</li>
+              <li class="p-list__item">Edit each machine, filling in the power type and other parameters, if they are not correct already</li>
+              <li class="p-list__item">Select all the machines and, using the &ldquo;Take action&rdquo; dropdown, &ldquo;Commission&rdquo; them</li>
+              <li class="p-list__item">Wait until all machines have a &ldquo;Ready&rdquo; status</li>
+              <li class="p-list__item">Verify the networking by going to the details page for the node(s) that have multiple NICs and check that the second NIC (the non-PXE one):
                 <ul class="p-list">
-                  <li class="p-list__item is-ticked">Is connected to the subnet</li>
-                  <li class="p-list__item is-ticked">Has the &ldquo;IP address&rdquo; field set to &ldquo;unconfigured&rdquo;</li>
+                  <li class="p-list__item">Is connected to the subnet</li>
+                  <li class="p-list__item">Has the &ldquo;IP address&rdquo; field set to &ldquo;unconfigured&rdquo;</li>
                 </ul>
               </li>
-              <li class="p-list__item is-ticked">The first NIC should be the same except the IP address field will be set to &ldquo;Auto assign&rdquo;</li>
+              <li class="p-list__item">The first NIC should be the same except the IP address field will be set to &ldquo;Auto assign&rdquo;</li>
             </ul>
           </div>
         </li>
@@ -144,41 +144,41 @@
               <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
             </p>
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Replace &lt;hostname&gt; above with the hostname of the machine that was selected for the Juju controller role. Do not add the domain name to it</li>
-              <li class="p-list__item is-ticked">
+              <li class="p-list__item">Replace &lt;hostname&gt; above with the hostname of the machine that was selected for the Juju controller role. Do not add the domain name to it</li>
+              <li class="p-list__item">
                 <p>Select &ldquo;Landscape&rdquo;</p>
                 <a href="{{ ASSET_SERVER_URL }}24390fd2-1_select_landscape.png">
                   <img src="{{ ASSET_SERVER_URL }}24390fd2-1_select_landscape.png?w=424" alt="Select landscape" />
                 </a>
               </li>
-              <li class="p-list__item is-ticked">
+              <li class="p-list__item">
                 <p>Select &ldquo;maas&rdquo; as the cloud type</p>
               </li>
-              <li class="p-list__item is-ticked">Fill in your:
+              <li class="p-list__item">Fill in your:
                 <ul class="p-list">
-                  <li class="p-list__item is-ticked">MAAS server IP</li>
-                  <li class="p-list__item is-ticked">MAAS user API key &mdash; found in your user&rsquo;s settings in the MAAS user interface (top-right corner)</li>
+                  <li class="p-list__item">MAAS server IP</li>
+                  <li class="p-list__item">MAAS user API key &mdash; found in your user&rsquo;s settings in the MAAS user interface (top-right corner)</li>
                 </ul>
                 <a href="{{ ASSET_SERVER_URL }}4e155f7e-3_maas_ip_api_key.png">
                   <img src="{{ ASSET_SERVER_URL }}4e155f7e-3_maas_ip_api_key.png?w=424" alt="Set IP and API key" />
                 </a>
               </li>
-              <li class="p-list__item is-ticked">
+              <li class="p-list__item">
                 <p>The next page will show you the list of applications that make up a Landscape deployment. In the case of Landscape, all applications will be deployed to one machine only using LXD containers. If you want to select which machine that will be, you can click on the &ldquo;Architect&rdquo; button of any application. Otherwise, click on &ldquo;Deploy&rdquo; on the bottom right</p>
                 <a href="{{ ASSET_SERVER_URL }}ab5505f6-4_list_of_applications.png">
                   <img src="{{ ASSET_SERVER_URL }}ab5505f6-4_list_of_applications.png?w=424" alt="Applications list" />
                 </a>
               </li>
-              <li class="p-list__item is-ticked">
+              <li class="p-list__item">
                 <p>When everything is installed, you will be asked to provide details about the Landscape administrator to be created: name, email and password</p>
               </li>
-              <li class="p-list__item is-ticked">
+              <li class="p-list__item">
                 <p>Finally, a summary will be displayed with a link for you to access Landscape and begin your Openstack deployment. Open that link to access Landscape</p>
                 <a href="{{ ASSET_SERVER_URL }}12db1ed7-8_summary.png">
                   <img src="{{ ASSET_SERVER_URL }}12db1ed7-8_summary.png?w=424" alt="Set IP and API key" />
                 </a>
               </li>
-              <li class="p-list__item is-ticked">
+              <li class="p-list__item">
                 <p>Login with your Admin Email and Password</p>
               </li>
             </ul>

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -70,24 +70,20 @@
             <p>To install MAAS, start off on your Ubuntu Server 16.04 LTS machine and  type the command below following the step-by-step instructions:</p>
             <p class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
-              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+              <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
             <p class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
-              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+              <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
-            <ul class="p-list">
-              <li class="p-list__item is-ticked">Create your admin credentials and optionally import your SSH key by typing:</li>
-            </ul>
+            <p>Create your admin credentials and optionally import your SSH key by typing:</p>
             <p class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
-              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+              <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
-            <ul class="p-list">
-              <li class="p-list__item">Login to the MAAS UI at http://&lt;maas.ip&gt;/MAAS/</li>
-              <li class="p-list__item">Fill in the details on the welcome page and import images for Ubuntu 14.04 LTS and 16.04 LTS. Importing images may take a while, but you can click &ldquo;continue&rdquo; as soon as it&rsquo;s started</li>
-              <li class="p-list__item">If you haven&rsquo;t imported your SSH key before, now is your chance to import one from Launchpad, GitHub or you can also upload it directly</li>
-            </ul>
+            <p>Login to the MAAS UI at <code>http://&lt;maas.ip&gt;/MAAS/</code></p>
+            <p>Fill in the details on the welcome page and import images for Ubuntu 14.04 LTS and 16.04 LTS. Importing images may take a while, but you can click &ldquo;continue&rdquo; as soon as it&rsquo;s started</p>
+            <p>If you haven&rsquo;t imported your SSH key before, now is your chance to import one from Launchpad, GitHub or you can also upload it directly</p>
           </div>
         </li>
 
@@ -104,9 +100,7 @@
         <li class="p-list-step__item col-12">
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Verify image syncing</h3>
           <div class="p-list-step__content">
-            <ul class="p-list">
-              <li class="p-list__item">Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. This is the process started earlier, and depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced</li>
-            </ul>
+            <p>Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. This is the process started earlier, and depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced</p>
           </div>
         </li>
 
@@ -137,14 +131,14 @@
             <p>Setup Landscape and launch the OpenStack Autopilot with the following commands:</p>
             <p class="p-code-snippet">
               <input class="p-code-snippet__input" value="snap install conjure-up --classic" readonly="readonly">
-              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+              <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
             <p class="p-code-snippet">
               <input class="p-code-snippet__input" value="conjure-up --bootstrap-to &lt;hostname&gt;" readonly="readonly">
-              <button class="js-copy-to-clipboard p-code-snippet__action">Copy to clipboard</button>
+              <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
             <ul class="p-list">
-              <li class="p-list__item">Replace &lt;hostname&gt; above with the hostname of the machine that was selected for the Juju controller role. Do not add the domain name to it</li>
+              <li class="p-list__item">Replace <code>&lt;hostname&gt;</code> above with the hostname of the machine that was selected for the Juju controller role. Do not add the domain name to it</li>
               <li class="p-list__item">
                 <p>Select &ldquo;Landscape&rdquo;</p>
                 <a href="{{ ASSET_SERVER_URL }}24390fd2-1_select_landscape.png">

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -90,10 +90,8 @@
         <li class="p-list-step__item col-12">
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Configure the MAAS subnet and&nbsp;DHCP</h3>
           <div class="p-list-step__content">
-            <ul class="p-list">
-              <li class="p-list__item">Go to the &ldquo;Subnets&rdquo; tab and click on your subnet. Verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are filled in and update as necessary</li>
-              <li class="p-list__item">Go back (or click on &ldquo;subnets&rdquo; again) and this time click on the &ldquo;untagged&rdquo; VLAN. Select &ldquo;Provide dhcp&rdquo; in the &ldquo;Take action&rdquo; button  and select a suitable Dynamic range. To start with, count one IP per NIC connected to the network</li>
-            </ul>
+            <p>Go to the &ldquo;Subnets&rdquo; tab and click on your subnet. Verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are filled in and update as necessary</p>
+            <p>Go back (or click on &ldquo;subnets&rdquo; again) and this time click on the &ldquo;untagged&rdquo; VLAN. Select &ldquo;Provide dhcp&rdquo; in the &ldquo;Take action&rdquo; button  and select a suitable Dynamic range. To start with, count one IP per NIC connected to the network</p>
           </div>
         </li>
 

--- a/templates/download/shared/_get_ebook-v1.html
+++ b/templates/download/shared/_get_ebook-v1.html
@@ -16,7 +16,7 @@
       <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
 
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1460">
-        <fieldset>
+        <fieldset style="padding: 0;">
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
               <label for="FirstName" class="mktoLabel ">First name:</label>


### PR DESCRIPTION
## Done

* update /download/cloud/autopilot to vbt

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/download/cloud/autopilot)
- compare to the [design](https://www.dropbox.com/work/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/9.%20Download?preview=download-cloud-autopilot.png) and the [demo](http://www.ubuntu.com-1612-cloud-openstack-autopilot.demo.haus/download/cloud/autopilot)

## Issue / Card

Fixes #1612
