### PR TITLE
1619 cloud training

### DIFF
--- a/static/sass/_v1_pattern_lists.scss
+++ b/static/sass/_v1_pattern_lists.scss
@@ -1,5 +1,4 @@
 // Site specific list styling
-
 @mixin list-link {
   display: block;
   height: $sp-x-large;
@@ -16,6 +15,7 @@
   @include ubuntu-p-is-quartered;
   @include ubuntu-p-nested-counter-lists;
   @include ubuntu-p-list-imgstack;
+  @include ubuntu-p-inline-definition-list;
 }
 
 @mixin ubuntu-p-is-ticked {
@@ -217,4 +217,25 @@
       margin-bottom: $sp-xx-large;
     }
   }
+}
+
+@mixin ubuntu-p-inline-definition-list {
+  .p-inline-definition-list {
+    margin: 0;
+    padding: 0;
+
+    &__title {
+      border: 0;
+      float: left;
+      font-size: 1rem;
+      font-weight: 400;
+      margin: 0 1rem 0 0;
+      padding: 0;
+    }
+
+    &__item {
+      margin: 0;
+    }
+  }
+
 }

--- a/static/sass/_v1_pattern_matrix.scss
+++ b/static/sass/_v1_pattern_matrix.scss
@@ -1,0 +1,98 @@
+// List Grid
+@mixin ubuntu-p-matrix {
+  @include vf-p-matrix;
+  .p-matrix {
+
+    // undo
+    &__item {
+      @media (min-width: $breakpoint-small) {
+        border: 0;
+        width: 100%;
+      }
+    }
+
+    &.is-split {
+      .p-matrix__item {
+        @media (min-width: $breakpoint-small) {
+          width: calc(50% - .666666rem);
+
+          &:nth-child(-n+1) {
+            border-top: 0;
+          }
+
+          &:nth-child(n+1) {
+            border-right: 1px dotted $color-mid-dark;
+            padding-right: $sp-medium;
+          }
+
+          &:nth-child(n+3) {
+            border-top: 1px dotted $color-mid-dark;
+          }
+
+          &:nth-child(2n) {
+            border-right: 0;
+            padding-right: 0;
+          }
+        }
+      }
+    }
+
+    &.is-trisected {
+      .p-matrix__item {
+
+        @media (min-width: $breakpoint-small) {
+          width: calc(33.333% - .666666rem);
+
+          &:nth-child(-n+3) {
+            border-top: 0;
+          }
+
+          &:nth-child(n) {
+            border-bottom: 1px dotted $color-mid-dark;
+            border-right: 1px dotted $color-mid-dark;
+            padding-right: $sp-medium;
+          }
+
+          &:nth-child(3n+1):nth-last-child(-n+3),
+          &:nth-child(3n+1):nth-last-child(-n+3) ~ li {
+            border-bottom: 0;
+          }
+
+          &:nth-child(3n) {
+            border-right: 0;
+            padding-right: 0;
+          }
+        }
+      }
+    }
+
+
+    &.is-quartered {
+      .p-matrix__item {
+        @media (min-width: $breakpoint-small) {
+          width: calc(25% - .666666rem);
+
+          &:nth-child(-n+4) {
+            border-top: 0;
+          }
+
+          &:nth-child(n) {
+            border-bottom: 1px dotted $color-mid-dark;
+            border-right: 1px dotted $color-mid-dark;
+            padding-right: $sp-medium;
+          }
+
+          &:nth-child(4n+1):nth-last-child(-n+4),
+          &:nth-child(4n+1):nth-last-child(-n+4) ~ li {
+            border-bottom: 0;
+          }
+
+          &:nth-child(4n) {
+            border-right: 0;
+            padding-right: 0;
+          }
+        }
+      }
+    }
+  }
+}

--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -28,6 +28,7 @@
 @import 'v1_pattern_hero';
 @import 'v1_pattern_pull_quotes';
 @import 'v1_utility_full-width';
+@import 'v1_pattern_matrix';
 
 @include ubuntu-p-site-search;
 @include ubuntu-p-navigation;
@@ -43,6 +44,7 @@
 @include ubuntu-p-hero;
 @include ubuntu-p-pull-quote;
 @include ubuntu-u-full-width;
