### PR TITLE
1615 cloud plans and pricing

### DIFF
--- a/static/sass/_v1_pattern_hero.scss
+++ b/static/sass/_v1_pattern_hero.scss
@@ -8,7 +8,6 @@
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    color: $color-x-light;
     margin-top: 0;
     padding-bottom: 5.625rem;
     padding-top: 5.625rem;

--- a/static/sass/_v1_pattern_matrix.scss
+++ b/static/sass/_v1_pattern_matrix.scss
@@ -1,0 +1,98 @@
+// List Grid
+@mixin ubuntu-p-matrix {
+  @include vf-p-matrix;
+  .p-matrix {
+
+    // undo
+    &__item {
+      @media (min-width: $breakpoint-small) {
+        border: 0;
+        width: 100%;
+      }
+    }
+
+    &.is-split {
+      .p-matrix__item {
+        @media (min-width: $breakpoint-small) {
+          width: calc(50% - .666666rem);
+
+          &:nth-child(-n+1) {
+            border-top: 0;
+          }
+
+          &:nth-child(n+1) {
+            border-right: 1px dotted $color-mid-dark;
+            padding-right: $sp-medium;
+          }
+
+          &:nth-child(n+3) {
+            border-top: 1px dotted $color-mid-dark;
+          }
+
+          &:nth-child(2n) {
+            border-right: 0;
+            padding-right: 0;
+          }
+        }
+      }
+    }
+
+    &.is-trisected {
+      .p-matrix__item {
+
+        @media (min-width: $breakpoint-small) {
+          width: calc(33.333% - .666666rem);
+
+          &:nth-child(-n+3) {
+            border-top: 0;
+          }
+
+          &:nth-child(n) {
+            border-bottom: 1px dotted $color-mid-dark;
+            border-right: 1px dotted $color-mid-dark;
+            padding-right: $sp-medium;
+          }
+
+          &:nth-child(3n+1):nth-last-child(-n+3),
+          &:nth-child(3n+1):nth-last-child(-n+3) ~ li {
+            border-bottom: 0;
+          }
+
+          &:nth-child(3n) {
+            border-right: 0;
+            padding-right: 0;
+          }
+        }
+      }
+    }
+
+
+    &.is-quartered {
+      .p-matrix__item {
+        @media (min-width: $breakpoint-small) {
+          width: calc(25% - .666666rem);
+
+          &:nth-child(-n+4) {
+            border-top: 0;
+          }
+
+          &:nth-child(n) {
+            border-bottom: 1px dotted $color-mid-dark;
+            border-right: 1px dotted $color-mid-dark;
+            padding-right: $sp-medium;
+          }
+
+          &:nth-child(4n+1):nth-last-child(-n+4),
+          &:nth-child(4n+1):nth-last-child(-n+4) ~ li {
+            border-bottom: 0;
+          }
+
+          &:nth-child(4n) {
+            border-right: 0;
+            padding-right: 0;
+          }
+        }
+      }
+    }
+  }
+}

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -28,6 +28,7 @@
 @import 'v1_pattern_hero';
 @import 'v1_pattern_pull_quotes';
 @import 'v1_utility_full-width';
+@import 'v1_pattern_matrix';
 
 @include ubuntu-p-site-search;
 @include ubuntu-p-navigation;
@@ -43,6 +44,7 @@
 @include ubuntu-p-hero;
 @include ubuntu-p-pull-quote;
 @include ubuntu-u-full-width;
+@include ubuntu-p-matrix;
 
 // **************************
 // Bug fixes

--- a/templates/cloud/_nav_secondary-v1.html
+++ b/templates/cloud/_nav_secondary-v1.html
@@ -1,11 +1,11 @@
-<ul class="{% if list_class %}{{ list_class }}{% endif %} hover-menu">
-    <li><a{% if level_1 == 'cloud' and not level_2 %} class="is-active"{% endif %} href="/cloud">Overview</a></li>
-    <li><a{% if level_2 == 'openstack' %} class="is-active"{% endif %} href="/cloud/openstack">OpenStack</a></li>
-    <li><a{% if level_2 == 'managed-cloud' %} class="is-active"{% endif %} href="/cloud/managed-cloud">Managed cloud</a></li>
-    <li><a{% if level_2 == 'public-cloud' %} class="is-active"{% endif %} href="/cloud/public-cloud">Public cloud</a></li>
-    <li><a{% if level_2 == 'juju' %} class="is-active"{% endif %} href="/cloud/juju">Juju</a></li>
-    <li><a{% if level_2 == 'storage' %} class="is-active"{% endif %} href="/cloud/storage">Storage</a></li>
-    <li><a{% if level_2 == 'partners' %} class="is-active"{% endif %} href="/cloud/partners">Partners</a></li>
-    <li><a{% if level_2 == 'training' %} class="is-active"{% endif %} href="/cloud/training">Training</a></li>
-    <li><a class="last-item{% if level_2 == 'plans-and-pricing' %} is-active{% endif %}" href="/cloud/plans-and-pricing">Plans and pricing</a></li>
+<ul class="{% if list_class %}{{ list_class }}{% else %}nav-secondary__menu p-inline-list{% endif %}">
+  <li{% if not list_class %}{% if not list_class %} class="p-inline-list__item"{% endif %}{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_1 == 'cloud' and not level_2 %} is-active{% endif %}" href="/cloud">Overview</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'openstack' %} is-active{% endif %}" href="/cloud/openstack">OpenStack</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'managed-cloud' %} is-active{% endif %}" href="/cloud/managed-cloud">Managed cloud</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'public-cloud' %} is-active{% endif %}" href="/cloud/public-cloud">Public cloud</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'juju' %} is-active{% endif %}" href="/cloud/juju">Juju</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'storage' %} is-active{% endif %}" href="/cloud/storage">Storage</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'partners' %} is-active{% endif %}" href="/cloud/partners">Partners</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'training' %} is-active{% endif %}" href="/cloud/training">Training</a></li>
+  <li{% if not list_class %} class="p-inline-list__item"{% endif %}><a class="{% if not list_class %}p-inline-list__link {% endif %}{% if level_2 == 'plans-and-pricing' %} is-active{% endif %}" href="/cloud/plans-and-pricing">Plans and pricing</a></li>
 </ul>

