### PR TITLE
update /internet-of-things/gateways to vbt

### DIFF
--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -59,6 +59,16 @@
   .p-strip--accent {
     @extend %strip--accent;
 
+    a:link,
+    a:visited {
+      color: $color-x-light;
+    }
+
+    .p-link--external {
+      background-image: url('#{$assets-path}0d55fd52-external-link-white.svg');
+      background-size: .85em;
+    }
+
     fieldset {
       background-color: $color-accent;
       border-color: $color-accent;

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -1,164 +1,171 @@
-{% extends "internet-of-things/base_things.html" %}
-
+{% extends "internet-of-things/base_things-v1.html" %}
 {% block title %}Gateways | Ubuntu for the Internet of Things {% endblock %}
-
 {% block meta_description %}Ubuntu Core is the perfect robust, reliable and secure OS host for the edge gateways and it&rsquo;s deployment.{% endblock meta_description %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-    {% include "templates/_nav_breadcrumb.html" with section_title="IoT" page_title="Digital Signage" %}
-</div>
+{% include "templates/_nav_breadcrumb-v1.html" with section_title="IoT" page_title="Digital Signage" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero strip-light">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="seven-col equal-height__item">
-            <h1>IoT gateways on Ubuntu</h1>
-            <div class="seven-col for-small align-center" style="padding-top: 1em;">
-                <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="300" alt="" />
-            </div>
-            <p>From industrial automation and building control to transportation and healthcare, gateways connect sensors and actuators to clouds while providing edge analytics and intelligence. Offload decision making to the gateway to ensure continuity and low-latency, and reduce the cost of backhaul for low-value data.</p>
-            <p>Ubuntu Core offers a secure, reliable and remotely upgradeable platform for intelligent edge devices.</p>
-        </div>
-        <div class="equal-height__item equal-height__align-vertically five-col last-col align-center not-for-small">
-            <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" alt="" />
-        </div>
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="u-equal-height">
+    <div class="col-7 suffix-1">
+      <h1>IoT gateways on Ubuntu</h1>
+      <div class="col-7 u-hidden--medium u-hidden--large u-align--center" style="padding-top: 1em;">
+        <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="300" alt="" />
+      </div>
+      <p>From industrial automation and building control to transportation and healthcare, gateways connect sensors and actuators to clouds while providing edge analytics and intelligence. Offload decision making to the gateway to ensure continuity and low-latency, and reduce the cost of backhaul for low-value data.</p>
+      <p>Ubuntu Core offers a secure, reliable and remotely upgradeable platform for intelligent edge devices.</p>
     </div>
-</section>
+    <div class="u-vertically-center col-5 u-align--center u-hidden--small">
+      <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" alt="" />
+    </div>
+  </div>
+</div>
+</div>
 
-<section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <h2>Webinars and case studies</h2>
-        <ul class="no-bullets equal-height--vertical-divider">
-            <li class="four-col equal-height--vertical-divider__item">
-                <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png?h=75" alt="" />
-                <p>Azeti uses Ubuntu Core to improve deployment operations and security for a wide range of industries.</p>
-                <p><a class="external" href="https://pages.ubuntu.com/AzetiCS.html?utm_campaign=Device_FY17_IOT&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=azeticasestudy">Read the case study</a></p>
-            </li>
-            <li class="four-col equal-height--vertical-divider__item">
-                <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png?h=75" alt="" />
-                <p>Watch CloudPlugs define Industry 4.0, the convergence of information and operations.</p>
-                <p><a class="external" href="https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs">Watch the webinar</a></p>
-            </li>
-            <li class="four-col last-col equal-height--vertical-divider__item no-margin-bottom">
-                <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg?h=75" alt="" />
-                <p>The Eclipse IoT Working Group outlines the three software stacks required for IoT.</p>
-                <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&amp;amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=eclipsewhitepaper">Read the white paper</a></p>
-            </li>
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Webinars and case studies</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png?h=75" alt="" />
+      <p>Azeti uses Ubuntu Core to improve deployment operations and security for a wide range of industries.</p>
+      <p><a class="p-link--external" href="https://pages.ubuntu.com/AzetiCS.html?utm_campaign=Device_FY17_IOT&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=azeticasestudy">Read the case study</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png?h=75" alt="" />
+      <p>Watch CloudPlugs define Industry 4.0, the convergence of information and operations.</p>
+      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs">Watch the webinar</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg?h=75" alt="" />
+      <p>The Eclipse IoT Working Group outlines the three software stacks required for IoT.</p>
+      <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&amp;amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=eclipsewhitepaper">Read the white paper</a></p>
+    </div>
+  </div>
+</div>
+</div>
+
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">IoT gateway partners on Ubuntu Core</h2>
+      </div>
+      </div>
+      <div class="row">
+      <div class="col-12">
+      <ul id="edge-gateway-partners" class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Edge%20Gateway" limit=10 as edge_gateway_partners %}
+        {% for partner in edge_gateway_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=edge-gateway" class="p-link--external">See all of our gateway partners</a></p>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <ul class="p-matrix is-trisected">
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title">Cost effective</h3>
+            <p class="p-matrix__desc">Multiple applications can run on the same hardware, with strict app confinement. Replace three  devices controlling light, AC and power with a single more flexible device.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title">Secure and reliable</h3>
+            <p class="p-matrix__desc">Transactional updates guarantee failsafe upgrades making sure your equipment stays secure. Regular and reliable updates ensure healthy ecosystems and regulatory compliance.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title">Multi-protocol support</h3>
+            <p class="p-matrix__desc">Use any of the libraries and code available for Ubuntu. Build the apps you need for your edge gateways, with Modbus, CAN, Zigbee, COAP or in the cloud  MQTT, AMQP.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title">Edge intelligence</h3>
+            <p class="p-matrix__desc">From video surveillance to neural networks, Ubuntu Core enables complex operations at the edge of the network. Use apps on gateways for lower latency, saving you the cost of network and cloud storage.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title">Diverse hardware</h3>
+            <p class="p-matrix__desc">From ARM to Intel, there is a board that suits your next device. Prototype quickly, then go straight to production with standard reference modules and a standard Linux platform.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title">Easy integration</h3>
+            <p class="p-matrix__desc">It&rsquo;s easy and fast to create and distribute applications for edge gateways. Ubuntu Core devices come with an app store and update mechanism included.</p>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+  </div>
+
+  <div class="p-strip is-deep">
+    <div class="row">
+      <div class="prepend-two col-12">
+        <h2 class="muted-heading">Software innovation for every industry</h2>
+        <ul class="p-inline-images no-margin">
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png" alt="CloudPlugs">
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png" alt="Azeti">
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg" alt="Eclipse">
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}518c2d91-partner-logo-evrythng.png" alt="Evrything">
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e8b58fdd-partner-logo-device-hive.png" alt="Device Hive">
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4b614123-nexiona_logo.png" alt="Nexiona">
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}c43b0c65-KNX_logo.svg" alt="KNX">
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}33c9b8cb-partner-logo-emutex.png" alt="Emutex">
+          </li>
         </ul>
+      </div>
     </div>
-</section>
+  </div>
 
-<section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col">
-            <h2 class="muted-heading">IoT gateway partners on Ubuntu Core</h2>
-            <ul id="edge-gateway-partners" class="inline-logos no-margin dynamic-logos">
-                {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Edge%20Gateway" limit=10 as edge_gateway_partners %}
-                {% for partner in edge_gateway_partners %}
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-                </li>
-                {% endfor %}
-            </ul>
-            <p class="align-center"><a href="http://partners.ubuntu.com/find-a-partner?technology=edge-gateway" class="external">See all of our gateway partners</a></p>
-        </div>
+  <div class="p-strip--accent is-deep">
+    <div class="row p-divider">
+      <div class="col-6 p-divider__block">
+        <h2>Enterprise peace of mind</h2>
+        <p>Canonical works with OEMs to deliver Ubuntu certified Edge Gateways. You can be sure Ubuntu Core will run out of the box with all the tools you require to manage and deploy software across all your devices.</p>
+        <p><a href="/internet-of-things/contact-us?product=gateways">Contact us to find out&nbsp;more&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-6 p-divider__block">
+        <h2>Simple development and distribution for ISVs and SIs</h2>
+        <p>Independent software vendors and system integrators develop with the familiar environment and use the wealth of libraries available in Ubuntu. With Ubuntu Core you can easily manage the  software you distribute. Use the Ubuntu Store to reach new customers.</p>
+        <p><a class="p-link--external" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
+      </div>
     </div>
-</section>
+  </div>
 
-<section class="row no-border">
-    <div class="strip-inner-wrapper">
-        <ul class="grid-list twelve-col no-bullets">
-            <li class="grid-list__item four-col">
-                <div class="grid-list__description four-col">
-                    <h3>Cost effective</h3>
-                    <p>Multiple applications can run on the same hardware, with strict app confinement. Replace three  devices controlling light, AC and power with a single more flexible device.</p>
-                </div>
-            </li>
-            <li class="grid-list__item four-col">
-                <div class="grid-list__description four-col">
-                    <h3>Secure and reliable</h3>
-                    <p>Transactional updates guarantee failsafe upgrades making sure your equipment stays secure. Regular and reliable updates ensure healthy ecosystems and regulatory compliance.</p>
-                </div>
-            </li>
-            <li class="grid-list__item four-col last-col">
-                <div class="grid-list__description four-col">
-                    <h3>Multi-protocol support</h3>
-                    <p>Use any of the libraries and code available for Ubuntu. Build the apps you need for your edge gateways, with Modbus, CAN, Zigbee, COAP or in the cloud  MQTT, AMQP.</p>
-                </div>
-            </li>
-            <li class="grid-list__item last-row four-col">
-                <div class="grid-list__description four-col">
-                    <h3>Edge intelligence</h3>
-                    <p>From video surveillance to neural networks, Ubuntu Core enables complex operations at the edge of the network. Use apps on gateways for lower latency, saving you the cost of network and cloud storage.</p>
-                </div>
-            </li>
-            <li class="grid-list__item last-row four-col">
-                <div class="grid-list__description four-col">
-                    <h3>Diverse hardware</h3>
-                    <p>From ARM to Intel, there is a board that suits your next device. Prototype quickly, then go straight to production with standard reference modules and a standard Linux platform.</p>
-                </div>
-            </li>
-            <li class="grid-list__item last-row four-col last-col">
-                <div class="grid-list__description four-col">
-                    <h3>Easy integration</h3>
-                    <p>It&rsquo;s easy and fast to create and distribute applications for edge gateways. Ubuntu Core devices come with an app store and update mechanism included.</p>
-                </div>
-            </li>
-        </ul>
-    </div>
-</section>
+  {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
 
-<section class="row strip-light no-border">
-    <div class="strip-inner-wrapper">
-        <div class="prepend-two eight-col">
-            <h2 class="muted-heading">Software innovation for every industry</h2>
-            <ul class="inline-logos no-margin">
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png" alt="CloudPlugs">
-                </li>
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png" alt="Azeti">
-                </li>
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg" alt="Eclipse">
-                </li>
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}518c2d91-partner-logo-evrythng.png" alt="Evrything">
-                </li>
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}e8b58fdd-partner-logo-device-hive.png" alt="Device Hive">
-                </li>
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}4b614123-nexiona_logo.png" alt="Nexiona">
-                </li>
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}c43b0c65-KNX_logo.svg" alt="KNX">
-                </li>
-                <li class="inline-logos__item">
-                    <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}33c9b8cb-partner-logo-emutex.png" alt="Emutex">
-                </li>
-            </ul>
-        </div>
-    </div>
-</section>
-
-<section class="row strip-dark no-border">
-    <div class="strip-inner-wrapper equal-height--vertical-divider">
-        <div class="six-col equal-height--vertical-divider__item no-margin-bottom">
-            <h2>Enterprise peace of mind</h2>
-            <p>Canonical works with OEMs to deliver Ubuntu certified Edge Gateways. You can be sure Ubuntu Core will run out of the box with all the tools you require to manage and deploy software across all your devices.</p>
-            <p><a href="/internet-of-things/contact-us?product=gateways">Contact us to find out&nbsp;more&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="six-col last-col equal-height--vertical-divider__item no-margin-bottom">
-            <h2>Simple development and distribution for ISVs and SIs</h2>
-            <p>Independent software vendors and system integrators develop with the familiar environment and use the wealth of libraries available in Ubuntu. With Ubuntu Core you can easily manage the  software you distribute. Use the Ubuntu Store to reach new customers.</p>
-            <p><a class="external" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
-        </div>
-    </div>
-</section>
-
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
-
-{% endblock content %}
+  {% endblock content %}

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -23,7 +23,6 @@
     </div>
   </div>
 </div>
