### PR TITLE
Update spacing on /about-ubuntu/governance

### DIFF
--- a/templates/about/about-ubuntu/governance.html
+++ b/templates/about/about-ubuntu/governance.html
@@ -13,9 +13,7 @@
       <h1>Governance</h1>
     </div>
   </div>
-</div>
-
-<div class="row">
+  <div class="row">
   <div class="col-8">
     <h3>We aim to make Ubuntu a wonderful place to participate.</h3>
     <p>From the outset, we have put governance at the forefront of how Ubuntu is led. We want to draw on the talents of a diverse global community, and to do that, we establish high standards for collaboration, debate, delegation of responsibility and ethics.</p>
@@ -65,4 +63,6 @@
     <p>The LoCo team action mostly happens on the Ubuntu wiki - see the <a href="http://loco.ubuntu.com/teams/">LoCo team directory</a> for more information.</p>
   </div>
 </div>
+</div>
+
 {% endblock content %}


### PR DESCRIPTION
## Done

Update spacing on /about/about-ubuntu/governance

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about/about-ubuntu/governance](http://0.0.0.0:8001/about/about-ubuntu/governance)
- Check improved spacing against live

## Issue / Card

Fixes #1553
