### PR TITLE
Remove u-vertical-spaced from contextual footers.

### DIFF
--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -85,10 +85,3 @@
     }
   }
 }
-
-@mixin ubuntu-p-strip--x-light {
-  .p-strip--x-light {
-    @include strip;
-    background-color: $color-x-light;
-  }
-}

--- a/templates/shared-v1/contextual_footers/_contextual_footer.html
+++ b/templates/shared-v1/contextual_footers/_contextual_footer.html
@@ -1,6 +1,6 @@
 <div class="p-strip--x-light contextual-footer">
   <div class="row">
-    <div class="p-divider u-vertically-spaced">
+    <div class="p-divider">
       {% if first_item %}
         {% with "shared-v1/contextual_footers/"|add:first_item|add:".html" as item_file %} {% include item_file %} {% endwith %}
       {% endif %}


### PR DESCRIPTION
## Done

Removed u-vertically-spaced from the contextual footer template on pages migrated to VBT.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support](http://0.0.0.0:8001/support))
- See the reduced padding in the contextual footer.


## Issue / Card

Fixes #1865 