-</div>
 
 <div class="p-strip is-deep is-bordered">
   <div class="row">

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -7,19 +7,21 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
+
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="u-equal-height">
-    <div class="col-7 suffix-1">
-      <h1>IoT gateways on Ubuntu</h1>
-      <div class="col-7 u-hidden--medium u-hidden--large u-align--center" style="padding-top: 1em;">
-        <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="300" alt="" />
+      <div class="col-7 suffix-1">
+        <h1>IoT gateways on Ubuntu</h1>
+        <div class="col-7 u-hidden--medium u-hidden--large u-align--center" style="padding-top: 1em;">
+          <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="300" alt="" />
+        </div>
+        <p>From industrial automation and building control to transportation and healthcare, gateways connect sensors and actuators to clouds while providing edge analytics and intelligence. Offload decision making to the gateway to ensure continuity and low-latency, and reduce the cost of backhaul for low-value data.</p>
+        <p>Ubuntu Core offers a secure, reliable and remotely upgradeable platform for intelligent edge devices.</p>
       </div>
-      <p>From industrial automation and building control to transportation and healthcare, gateways connect sensors and actuators to clouds while providing edge analytics and intelligence. Offload decision making to the gateway to ensure continuity and low-latency, and reduce the cost of backhaul for low-value data.</p>
-      <p>Ubuntu Core offers a secure, reliable and remotely upgradeable platform for intelligent edge devices.</p>
-    </div>
-    <div class="u-vertically-center col-5 u-align--center u-hidden--small">
-      <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" alt="" />
+      <div class="u-vertically-center col-5 u-align--center u-hidden--small">
+        <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" alt="" />
+      </div>
     </div>
   </div>
 </div>
