### PR TITLE
Remove duplicated scss and add link class to the kubernetes takeover …

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -310,14 +310,6 @@ pre {
   }
 }
 
-// XXX orange quotes in pull quotes
-.p-pull-quote > p:first-of-type::before,
-.p-pull-quote--accent > p:first-of-type::before,
-.p-pull-quote > p:last-of-type::after,
-.p-pull-quote--accent > p:last-of-type::after {
-  color: $color-brand;
-}
-
 // XXX sup is too high in Vanilla
 // bug - https://github.com/vanilla-framework/vanilla-framework/issues/1109
 sup {

--- a/templates/takeovers/_kubernetes_webinar.html
+++ b/templates/takeovers/_kubernetes_webinar.html
@@ -8,7 +8,7 @@
           <img src="{{ ASSET_SERVER_URL }}331f3baf-kubernetes-logo.svg" alt="Kubernetes logo" />
         </div>
         <p><a class="p-button--neutral" href="http://ubunt.eu/GUWzfp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Kubernetes webinar takeover', 'eventLabel' : 'Watch the webinar', 'eventValue' : undefined });">Watch the webinar</a></p>
-        <p><a href="http://ubunt.eu/jMgdKN " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Kubernetes takeover', 'eventLabel' : 'Find out more about Kubernetes', 'eventValue' : undefined });">Find out more about Kubernetes&nbsp;&rsaquo;</a></p>
+        <p><a href="http://ubunt.eu/jMgdKN " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Kubernetes takeover', 'eventLabel' : 'Find out more about Kubernetes', 'eventValue' : undefined });" class="p-link--inverted">Find out more about Kubernetes&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
…to make it white.

## Done

 - Fixed the homepage takeover link so that it is white again (was broken by a regression)
 - Removed duplicated SCSS

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the link under the button is white.