### PR TITLE
Fix nav spacing on S screen nav

### DIFF
--- a/static/sass/_pattern_contribution.scss
+++ b/static/sass/_pattern_contribution.scss
@@ -3,7 +3,6 @@
 
 @mixin ubuntu-p-contribute {
 
-
   .contribute {
     .no-js & {
       display: none;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -139,8 +139,11 @@
           width: 100%;
           display: inline-block;
           padding: $sp-x-small;
-          margin-bottom: $sp-x-small;
           color: $color-dark;
+
+          @media (max-width: $breakpoint-medium) {
+            padding-left: $sp-medium;
+          }
         }
       }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -199,7 +199,7 @@
         content: '\203A';
         font-weight: 400;
         color: $color-mid-dark;
-        left: -$sp-medium;
+        left: -0.95rem;
         position: absolute;
         top: 0;
       }
@@ -327,8 +327,9 @@
     }
 
     @media (min-width: $breakpoint-medium) {
-      margin-left: 1.5rem;
+      margin-left: 1.85rem;
       display: inline-block;
+      padding-left: .35rem;
 
       .p-inline-list__item {
         margin-right: .75rem;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -132,6 +132,7 @@
           transform: translate(-50%, 0);
           width: 100%;
           margin-left: 0;
+          margin-bottom: 0;
         }
 
         &__link {
@@ -140,10 +141,7 @@
           display: inline-block;
           padding: $sp-x-small;
           color: $color-dark;
-
-          @media (max-width: $breakpoint-medium) {
-            padding-left: $sp-medium;
-          }
+          margin-bottom: $sp-xx-small;
         }
       }
 
@@ -162,7 +160,7 @@
         }
 
         .p-inline-list__link {
-          padding: $sp-x-small;
+          padding: $sp-xx-small;
           color: $color-x-dark;
           display: inline-block;
         }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -199,7 +199,7 @@
         content: '\203A';
         font-weight: 400;
         color: $color-mid-dark;
-        left: -$sp-small;
+        left: -$sp-medium;
         position: absolute;
         top: 0;
       }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -139,7 +139,7 @@
           border-bottom: 1px solid $color-mid-light;
           width: 100%;
           display: inline-block;
-          padding: $sp-x-small;
+          padding: $sp-x-small $sp-x-small $sp-x-small .9rem;
           color: $color-dark;
           margin-bottom: $sp-xx-small;
         }


### PR DESCRIPTION
## Done

Fix spacing on S screen nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about](http://0.0.0.0:8001/about)
- Reduce viewport to S screen size
- Observe correct spacing around navigation
- Also check http://0.0.0.0:8001/about/about-ubuntu

## Issue / Card

Fixes #1931, Closes #1893

## Screenshots

Before:
<img width="673" alt="screen shot 2017-06-08 at 14 46 07" src="https://user-images.githubusercontent.com/505570/26931763-71b389a4-4c59-11e7-93a7-041ce42dfdb0.png">

After:
<img width="715" alt="screen shot 2017-06-08 at 14 45 48" src="https://user-images.githubusercontent.com/505570/26931779-7c00f5fe-4c59-11e7-883e-03933252f2ab.png">

## Demo

http://www.ubuntu.com-1931-s-screen-nav.demo.haus/about/about-ubuntu




