### PR TITLE
Update spacing on /about-us/about-ubuntu/ubuntu-and-debian

### DIFF
--- a/templates/about/about-ubuntu/ubuntu-and-debian.html
+++ b/templates/about/about-ubuntu/ubuntu-and-debian.html
@@ -7,6 +7,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
+
 <div class="p-strip is-deep">
   <div class="row">
     <div class="col-8">
@@ -14,20 +15,16 @@
       <h3>Ubuntu and Debian are closely related.</h3>
     </div>
   </div>
-</div>
-
-<div class="row">
-  <div class="col-8">
-    <p>Ubuntu builds on the foundations of Debian&#39;s architecture and infrastructure, but there are important differences. Ubuntu has its own user interface, a separate developer community (though many developers participate in both projects) and a different
-      release process.</p>
-
-    <h3>About Debian</h3>
-    <p><a href="http://www.debian.org/">Debian</a> can be considered the rock upon which Ubuntu is built. It is a volunteer project that has developed and maintained a GNU/Linux operating system of the same name for well over a decade. Since its launch, the Debian project has grown to comprise more than 1,000 members with official developer status, alongside many more volunteers and contributors. Today, Debian encompasses over 20,000 packages of free, open source applications and documentation.</p>
-
-    <h3>About Ubuntu</h3>
-    <p>Ubuntu is an open source project that develops and maintains a cross-platform, open-source operating system based on Debian. It includes Unity, a consistent user interface for the smartphone, the tablet and the PC. Upgrades are released every six months and support is guaranteed by Canonical for up to five years. Canonical also provides commercial support for Ubuntu deployments across the desktop, the server and the cloud.</p>
-
-    <p><a href="https://wiki.ubuntu.com/Debian">Learn more about how Debian and Ubuntu fit together</a>.</p>
+  <div class="row">
+    <div class="col-8">
+      <p>Ubuntu builds on the foundations of Debian&#39;s architecture and infrastructure, but there are important differences. Ubuntu has its own user interface, a separate developer community (though many developers participate in both projects) and a different release process.</p>
+      <h3>About Debian</h3>
+      <p><a href="http://www.debian.org/">Debian</a> can be considered the rock upon which Ubuntu is built. It is a volunteer project that has developed and maintained a GNU/Linux operating system of the same name for well over a decade. Since its launch, the Debian project has grown to comprise more than 1,000 members with official developer status, alongside many more volunteers and contributors. Today, Debian encompasses over 20,000 packages of free, open source applications and documentation.</p>
+      <h3>About Ubuntu</h3>
+      <p>Ubuntu is an open source project that develops and maintains a cross-platform, open-source operating system based on Debian. It includes Unity, a consistent user interface for the smartphone, the tablet and the PC. Upgrades are released every six months and support is guaranteed by Canonical for up to five years. Canonical also provides commercial support for Ubuntu deployments across the desktop, the server and the cloud.</p>
+      <p><a href="https://wiki.ubuntu.com/Debian">Learn more about how Debian and Ubuntu fit together</a>.</p>
+    </div>
   </div>
 </div>
+
 {% endblock content %}


### PR DESCRIPTION
Fixes #1556

## Done

Update spacing on /about-us/about-ubuntu/ubuntu-and-debian

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about-us/about-ubuntu/ubuntu-and-debian](http://0.0.0.0:8001/about-us/about-ubuntu/ubuntu-and-debian))
- Check spacing is correct


## Issue / Card

Fixes #1556 