### PR TITLE
fix for accent links and buttons

### DIFF
--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -61,10 +61,10 @@
   .p-strip--dark {
     @extend %strip--accent;
 
-    a:link,
-    a:visited {
-      color: $color-x-light;
-    }
+      p > a:link:not(.p-button--neutral),
+      p > a:visited:not(.p-button--neutral) {
+        color: $color-x-light;
+      }
 
     .p-link--external {
       background-image: url('#{$assets-path}0d55fd52-external-link-white.svg');
@@ -74,17 +74,6 @@
     fieldset {
       background-color: $color-accent;
       border-color: $color-accent;
-    }
-
-    .p-button--neutral {
-      &:link,
-      &:visited {
-        background-color: $color-x-light;
-        color: $color-accent;
-      }
-      &:hover {
-        background-color: $color-mid-light;
-      }
     }
   }
 

--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -61,15 +61,10 @@
   .p-strip--dark {
     @extend %strip--accent;
 
-      p > a:link:not(.p-button--neutral),
-      p > a:visited:not(.p-button--neutral) {
-        color: $color-x-light;
-      }
-
-    .p-link--external {
-      background-image: url('#{$assets-path}0d55fd52-external-link-white.svg');
-      background-size: .85em;
-    }
+        .p-link--external {
+          background-image: url('#{$assets-path}0d55fd52-external-link-white.svg');
+          background-size: .85em;
+        }
 
     fieldset {
       background-color: $color-accent;

--- a/static/sass/_v1_pattern_strip.scss
+++ b/static/sass/_v1_pattern_strip.scss
@@ -57,14 +57,16 @@
   }
 
 // XXX many of these might have to go up to vbt
+// - the svg icon in .p-link--external.p-link--inverted should be $color-light https://github.com/vanilla-framework/vanilla-framework/issues/1112
+// - fieldset should be dark with .p-strip--dark/accent (vbt) https://github.com/vanilla-framework/vanilla-framework/issues/1113
   .p-strip--accent,
   .p-strip--dark {
     @extend %strip--accent;
 
-        .p-link--external {
-          background-image: url('#{$assets-path}0d55fd52-external-link-white.svg');
-          background-size: .85em;
-        }
+    .p-link--external {
+      background-image: url('#{$assets-path}0d55fd52-external-link-white.svg');
+      background-size: .85em;
+    }
 
     fieldset {
       background-color: $color-accent;

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -143,7 +143,7 @@
       <p>An increasing number of private and public entities are migrating to Ubuntu, as it offers a robust solution with equivalent performance to other proprietary systems but at a much lower cost. Canonical is ready to share best practices with organisations wishing to deploy Ubuntu.</p>
       <p>We have extensive experience helping companies worldwide. We have registered global deployments of over two million computers. Canonical can help to meet this growing demand by supporting organisations who are inviting requests for tender.</p>
       <p><a href="https://www.ubuntu.com/desktop/tenders/contact-us" class="p-button--neutral">Contact us about your tender</a></p>
-      <p><a href="https://insights.ubuntu.com/2015/04/17/tendering-with-ubuntu/" class="p-link--external">Learn more about tendering with Ubuntu</a></p>
+      <p><a href="https://insights.ubuntu.com/2015/04/17/tendering-with-ubuntu/" class="p-link--external p-link--inverted">Learn more about tendering with Ubuntu</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

* allow non-.p-button--neutral links to be white

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/desktop/partners)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/27030314-a8bac748-4f63-11e7-933e-3521263b544a.png)
