### PR TITLE
Fix up spacing on /about/about-ubuntu/diversity

### DIFF
--- a/templates/about/about-ubuntu/diversity.html
+++ b/templates/about/about-ubuntu/diversity.html
@@ -7,25 +7,25 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-  <div class="p-strip is-deep">
+  <section class="p-strip is-deep">
     <div class="row">
       <div class="col-8">
         <h1>Diversity</h1>
       </div>
     </div>
-  </div>
+    <div class="row">
+      <div class="col-8">
+        <p>The Ubuntu project welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about  joining. Although we may not be able to satisfy everyone, we will always  work to treat everyone well.</p>
 
-  <div class="row">
-    <div class="col-8">
-      <p>The Ubuntu project welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about  joining. Although we may not be able to satisfy everyone, we will always  work to treat everyone well.</p>
+        <p>Standards for behaviour in the Ubuntu community are detailed in the  <a href="/about/about-ubuntu/conduct">Code of Conduct</a>. We expect participants  in our community to meet these standards in all their interactions and  to help others to do so as well.</p>
 
-      <p>Standards for behaviour in the Ubuntu community are detailed in the  <a href="/about/about-ubuntu/conduct">Code of Conduct</a>. We expect participants  in our community to meet these standards in all their interactions and  to help others to do so as well.</p>
+        <p>Whenever any participant has made a mistake, we expect them to take  responsibility for it. If someone has been harmed or offended, it is our  responsibility to listen carefully and respectfully, and do our best to  right the wrong.</p>
 
-      <p>Whenever any participant has made a mistake, we expect them to take  responsibility for it. If someone has been harmed or offended, it is our  responsibility to listen carefully and respectfully, and do our best to  right the wrong.</p>
+        <p>Although this list cannot be exhaustive, we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or  expression, language, national origin, neurotype, phenotype, political  beliefs, profession, race, religion, sexual orientation, socio-economic  status, subculture and technical ability.</p>
 
-      <p>Although this list cannot be exhaustive, we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or  expression, language, national origin, neurotype, phenotype, political  beliefs, profession, race, religion, sexual orientation, socio-economic  status, subculture and technical ability.</p>
-
-      <p>Some of the ideas and wording for this statement were based on diversity statements from the <a href="http://www.python.org/community/diversity">Python community</a> and <a href="http://www.dreamwidth.org/legal/diversity">Dreamwidth Studios</a> (CC-BY-SA 3.0).</p>
+        <p>Some of the ideas and wording for this statement were based on diversity statements from the <a href="http://www.python.org/community/diversity">Python community</a> and <a href="http://www.dreamwidth.org/legal/diversity">Dreamwidth Studios</a> (CC-BY-SA 3.0).</p>
+      </div>
     </div>
-  </div>
+  </section>
+
 {% endblock content %}


### PR DESCRIPTION
## Done
Fix up spacing on /about/about-ubuntu/diversity

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about/about-ubuntu/diversity](http://0.0.0.0:8001/about/about-ubuntu/diversity)
- Check that spacing is correct, compare with live for comparison

## Issue / Card

Fixes #1551 