### PR TITLE
Remove left margin and padding from inline-images

### DIFF
--- a/static/sass/_v1_pattern_inline-images.scss
+++ b/static/sass/_v1_pattern_inline-images.scss
@@ -23,6 +23,8 @@
     @extend %clearfix;
     display: block;
     list-style: none; // if list is used as wrapper
+    margin-left: 0;
+    padding-left: 0;
     text-align: center;
 
     &__item {


### PR DESCRIPTION
## Done

Remove left margin and padding from inline-images. This isn’t on live as yet but is on Master via https://github.com/canonical-websites/www.ubuntu.com/commit/1ac6fa8eb49c98dc2231d0dff13a47506675fcc1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/server](http://0.0.0.0:8001/server))
- Make sure that inline logos don’t have left margin or padding

## Screenshots

![screen shot 2017-05-30 at 12 58 15](https://cloud.githubusercontent.com/assets/2152/26582100/b362c71c-4537-11e7-85b8-d53aa98fe079.png)