+@include ubuntu-p-matrix;
 
 // **************************
 // Bug fixes

--- a/templates/cloud/training.html
+++ b/templates/cloud/training.html
@@ -1,144 +1,146 @@
-{% extends "cloud/base_cloud.html" %}
-
+{% extends "cloud/base_cloud-v1.html" %}
 {% block title %}Training | Cloud{% endblock %}
-
 {% block meta_description %}Canonical run OpenStack and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
 
 {% block second_level_nav_items %}
-<div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Cloud" subsection_title="OpenStack" page_title="Jumpstart" %}
-</div>
+{% include "templates/_nav_breadcrumb-v1.html" with section_title="Cloud" subsection_title="OpenStack" page_title="Jumpstart" %}
 {% endblock second_level_nav_items %}
 
 {% block outer_content %}
 {% block content %}
-<section class="row row-hero row--training strip-light">
-  <div class="strip-inner-wrapper row--training__content">
-    <h1>Train with Ubuntu</h1>
-    <div class="six-col">
+<section class="p-strip is-deep is-bordered u-image-position">
+  <div class="row">
+    <div class="col-6">
+      <h1>Train with Ubuntu</h1>
       <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack. All classes and materials are provided in English.</p>
     </div>
-    <img class="row--training__image not-for-small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" />
+    <img class="u-image-position--top u-image-position--right u-hidden--small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" style="right: 150px;"/>
   </div>
 </section>
 
-<section class="row strip-light">
-  <div class="strip-inner-wrapper">
-    <div class="eight-col">
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-7">
       <h2>OpenStack Fundamentals</h2>
+      <h3>Online training by Hastexo</h3>
+      <p>Independent providers of online OpenStack training materials, certified by&nbsp;Canonical.</p>
+      <p><a href="https://academy.hastexo.com/courses/course-v1:hastexo+hx201+201610-juju/about" class="p-link--external">OpenStack 101 by Hastexo</a></p>
     </div>
-    <ul class="twelve-col list no-bullets training-list">
-      <li class="training-list__item">
-        <div class="equal-height--vertical-divider">
-          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-            <h3>Online training</h3>
-            <p>Independent providers of online OpenStack training materials, certified by&nbsp;Canonical.</p>
-            <p><a href="https://academy.hastexo.com/courses/course-v1:hastexo+hx201+201610-juju/about" class="external">OpenStack 101 by Hastexo</a></p>
-          </div>
-        </div>
-      </li>
-      <li class="training-list__item">
-        <div class="equal-height--vertical-divider">
-          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-            <h3>On-site training</h3>
-            <p>3-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
-            <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/Ubuntu_OpenStack_Fundamentals_Training.pdf">Read the course outline (PDF)</a></p>
-          </div>
-          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-              <dt>Duration</dt>
-              <dd>3 days</dd>
-              <dt>Cost</dt>
-              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
-              <dt>Location</dt>
-              <dd>Your premises</dd>
-              <dt>Availability</dt>
-              <dd>Private groups only</dd>
-            </dl>
-            <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </li>
-      <li class="training-list__item">
-        <div class="equal-height--vertical-divider">
-          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-            <h3>High Availability Architecture add-on training</h3>
-            <p>This is a half day add-on course that is bundled with the OpenStack Fundamentals course, at your premises, for up to 15 students, that will provide fundamental instruction on High Availability for OpenStack.</p>
-            <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/8032/ubuntu-openstack-high-availability-architecture.pdf">Read the course outline (PDF)</a></p>
-          </div>
-          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-              <dt>Duration</dt>
-              <dd>4.5 hrs</dd>
-              <dt>Cost</dt>
-              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
-              <dt>Location</dt>
-              <dd>Your premises</dd>
-              <dt>Availability</dt>
-              <dd>From 26 September 2016</dd>
-            </dl>
-            <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </li>
-      <li class="training-list__item">
-        <h2>Ubuntu Server Administration</h2>
-        <div class="equal-height--vertical-divider">
-          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-            <h3>Basic on-site training</h3>
-            <p>3-day hands-on course at your premises for up to 15 students, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
-            <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/1ee7/Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)</a></p>
-          </div>
-          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-              <dt>Duration</dt>
-              <dd>3 days</dd>
-              <dt>Cost</dt>
-              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
-              <dt>Location</dt>
-              <dd>Your premises</dd>
-              <dt>Availability</dt>
-              <dd>From 10 October 2016</dd>
-            </dl>
-            <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </li>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+      <h3>On-site training</h3>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>3-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
+      <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/Ubuntu_OpenStack_Fundamentals_Training.pdf">Read the course outline (PDF)</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">3 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
+      </dl>
+      <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
 
