### PR TITLE
Ensure second last item in nav has border on S screen

### DIFF
--- a/static/sass/_v1_pattern_navigation.scss
+++ b/static/sass/_v1_pattern_navigation.scss
@@ -60,7 +60,8 @@
             border-left: 0;
           }
 
-          &:last-of-type {
+          &:last-of-type,
+          &:nth-last-child(2) {
             border-bottom: 1px solid $color-mid-light;
           }
         }


### PR DESCRIPTION
## Done

Fixed bug where orange line was appearing under 'Support' in S screens in primary nav

Before: 
<img width="526" alt="screen shot 2017-05-30 at 19 01 30" src="https://cloud.githubusercontent.com/assets/505570/26597639/8d9cc720-456a-11e7-9cf5-50cc707704c3.png">

After:
<img width="547" alt="screen shot 2017-05-30 at 19 01 44" src="https://cloud.githubusercontent.com/assets/505570/26597655/981dadea-456a-11e7-95c3-bbeabe5242af.png">

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/))
- Reduce screen to small screen
- Verify that orange line under 'Support' is now gone


## Issue / Card

Fixes #1876 

## Demo

http://www.ubuntu.com-1876-border-bug.demo.haus/about/