### PR TITLE
Fix spacing on /about/canonical-and-ubuntu

### DIFF
--- a/templates/about/canonical-and-ubuntu.html
+++ b/templates/about/canonical-and-ubuntu.html
@@ -14,13 +14,12 @@
       <h3>As the leader of the Ubuntu Project, Canonical knows Ubuntu inside out.</h3>
     </div>
   </div>
-</div>
-<div class="row">
-  <div class="col-8">
-    <p>Working with a close-knit team from the open-source community, Canonical is responsible for delivering six-monthly releases, as well as co-ordinating security, trouble-shooting and providing an online platform for community interaction.</p>
-    <p>The number-one provider of Ubuntu services, Canonical works closely with businesses and individuals alike. Canonical also develops bespoke systems, provides comprehensive support and all the training that&rsquo;s necessary to get everybody up and
-      running. With more than 500 employees in over 39 countries, the company continues expanding to support the millions of Ubuntu users around the world.</p>
-    <p><a href="http://www.canonical.com">Find out more on the Canonical website&nbsp;&rsaquo;</a></p>
+  <div class="row">
+    <div class="col-8">
+      <p>Working with a close-knit team from the open-source community, Canonical is responsible for delivering six-monthly releases, as well as co-ordinating security, trouble-shooting and providing an online platform for community interaction.</p>
+      <p>The number-one provider of Ubuntu services, Canonical works closely with businesses and individuals alike. Canonical also develops bespoke systems, provides comprehensive support and all the training that&rsquo;s necessary to get everybody up and running. With more than 500 employees in over 39 countries, the company continues expanding to support the millions of Ubuntu users around the world.</p>
+      <p><a href="http://www.canonical.com">Find out more on the Canonical website&nbsp;&rsaquo;</a></p>
+    </div>
   </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
## Done

Fix spacing on /about/canonical-and-ubuntu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about/canonical-and-ubuntu](http://0.0.0.0:8001/about/canonical-and-ubuntu))
- Check spacing looks correct

## Issue / Card

Fixes #1557 