--- a/templates/cloud/_nav_tertiary-v1.html
+++ b/templates/cloud/_nav_tertiary-v1.html
@@ -1,23 +1,23 @@
-<ul class="third-level-nav">
-    {% if level_2 == 'openstack' and not level_4 %}
-    <li><a{% if level_3 == 'autopilot'%} class="is-active"{% endif %} href="/cloud/openstack/autopilot">Autopilot</a></li>
-    {% endif %}
-    {% if level_3 == 'managed-cloud' and level_4 %}
-    <li><a href="/{{level_1}}/{{level_2}}/{{level_3}}">Managed cloud</a></li>
-    {% endif %}
-    {% if level_3 == 'autopilot' and level_4 %}
-    <li><a href="/{{level_1}}/{{level_2}}/{{level_3}}">Autopilot</a></li>
-    {% endif %}
-    {% if 'thank-you' in level_3 %}
-    <li><a{% if level_3 == 'thank-you' %} class="is-active"{% endif %}href="/{{level_1}}/{{level_2}}/{{level_3}}">Thank you</a></li>
-    {% endif %}
-    {% if 'contact-us' in level_3 %}
-    <li><a {% if level_3 == 'contact-us' %} class="is-active"{% endif %} href="/{{level_1}}/{{level_2}}/{{level_3}}">Contact us</a></li>
-    {% endif %}
-    {% if 'thank-you' in level_4 %}
-    <li><a{% if level_4 == 'thank-you' %} class="is-active"{% endif %}href="/{{level_1}}/{{level_2}}/{{level_3}}/{{level_4}}">Thank you</a></li>
-    {% endif %}
-    {% if 'contact-us' in level_4 %}
-    <li><a {% if level_4 == 'contact-us' %} class="is-active"{% endif %} href="/{{level_1}}/{{level_2}}/{{level_3}}/{{level_4}}">Contact us</a></li>
-    {% endif %}
+<ul class="p-inline-list nav-tertiary__menu">
+  {% if level_2 == 'openstack' and not level_4 %}
+  <li class="p-inline-list__item"><a{% if level_3 == 'autopilot'%} class="is-active"{% endif %} href="/cloud/openstack/autopilot">Autopilot</a></li>
+  {% endif %}
+  {% if level_3 == 'managed-cloud' and level_4 %}
+  <li class="p-inline-list__item" class="p-inline-list__item"><a href="/{{level_1}}/{{level_2}}/{{level_3}}">Managed cloud</a></li>
+  {% endif %}
+  {% if level_3 == 'autopilot' and level_4 %}
+  <li class="p-inline-list__item"><a href="/{{level_1}}/{{level_2}}/{{level_3}}">Autopilot</a></li>
+  {% endif %}
+  {% if 'thank-you' in level_3 %}
+  <li class="p-inline-list__item"><a{% if level_3 == 'thank-you' %} class="is-active"{% endif %}href="/{{level_1}}/{{level_2}}/{{level_3}}">Thank you</a></li>
+  {% endif %}
+  {% if 'contact-us' in level_3 %}
+  <li class="p-inline-list__item"><a {% if level_3 == 'contact-us' %} class="is-active"{% endif %} href="/{{level_1}}/{{level_2}}/{{level_3}}">Contact us</a></li>
+  {% endif %}
+  {% if 'thank-you' in level_4 %}
+  <li class="p-inline-list__item" class="p-inline-list__item"><a{% if level_4 == 'thank-you' %} class="is-active"{% endif %}href="/{{level_1}}/{{level_2}}/{{level_3}}/{{level_4}}">Thank you</a></li>
+  {% endif %}
+  {% if 'contact-us' in level_4 %}
+  <li class="p-inline-list__item"><a {% if level_4 == 'contact-us' %} class="is-active"{% endif %} href="/{{level_1}}/{{level_2}}/{{level_3}}/{{level_4}}">Contact us</a></li>
+  {% endif %}
 </ul>

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -1,11 +1,13 @@
 {% extends "cloud/base_cloud-v1.html" %}
+
 {% block title %}Plans and pricing | Cloud{% endblock %}
 
 {% block second_level_nav_items %}
-{% include "templates/_nav_breadcrumb-v1.html" with section_title="Cloud" page_title="Plans and pricing" %}
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Cloud" page_title="Plans and pricing" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
+
 <section class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-6">
@@ -59,7 +61,7 @@
   <div class="row">
     <div class="col-8">
       <h3>Metered</h3>
