### PR TITLE
Update markup for /desktop/snappy

### DIFF
--- a/static/sass/_v1_pattern_lists.scss
+++ b/static/sass/_v1_pattern_lists.scss
@@ -15,6 +15,7 @@
   @include ubuntu-p-is-trisected;
   @include ubuntu-p-is-quartered;
   @include ubuntu-p-nested-counter-lists;
+  @include ubuntu-p-list-imgstack;
 }
 
 @mixin ubuntu-p-is-ticked {
@@ -205,6 +206,15 @@
           content: counters(item, ".") " ";
         }
       }
+    }
+  }
+}
+
+@mixin ubuntu-p-list-imgstack {
+  .p-list--imgstack {
+
+    .p-list__item {
+      margin-bottom: $sp-xx-large;
     }
   }
 }

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -234,3 +234,12 @@ ul.p-list  ul.p-list {
 .p-list-step__bullet {
   padding: .65rem .4rem;
 }
+
+// XXX add margin bottom to code snippets
+.p-code-snippet {
+  margin-bottom: $sp-large;
+
+  & + p {
+    margin-bottom: $sp-small;
+  }
+}

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -236,10 +236,11 @@ ul.p-list  ul.p-list {
 }
 
 // XXX add margin bottom to code snippets
-.p-code-snippet {
+.p-code-snippet,
+pre {
   margin-bottom: $sp-large;
 
-  & + p {
-    margin-bottom: $sp-small;
+  p + & {
+    margin-top: -$sp-small;
   }
 }

--- a/templates/desktop/_nav_secondary-v1.html
+++ b/templates/desktop/_nav_secondary-v1.html
@@ -15,5 +15,5 @@
 
   <li{% if not list_class %} class="p-inline-list__item"><a class="p-inline-list__link {% else %}><a class="{% endif %}{% if level_2 == 'ubuntu-flavours' %} is-active"{% endif %}" href="/desktop/partners">For partners</a></li>
 
-  <li{% if not list_class %} class="p-inline-list__item"><a class="p-inline-list__link {% else %}><a class="{% endif %}{% if level_2 == 'ubuntu-flavours' %} is-active"{% endif %}" href="/desktop/snappy">Snappy</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"><a class="p-inline-list__link {% else %}><a class="{% endif %}{% if level_2 == 'snappy' %} is-active"{% endif %}" href="/desktop/snappy">Snappy</a></li>
 </ul>

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -124,46 +124,48 @@
       <h2>How to use snaps from the command line</h2>
       <p>If you are running Ubuntu 16.04 LTS or later, you can already use snaps from the command line. Otherwise do not despair, we have instructions for <a class="p-link--external" href="http://snapcraft.io/docs/core/install">multiple distros</a>.</p>
 
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo snap list" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
-      </div>
+      <p>To list all snaps installed on your machine:</p>
+
+<pre>
+<code>sudo snap list</code>
+</pre>
 
       <p>To find a snap in the store:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo snap find &lt;text to search&gt;" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
-      </div>
+
+<pre>
+<code>sudo snap find &lt;text to search&gt;</code>
+</pre>
 
       <p>To install a snap:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo snap install &lt;snap name&gt;" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
-      </div>
+
+<pre>
+<code>sudo snap install &lt;snap name&gt;</code>
+</pre>
 
       <p>To update a snap:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo snap refresh &lt;snap name&gt;" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
-      </div>
+
+<pre>
+<code>sudo snap refresh &lt;snap name&gt;</code>
+</pre>
 
       <p>To update all your snaps:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo snap refresh all" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
-      </div>
+
+<pre>
+<code>sudo snap refresh all</code>
+</pre>
 
       <p>To revert a snap to the previously installed version:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo snap revert &lt;snap name&gt;" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
-      </div>
+
+<pre>
+<code>sudo snap revert &lt;snap name&gt;</code>
+</pre>
 
       <p>Or remove the snap:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo snap remove &lt;snap name&gt;" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
-      </div>
+
+<pre>
+<code>sudo snap remove &lt;snap name&gt;</code>
+</pre>
+
     </div>
   </div>
 </div>

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -16,7 +16,7 @@
       <p>Snaps work on any distribution or device. Snaps are faster to install, easier to create, safer to run, and they update automatically and transactionally so your app is always fresh and never broken.</p>
 
       <p>The public collection of snaps includes the latest and best apps from GitHub and beyond, so you have the whole world of Linux apps at your fingertips.</p>
-      <p><a class="p-button--brand" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
+      <p><a class="p-button--brand p-link--external" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
     </div>
     <div class="col-6 prefix-1 suffix-2">
       <ul class="p-list u-hidden--small">
@@ -173,7 +173,7 @@
     <div class="col-8">
       <h2>Creating a snap is easy!</h2>
       <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps
-        to the world. Read how to <a class="external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a>      and on the <a class="external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>
+        to the world. Read how to <a class="p-link--external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="p-link--external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a>      and on the <a class="p-link--external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>
     </div>
   </div>
 </div>

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -11,15 +11,15 @@
 {% block content %}
 <div class="p-strip--grey is-deep is-bordered">
   <div class="row">
-    <div class="col-6">
+    <div class="col-7">
       <h1>A &lsquo;snap&rsquo; is a universal Linux package</h1>
       <p>Snaps work on any distribution or device. Snaps are faster to install, easier to create, safer to run, and they update automatically and transactionally so your app is always fresh and never broken.</p>
 
       <p>The public collection of snaps includes the latest and best apps from GitHub and beyond, so you have the whole world of Linux apps at your fingertips.</p>
       <p><a class="p-button--brand p-link--external" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
     </div>
-    <div class="col-6 prefix-1 suffix-2">
-      <ul class="p-list u-hidden--small">
+    <div class="col-5 prefix-1 suffix-2">
+      <ul class="p-list p-list--imgstack u-hidden--small">
         <li class="p-list__item">
           <img src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" class="inline-logos__image" alt="Intel logo" /></li>
         <li class="p-list__item">

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -1,183 +1,183 @@
-{% extends "cloud/base_cloud.html" %}
+{% extends "cloud/base_cloud-v1.html" %}
 
 {% block title %}Snaps on Ubuntu | Desktop{% endblock %}
 
 {% block meta_description %}Introducing snaps on Ubuntu, the new way to install, update and find apps.{% endblock meta_description %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Desktop" page_title="Snaps on Ubuntu" %}
-</div>
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Desktop" page_title="Snaps on Ubuntu" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero row-grey">
-  <div class="strip-inner-wrapper equal-height">
-    <div class="six-col equal-height__item">
+<div class="p-strip--grey is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
       <h1>A &lsquo;snap&rsquo; is a universal Linux package</h1>
       <p>Snaps work on any distribution or device. Snaps are faster to install, easier to create, safer to run, and they update automatically and transactionally so your app is always fresh and never broken.</p>
 
       <p>The public collection of snaps includes the latest and best apps from GitHub and beyond, so you have the whole world of Linux apps at your fingertips.</p>
-      <p><a class="button--primary" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
+      <p><a class="p-button--brand" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
     </div>
-    <div class="six-col last-col equal-height__item equal-height__align-vertically">
-      <ul class="inline-logos">
-        <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" class="inline-logos__image" alt="Intel logo" /></li>
-        <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}47e40767-power8.png" class="inline-logos__image" alt="POWER logo" /></li>
-        <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}15214c8e-logo-arm.png" alt="ARM logo" /></li>
+    <div class="col-6 prefix-1 suffix-2">
+      <ul class="p-list u-hidden--small">
+        <li class="p-list__item">
+          <img src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" class="inline-logos__image" alt="Intel logo" /></li>
+        <li class="p-list__item">
+          <img src="{{ ASSET_SERVER_URL }}47e40767-power8.png" class="inline-logos__image" alt="POWER logo" /></li>
+        <li class="p-list__item">
+          <img src="{{ ASSET_SERVER_URL }}15214c8e-logo-arm.png" alt="ARM logo" /></li>
       </ul>
     </div>
   </div>
-</section>
+</div>
 
-<section class="row row-white">
-  <div class="strip-inner-wrapper">
-    <div class="wrapper">
-      <div class="seven-col">
-        <h2>Popular snaps</h2>
-        <p>To find snaps you can check out <a class="external" href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a> or just use the command line to install any of these great snaps:</p>
-      </div>
-
-      <ul class="grid-list twelve-col no-bullets no-margin-bottom equal-height">
-        <li class="equal-height__align-vertically grid-list__item four-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}e512b0e2-jenkins.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Jenkins</h3>
-          </div>
-        </li>
-        <li class="equal-height__align-vertically grid-list__item four-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}b3155b2d-Rocket-dot-Chat.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Rocket.Chat</h3>
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Popular snaps</h2>
+      <p>To find snaps you can check out <a class="p-link--external" href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a> or just use the command line to install any of these great snaps:</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <ul class="p-matrix u-clearfix">
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}e512b0e2-jenkins.svg" alt="Jenkins logo">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Jenkins</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col last-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}3ad2e1e3-notes.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Notes</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}b3155b2d-Rocket-dot-Chat.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Rocket.Chat</h3>
           </div>
         </li>
-
-        <li class="equal-height__align-vertically grid-list__item four-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}476aaa77-cassandra.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Cassandra</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}3ad2e1e3-notes.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Notes</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}24badefc-freecad.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Freecad</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}476aaa77-cassandra.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Casandra</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col last-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}aacc8ea7-shout.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Shout</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}24badefc-freecad.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Freecad</h3>
           </div>
         </li>
-
-        <li class="equal-height__align-vertically grid-list__item four-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}de9ddfd4-stellarium.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Stellarium</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}aacc8ea7-shout.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Shout</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}c675c7a0-webdm.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>WebDM</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}de9ddfd4-stellarium.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Stellarium</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col last-col">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}b0f30b97-hangups.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Hangups</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}c675c7a0-webdm.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">WebDM</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col last-row">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}1da2538b-krita.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>Krita</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}b0f30b97-hangups.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Hangups</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col last-row">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}33f5e395-vlc.svg" alt="icon">
-          </div>
-          <div class="three-col last-col">
-            <h3>VLC</h3>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}1da2538b-krita.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Krita</h3>
           </div>
         </li>
