### PR TITLE
remove padding at S screen for .u-padding-bottom class

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -137,14 +137,23 @@ html {
 /// XXX Utility to add bottom padding
 /// Proposal for inlcusion in vanilla: https://github.com/vanilla-framework/vanilla-framework/issues/1091
 .u-padding-bottom {
-  padding-bottom: $sp-medium;
+
+  @media (min-width: $breakpoint-medium) {
+    padding-bottom: $sp-medium;
+  }
 
   &--large {
-    padding-bottom: $sp-large;
+
+    @media (min-width: $breakpoint-medium) {
+      padding-bottom: $sp-large;
+    }
   }
 
   &--x-large {
-    padding-bottom: $sp-x-large;
+
+    @media (min-width: $breakpoint-medium) {
+      padding-bottom: $sp-x-large;
+    }
   }
 }
 


### PR DESCRIPTION
## Done

* removed for all variations of .u-padding-bottom for the Small screen

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/cloud/juju)
- [demo](http://www.ubuntu.com-1914-u-padding-bottom--x-large-small.demo.haus/cloud/juju) - juju at a glance section has one between the images and the link

## Issue / Card

Fixes #1914

## Screenshots

**before**
![image](https://user-images.githubusercontent.com/441217/27000877-66f62822-4db3-11e7-9441-98d23018847a.png)

**after**
![image](https://user-images.githubusercontent.com/441217/27000867-54c63e80-4db3-11e7-829d-4bb751b908f5.png)