-      <p>Pay only for resources you consume.  Build your own cloud using Ubuntu OpenStack with Canonical tooling using a Canonical&#39;s OpenStack reference architecture. Ubuntu Advantage is delivered as a price per guest VM per hour and per gigabyte of storage used per month.</p>
+      <p>Pay only for resources you consume. Build your own cloud using Ubuntu OpenStack with Canonical tooling using a Canonical&#39;s OpenStack reference architecture. Ubuntu Advantage is delivered as a price per guest VM per hour and per gigabyte of storage used per month.</p>
       <p>The metered model is also available as a fully managed service: BootStack. This model suits customers seeking to manage cost based on utilisation of their cloud in a similar to that of public cloud providers such as Amazon EC2 and Azure.</p>
     </div>
   </div>
@@ -71,7 +73,7 @@
   <div class="row">
     <div class="col-8">
       <h3>Service provider</h3>
-      <p>For large volume and public clouds, build your own cloud using Ubuntu OpenStack with Canonical tooling using Canonical&#39;s OpenStack reference architecture.  Ubuntu Advantage is priced per OpenStack region.  Different packages offer a choice of SLAs based on customer needs and the number of nodes per region. This model suits customers seeking to cap the cost of OpenStack deployment at scale.</p>
+      <p>For large volume and public clouds, build your own cloud using Ubuntu OpenStack with Canonical tooling using Canonical&#39;s OpenStack reference architecture. Ubuntu Advantage is priced per OpenStack region. Different packages offer a choice of SLAs based on customer needs and the number of nodes per region. This model suits customers seeking to cap the cost of OpenStack deployment at scale.</p>
     </div>
   </div>
   <div class="row">
@@ -133,7 +135,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Ubuntu on public clouds</h2>
-      <p>Ubuntu Server is available as a cloud guest on participating public clouds. Pricing depends on size of virtual machine.  Check with each provider for more details.</p>
+      <p>Ubuntu Server is available as a cloud guest on participating public clouds. Pricing depends on size of virtual machine. Check with each provider for more details.</p>
     </div>
   </div>
   <div class="row">

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -158,35 +158,30 @@
         <thead>
           <tr>
             <th scope="col">&nbsp;</th>
-            <th scope="col" colspan="2">Price</th>
+            <th scope="col" colspan="2" class="u-align--center">Price</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <th scope="row"><a href="/server/maas">MAAS</a></th>
-            <td colspan="2">FREE</td>
+            <td colspan="2" class="u-align--center">FREE</td>
           </tr>
           <tr>
             <th scope="row"><a href="/cloud/juju">Juju</a></th>
-            <td colspan="2">FREE</td>
+            <td colspan="2" class="u-align--center">FREE</td>
           </tr>
           <tr>
             <th scope="row"><a href="/cloud/openstack">Ubuntu OpenStack</a></th>
-            <td colspan="2">FREE</td>
+            <td colspan="2" class="u-align--center">FREE</td>
           </tr>
           <tr>
             <th scope="row"><a href="/support">Landscape</a></th>
-            <td colspan="2">Comes as part of <a href="/support/plans-and-pricing">Ubuntu Advantage</a> subscription</td>
+            <td class="u-align--center"><span class="p-heading--muted">SaaS</span><br  />1¢ per machine per hour</td>
+            <td class="u-align--center"><span class="p-heading--muted">On-premises</span><br />Free up to ten machines</td>
           </tr>
           <tr>
-            <td> - Landscape SaaS</td>
-            <td>Get $100 free credit for 60 days</td>
-            <td>1¢ per machine per hour</td>
-          </tr>
-          <tr>
-            <td> - Landscape On-premises</td>
-            <td>Free up to ten machines</td>
-            <td>UA subscription required for more than 10 machines</td>
+            <td>&nbsp;</td>
+            <td class="u-align--center" colspan="2">Or, comes as part of <a href="/support/plans-and-pricing">Ubuntu Advantage</a> subscription</td>
           </tr>
         </tbody>
       </table>

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -141,7 +141,6 @@
       {% include "cloud/shared/_guest-list-v1.html" %}
     </div>
   </div>