@@ -48,19 +50,17 @@
     </div>
   </div>
 </div>
-</div>
 
 <div class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
       <h2 class="p-heading--muted u-align--center">IoT gateway partners on Ubuntu Core</h2>
-      </div>
-      </div>
-      <div class="row">
-      <div class="col-12">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
       <ul id="edge-gateway-partners" class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Edge%20Gateway" limit=10 as edge_gateway_partners %}
-        {% for partner in edge_gateway_partners %}
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Edge%20Gateway" limit=10 as edge_gateway_partners %} {% for partner in edge_gateway_partners %}
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
         </li>
@@ -78,7 +78,7 @@
         <li class="p-matrix__item">
           <div>
             <h3 class="p-matrix__title">Cost effective</h3>
-            <p class="p-matrix__desc">Multiple applications can run on the same hardware, with strict app confinement. Replace three  devices controlling light, AC and power with a single more flexible device.</p>
+            <p class="p-matrix__desc">Multiple applications can run on the same hardware, with strict app confinement. Replace three devices controlling light, AC and power with a single more flexible device.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -90,7 +90,7 @@
         <li class="p-matrix__item">
           <div>
             <h3 class="p-matrix__title">Multi-protocol support</h3>
-            <p class="p-matrix__desc">Use any of the libraries and code available for Ubuntu. Build the apps you need for your edge gateways, with Modbus, CAN, Zigbee, COAP or in the cloud  MQTT, AMQP.</p>
+            <p class="p-matrix__desc">Use any of the libraries and code available for Ubuntu. Build the apps you need for your edge gateways, with Modbus, CAN, Zigbee, COAP or in the cloud MQTT, AMQP.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -114,57 +114,55 @@
       </ul>
     </div>
   </div>
