### PR TITLE
Use latest versioned-static - reads whole files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.versioned_static==1.0.1
+canonicalwebteam.versioned_static==1.0.2
 Django==1.11.1
 whitenoise==3.3.0
 django-yaml-redirects==0.5.3


### PR DESCRIPTION
We were having a problem that versioned-static was only generating a
hash based on the first 4096 bytes of the file, so if you changed the
last part, it wouldn't update.

QA
--

`./run`

Then go to `view-source:http://0.0.0.0:8001/`, and see the line:

``` html
<link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles-v1.css?v=457e1b1" />
```

Now add `/* hello world */` to the **end** of `static/css/styles-v1.css`, reload and check the hash value changes.