### PR TITLE
Re add ./run docker serve options

### DIFF
--- a/run
+++ b/run
@@ -233,7 +233,7 @@ case $run_command in
 
 
         # Run the serve container, publishing the port, and detaching if required
-        django_run "${project}-serve" "" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}"
+        django_run "${project}-serve" "" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}"
 
     ;;
     "stop")


### PR DESCRIPTION
Re add options used by demo system as it is preventing them firing up

## QA

`./run` should work correctly, with no errors