### PR TITLE
Fix display of search icon on S screens

### DIFF
--- a/static/sass/_v1_pattern_site_search.scss
+++ b/static/sass/_v1_pattern_site_search.scss
@@ -71,7 +71,7 @@
       top: 0;
       right: 1.75rem;
       width: 1.5rem;
-      height: 1.5rem;
+      height: 3rem;
       border: 0;
       background-repeat: no-repeat;
       background-color: transparent;


### PR DESCRIPTION
## Done

On Safari on OSX on small screens, the search icon was appearing like this:

<img width="483" alt="5ccf7903e3a4d3fd34ee0807bb6cb53c _screen shot 2017-06-13 at 16 26 07" src="https://user-images.githubusercontent.com/505570/27090776-11266128-5056-11e7-83fb-808cc8d1fb8a.png">

It should now appear properly, like this:

<img width="607" alt="screen shot 2017-06-13 at 16 34 17" src="https://user-images.githubusercontent.com/505570/27090816-2f2ba0c0-5056-11e7-9061-b79b08363146.png">

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- View in Safari 
- Drop to small screen
- Open search input
- Verify icon appears correctly