-  </div>
+</div>
 
-  <div class="p-strip is-deep">
-    <div class="row">
-      <div class="prepend-two col-12">
-        <h2 class="muted-heading">Software innovation for every industry</h2>
-        <ul class="p-inline-images no-margin">
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png" alt="CloudPlugs">
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png" alt="Azeti">
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg" alt="Eclipse">
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}518c2d91-partner-logo-evrythng.png" alt="Evrything">
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e8b58fdd-partner-logo-device-hive.png" alt="Device Hive">
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4b614123-nexiona_logo.png" alt="Nexiona">
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}c43b0c65-KNX_logo.svg" alt="KNX">
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}33c9b8cb-partner-logo-emutex.png" alt="Emutex">
-          </li>
-        </ul>
-      </div>
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="prepend-two col-12">
+      <h2 class="muted-heading">Software innovation for every industry</h2>
+      <ul class="p-inline-images no-margin">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png" alt="CloudPlugs">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png" alt="Azeti">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg" alt="Eclipse">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}518c2d91-partner-logo-evrythng.png" alt="Evrything">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e8b58fdd-partner-logo-device-hive.png" alt="Device Hive">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4b614123-nexiona_logo.png" alt="Nexiona">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}c43b0c65-KNX_logo.svg" alt="KNX">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}33c9b8cb-partner-logo-emutex.png" alt="Emutex">
+        </li>
+      </ul>
     </div>
   </div>