-</div>
 </section>
 
 <section class="p-strip">

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -1,198 +1,198 @@
-{% extends "cloud/base_cloud.html" %}
-
+{% extends "cloud/base_cloud-v1.html" %}
 {% block title %}Plans and pricing | Cloud{% endblock %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-{% include "templates/_nav_breadcrumb.html" with section_title="Cloud" page_title="Plans and pricing" %}
-</div>
+{% include "templates/_nav_breadcrumb-v1.html" with section_title="Cloud" page_title="Plans and pricing" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero strip-dark">
-    <div class="strip-inner-wrapper">
-        <div class="six-col">
-            <h1>Plans and pricing</h1>
-            <p class="intro">Ubuntu OpenStack offers the best economics of any commercially supported OpenStack solution.</p>
-            <p>Canonical offers everything you need from fully managed clouds to training and support. We aim to be as easy and economical as possible to work with and that includes flexible pricing.</p>
-        </div>
+<section class="p-strip--accent is-deep">
+  <div class="row">
+    <div class="col-6">
+      <h1>Plans and pricing</h1>
+      <p>Ubuntu OpenStack offers the best economics of any commercially supported OpenStack solution.</p>
+      <p>Canonical offers everything you need from fully managed clouds to training and support. We aim to be as easy and economical as possible to work with and that includes flexible pricing.</p>
     </div>
+  </div>
 </section>
 
-<section class="row strip-light row-ubuntu-advantage-promo">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h2>Landscape: Server management</h2>
-            <p>
-                Landscape allows you to manage thousands of Ubuntu machines as
-                easily as one, making the administration of Ubuntu desktops,
-                servers and cloud instances more cost-effective. It&rsquo;s
-                easy to set up, easy to use and it requires no special
-                hardware. It features:
-            </p>
-            <ul class="list-ticks--compact">
-                <li>Management at scale</li>
-                <li>Deploy or rollback security updates</li>
-                <li>Compliance reports</li>
-                <li>Role-based access</li>
-                <li>Informative monitoring</li>
-            </ul>
-            <p><a href="https://landscape.canonical.com/">Learn more about Landscape&nbsp;&rsaquo;</a></p>
-        </div>
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h2>Landscape: Server management</h2>
+      <p>Landscape allows you to manage thousands of Ubuntu machines as easily as one, making the administration of Ubuntu desktops, servers and cloud instances more cost-effective. It&rsquo;s easy to set up, easy to use and it requires no special hardware. It features:
+      </p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Management at scale</li>
+        <li class="p-list__item is-ticked">Deploy or rollback security updates</li>
+        <li class="p-list__item is-ticked">Compliance reports</li>
+        <li class="p-list__item is-ticked">Role-based access</li>
+        <li class="p-list__item is-ticked">Informative monitoring</li>
+      </ul>
+      <p><a class="p-link--external" href="https://landscape.canonical.com/">Learn more about Landscape&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="col-5 p-hero__item u-hidden--small">
+      <img class="p-hero__image" src="{{ ASSET_SERVER_URL }}65274d19-landscape-screenshot.png?op=region&amp;rect=0,0,1324,450&amp;w=500" alt="screenshot of Landscape" />
+    </div>
+  </div>
 </section>
 
-<section class="row no-border no-padding-bottom strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col no-margin-bottom">
-            <h2>Ubuntu Advantage for OpenStack</h2>
-            <p>Ubuntu Advantage for OpenStack plans are delivered through Ubuntu Advantage, a professional package of integrated management tooling and enterprise class support. It includes access to Landscape, the systems management tool for using Ubuntu at scale, as well as 24x7 telephone support, online support library and legal assurance.</p>
-            <p>Ubuntu Advantage for OpenStack is available in three flexible packages, to help you to scale your business in the most cost-effective way.</p>
-        </div>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Ubuntu Advantage for OpenStack</h2>
+      <p>Ubuntu Advantage for OpenStack plans are delivered through Ubuntu Advantage, a professional package of integrated management tooling and enterprise class support. It includes access to Landscape, the systems management tool for using Ubuntu at scale, as well as 24x7 telephone support, online support library and legal assurance.</p>
+      <p>Ubuntu Advantage for OpenStack is available in three flexible packages, to help you to scale your business in the most cost-effective way.</p>
     </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h3>Per node</h3>
+      <p>Build your own cloud using Ubuntu OpenStack with Canonical tools or tooling of your choice. Priced per node per year with alternate packages that offer a choice of SLAs based on your requirements.</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-10">
+      {% include "shared-v1/_ubuntu_advantage_cloud_per_node.html" %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h3>Metered</h3>
+      <p>Pay only for resources you consume.  Build your own cloud using Ubuntu OpenStack with Canonical tooling using a Canonical&#39;s OpenStack reference architecture. Ubuntu Advantage is delivered as a price per guest VM per hour and per gigabyte of storage used per month.</p>
+      <p>The metered model is also available as a fully managed service: BootStack. This model suits customers seeking to manage cost based on utilisation of their cloud in a similar to that of public cloud providers such as Amazon EC2 and Azure.</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-10">
+      {% include "shared-v1/_ubuntu_advantage_cloud_metered.html" %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h3>Service provider</h3>
+      <p>For large volume and public clouds, build your own cloud using Ubuntu OpenStack with Canonical tooling using Canonical&#39;s OpenStack reference architecture.  Ubuntu Advantage is priced per OpenStack region.  Different packages offer a choice of SLAs based on customer needs and the number of nodes per region. This model suits customers seeking to cap the cost of OpenStack deployment at scale.</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-10">
+      {% include "shared-v1/_ubuntu_advantage_cloud_service_provider.html" %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p><a href="/management/contact-us">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
 </section>
 
-<section class="row no-border no-padding-bottom strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h3>Per node</h3>
-            <p>Build your own cloud using Ubuntu OpenStack with Canonical tools or tooling of your choice. Priced per node per year with alternate packages that offer a choice of SLAs based on your requirements.</p>
-        </div>
-        <div class="ten-col no-margin-bottom">
-            {% include "shared/_ubuntu_advantage_cloud_per_node.html" %}
-        </div>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>OpenStack Autopilot</h2>
+      <p>The quickest and easiest way to install and manage Ubuntu OpenStack is to use Canonical&#39;s OpenStack Autopilot. Autopilot users also get full access to Landscape systems management free of charge for up to 10 machines.</p>
+      <p><a href="/cloud/openstack/autopilot">Get Autopilot&nbsp;&rsaquo;</a></p>
     </div>
+  </div>
 </section>
 
-<section class="row no-border no-padding-bottom strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-            <h3>Metered</h3>
-            <p>Pay only for resources you consume.  Build your own cloud using Ubuntu OpenStack with Canonical tooling using a Canonical&#39;s OpenStack reference architecture. Ubuntu Advantage is delivered as a price per guest VM per hour and per gigabyte of storage used per month.</p>
-            <p>The metered model is also available as a fully managed service: BootStack. This model suits customers seeking to manage cost based on utilisation of their cloud in a similar to that of public cloud providers such as Amazon EC2 and Azure.</p>
-        </div>
-        <div class="ten-col no-margin-bottom">
-            {% include "shared/_ubuntu_advantage_cloud_metered.html" %}
-        </div>
+<section class="p-strip is-bordered" id="bootstack-fully-managed-cloud">
+  <div class="row">
+    <div class="col-8">
+      <h2>BootStack fully managed OpenStack Cloud</h2>
+      <p>Let us build, operate and support your OpenStack Cloud.</p>
+      <table class="audience-enterprise ua-table">
+        <tr>
+          <th scope="row">Cost per server per day</th>
+          <td>$15</td>
+        </tr>
+        <tr>
+          <th scope="row">Cost per fully managed VM per hour</th>
+          <td>$0.05</td>
+        </tr>
+      </table>
+      <p><a href="/cloud/openstack/managed-cloud/contact-us">Schedule a BootStack demo&nbsp;&rsaquo;</a></p>
     </div>
+  </div>
 </section>
 
-<section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
-        <h3>Service provider</h3>
-        <p>For large volume and public clouds, build your own cloud using Ubuntu OpenStack with Canonical tooling using Canonical&#39;s OpenStack reference architecture.  Ubuntu Advantage is priced per OpenStack region.  Different packages offer a choice of SLAs based on customer needs and the number of nodes per region. This model suits customers seeking to cap the cost of OpenStack deployment at scale.</p>
-        </div>
-        <div class="ten-col">
-        {% include "shared/_ubuntu_advantage_cloud_service_provider.html" %}
-        </div>
-
-        <div class="eight-col">
-            <p><a href="/management/contact-us">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
-        </div>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h2>Consulting</h2>
+      <p>Need greater customisation? We have helped the world&rsquo;s leading telcos and service providers take their OpenStack clouds from concept all the way to production. We have an extensive portfolio of services to help you build and support an Extreme OpenStack cloud.</p>
+      <p><a href="/cloud/contact-us">Contact us to discuss your needs&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="col-5 u-align--center">
+      <img src="{{ ASSET_SERVER_URL }}3ba54a27-picto-contact-midaubergine.svg" width="200" alt="" />
+    </div>
+  </div>
 </section>
 
-<section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col append-four">
-            <h2>OpenStack Autopilot</h2>
-            <p>The quickest and easiest way to install and manage Ubuntu OpenStack is to use Canonical&#39;s OpenStack Autopilot. Autopilot users also get full access to Landscape systems management free of charge for up to 10 machines.</p>
-            <p><a href="/cloud/openstack/autopilot">Get Autopilot&nbsp;&rsaquo;</a></p>
-        </div>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Ubuntu on public clouds</h2>
+      <p>Ubuntu Server is available as a cloud guest on participating public clouds. Pricing depends on size of virtual machine.  Check with each provider for more details.</p>
     </div>
-</section><!-- end row -->
-
-<section class="row strip-light" id="bootstack-fully-managed-cloud">
-    <div class="strip-inner-wrapper">
-        <h2>BootStack fully managed OpenStack Cloud</h2>
-        <div class="eight-col append-four no-margin-bottom">
-            <p>Let us build, operate and support your OpenStack Cloud.</p>
-            <table class="audience-enterprise ua-table">
-                <tr>
-                    <th rowspan="1" scope="row">Cost per server per day</th>
-                    <td>$15</td>
-                </tr>
-                <tr>
-                    <th rowspan="1" scope="row">Cost per fully managed VM per hour</th>
-                    <td>$0.05</td>
-                </tr>
-            </table>
-        </div>
-        <div class="eight-col">
-            <p><a href="/cloud/openstack/managed-cloud/contact-us">Schedule a BootStack demo&nbsp;&rsaquo;</a></p>
-        </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      {% include "cloud/shared/_guest-list-v1.html" %}
     </div>
+  </div>
+</div>
 </section>
 
-<section class="row strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="seven-col">
-            <h2>Consulting</h2>
-            <p>Need greater customisation? We have helped the world&rsquo;s leading telcos and service providers take their OpenStack clouds from concept all the way to production. We have an extensive portfolio of services to help you build and support an Extreme OpenStack cloud.</p>
-            <p><a href="/cloud/contact-us">Contact us to discuss your needs&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="five-col text-center last-col">
-            <img src="{{ ASSET_SERVER_URL }}3ba54a27-picto-contact-midaubergine.svg" width="200" alt="" />
-        </div>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Cloud tools</h2>
+      <p>Ubuntu provides tools to help you create, scale and manage your cloud.</p>
     </div>
+  </div>
+  <div class="row">
+    <div class="col-10">
+      <table class="audience-enterprise ua-table">
+        <thead>
+          <tr>
+            <th scope="col">&nbsp;</th>
+            <th scope="col" colspan="2">Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row"><a href="/server/maas">MAAS</a></th>
+            <td colspan="2">FREE</td>
+          </tr>
+          <tr>
+            <th scope="row"><a href="/cloud/juju">Juju</a></th>
+            <td colspan="2">FREE</td>
+          </tr>
+          <tr>
+            <th scope="row"><a href="/cloud/openstack">Ubuntu OpenStack</a></th>
+            <td colspan="2">FREE</td>
+          </tr>
+          <tr>
+            <th scope="row"><a href="/support">Landscape</a></th>
+            <td colspan="2">Comes as part of <a href="/support/plans-and-pricing">Ubuntu Advantage</a> subscription</td>
+          </tr>
+          <tr>
+            <td> - Landscape SaaS</td>
+            <td>Get $100 free credit for 60 days</td>
+            <td>1¢ per machine per hour</td>
+          </tr>
+          <tr>
+            <td> - Landscape On-premises</td>
+            <td>Free up to ten machines</td>
+            <td>UA subscription required for more than 10 machines</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </section>
 
-<section class="row row-get-started strip-light">
-    <div class="strip-inner-wrapper">
-        <h2>Ubuntu on public clouds</h2>
-        <p class="eight-col">Ubuntu Server is available as a cloud guest on participating public clouds. Pricing depends on size of virtual machine.  Check with each provider for more details.</p>
-        <div>
-            {% include "cloud/shared/_guest-list.html" %}
-        </div>
-    </div>
-</section>
-
-<section class="row no-border strip-light">
-    <div class="strip-inner-wrapper">
-        <h2>Cloud tools</h2>
-        <p>Ubuntu provides tools to help you create, scale and manage your cloud.</p>
-        <div class="eight-col append-four no-margin-bottom">
-            <table class="audience-enterprise ua-table">
-              <thead>
-                <tr>
-                  <th scope="col">&nbsp;</th>
-                  <th scope="col" colspan="2">Price</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th rowspan="1" scope="row"><a href="/server/maas">MAAS</a></th>
-                  <td colspan="2">FREE</td>
-                </tr>
-                <tr>
-                  <th rowspan="1" scope="row"><a href="/cloud/juju">Juju</a></th>
-                  <td colspan="2">FREE</td>
-                </tr>
-                <tr>
-                  <th rowspan="1" scope="row"><a href="/cloud/openstack">Ubuntu OpenStack</a></th>
-                  <td colspan="2">FREE</td>
-                </tr>
-                <tr>
-                  <th rowspan="2" scope="row"><a href="/support">Landscape</a></th>
-                  <td width="50%">
-                      <h6 class="no-margin-bottom">SaaS</h6>
-                      <p>$0.01 per machine hour</p>
-                  </td>
-                  <td width="50%">
-                      <h6 class="no-margin-bottom">On-premises</h6>
-                      <p>Free up to ten machines</p>
-                  </td>
-                </tr>
-                <tr>
-                    <td colspan="2">Or comes as part of <a href="/support/plans-and-pricing">Ubuntu Advantage</a> subscription</td>
-                <tr>
-              </tbody>
-            </table>
-        </div>
-    </div>
-</section>
-
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared-v1/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
 
 {% endblock content %}

--- a/templates/cloud/shared/_guest-list-v1.html
+++ b/templates/cloud/shared/_guest-list-v1.html
@@ -1,0 +1,75 @@
+<div class="row">
+  <div class="u-equal-height">
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}bd47d87c-google-cloud.svg" alt="Google Cloud Platform logo" />
+      </header>
+      <h3 class="p-card__title u-hidden">Google Cloud Platform</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://cloud.google.com/partners/partnercredit/?PCN=a0n60000003kyX1&utm_medium=partners&utm_campaign=partner-credit">Get started on GCP</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}c6fe5e8f-AmazonWebservices_Logo.svg" alt="Amazon Web Services (EC2) logo" />
+      </header>
+      <h3 class="p-card__title u-hidden">Amazon Web Services</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://help.ubuntu.com/community/EC2StartersGuide">The Ubuntu guide to EC2</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}08646a72-logo-oracle.svg" alt="Oracle Cloud logo" />
+      </header>
+      <h3 class="p-card__title u-hidden">Oracle Cloud</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://cloud.oracle.com/marketplace/listing/6071138?_afrLoop=105446854237053&amp;_afrWindowMode=0&amp;_afrWindowId=null">Get started on Oracle Cloud</a></p>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="u-equal-height">
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}eb041659-Microsoft-Azure_rgb_Blk.svg" alt="Microsoft Azure logo" />
+      </header>
+      <h3 class="p-card__title u-hidden">Microsoft Azure</h3>
+      <p class="p-card__content"><a class="p-link--external" href="http://www.windowsazure.com/en-us/documentation/services/virtual-machines/">Get started on Microsoft Azure</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}d3959703-T-SYSTEMS-LOGO2013.svg" alt="T Systems logo" />
+      </header>
+      <h3 class="p-card__title u-hidden">T Systems</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://www.t-systems.com/de/en/solutions/cloud/solutions/open-telekom-cloud/public-cloud-for-business-customers-247826">Get started on T Systems</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}d584bd83-logo-vmware.svg" alt="VMware logo" height="35" />
+      </header>
+      <h3 class="p-card__title u-hidden">VMware</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://solutionexchange.vmware.com/store/products/ubuntu-12-04-lts--2#.VA_9Dq2zDsa">Get started on VMware</a></p>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="u-equal-height">
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}7cd13ce0-vexxhost-logo-01.svg?w=275" alt="Vexxhost logo" />
+      </header>
+      <h3 class="p-card__title u-hidden">Vexxhost</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://vexxhost.com/public-cloud/">Get started on Vexxhost</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}43c55d04-logo-brightbox.svg?w=275" alt="Brightbox logo" height="35" />
+      </header>
+      <h3 class="p-card__title u-hidden">Brightbox</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://www.brightbox.com/">Get started on Brightbox</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}3579c4ed-softlayer.svg" alt="Softlayer logo" />
+      </header>
+      <h3 class="p-card__title u-hidden">Softlayer</h3>
+      <p class="p-card__content"><a class="p-link--external" href="http://www.softlayer.com/">Get started on Softlayer</a></p>
+    </div>
+  </div>
+</div>

--- a/templates/server/management.html
+++ b/templates/server/management.html
@@ -74,7 +74,7 @@
   </div>
 </div>
 
-<div class="p-strip is-bordered row-hero">
+<div class="p-strip is-bordered p-hero">
   <div class="row">
     <div class="col-7">
       <h2>Ubuntu Advantage: what&rsquo;s included?</h2>

--- a/templates/shared-v1/_ubuntu_advantage_cloud_metered.html
+++ b/templates/shared-v1/_ubuntu_advantage_cloud_metered.html
@@ -1,7 +1,7 @@
 <table class="audience-enterprise ua-table">
   <thead>
     <tr>
-      <th scope="col" class="row-title pricing-features-column">&nbsp;</th>
+      <th scope="col">&nbsp;</th>
       <th scope="col">Standard</th>
       <th scope="col">Advanced</th>
       <th scope="col">Managed</th>
@@ -23,7 +23,7 @@
   </tbody>
 </table>
 <p>Each metered package includes:</p>
-<ul class="list-ticks--canonical seven-col">
-  <li>Telephone support for Ubuntu hosts, Ubuntu OpenStack and Ubuntu guest VMs or containers at indicated level backed by Canonical&#39;s OpenStack experts</li>
-  <li>Landscape systems management for hosts and Ubuntu guests</li>
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Telephone support for Ubuntu hosts, Ubuntu OpenStack and Ubuntu guest VMs or containers at indicated level backed by Canonical&#39;s OpenStack experts</li>
+  <li class="p-list__item is-ticked">Landscape systems management for hosts and Ubuntu guests</li>
 </ul>

--- a/templates/shared-v1/_ubuntu_advantage_cloud_per_node.html
+++ b/templates/shared-v1/_ubuntu_advantage_cloud_per_node.html
@@ -1,7 +1,7 @@
 <table class="audience-enterprise ua-table">
   <thead>
     <tr>
-      <th scope="col" class="row-title pricing-features-column">&nbsp;</th>
+      <th scope="col">&nbsp;</th>
       <th scope="col">Standard</th>
       <th scope="col">Advanced</th>
       <th scope="col">Managed</th>
@@ -23,8 +23,8 @@
   </tbody>
 </table>
 <p>Each per node package includes:</p>
-<ul class="list-ticks--canonical seven-col">
-  <li>Telephone support for Ubuntu Hosts, Ubuntu OpenStack and Ubuntu guest VMs or containers at indicated level backed by Canonical&#39;s OpenStack experts</li>
-  <li>Landscape systems management for hosts and Ubuntu guests</li>
-  <li>3 terabytes of Ceph or Swift based usable storage</li>
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Telephone support for Ubuntu Hosts, Ubuntu OpenStack and Ubuntu guest VMs or containers at indicated level backed by Canonical&#39;s OpenStack experts</li>
+  <li class="p-list__item is-ticked">Landscape systems management for hosts and Ubuntu guests</li>
+  <li class="p-list__item is-ticked">3 terabytes of Ceph or Swift based usable storage</li>
 </ul>

--- a/templates/shared-v1/_ubuntu_advantage_cloud_service_provider.html
+++ b/templates/shared-v1/_ubuntu_advantage_cloud_service_provider.html
@@ -1,7 +1,7 @@
 <table class="audience-enterprise ua-table">
   <thead>
     <tr>
-      <th scope="col" class="row-title pricing-features-column">&nbsp;</th>
+      <th scope="col">&nbsp;</th>
       <th scope="col">Small region</th>
       <th scope="col">Medium region</th>
       <th scope="col">Large region</th>
@@ -23,8 +23,8 @@
   </tbody>
 </table>
 <p>Each service provider package includes:</p>
-<ul class="list-ticks--canonical seven-col">
-  <li>Telephone support for Ubuntu hosts, Ubuntu OpenStack and Ubuntu guest VMs or containers at indicated level backed by Canonical&#39;s OpenStack experts</li>
-  <li>Landscape systems management for hosts and Ubuntu guests</li>
-  <li>Storage at indicated level</li>
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Telephone support for Ubuntu hosts, Ubuntu OpenStack and Ubuntu guest VMs or containers at indicated level backed by Canonical&#39;s OpenStack experts</li>
+  <li class="p-list__item is-ticked">Landscape systems management for hosts and Ubuntu guests</li>
+  <li class="p-list__item is-ticked">Storage at indicated level</li>
 </ul>

--- a/templates/shared-v1/_ubuntu_advantage_server.html
+++ b/templates/shared-v1/_ubuntu_advantage_server.html
@@ -1,7 +1,7 @@
 <table>
   <thead>
     <tr>
-      <th scope="col" class="row-title pricing-features-column">Features</th>
+      <th scope="col">Features</th>
       <th scope="col">Essential</th>
       <th scope="col">Standard</th>
       <th scope="col">Advanced</th>

--- a/templates/shared-v1/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared-v1/contextual_footers/_cloud_contact_us.html
@@ -8,19 +8,19 @@
       <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
           <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
           <ul class="p-list mktoFormRow u-clearfix">
-              <li class="mktoFormCol p-list__item">
+              <li class="mktoFormCol">
                   <label class="u-off-screen mktoLabel" for="Email">Your email</label>
                   <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
               </li>
-              <li class="mktField mktLblRight p-list__item">
+              <li class="mktField mktLblRight">
                   <span class="mktInput mktLblRight">
                       <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
                       <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
                   </span>
               </li>
-              <li class=" p-list__item">
+              <li>
                   <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
-                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
                   <input type="hidden" name="NewsletterOpt-In" value="yes" />
                   <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
                   <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />

--- a/templates/shared-v1/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared-v1/contextual_footers/_cloud_contact_us.html
@@ -8,19 +8,19 @@
       <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
           <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
           <ul class="p-list mktoFormRow u-clearfix">
-              <li class="mktoFormCol">
+              <li class="mktoFormCol p-list__item">
                   <label class="u-off-screen mktoLabel" for="Email">Your email</label>
                   <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
               </li>
-              <li class="mktField mktLblRight">
+              <li class="mktField mktLblRight p-list__item">
                   <span class="mktInput mktLblRight">
                       <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
                       <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
                   </span>
               </li>
-              <li>
+              <li class=" p-list__item">
                   <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
-                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
                   <input type="hidden" name="NewsletterOpt-In" value="yes" />
                   <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
                   <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />

--- a/templates/shared-v1/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared-v1/contextual_footers/_cloud_contact_us.html
@@ -1,40 +1,5 @@
 <div class="col-4 p-divider__block">
-
   <h3 class="p-heading--four">Get in touch</h3>
   <p>Contact us for more information or to discuss your specific needs.</p>
-  <p><a href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
-
-  <div class="box-digest">
-      <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
-          <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
-          <ul class="p-list mktoFormRow u-clearfix">
-              <li class="mktoFormCol">
-                  <label class="u-off-screen mktoLabel" for="Email">Your email</label>
-                  <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
-              </li>
-              <li class="mktField mktLblRight">
-                  <span class="mktInput mktLblRight">
-                      <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
-                      <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
-                  </span>
-              </li>
-              <li>
-                  <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
-                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
-                  <input type="hidden" name="NewsletterOpt-In" value="yes" />
-                  <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
-                  <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />
-                  <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
-                  <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
-                  <input type="hidden" name="ret" value="http://ubuntu.com/cloud/newsletter-thank-you" />
-                  <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden" />
-                  <input type="hidden" name="kw" value="" />
-                  <input type="hidden" name="cr" value="" />
-                  <input type="hidden" name="searchstr" value="" />
-                  <input type="hidden" name="_mkt_disp" value="return" />
-                  <input type="hidden" name="_mkt_trk" value="" />
-              </li>
-          </ul>
-      </form>
-  </div>
+  <p><a class="p-button--neutral" href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_cloud_juju.html
+++ b/templates/shared-v1/contextual_footers/_cloud_juju.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Experience Juju</h3>
-  <p>Try our demo and see how easy it can be to manage services in the cloud.</p>
-  <p><a href="https://demo.jujucharms.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'jujucharms demo', 'eventLabel' : 'Experience Juju', 'eventValue' : undefined });">Try the Juju demo</a></p>
+  <h3 class="p-heading--four">Experience JAAS</h3>
+  <p>Try Juju as a Service and see how easy it can be to manage your services in the cloud.</p>
+  <p><a href="https://jujucharms.com/jaas" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'jujucharms demo', 'eventLabel' : 'Experience Juju', 'eventValue' : undefined });">Try the JAAS</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared-v1/contextual_footers/_cloud_newsletter.html
@@ -1,0 +1,33 @@
+<div class="col-4 p-divider__block">
+  <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
+    <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
+    <ul class="p-list mktoFormRow u-clearfix">
+      <li class="mktoFormCol p-list__item">
+        <label class="u-off-screen mktoLabel" for="Email">Your email</label>
+        <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
+      </li>
+      <li class="mktField mktLblRight p-list__item">
+        <span class="mktInput mktLblRight">
+          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
+          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
+        </span>
+      </li>
+      <li class="p-list__item">
+        <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
+        <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+        <input type="hidden" name="NewsletterOpt-In" value="yes" />
+        <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
+        <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />
+        <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
+        <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
+        <input type="hidden" name="ret" value="http://ubuntu.com/cloud/newsletter-thank-you" />
+        <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden" />
+        <input type="hidden" name="kw" value="" />
+        <input type="hidden" name="cr" value="" />
+        <input type="hidden" name="searchstr" value="" />
+        <input type="hidden" name="_mkt_disp" value="return" />
+        <input type="hidden" name="_mkt_trk" value="" />
+      </li>
+    </ul>
+  </form>
+</div>


### PR DESCRIPTION
## Done

* update /cloud/plans-and-pricing to vbt
* hero is accent colour, like on live
* landscape table layout required a change… please review
* collapsed some vertical space

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/cloud/plans-and-pricing)
- compare to the [design](https://www.dropbox.com/work/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/2.%20Cloud?preview=cloud-plans-and-pricing.png)

## Issue / Card

Fixes #1615