### PR TITLE
1610 cloud newsletter thank you

### DIFF
--- a/templates/cloud/_nav_tertiary-v1.html
+++ b/templates/cloud/_nav_tertiary-v1.html
@@ -1,3 +1,4 @@
+{% if level_3 %}
 <ul class="p-inline-list nav-tertiary__menu">
   {% if level_2 == 'openstack' and not level_4 %}
   <li class="p-inline-list__item"><a{% if level_3 == 'autopilot'%} class="is-active"{% endif %} href="/cloud/openstack/autopilot">Autopilot</a></li>
@@ -21,3 +22,4 @@
   <li class="p-inline-list__item"><a {% if level_4 == 'contact-us' %} class="is-active"{% endif %} href="/{{level_1}}/{{level_2}}/{{level_3}}/{{level_4}}">Contact us</a></li>
   {% endif %}
 </ul>
+{% endif %}

--- a/templates/cloud/newsletter-thank-you.html
+++ b/templates/cloud/newsletter-thank-you.html
@@ -1,28 +1,13 @@
-{% extends "cloud/base_cloud.html" %}
-
+{% extends "cloud/base_cloud-v1.html" %}
 {% block extra_body_class %}cloud-thank-you{% endblock %}
-
 {% block title %}Thank you{% endblock %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Cloud" subsection_title="Newsletter" page_title="Thank you" tertiary="true" %}
-</div>
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Cloud" subsection_title="Newsletter" page_title="Thank you" tertiary="true" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero no-border strip-light">
-  <div class="strip-inner-wrapper">
-    <div class="equal-height">
-      <div class="thank-you eight-col equal-height__item">
-        <h1>Thank you for subscribing!</h1>
-        <p class="intro">You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.</p>
-      </div>
-      <div class="four-col last-col equal-height__item equal-height__align-vertically">
-        <img src="{{ ASSET_SERVER_URL }}52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
-      </div>
-    </div>
-  </div>
-</section><!-- /.row-hero -->
-{% include "shared/_thank_you_footer.html" %}
+
+{% include "shared-v1/_thank_you.html" with thanks_context="subscribing!" thanks_message="You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email." %}
+
 {% endblock content %}

--- a/templates/shared-v1/_thank_you.html
+++ b/templates/shared-v1/_thank_you.html
@@ -3,7 +3,7 @@
     <div class="u-equal-height">
       <div class="col-7">
         <h1>Thank you for {{ thanks_context }}</h1>
-        <p class="p-heading--four">A member of our team will be in touch {{ details }}within one working day</p>
+        <p class="p-heading--four">{% if thanks_message %}{{ thanks_message }}{% else %}A member of our team will be in touch {{ details }}within one working day{% endif %}</p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />


### PR DESCRIPTION
## Done

* update /cloud/newsletter-thank-you to vbt
* extended thank-you partial to have a message
* made 3rd level nav only appear when there was level_3 to remove stray > in cloud section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/cloud/newsletter-thank-you)

## Issue / Card

Fixes #1610