-      <li class="training-list__item">
-        <div class="equal-height--vertical-divider">
-          <div class="equal-height--vertical-divider__item seven-col no-margin-bottom training-list__course-summary">
-            <h3>Advanced on-site training</h3>
-            <p>You&rsquo;ve been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive 3-day hands-on course in which you will learn and use advanced techniques.</p>
-            <p><a class="external" href="https://insights.ubuntu.com/wp-content/uploads/138d/Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)</a></p>
-          </div>
-          <div class="equal-height--vertical-divider__item five-col last-col no-margin-bottom">
-            <dl class="training-list__course-details" itemscope itemtype="https://schema.org/Product">
-              <dt>Duration</dt>
-              <dd>3 days</dd>
-              <dt>Cost</dt>
-              <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
-              <dt>Location</dt>
-              <dd>Your premises</dd>
-              <dt>Availability</dt>
-              <dd>From 6 February 2017</dd>
-            </dl>
-            <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </li>
-    </ul>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+      <h3>High Availability Architecture add-on training</h3>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>This is a half day add-on course that is bundled with the OpenStack Fundamentals course, at your premises, for up to 15 students, that will provide fundamental instruction on High Availability for OpenStack.</p>
+      <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/8032/ubuntu-openstack-high-availability-architecture.pdf">Read the course outline (PDF)</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">4.5 hrs</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">From 26 September 2016</dd>
+      </dl>
+      <p><a href="/cloud/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
   </div>
 </section>
 
-<section class="row no-border strip-light">
-  <div class="strip-inner-wrapper">
-    <div class="seven-col">
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Ubuntu Server Administration</h2>
+      <h3>Basic on-site training</h3>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>3-day hands-on course at your premises for up to 15 students, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
+      <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/1ee7/Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">3 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">From 10 October 2016</dd>
+      </dl>
+      <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+      <h3>Advanced on-site training</h3>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>You&rsquo;ve been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive 3-day hands-on course in which you will learn and use advanced techniques.</p>
+      <p><a class="p-link--external" href="https://insights.ubuntu.com/wp-content/uploads/138d/Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">3 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">From 6 February 2017</dd>
+      </dl>
+      <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
       <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="five-col align-center last-col">
+    <div class="col-5 u-align--center u-hidden--small">
       <img src="{{ ASSET_SERVER_URL }}9b170f06-picto-help-orange.svg" width="135" alt="" />
     </div>
   </div>

--- a/templates/cloud/training.html
+++ b/templates/cloud/training.html
@@ -1,20 +1,23 @@
 {% extends "cloud/base_cloud-v1.html" %}
+
 {% block title %}Training | Cloud{% endblock %}
+
 {% block meta_description %}Canonical run OpenStack and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
 
 {% block second_level_nav_items %}
-{% include "templates/_nav_breadcrumb-v1.html" with section_title="Cloud" subsection_title="OpenStack" page_title="Jumpstart" %}
+  {% include "templates/_nav_breadcrumb-v1.html" with section_title="Cloud" subsection_title="OpenStack" page_title="Jumpstart" %}
 {% endblock second_level_nav_items %}
 
 {% block outer_content %}
 {% block content %}
+
 <section class="p-strip is-deep is-bordered u-image-position">
   <div class="row">
     <div class="col-6">
       <h1>Train with Ubuntu</h1>
       <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack. All classes and materials are provided in English.</p>
     </div>
-    <img class="u-image-position--top u-image-position--right u-hidden--small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" style="right: 150px;"/>
+    <img class="u-image-position--top u-image-position--right u-hidden--small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" style="right: 150px;" />
   </div>
 </section>
 
