### PR TITLE
Remove conditional which is breaking secondary level nav

### DIFF
--- a/templates/templates/base-v1.html
+++ b/templates/templates/base-v1.html
@@ -142,7 +142,7 @@
 
     <div class="wrapper">
       <div id="main-content" class="inner-wrapper">
-        {% if level_1 and second_level_nav_items %}
+        {% if level_1 %}
           {% block second_level_nav %}
             <nav class="p-breadcrumbs nav-secondary clearfix">{% spaceless %}{% block second_level_nav_items %}{% endblock second_level_nav_items %}{% endspaceless %}</nav>
           {% endblock second_level_nav %}


### PR DESCRIPTION
## Done

Remove conditional which is breaking secondary level nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check `/about` and verify that secondary level nav is present


## Issue / Card

Fixes #1934 
