### PR TITLE
Remove ua server essential

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -358,12 +358,6 @@
         </thead>
         <tbody>
           <tr>
-            <td>24x7 self-service customer care portal and knowledge base (see <a href="#ua-support-scope">Section 2)</a></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
             <td>8x5 ticket support for the default packages in the Ubuntu Server image (see <a href="#response-times">Section 3</a>)</td>
             <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
             <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>

--- a/templates/shared-v1/_ubuntu_advantage_cloud_virtual_guests.html
+++ b/templates/shared-v1/_ubuntu_advantage_cloud_virtual_guests.html
@@ -1,4 +1,4 @@
-  <h3 name="#ua-virtual-guests">Ubuntu Advantage for virtual guests</h3>
+  <h3 id="ua-virtual-guests">Ubuntu Advantage for virtual guests</h3>
   <p>Ubuntu Advantage for virtual guests has the same features as Ubuntu Advantage for server however:</p>
   <ul class="p-list">
     <li class="p-list__item is-ticked">It must be bought in 10-pack units</li>

--- a/templates/shared-v1/_ubuntu_advantage_server.html
+++ b/templates/shared-v1/_ubuntu_advantage_server.html
@@ -23,7 +23,7 @@
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
-      <th scope="row">Live Patching (16.04 only)</th>
+      <th scope="row">Live Patching (14.04 and 16.04 only)</th>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>

--- a/templates/shared-v1/_ubuntu_advantage_server.html
+++ b/templates/shared-v1/_ubuntu_advantage_server.html
@@ -49,7 +49,7 @@
     </tr>
     <tr>
       <th scope="row">Ceph support</th>
-      <td>&nbsp;</td>
+      <td class="u-align--center">Optional</td>
       <td class="u-align--center">Optional</td>
     </tr>
     <tr>

--- a/templates/shared-v1/_ubuntu_advantage_server.html
+++ b/templates/shared-v1/_ubuntu_advantage_server.html
@@ -2,7 +2,6 @@
   <thead>
     <tr>
       <th scope="col">Features</th>
-      <th scope="col">Essential</th>
       <th scope="col">Standard</th>
       <th scope="col">Advanced</th>
     </tr>
@@ -12,11 +11,9 @@
       <th scope="row">8x5 ticket support for the default packages in the Ubuntu Server image</th>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th scope="row">Landscape Management</th>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
@@ -24,41 +21,34 @@
       <th scope="row">Ubuntu Legal Assurance programme</th>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th scope="row">Live Patching (16.04 only)</th>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th scope="row">10x5 phone and ticket support for all packages in Ubuntu main</th>
-      <td>&nbsp;</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th scope="row">Unlimited Ubuntu LXD guest support</th>
-      <td>&nbsp;</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th scope="row">24x7 phone and ticket support for all packages in Ubuntu main and Canonical-maintained packages in backports and universe</th>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th scope="row">Unlimited Ubuntu KVM guest support</th>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th scope="row">Ceph support</th>
-      <td>&nbsp;</td>
       <td>&nbsp;</td>
       <td class="u-align--center">Optional</td>
     </tr>
@@ -66,17 +56,14 @@
       <th scope="row">Technical Account Manager</th>
       <td class="u-align--center">Optional</td>
       <td class="u-align--center">Optional</td>
-      <td class="u-align--center">Optional</td>
     </tr>
     <tr>
       <th scope="row">Ubuntu Advantage price per server per year</th>
-      <td class="u-align--center">$150</td>
       <td class="u-align--center">$750</td>
       <td class="u-align--center">$1,500</td>
     </tr>
     <tr>
       <th scope="row"><a href="#ua-virtual-guests">Ubuntu Advantage for virtual guests</a></th>
-      <td>&nbsp;</td>
       <td class="u-align--center">$2,500</td>
       <td class="u-align--center">$3,150</td>
     </tr>

--- a/templates/shared-v1/_ubuntu_advantage_server.html
+++ b/templates/shared-v1/_ubuntu_advantage_server.html
@@ -9,12 +9,6 @@
   </thead>
   <tbody>
     <tr>
-      <th scope="row">24x7 self-service customer care portal and knowledge base</th>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-    </tr>
-    <tr>
       <th scope="row">8x5 ticket support for the default packages in the Ubuntu Server image</th>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>

