### PR TITLE
Intelligently generate top menu and footer nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1,0 +1,374 @@
+cloud:
+  title: Cloud
+  path: /cloud
+
+  children:
+    - title: Overview
+      path: /cloud
+    - title: OpenStack
+      path: /cloud/openstack
+
+      children:
+        - title: Autopilot
+          path: /cloud/openstack/autopilot
+
+    - title: Managed cloud
+      path: /cloud/managed-cloud
+    - title: Public cloud
+      path: /cloud/public-cloud
+    - title: Juju
+      path: /cloud/juju
+    - title: Storage
+      path: /cloud/storage
+    - title: Partners
+      path: /cloud/partners
+    - title: Training
+      path: /cloud/training
+    - title: Plans and pricing
+      path: /cloud/plans-and-pricing
+
+    - title: Thank you
+      path: /cloud/newsletter-thank-you
+      hidden: True
+    - title: Contact us
+      path: /cloud/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /cloud/thank-you
+          hidden: True
+
+server:
+  title: Server
+  path: /server
+
+  children:
+    - title: Overview
+      path: /server
+    - title: Server management
+      path: /server/management
+    - title: Hyperscale
+      path: /server/hyperscale
+    - title: Livepatch
+      path: /server/livepatch
+    - title: Server provisioning
+      path: /server/maas
+
+    - title: Contact us
+      path: /server/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /server/thank-you
+          hidden: True
+
+containers:
+  title: Containers
+  path: /containers
+
+  children:
+    - title: Overview
+      path: /containers
+    - title: LXD
+      path: /containers/lxd
+    - title: Kubernetes
+      path: /containers/kubernetes
+    - title: Docker Engine
+      path: /containers/docker-ubuntu
+
+    - title: Contact us
+      path: /containers/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /containers/thank-you
+          hidden: True
+
+desktop:
+  title: Desktop
+  path: /desktop
+
+  children:
+    - title: Overview
+      path: /desktop
+    - title: Features
+      path: /desktop/features
+    - title: For enterprise
+      path: /desktop/enterprise
+    - title: For education
+      path: /desktop/education
+    - title: For government
+      path: /desktop/government
+    - title: For developers
+      path: /desktop/developers
+    - title: For China
+      path: /desktop/ubuntu-kylin
+    - title: For partners
+      path: /desktop/partners
+    - title: Snappy
+      path: /desktop/snappy
+
+    - title: Contact us
+      path: /desktop/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /desktop/thank-you
+          hidden: True
+
+core:
+  title: Core
+  path: /core
+
+  children:
+    - title: Overview
+      path: /core
+
+    - title: Contact us
+      path: /core/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /core/thank-you
+          hidden: True
+
+iot:
+  title: IoT
+  path: /internet-of-things
+
+  children:
+    - title: Overview
+      path: /internet-of-things
+    - title: Digital signage
+      path: /internet-of-things/digital-signage
+    - title: Robotics
+      path: /internet-of-things/robotics
+    - title: Gateways
+      path: /internet-of-things/gateways
+
+    - title: Thank you
+      path: /internet-of-things/newsletter-thank-you
+      hidden: True
+    - title: Contact us
+      path: /internet-of-things/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /internet-of-things/thank-you
+          hidden: True
+
+support:
+  title: Support
+  path: /support
+
+  children:
+    - title: Overview
+      path: /support
+    - title: Community support
+      path: /support/community-support
+    - title: Plans and pricing
+      path: /support/plans-and-pricing
+    - title: ESM
+      path: /support/esm
+
+    - title: Contact us
+      path: /support/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /support/thank-you
+          hidden: True
+
+download:
+  title: Downloads
+  path: /download
+
+  children:
+    - title: Overview
+      path: /download
+    - title: Cloud
+      path: /download/cloud
+
+      children:
+        - title: Autopilot
+          path: /download/cloud/autopilot
+        - title: Conjure-up
+          path: /download/cloud/conjure-up
+
+    - title: Server
+      path: /download/server
+
+      children:
+        - title: ARM
+          path: /download/server/arm
+        - title: POWER8
+          path: /download/server/power8
+        - title: LinuxONE
+          path: /download/server/linuxone
+        - title: Provisioning
+          path: /download/server/provisioning
+        - title: Installing Ubuntu Server
+          path: /download/server/install-ubuntu-server
+
+        - title: Thank you
+          path: /download/server/thank-you
+          hidden: True
+        - title: Thank you
+          path: /download/server/thank-you-linuxone
+          hidden: True
+
+    - title: Desktop
+      path: /download/desktop
+
+      children:
+        - title: Contribute
+          path: /download/desktop/contribute
+          hidden: True
+        - title: Thank you
+          path: /download/desktop/thank-you
+          hidden: True
+
+    - title: Ubuntu Kylin
+      path: /download/ubuntu-kylin
+    - title: Alternative downloads
+      path: /download/alternative-downloads
+    - title: Ubuntu flavours
+      path: /download/ubuntu-flavours
+
+about:
+  title: About
+  path: /about
+
+  children:
+    - title: Overview
+      path: /about
+    - title: About Ubuntu
+      path: /about/about-ubuntu
+
+      children:
+        - title: Philosophy
+          path: /about/about-ubuntu/our-philosophy
+        - title: Licensing
+          path: /about/about-ubuntu/licensing
+        - title: Governance
+          path: /about/about-ubuntu/governance
+        - title: Code of Conduct
+          path: /about/about-ubuntu/conduct
+        - title: Diversity
+          path: /about/about-ubuntu/diversity
+        - title: Ubuntu and Debian
+          path: /about/about-ubuntu/ubuntu-and-debian
+        - title: Flavours
+          path: /about/about-ubuntu/flavours
+
+    - title: Canonical and Ubuntu
+      path: /about/canonical-and-ubuntu
+    - title: Contact us
+      path: /about/contact-us
+
+    - title: Contact us
+      path: /about/contact-us/form
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /about/contact-us/form/thank-you
+          hidden: True
+
+eol:
+  title: Ubuntu release end of life
+  path: /info/release-end-of-life
+
+  children:
+    - title: Overview
+      path: /info/release-end-of-life
+
+legal:
+  title: Legal
+  path: /legal
+
+  children:
+    - title: Overview
+      path: /legal
+    - title: Terms and policies
+      path: /legal/terms-and-policies
+
+      children:
+        - title: Terms and conditions
+          path: /legal/terms-and-policies/terms
+        - title: Privacy policy
+          path: /legal/terms-and-policies/privacy-policy
+        - title: Intellectual property
+          path: /legal/terms-and-policies/intellectual-property-policy
+        - title: Online account terms
+          path: /legal/terms-and-policies/online-account-terms
+        - title: U1 Terms of Service
+          path: /legal/terms-and-policies/terms-of-service
+        - title: Confidentiality agreement
+          path: /legal/terms-and-policies/confidentiality-agreement
+        - title: Developer terms
+          path: /legal/terms-and-policies/developer-terms-and-conditions
+        - title: Livepatch terms
+          path: /legal/terms-and-policies/livepatch-terms-of-service
+        - title: JAAS terms
+          path: /legal/terms-and-policies/jaas-beta-terms-of-service
+
+    - title: Ubuntu Advantage
+      path: /legal/ubuntu-advantage
+
+      children:
+        - title: Service description
+          path: /legal/ubuntu-advantage/service-description
+        - title: Ubuntu Assurance
+          path: /legal/ubuntu-advantage/assurance
+
+    - title: BootStack
+      path: /legal/bootstack
+
+      children:
+        - title: Service description
+          path: /legal/bootstack/service-description
+        - title: Privacy
+          path: /legal/bootstack/privacy
+
+    - title: Contributors
+      path: /legal/contributors
+
+      children:
+        - title: Licence agreement FAQ
+          path: /legal/contributors/licence-agreement-faq
+        - title: Submit
+          path: /legal/contributors/submit
+
+        - title: Thank you
+          path: /legal/contributors/thank-you
+          hidden: True
+
+    - title: Short terms
+      path: /legal/short-terms
+
+      children:
+        - title: JA
+          path: /legal/short-terms/ja
+        - title: 2016-05-20
+          path: /legal/short-terms/2016-05-20
+        - title: 2015-09-09
+          path: /legal/short-terms/2015-09-09
+        - title: 2015-06-24
+          path: /legal/short-terms/2015-06-24
+
+    - title: Contact us
+      path: /legal/terms-and-policies/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /legal/terms-and-policies/thank-you
+          hidden: True

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -1,0 +1,13 @@
+<li class="p-footer__item">
+  <h2 class="p-footer__title">
+    <a class="p-link--soft" href="{{ section.path }}">{{ section.title }}</a>
+  </h2>
+
+  <ul class="second-level-nav">
+    {% for child in section.children %}
+      {% if not child.hidden %}
+        <li><a href="{{ child.path }}">{{ child.title }}</a></li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</li>

