### PR TITLE
updated /desktop/contact-us to vbt

### DIFF
--- a/templates/core/contact-us.html
+++ b/templates/core/contact-us.html
@@ -3,11 +3,9 @@
 
 
 {% block content %}
-  <div class="p-strip is-deep">
-    <div class="row">
-      {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us"  intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything else, please fill in your details below and a member of our team will get in touch." formid="1266" lpId="2166"  returnURL="https://www.ubuntu.com/core/thank-you" %}
-    </div>
-  </div>
+
+  {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us"  intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything else, please fill in your details below and a member of our team will get in touch." formid="1266" lpId="2166"  returnURL="https://www.ubuntu.com/core/thank-you" %}
+
 {% endblock content %}
 
 {% block footer_extra %}

--- a/templates/desktop/contact-us.html
+++ b/templates/desktop/contact-us.html
@@ -1,45 +1,23 @@
-{% extends "desktop/base_desktop.html" %}
+{% extends "desktop/base_desktop-v1.html" %}
 
 {% block title %}Contact us{% endblock %}
 {% block meta_description %}Fast, easy and quick to deploy, switching to Ubuntu has never been easier{% endblock %}
 
-
 {% block content %}
-<section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
-    <div class="strip-inner-wrapper">
 
-        {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your organisation? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you"  %}
-
-        </div>
-
-        <div class="four-col box last-col" />
-            <h3>Need help with Ubuntu?</h3>
-            <p>If you are just looking for some free support for yourself, you can try:</p>
-            <ul class="list">
-                <li><a class="external" href="http://askubuntu.com/">Ask Ubuntu</a></li>
-                <li><a class="external" href="http://ubuntuforums.org/">The Ubuntu forum</a></li>
-                <li><a class="external" href="https://help.ubuntu.com/">Help docs</a></li>
-            </ul>
-        </div>
-        <div class="four-col box last-col">
-            <h3>Looking for a little professional support?</h3>
-            <p>If you are a small organisation, you can purchase packs of Ubuntu Advantage in our shop.</p>
-            <p><a href="https://buy.ubuntu.com/">Visit the Ubuntu Advantage shop&nbsp;&rsaquo;</a></p>
-        </div>
-    </div>
-</section>
+{% include "shared-v1/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your organisation? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" side1="shared-v1/forms/_desktop_help.html" side2="shared-v1/forms/_desktop_ua-shop.html" %}
 
 {% endblock content %}
 {% block footer_extra %}
 <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
 <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
 <script>
-  $("#mktoForm").validate({
-    errorElement: "span",
-    errorClass: "mktFormMsg mktError",
-    onkeyup: false,
-    onclick: false,
-    onblur: false
-  });
+$("#mktoForm").validate({
+  errorElement: "span",
+  errorClass: "mktFormMsg mktError",
+  onkeyup: false,
+  onclick: false,
+  onblur: false
+});
 </script>
 {% endblock footer_extra %}

--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -3,41 +3,36 @@
 
 
 {% block content %}
-<div class="p-strip is-deep">
-    <div class="row">
 
-        {% if product == 'digital-signage' %}
+  {% if product == 'digital-signage' %}
 
-            {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us about digital signage" intro_text="If you are thinking about building a digital signage product on Ubuntu, please fill in your details below and a member of our team will get in touch."  formid="1422" lpId="2166"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=digital-signage"  %}
+    {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us about digital signage" intro_text="If you are thinking about building a digital signage product on Ubuntu, please fill in your details below and a member of our team will get in touch."  formid="1422" lpId="2166"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=digital-signage"  %}
 
-        {% elif product == 'gateways' %}
+  {% elif product == 'gateways' %}
 
-            {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us about gateways"  intro_text="If you would like to know more about Ubuntu for edge gateways please fill in your details below and a member of our team will get in touch."  formid="1663" lpId="3143"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=gateways"  %}
+    {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us about gateways"  intro_text="If you would like to know more about Ubuntu for edge gateways please fill in your details below and a member of our team will get in touch."  formid="1663" lpId="3143"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=gateways"  %}
 
-        {% elif product == 'robotics' %}
+  {% elif product == 'robotics' %}
 
-            {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us about robotics"  intro_text="If you would like to know more about Ubuntu for Robotics please fill in your details below and a member of our team will get in touch."  formid="1650" lpId="2838"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=robotics"  %}
+    {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us about robotics"  intro_text="If you would like to know more about Ubuntu for Robotics please fill in your details below and a member of our team will get in touch."  formid="1650" lpId="2838"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=robotics"  %}
 
-        {% else %}
+  {% else %}
 
-            {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us" intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch."  formid="1266" lpId="2551"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=iot"  %}
+    {% include "shared-v1/_client-contact-us-form.html" with h1="Contact us" intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch."  formid="1266" lpId="2551"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=iot"  %}
 
-        {% endif %}
-
-    </div>
-</div>
+  {% endif %}
 
 {% endblock content %}
 {% block footer_extra %}
 <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
 <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
 <script>
-  $("#mktoForm").validate({
-    errorElement: "span",
-    errorClass: "mktFormMsg mktError",
-    onkeyup: false,
-    onclick: false,
-    onblur: false
-  });
+$("#mktoForm").validate({
+  errorElement: "span",
+  errorClass: "mktFormMsg mktError",
+  onkeyup: false,
+  onclick: false,
+  onblur: false
+});
 </script>
 {% endblock footer_extra %}

--- a/templates/shared-v1/_client-contact-us-form.html
+++ b/templates/shared-v1/_client-contact-us-form.html
@@ -1,77 +1,83 @@
-<div class="row">
-  <div class="col-8">
-    <h1>{{h1}}</h1>
-    <p>{{intro_text}}</p>
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>{{h1}}</h1>
+      <p>{{intro_text}}</p>
+    </div>
   </div>
-</div>
-<div class="row">
-  <div class="col-8">
-    <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
-      <fieldset>
-        <h3>About you</h3>
-        <ul class="p-list">
-          <li class="mktFormReq mktField p-list__item">
-            <label for="FirstName" class="mktoLabel">First name:</label>
-            <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
-          </li>
-          <li class="mktFormReq mktField p-list__item">
-            <label for="LastName" class="mktoLabel">Last name:</label>
-            <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
-          </li>
-          <li class="mktFormReq mktField p-list__item">
-            <label for="Email" class="mktoLabel">Email address:</label>
-            <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
-          </li>
-          <li class="mktFormReq mktField p-list__item">
-            <label for="Phone" class="mktoLabel">Phone number:</label>
-            <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
-          </li>
-          {% include "shared-v1/forms/_country.html" %} {% include "shared-v1/forms/_state.html" %}
-        </ul>
-      </fieldset>
+  <div class="row">
+    <div class="col-8">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
+        <fieldset>
+          <h3>About you</h3>
+          <ul class="p-list">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel">First name:</label>
+              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="LastName" class="mktoLabel">Last name:</label>
+              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Email" class="mktoLabel">Email address:</label>
+              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Phone" class="mktoLabel">Phone number:</label>
+              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+            </li>
+            {% include "shared-v1/forms/_country.html" %} {% include "shared-v1/forms/_state.html" %}
+          </ul>
+        </fieldset>
 
-      <fieldset>
-        <h3>About your company</h3>
-        <ul class="p-list">
-          <li class="mktFormReq mktField p-list__item">
-            <label for="Company" class="mktoLabel">Company:</label>
-            <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
-          </li>
-          <li class="mktFormReq mktField p-list__item">
-            <label for="Title" class="mktoLabel">Job title:</label>
-            <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
-          </li>
+        <fieldset>
+          <h3>About your company</h3>
+          <ul class="p-list">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Company" class="mktoLabel">Company:</label>
+              <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Title" class="mktoLabel">Job title:</label>
+              <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
 
-        </ul>
-      </fieldset>
+          </ul>
+        </fieldset>
 
-      <fieldset>
-        <h3>Your comments</h3>
-        <ul class="p-list">
-          <li class="mktFormReq mktField p-list__item">
-            <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-            <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField mktoRequired" maxlength="2000"></textarea>
-          </li>
-          <li class="mktField p-list__item">
-            <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="NewsletterOpt-In" type="checkbox" />
-            <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
-          </li>
-          <li class="p-list__item">All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
-          <li class="mktField p-list__item">
-            <button type="submit" class="mktoButton p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
-          </li>
-        </ul>
-        <input type="hidden" name="formid" class="mktoField" value="{{formid}}" />
-        <input type="hidden" name="lpId" class="mktoField" value="{{lpId}}" />
-        <input type="hidden" name="subId" class="mktoField" value="30" />
-        <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
-        <input type="hidden" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/things-contact-us.html?cr={creative}&amp;kw={keyword}" />
-        <input type="hidden" name="cr" class="mktoField" value="" />
-        <input type="hidden" name="kw" class="mktoField" value="" />
-        <input type="hidden" name="q" class="mktoField" value="" />
-        <input type="hidden" name="returnURL" value="{{returnURL}}" />
-        <input type="hidden" name="retURL" value="{{returnURL}}" />
-      </fieldset>
-    </form>
+        <fieldset>
+          <h3>Your comments</h3>
+          <ul class="p-list">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField mktoRequired" maxlength="2000"></textarea>
+            </li>
+            <li class="mktField p-list__item">
+              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="NewsletterOpt-In" type="checkbox" />
+              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+            </li>
+            <li class="p-list__item">All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
+            <li class="mktField p-list__item">
+              <button type="submit" class="mktoButton p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+            </li>
+          </ul>
+          <input type="hidden" name="formid" class="mktoField" value="{{formid}}" />
+          <input type="hidden" name="lpId" class="mktoField" value="{{lpId}}" />
+          <input type="hidden" name="subId" class="mktoField" value="30" />
+          <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
+          <input type="hidden" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/things-contact-us.html?cr={creative}&amp;kw={keyword}" />
+          <input type="hidden" name="cr" class="mktoField" value="" />
+          <input type="hidden" name="kw" class="mktoField" value="" />
+          <input type="hidden" name="q" class="mktoField" value="" />
+          <input type="hidden" name="returnURL" value="{{returnURL}}" />
+          <input type="hidden" name="retURL" value="{{returnURL}}" />
+        </fieldset>
+      </form>
+    </div>
+    <div class="col-4">
+      {% if side1 %}{% include side1 %}{% endif %}
+      {% if side2 %}{% include side2 %}{% endif %}
+    </div>
   </div>
-</div>
+</section>

--- a/templates/shared-v1/forms/_desktop_help.html
+++ b/templates/shared-v1/forms/_desktop_help.html
@@ -1,0 +1,9 @@
+<div class="p-card">
+  <h3 class="p-card__title">Need help with Ubuntu?</h3>
+  <p class="p-card__content">If you are just looking for some free support for yourself, you can try:</p>
+  <ul class="p-list">
+    <li class="p-list__item"><a class="p-link--external" href="http://askubuntu.com/">Ask Ubuntu</a></li>
+    <li class="p-list__item"><a class="p-link--external" href="http://ubuntuforums.org/">The Ubuntu forum</a></li>
+    <li class="p-list__item"><a class="p-link--external" href="https://help.ubuntu.com/">Help docs</a></li>
+  </ul>
+</div>

--- a/templates/shared-v1/forms/_desktop_ua-shop.html
+++ b/templates/shared-v1/forms/_desktop_ua-shop.html
@@ -1,0 +1,5 @@
+<div class="p-card">
+  <h3 class="p-card__title">Looking for a little professional support?</h3>
+  <p class="p-card__content">If you are a small organisation, you can purchase packs of Ubuntu Advantage in our shop.</p>
+  <p class="p-card__content"><a class="p-link--external" href="https://buy.ubuntu.com/">Visit the Ubuntu Advantage shop</a></p>
+</div>


### PR DESCRIPTION
## Done

* updated /desktop/contact-us to vbt
* created sidebar options for page - good to add for /core and /iot later
* updated core and iot thank-yous to work

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/desktop/contact-us)
- look at [core contact-us](http://0.0.0.0:8001/core/contact-us)
- look at [internet-of-things contact us](http://0.0.0.0:8001/internet-of-things/contact-us)

## Issue / Card

Fixes #1655

