### PR TITLE
Add p-link--inverted to accented strips.

### DIFF
--- a/templates/cloud/openstack/index.html
+++ b/templates/cloud/openstack/index.html
@@ -114,7 +114,7 @@
           <li class="p-list__item is-ticked">Guaranteed availability backed by a clear SLA</li>
           <li class="p-list__item is-ticked">Transfer operations anytime you want</li>
         </ul>
-        <p><a href="/cloud/openstack/managed-cloud">Learn more about BootStack&nbsp;&rsaquo;</a></p>
+        <p><a href="/cloud/openstack/managed-cloud" class="p-link--inverted">Learn more about BootStack&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}466046c7-illustration-cloud-bootstack.svg?w=320" alt="" class="u-hidden—small" width="320" />

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -47,19 +47,19 @@
     <div class="col-4 p-divider__block">
       <h3>Penn Manor school district, USA</h3>
       <p>Penn Manor saved $345,000 on 1,725 Ubuntu PCs at a fraction of what proprietary software costs.</p>
-      <p><a href="https://insights.ubuntu.com/2014/03/25/an-ubuntu-pc-for-everyone-in-penn-manor-school-district-pennsylvania-usa/" class="p-link--external">Read the <span class="u-off-screen">'Penn Manor school district, USA' </span>case study</a></p>
+      <p><a href="https://insights.ubuntu.com/2014/03/25/an-ubuntu-pc-for-everyone-in-penn-manor-school-district-pennsylvania-usa/" class="p-link--external p-link--inverted">Read the <span class="u-off-screen">'Penn Manor school district, USA' </span>case study</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>The Andalusian Regional Government, Spain</h3>
       <blockquote class="p-pull-quote--accent is-compact">
         <p class="p-pull-quote__item">Students throughout Andalusia now have access to a stable and easy-to-use technology environment.</p>
       </blockquote>
-      <p><a href="https://insights.ubuntu.com/2010/03/13/andalusia-deploys-220000-ubuntu-desktops-in-schools-throughout-the-region/" class="p-link--external">Read the <span class="u-off-screen">'The Andalusian Regional Government, Spain' </span>case study</a></p>
+      <p><a href="https://insights.ubuntu.com/2010/03/13/andalusia-deploys-220000-ubuntu-desktops-in-schools-throughout-the-region/" class="p-link--external p-link--inverted">Read the <span class="u-off-screen">'The Andalusian Regional Government, Spain' </span>case study</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Universit&eacute; de Nantes, France</h3>
       <p>Reduced the total cost of ownership across 40,000 Windows-dominated desktops.</p>
-      <p><a href="https://insights.ubuntu.com/2014/09/02/meeting-evolving-it-needs-at-the-university-of-nantes-france/" class="p-link--external">Read the <span class="u-off-screen">'Universit&eacute; de Nantes, France' </span>case study</a></p>
+      <p><a href="https://insights.ubuntu.com/2014/09/02/meeting-evolving-it-needs-at-the-university-of-nantes-france/" class="p-link--external p-link--inverted">Read the <span class="u-off-screen">'Universit&eacute; de Nantes, France' </span>case study</a></p>
     </div>
   </div>
 </div>

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -49,12 +49,12 @@
       <blockquote class="p-pull-quote--accent is-compact">
         <p>We simply wouldn&rsquo;t be able to deliver our work as fast and cost-effectively as this with any other platform&hellip; Ubuntu gives us wings!</p>
       </blockquote>
-      <p><a href="https://insights.ubuntu.com/2015/02/10/ubuntu-delivers-a-bulletproof-workstation-platform-for-media-productio/" class="p-link--external">Read the <span class="u-off-screen">'Carbonado Intermedia and Auteuristic' </span>case study</a></p>
+      <p><a href="https://insights.ubuntu.com/2015/02/10/ubuntu-delivers-a-bulletproof-workstation-platform-for-media-productio/" class="p-link--external p-link--inverted">Read the <span class="u-off-screen">'Carbonado Intermedia and Auteuristic' </span>case study</a></p>
     </div>
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--four">Bukwang Pharmaceuticals</h3>
       <p>Faced with an expensive new contract from Microsoft, Bukwang Pharma switched 400 PCs to Ubuntu and saved $300,000 on annual licensing alone.</p>
-      <p><a href="https://insights.ubuntu.com/2014/07/31/bukwang-pharmaceuticals-cut-it-costs-and-created-business-value-with-ubuntu/" class="p-link--external">Read the <span class="u-off-screen">'Bukwang Pharmaceuticals' </span>case study</a></p>
+      <p><a href="https://insights.ubuntu.com/2014/07/31/bukwang-pharmaceuticals-cut-it-costs-and-created-business-value-with-ubuntu/" class="p-link--external p-link--inverted">Read the <span class="u-off-screen">'Bukwang Pharmaceuticals' </span>case study</a></p>
     </div>
   </div>
 </section>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -152,12 +152,12 @@
     <div class="col-6 p-divider__block">
       <h2>Enterprise peace of mind</h2>
       <p>Canonical works with OEMs to deliver Ubuntu certified Edge Gateways. You can be sure Ubuntu Core will run out of the box with all the tools you require to manage and deploy software across all your devices.</p>
-      <p><a href="/internet-of-things/contact-us?product=gateways">Contact us to find out&nbsp;more&nbsp;&rsaquo;</a></p>
+      <p><a href="/internet-of-things/contact-us?product=gateways" class="p-link--inverted">Contact us to find out&nbsp;more&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-divider__block">
       <h2>Simple development and distribution for ISVs and SIs</h2>
       <p>Independent software vendors and system integrators develop with the familiar environment and use the wealth of libraries available in Ubuntu. With Ubuntu Core you can easily manage the software you distribute. Use the Ubuntu Store to reach new customers.</p>
-      <p><a class="p-link--external" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
+      <p><a class="p-link--external p-link--inverted" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Made sure that the p-link--inverted class is used on all text links in accented rows.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`

Check the following pages' accented rows (aubergine-coloured) and see that the links are now light.
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud/openstack](http://0.0.0.0:8001/cloud/openstack)
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/education](http://0.0.0.0:8001/desktop/education)
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/enterprise](http://0.0.0.0:8001/desktop/enterprise)
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/gateways](http://0.0.0.0:8001/internet-of-things/gateways)