@@ -145,8 +148,10 @@
     </div>
   </div>
 </section>
+
 {% endblock content %}
 {% endblock outer_content %}
+
 {% block footer_extra %}
 <!-- twitter tracking code -->
 <script src="https://platform.twitter.com/oct.js"></script>

--- a/templates/shared-v1/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared-v1/contextual_footers/_cloud_contact_us.html
@@ -8,19 +8,19 @@
       <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
           <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
           <ul class="p-list mktoFormRow u-clearfix">
-              <li class="mktoFormCol p-list__item">
+              <li class="mktoFormCol">
                   <label class="u-off-screen mktoLabel" for="Email">Your email</label>
                   <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
               </li>
-              <li class="mktField mktLblRight p-list__item">
+              <li class="mktField mktLblRight">
                   <span class="mktInput mktLblRight">
                       <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
                       <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
                   </span>
               </li>
-              <li class=" p-list__item">
+              <li>
                   <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
-                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
                   <input type="hidden" name="NewsletterOpt-In" value="yes" />
                   <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
                   <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />

--- a/templates/shared-v1/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared-v1/contextual_footers/_cloud_contact_us.html
@@ -1,40 +1,5 @@
 <div class="col-4 p-divider__block">
-
   <h3 class="p-heading--four">Get in touch</h3>
   <p>Contact us for more information or to discuss your specific needs.</p>
-  <p><a href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
-
-  <div class="box-digest">
-      <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
-          <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
-          <ul class="p-list mktoFormRow u-clearfix">
-              <li class="mktoFormCol">
-                  <label class="u-off-screen mktoLabel" for="Email">Your email</label>
-                  <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
-              </li>
-              <li class="mktField mktLblRight">
-                  <span class="mktInput mktLblRight">
-                      <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
-                      <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
-                  </span>
-              </li>
-              <li>
-                  <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
-                  <span class="mktoButtonWrap"><button type="submit" class="mktoButton"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
-                  <input type="hidden" name="NewsletterOpt-In" value="yes" />
-                  <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
-                  <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />
-                  <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
-                  <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
-                  <input type="hidden" name="ret" value="http://ubuntu.com/cloud/newsletter-thank-you" />
-                  <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden" />
-                  <input type="hidden" name="kw" value="" />
-                  <input type="hidden" name="cr" value="" />
-                  <input type="hidden" name="searchstr" value="" />
-                  <input type="hidden" name="_mkt_disp" value="return" />
-                  <input type="hidden" name="_mkt_trk" value="" />
-              </li>
-          </ul>
-      </form>
-  </div>
+  <p><a class="p-button--neutral" href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared-v1/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared-v1/contextual_footers/_cloud_newsletter.html
@@ -1,0 +1,33 @@
+<div class="col-4 p-divider__block">
+  <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
+    <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
+    <ul class="p-list mktoFormRow u-clearfix">
+      <li class="mktoFormCol p-list__item">
+        <label class="u-off-screen mktoLabel" for="Email">Your email</label>
+        <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
+      </li>
+      <li class="mktField mktLblRight p-list__item">
+        <span class="mktInput mktLblRight">
+          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
+          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
+        </span>
+      </li>
+      <li class="p-list__item">
+        <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
+        <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+        <input type="hidden" name="NewsletterOpt-In" value="yes" />
+        <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
+        <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />
+        <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
+        <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
+        <input type="hidden" name="ret" value="http://ubuntu.com/cloud/newsletter-thank-you" />
+        <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden" />
+        <input type="hidden" name="kw" value="" />
+        <input type="hidden" name="cr" value="" />
+        <input type="hidden" name="searchstr" value="" />
+        <input type="hidden" name="_mkt_disp" value="return" />
+        <input type="hidden" name="_mkt_trk" value="" />
+      </li>
+    </ul>
+  </form>
+</div>


### PR DESCRIPTION
## Done

* update /cloud/training to vbt
* added a compact definition list pattern

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/cloud/training)
- compare to [design](https://www.dropbox.com/work/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/2.%20Cloud?preview=cloud-training.png)

## Issue / Card

Fixes #1619