--- a/templates/templates/_menu_section-v1.html
+++ b/templates/templates/_menu_section-v1.html
@@ -1,0 +1,15 @@
+<li class="p-navigation__link">
+  <a
+  class="{% if section.active %}is-active{% endif %}"
+  href="{{ section.path }}"
+  >{{ section.title }}</a>
+  <ul class="hover-menu">
+    {% if section.children %}
+      {% for child in section.children %}
+        {% if not child.hidden %}
+          <li><a href="{{ child.path }}">{{ child.title }}</a></li>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  </ul>
+</li>

--- a/templates/templates/_menu_section.html
+++ b/templates/templates/_menu_section.html
@@ -1,0 +1,16 @@
+<li>
+  <a
+    class="{% if section.active %}active{% endif %}"
+    href="{{ section.path }}"
+  >{{ section.title }}</a>
+
+  <ul class="second-level-nav">
+    {% if section.children %}
+      {% for child in section.children %}
+        {% if not child.hidden %}
+          <li><a href="{{ child.path }}">{{ child.title }}</a></li>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  </ul>
+</li>

--- a/templates/templates/base-v1.html
+++ b/templates/templates/base-v1.html
@@ -92,38 +92,14 @@
             <a href="#main-content">Jump to main content</a>
           </span>
           <ul class="p-navigation__links">
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'cloud' %}is-active{% endif %}" href="/cloud">Cloud</a>
-              {% include "cloud/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'server' %}is-active{% endif %}" href="/server">Server</a>
-              {% include "server/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'containers' %}is-active{% endif %}" href="/containers">Containers</a>
-              {% include "containers/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'desktop' %}is-active{% endif %}" href="/desktop">Desktop</a>
-              {% include "desktop/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'core' %}is-active{% endif %}" href="/core">Core</a>
-              {% include "core/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'internet-of-things' %}is-active{% endif %}" href="/internet-of-things">IoT</a>
-              {% include "internet-of-things/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'support' %}is-active{% endif %}" href="/support">Support</a>
-              {% include "support/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
-            <li class="p-navigation__link">
-              <a class="{% if level_1 == 'download' %}is-active{% endif %} " href="/download">Downloads</a>
-              {% include "download/_nav_secondary-v1.html" with list_class="hover-menu" %}
-            </li>
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.cloud %}
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.server %}
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.containers %}
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.desktop %}
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.core %}
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.iot %}
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.support %}
+            {% include 'templates/_menu_section-v1.html' with section=nav_sections.download %}
           </ul>
         </nav>
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -87,30 +87,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <div id="nav">
             <ul>
               <li class="accessibility-aid"><a accesskey="s" href="#main-content">Jump to content</a></li>
