### PR TITLE
Fix footer nav stacking at 768px

### DIFF
--- a/static/sass/_v1_pattern_footer.scss
+++ b/static/sass/_v1_pattern_footer.scss
@@ -20,7 +20,7 @@
       padding: $sp-xx-large 0;
     }
 
-    @media only screen and (max-width: $breakpoint-medium) {
+    @media only screen and (max-width: $breakpoint-medium - 1) {
       &__nav-col {
         width: 100%;
       }
@@ -39,6 +39,10 @@
       border: 0;
       border-bottom: 1px dotted $color-x-dark;
       border-collapse: separate;
+
+      @media only screen and (max-width: $breakpoint-medium - 1px) {
+        display: none;
+      }
     }
 
     &__links {
@@ -51,7 +55,7 @@
       margin-bottom: 0;
 
       + .p-footer__item {
-        @media only screen and (min-width: $breakpoint-medium + 1) {
+        @media only screen and (min-width: $breakpoint-medium) {
           margin-top: $sp-large;
         }
       }

--- a/templates/templates/footer-v1.html
+++ b/templates/templates/footer-v1.html
@@ -39,7 +39,7 @@
   <div class="row">
     <div class="nav-global-footer"></div>
   </div>
-  <hr class="p-footer__divider u-hidden--small" />
+  <hr class="p-footer__divider" />
   <div class="row">
     <div class="p-footer--secondary">
       <div class="col-7">


### PR DESCRIPTION
## Done

Fix footer nav stacking at 768px

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Reduce screen width to 768px
- Verify that footer stacks correctly

## Expected

<img width="768" alt="screen shot 2017-06-14 at 16 05 53" src="https://user-images.githubusercontent.com/505570/27139696-9e4782a6-511b-11e7-84f2-b9da11ab4a69.png">