-        <li class="equal-height__align-vertically grid-list__item four-col last-col last-row">
-          <div class="one-col ">
-            <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}d4a78a2c-blender.svg" alt="icon">
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}33f5e395-vlc.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">VLC</h3>
           </div>
-          <div class="three-col last-col">
-            <h3>Blender</h3>
+        </li>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}d4a78a2c-blender.svg" alt="icon">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Blender</h3>
           </div>
         </li>
       </ul>
     </div>
   </div>
-</section>
+</div>
 
-<section class="row row-grey">
-  <div class="strip-inner-wrapper">
-    <div class="wrapper">
-      <div class="eight-col">
-        <h2>How to use snaps from the command line</h2>
-        <p>If you are running Ubuntu 16.04 LTS or later, you can already use snaps from the command line. Otherwise do not despair, we have instructions for <a class="external" href="http://snapcraft.io/docs/core/install">multiple distros</a>.</p>
-        <p>To list all snaps installed on your machine:</p>
-        <pre class="command-line code-block"><code>$ sudo snap list</code></pre>
-        <p>To find a snap in the store:</p>
-        <pre class="command-line code-block"><code>$ sudo snap find &lt;text to search&gt;</code></pre>
-        <p>To install a snap:</p>
-        <pre class="command-line code-block"><code>$ sudo snap install &lt;snap name&gt;</code></pre>
-        <p>To update a snap:</p>
-        <pre class="command-line code-block"><code>$ sudo snap refresh &lt;snap name&gt;</code></pre>
-        <p>To update all your snaps:</p>
-        <pre class="command-line code-block"><code>$ sudo snap refresh all</code></pre>
-        <p>To revert a snap to the previously installed  version:</p>
-        <pre class="command-line code-block"><code>$ sudo snap revert &lt;snap name&gt;</code></pre>
-        <p>Or remove the snap:</p>
-        <pre class="command-line code-block"><code>$ sudo snap remove &lt;snap name&gt;</code></pre>
+<div class="p-strip--grey is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>How to use snaps from the command line</h2>
+      <p>If you are running Ubuntu 16.04 LTS or later, you can already use snaps from the command line. Otherwise do not despair, we have instructions for <a class="p-link--external" href="http://snapcraft.io/docs/core/install">multiple distros</a>.</p>
+
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo snap list" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+
+      <p>To find a snap in the store:</p>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo snap find &lt;text to search&gt;" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+
+      <p>To install a snap:</p>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo snap install &lt;snap name&gt;" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+
+      <p>To update a snap:</p>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo snap refresh &lt;snap name&gt;" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+
+      <p>To update all your snaps:</p>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo snap refresh all" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+
+      <p>To revert a snap to the previously installed version:</p>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo snap revert &lt;snap name&gt;" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+
+      <p>Or remove the snap:</p>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo snap remove &lt;snap name&gt;" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
       </div>
     </div>
   </div>
