### PR TITLE
Fix global nav 'more' dropdown

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -95,6 +95,12 @@
   }
 }
 
+// global menu has too much top spacing
+#nav-global ul ul {
+  @media (min-width: $breakpoint-medium ) {
+    top: 15px;
+  }
+}
 
 /// XXX Base font size is set to 16px across all viewports
 /// This is a change to be made upstream in vanilla-framework


### PR DESCRIPTION
## Done

Fixed the 'more' dropdown on the global nav.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Drop down the 'more' menu in the global nav and see that it no longer has a large gap.