--- a/templates/shared/_ubuntu_advantage_server.html
+++ b/templates/shared/_ubuntu_advantage_server.html
@@ -2,7 +2,6 @@
   <thead>
     <tr>
       <th scope="col" class="row-title pricing-features-column">Features</th>
-      <th scope="col">Essential</th>
       <th scope="col">Standard</th>
       <th scope="col">Advanced</th>
     </tr>
@@ -12,11 +11,9 @@
       <th>8x5 ticket support for the default packages in the Ubuntu Server image</th>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th>Landscape Management</th>
-      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
@@ -24,41 +21,34 @@
       <th>Ubuntu Legal Assurance programme</th>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th>Live Patching (16.04 only)</th>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th>10x5 phone and ticket support for all packages in Ubuntu main</th>
-      <td>&nbsp;</td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th>Unlimited Ubuntu LXD guest support</th>
-      <td>&nbsp;</td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th>24x7 phone and ticket support for all packages in Ubuntu main and Canonical-maintained packages in backports and universe</th>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th>Unlimited Ubuntu KVM guest support</th>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
       <th>Ceph support</th>
-      <td>&nbsp;</td>
       <td>&nbsp;</td>
       <td>Optional</td>
     </tr>
@@ -66,17 +56,14 @@
       <th>Technical Account Manager</th>
       <td>Optional</td>
       <td>Optional</td>
-      <td>Optional</td>
     </tr>
     <tr>
       <th>Ubuntu Advantage price per server per year</th>
-      <td>$150</td>
       <td>$750</td>
       <td>$1,500</td>
     </tr>
     <tr>
       <th><a href="#ua-virtual-guests">Ubuntu Advantage for virtual guests</a></th>
-      <td>&nbsp;</td>
       <td>$2,500</td>
       <td>$3,150</td>
     </tr>

--- a/templates/shared/_ubuntu_advantage_server.html
+++ b/templates/shared/_ubuntu_advantage_server.html
@@ -49,7 +49,7 @@
     </tr>
     <tr>
       <th>Ceph support</th>
-      <td>&nbsp;</td>
+      <td>Optional</td>
       <td>Optional</td>
     </tr>
     <tr>

--- a/templates/shared/_ubuntu_advantage_server.html
+++ b/templates/shared/_ubuntu_advantage_server.html
@@ -8,18 +8,6 @@
     </tr>
   </thead>
   <tbody>
-    <!--<tr>
-      <td>&nbsp;</td>
-      <td>Ideal for Ubuntu scale out workloads and microservice architectures  in the enterprise</td>
-      <td>Perfect for Ubuntu in production data centres hosting virtualisation and container</td>
-      <td>Tailored for mission critical Ubuntu clouds and clusters, where uptime and availability are imperative</td>
-  </tr>-->
-    <tr>
-      <th>24x7 self-service customer care portal and knowledge base</th>
-      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-    </tr>
     <tr>
       <th>8x5 ticket support for the default packages in the Ubuntu Server image</th>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -52,7 +52,7 @@
         </div>
       </div>
       <footer class="p-card__footer">
-        <p class="p-card__title">From <span class="ua-price">$150</span> per year</p>
+        <p class="p-card__title">From <span class="ua-price">$2,500</span> per year</p>
       </footer>
       <footer class="p-card__footer">
         <p><a href="#ubuntu-advantage-for-server">Learn more&nbsp;&rsaquo;</a></p>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -52,7 +52,7 @@
         </div>
       </div>
       <footer class="p-card__footer">
-        <p class="p-card__title">From <span class="ua-price">$2,500</span> per year</p>
+        <p class="p-card__title">From <span class="ua-price">$750</span> per year</p>
       </footer>
       <footer class="p-card__footer">
         <p><a href="#ubuntu-advantage-for-server">Learn more&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done

* removed Ubuntu Advantage server essential product
* removed 24x7 support row
* raised starting price

_per Dustin Kirkland request_

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [server management page](http://0.0.0.0:8001/server/management) and the [support plans and pricing page](http://0.0.0.0:8001/support/plans-and-pricing)
- compare to the updated copy docs [server mgmt](https://docs.google.com/document/d/1Oqzs4utcIAdmFwZlSqlA6m5ioDlNnAjj_OTi_RHF2f8/edit) and [plans and pricing](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit)
- [demo - s/m](http://www.ubuntu.com-remove-ua-server-essential.demo.haus/server/management) and [demo - p + p](http://www.ubuntu.com-remove-ua-server-essential.demo.haus/support/plans-and-pricing) 