-              <li><a class="first{% if level_1 == 'cloud' %} active{% endif %}" href="/cloud">Cloud</a>
-                {% include "cloud/_nav_secondary.html" with promo="true" %}
-              </li>
-              <li><a{% if level_1 == 'server' %} class="active"{% endif %} href="/server">Server</a>
-                {% include "server/_nav_secondary.html" with promo="true" %}
-              </li>
-              <li><a class="first{% if level_1 == 'containers' %} active{% endif %}" href="/containers">Containers</a>
-                {% include "containers/_nav_secondary.html" with promo="true" %}
-              </li>
-              <li><a {% if level_1 == 'desktop' %} class="active"{% endif %} href="/desktop">Desktop</a>
-                {% include "desktop/_nav_secondary.html" with promo="true" %}
-              </li>
-              <li><a{% if level_1 == 'core' %} class="active"{% endif %} href="/core">Core</a>
-                {% include "core/_nav_secondary.html" with promo="true" %}
-              </li>
-              <li><a{% if level_1 == 'internet-of-things' %} class="active"{% endif %} href="/internet-of-things">IoT</a>
-                {% include "internet-of-things/_nav_secondary.html" with promo="true" %}
-              </li>
-              <li><a{% if level_1 == 'support' %} class="active"{% endif %} href="/support">Support</a>
-                {% include "support/_nav_secondary.html" with promo="true" %}
-              </li>
-              <li><a{% if level_1 == 'download' %} class="active"{% endif %} href="/download">Downloads</a>
-                {% include "download/_nav_secondary.html" with promo="true" %}
-              </li>
+              {% include 'templates/_menu_section.html' with section=nav_sections.cloud %}
+              {% include 'templates/_menu_section.html' with section=nav_sections.server %}
+              {% include 'templates/_menu_section.html' with section=nav_sections.containers %}
+              {% include 'templates/_menu_section.html' with section=nav_sections.desktop %}
+              {% include 'templates/_menu_section.html' with section=nav_sections.core %}
+              {% include 'templates/_menu_section.html' with section=nav_sections.iot %}
+              {% include 'templates/_menu_section.html' with section=nav_sections.support %}
+              {% include 'templates/_menu_section.html' with section=nav_sections.download %}
             </ul>
           </div>
           <div id="site-search">

