### PR TITLE
Remove local override for base font sizing; vanilla now sets the base font size to 16px

### DIFF
--- a/static/sass/styles-v1.scss
+++ b/static/sass/styles-v1.scss
@@ -109,17 +109,6 @@
   }
 }
 
-/// XXX Base font size is set to 16px across all viewports
-/// This is a change to be made upstream in vanilla-framework
-/// Issue: https://github.com/vanilla-framework/vanilla-framework/issues/1053
-html {
-  font-size: $font-base-size;
-
-  @media (min-width: $breakpoint-medium) {
-    font-size: $font-base-size;
-  }
-}
-
 /// XXX Compact button style
 /// This should be considered for inclusion in vanilla-framework
 .p-button--neutral.is-compact {


### PR DESCRIPTION
## Done

Removed a no longer needed local override for the base font size.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the base font size is still 16px
