### PR TITLE
update error pages to vbt

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,19 +1,19 @@
 {% extends "templates/one-column.html" %}
-
 {% block title %}404 Page not found{% endblock %}
-
 {% block extra_body_class %}error-page error404{% endblock %}
 
-{% block head_extra %}{% endblock %}
-
 {% block content %}
-<div class="row no-border hero-box">
-	<div class="six-col">
-		<img src="{{ ASSET_SERVER_URL }}bcdcf2c8-image-404.svg" alt="Error owl" width="365" />
-	</div>
-	<div class="six-col last-col">
-		<h1>404: Page not found.</h1>
-		<p>Sorry, we couldn&rsquo;t find that page.</p>
-	</div>
-</div><!-- / .row -->
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 u-vertically-center u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}bcdcf2c8-image-404.svg?w=365" alt="Error owl" width="365" />
+      </div>
+      <div class="col-6" style="padding-top: 10rem;">
+        <h1>404: Page not found</h1>
+        <p class="p-heading--four">Sorry, we couldn&rsquo;t find that page.</p>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
-{% block title %}404 Page not found{% endblock %}
+{% block title %}404: Page not found{% endblock %}
 {% block extra_body_class %}error-page error404{% endblock %}
+{% block second_level_nav %}{% endblock second_level_nav %}
 
 {% block content %}
 <div class="p-strip is-deep">
@@ -9,9 +10,11 @@
       <div class="col-6 u-vertically-center u-align--center">
         <img src="{{ ASSET_SERVER_URL }}bcdcf2c8-image-404.svg?w=365" alt="Error owl" width="365" />
       </div>
-      <div class="col-6" style="padding-top: 10rem;">
-        <h1>404: Page not found</h1>
-        <p class="p-heading--four">Sorry, we couldn&rsquo;t find that page.</p>
+      <div class="col-6 u-vertically-center">
+        <div>
+          <h1>404: Page not found</h1>
+          <p class="p-heading--four">Sorry, we couldn&rsquo;t find that page.</p>
+        </div>
       </div>
     </div>
   </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,18 +1,19 @@
 {% extends "templates/one-column.html" %}
-
-{% block title %}Server error{% endblock %}
-
+{% block title %}500 Server error{% endblock %}
 {% block extra_body_class %}error-page error500{% endblock %}
 
 {% block content %}
-<div class="row no-border hero-box">
-	<div class="six-col">
-		<img src="https://assets.ubuntu.com/v1/17a02192-image-knowledge-365.png" alt='Error "a owl"' />
-		<span>!</span>
-	</div>
-	<div class="six-col last-col">
-		<h1>500: Server error.</h1>
-		<p>Something's gone wrong, try reloading.</p>
-	</div>
-</div><!-- / .row -->
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 u-vertically-center u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}bcdcf2c8-image-404.svg?w=365" alt="Error owl" width="365" />
+      </div>
+      <div class="col-6" style="padding-top: 10rem;">
+        <h1>500: Server error</h1>
+        <p class="p-heading--four">Something&rsquo;s gone wrong, try reloading.</p>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
-{% block title %}500 Server error{% endblock %}
+{% block title %}500: Server error{% endblock %}
 {% block extra_body_class %}error-page error500{% endblock %}
+{% block second_level_nav %}{% endblock second_level_nav %}
 
 {% block content %}
 <div class="p-strip is-deep">
@@ -9,9 +10,11 @@
       <div class="col-6 u-vertically-center u-align--center">
         <img src="{{ ASSET_SERVER_URL }}bcdcf2c8-image-404.svg?w=365" alt="Error owl" width="365" />
       </div>
-      <div class="col-6" style="padding-top: 10rem;">
-        <h1>500: Server error</h1>
-        <p class="p-heading--four">Something&rsquo;s gone wrong, try reloading.</p>
+      <div class="col-6 u-vertically-center">
+        <div>
+          <h1>500: Server error</h1>
+          <p class="p-heading--four">Something&rsquo;s gone wrong, try reloading.</p>
+        </div>
       </div>
     </div>
   </div>

--- a/templates/templates/one-column.html
+++ b/templates/templates/one-column.html
@@ -1,4 +1,4 @@
-{% extends "templates/base.html" %}
+{% extends "templates/base-v1.html" %}
 
 {% block outer_content %}
     {% block content %}{% endblock %}

--- a/templates/templates/one-column.html
+++ b/templates/templates/one-column.html
@@ -1,5 +1,5 @@
 {% extends "templates/base-v1.html" %}
 
 {% block outer_content %}
-    {% block content %}{% endblock %}
+  {% block content %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Demo

* update 404 and 500 error pages to vbt
* made the technically complicated 500 page look like the 400 page
* @yaili perhaps we want an image version with a ‘!’ for the 500?

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [404 page](http://0.0.0.0:8001/404) and [400 page](http://0.0.0.0:8001/500)
- compare to the [design](https://www.dropbox.com/work/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/13.%20Misc?preview=error-404.png) and [demo - 404](http://www.ubuntu.com-pr-1896.run.demo.haus/404) and [demo -500](http://www.ubuntu.com-pr-1896.run.demo.haus/500)

## Issue / Card

Fixes #1575 and #1574

## Screenshot

404 - 
![image](https://cloud.githubusercontent.com/assets/441217/26747319/d4d436c6-47ec-11e7-8bc6-e6ea7a4fa978.png)

500 - 
![image](https://cloud.githubusercontent.com/assets/441217/26747327/e2d3c296-47ec-11e7-82e1-1a4193878726.png)