-</section>
+</div>
 
-<section class="row row-white no-border">
-  <div class="strip-inner-wrapper">
-    <div class="wrapper">
-      <div class="eight-col">
-        <h2>Creating a snap is easy!</h2>
-        <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps to the world. Read how to <a class="external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a> and on the <a class="external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>
-      </div>
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Creating a snap is easy!</h2>
+      <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps
+        to the world. Read how to <a class="external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a>      and on the <a class="external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>
     </div>
   </div>
-</section>
+</div>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
+{% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
 
 {% endblock content %}

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -14,9 +14,8 @@
     <div class="col-7">
       <h1>A &lsquo;snap&rsquo; is a universal Linux package</h1>
       <p>Snaps work on any distribution or device. Snaps are faster to install, easier to create, safer to run, and they update automatically and transactionally so your app is always fresh and never broken.</p>
-
       <p>The public collection of snaps includes the latest and best apps from GitHub and beyond, so you have the whole world of Linux apps at your fingertips.</p>
-      <p><a class="p-button--brand p-link--external" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
+      <p><a class="p-button--brand" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
     </div>
     <div class="col-5 prefix-1 suffix-2">
       <ul class="p-list p-list--imgstack u-hidden--small">

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -120,7 +120,7 @@
 
 <div class="p-strip--grey is-bordered">
   <div class="row">
-    <div class="col-8">
+    <div class="col-9">
       <h2>How to use snaps from the command line</h2>
       <p>If you are running Ubuntu 16.04 LTS or later, you can already use snaps from the command line. Otherwise do not despair, we have instructions for <a class="p-link--external" href="http://snapcraft.io/docs/core/install">multiple distros</a>.</p>
 
@@ -170,7 +170,7 @@
 
 <div class="p-strip">
   <div class="row">
-    <div class="col-8">
+    <div class="col-7">
       <h2>Creating a snap is easy!</h2>
       <p>Snaps have a very simple internal structure &mdash; you can easily craft them by hand! But the easiest way to build a snap is with snapcraft, which supports building from source and from existing packages. Snapcraft also handles publishing your snaps
         to the world. Read how to <a class="p-link--external" href="http://snapcraft.io/docs/build-snaps/">create a snap</a> and join the snap crafting community &mdash; we have a fun crowd of people who hang out on <a class="p-link--external" href="https://rocket.ubuntu.com/channel/snapcraft">Rocket Chat</a>      and on the <a class="p-link--external" href="https://forum.snapcraft.io/">snapcraft forum</a>.</p>


### PR DESCRIPTION
## Done

Update markup for /desktop/snappy to VBT

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/snappy](http://0.0.0.0:8001/desktop/snappy)
- Check that page layout matches the [pattern guide](https://www.dropbox.com/home/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/5.%20Desktop?preview=desktop-snappy.png)


## Issue / Card

Fixes #1662 