--- a/templates/templates/footer-v1.html
+++ b/templates/templates/footer-v1.html
@@ -5,74 +5,34 @@
     <nav id="main-navigation" class="p-footer__nav u-clearfix">
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/cloud">Cloud</a>
-            </h2>
-            {% include "cloud/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.cloud %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/server">Server</a>
-            </h2>
-            {% include "server/_nav_secondary.html" %}
-          </li>
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/server">Containers</a>
-            </h2>
-            {% include "containers/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.server %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.containers %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/desktop">Desktop</a>
-            </h2>
-            {% include "desktop/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.desktop %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/core">Core</a>
-            </h2>
-            {% include "core/_nav_secondary.html" %}
-          </li>
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/internet-of-things">IoT</a>
-            </h2>
-            {% include "internet-of-things/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.core %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.iot %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/support">Support</a>
-            </h2>
-            {% include "support/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.support %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom last-col">
         <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <h2 class="p-footer__title">
-              <a class="p-link--soft" href="/download">Downloads</a>
-            </h2>
-            {% include "download/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.download %}
         </ul>
       </div>
     </nav>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -5,50 +5,34 @@
     <div class="strip-inner-wrapper strip-inner-wrapper--nav">
       <div class="p-footer__nav-col two-col u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/cloud">Cloud</a></h2>
-            {% include "cloud/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.cloud %}
         </ul>
       </div>
       <div class="p-footer__nav-col two-col u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/server">Server</a></h2>
-            {% include "server/_nav_secondary.html" %}
-          </li>
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/server">Containers</a></h2>
-            {% include "containers/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.server %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.containers %}
         </ul>
       </div>
       <div class="p-footer__nav-col two-col u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/desktop">Desktop</a></h2>
-            {% include "desktop/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.desktop %}
         </ul>
       </div>
       <div class="p-footer__nav-col two-col u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/core">Core</a></h2>
-            {% include "core/_nav_secondary.html" %}
-          </li>
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/internet-of-things">IoT</a></h2>
-            {% include "internet-of-things/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.core %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.iot %}
         </ul>
       </div>
       <div class="p-footer__nav-col two-col u-no-margin--bottom">
         <ul class="p-footer__links">
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/support">Support</a></h2>
-            {% include "support/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.support %}
         </ul>
       </div>
       <div class="p-footer__nav-col two-col u-no-margin--bottom last-col">
         <ul class="p-footer__links">
-          <li class="p-footer__item"><h2 class="p-footer__title"><a class="p-link--soft" href="/download">Downloads</a></h2>
-            {% include "download/_nav_secondary.html" %}
-          </li>
+          {% include 'templates/_footer_item.html' with section=nav_sections.download %}
         </ul>
       </div>
     </div>

--- a/webapp/context_processors.py
+++ b/webapp/context_processors.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from copy import deepcopy
+
+
+def navigation(request):
+    """
+    Set any context that we want to pass to all pages
+    """
+
+    path = request.path
+    nav_sections = deepcopy(settings.NAV_SECTIONS)
+
+    for nav_section_name, nav_section in nav_sections.items():
+        for child in nav_section['children']:
+            if child['path'] == path:
+                nav_section['active'] = True
+            else:
+                for grandchild in child.get('children', []):
+                    if grandchild['path'] == path:
+                        nav_section['active'] = True
+
+    return {
+        'nav_sections': nav_sections,
+    }

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -9,6 +9,8 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
 import os
+import yaml
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 SECRET_KEY = os.environ.get('SECRET_KEY', 'no_secret')
@@ -58,6 +60,10 @@ STATICFILES_FINDERS = [
     'django_static_root_finder.finders.StaticRootFinder'
 ]
 
+# Read navigation.yaml
+with open('navigation.yaml') as navigation_file:
+    NAV_SECTIONS = yaml.load(navigation_file.read())
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -70,6 +76,7 @@ TEMPLATES = [
             ],
             'context_processors': [
                 'django_asset_server_url.asset_server_url',
+                'webapp.context_processors.navigation',
             ],
         },
     },


### PR DESCRIPTION
Introducing a new `navigation.yaml` document, which describes the pages included in the navigation and their relationships to each other.

This is then used to generate the top menu and the footer nav.

This is the first step in fixing #1944 

Demo: http://www.ubuntu.com-navigation-menu-footer.demo.haus/

QA
--

`./run`, then browse around the site and check the top menu and the footer nav work as expected. Especially:

- That pages not included in the menu (e.g. contact-us pages) still show everything correctly
- That the current section is highlighted in the top nav
- Try changing something in `navigation.yaml`, check the menu responds as you would expect (you'll need to reload the server to see changes).