+</div>
 
-  <div class="p-strip--accent is-deep">
-    <div class="row p-divider">
-      <div class="col-6 p-divider__block">
-        <h2>Enterprise peace of mind</h2>
-        <p>Canonical works with OEMs to deliver Ubuntu certified Edge Gateways. You can be sure Ubuntu Core will run out of the box with all the tools you require to manage and deploy software across all your devices.</p>
-        <p><a href="/internet-of-things/contact-us?product=gateways">Contact us to find out&nbsp;more&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-6 p-divider__block">
-        <h2>Simple development and distribution for ISVs and SIs</h2>
-        <p>Independent software vendors and system integrators develop with the familiar environment and use the wealth of libraries available in Ubuntu. With Ubuntu Core you can easily manage the  software you distribute. Use the Ubuntu Store to reach new customers.</p>
-        <p><a class="p-link--external" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
-      </div>
+<div class="p-strip--accent is-deep">
+  <div class="row p-divider">
+    <div class="col-6 p-divider__block">
+      <h2>Enterprise peace of mind</h2>
+      <p>Canonical works with OEMs to deliver Ubuntu certified Edge Gateways. You can be sure Ubuntu Core will run out of the box with all the tools you require to manage and deploy software across all your devices.</p>
+      <p><a href="/internet-of-things/contact-us?product=gateways">Contact us to find out&nbsp;more&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 p-divider__block">
+      <h2>Simple development and distribution for ISVs and SIs</h2>
+      <p>Independent software vendors and system integrators develop with the familiar environment and use the wealth of libraries available in Ubuntu. With Ubuntu Core you can easily manage the software you distribute. Use the Ubuntu Store to reach new customers.</p>
+      <p><a class="p-link--external" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
     </div>
   </div>
+</div>
 
-  {% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
-
-  {% endblock content %}
+{% include "shared-v1/contextual_footers/_contextual_footer.html" with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %} {% endblock content %}

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<div class="p-strip is-deep is-bordered">
+<section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="u-equal-height">
       <div class="col-7 suffix-1">
@@ -24,9 +24,9 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-deep is-bordered">
+<section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>Webinars and case studies</h2>
@@ -49,9 +49,9 @@
       <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&amp;amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=eclipsewhitepaper">Read the white paper</a></p>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
       <h2 class="p-heading--muted u-align--center">IoT gateway partners on Ubuntu Core</h2>
@@ -69,9 +69,9 @@
       <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=edge-gateway" class="p-link--external">See all of our gateway partners</a></p>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip--light is-deep is-bordered">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
       <ul class="p-matrix is-trisected">
@@ -114,9 +114,9 @@
       </ul>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-deep">
+<section class="p-strip is-deep">
   <div class="row">
     <div class="prepend-two col-12">
       <h2 class="muted-heading">Software innovation for every industry</h2>
@@ -148,9 +148,9 @@
       </ul>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip--accent is-deep">
+<section class="p-strip--accent is-deep">
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h2>Enterprise peace of mind</h2>
@@ -163,6 +163,6 @@
       <p><a class="p-link--external" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
     </div>
   </div>
-</div>
+</section>
 
 {% include "shared-v1/contextual_footers/_contextual_footer.html" with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %} {% endblock content %}


### PR DESCRIPTION
## Done

* update /internet-of-things/gateways to vbt
* made p-strip—accent links white per @yaili’s design

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/internet-of-things/gateways)
- compare to the [design](https://www.dropbox.com/work/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/7.%20IoT?preview=iot-gateways.png) and the [demo](http://www.ubuntu.com-1594-internet-of-things-gateways.demo.haus/internet-of-things/gateways)


## Issue / Card

Fixes #1594

