### PR TITLE
Move news strip

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -319,3 +319,12 @@ sup {
     width: 100%;
   }
 }
+
+/// XXX responsive bottom margin
+.u-less-margin--bottom {
+  margin-bottom: .5rem;
+
+  @media (min-width: $breakpoint-medium ) {
+    margin-bottom: 1rem;
+  }
+}

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -285,7 +285,7 @@
 </section>
 
 
-{% include "shared-v1/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed/?topic=cloud" rss_news_url="https://insights.ubuntu.com/feed?topic=cloud" strip_classes="p-strip--light is-deep is-bordered" gtm_event_label="ubuntu.com cloud overview" %}
+{% include "shared/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed/?topic=cloud" rss_news_url="https://insights.ubuntu.com/feed?topic=cloud" strip_classes="p-strip--light is-deep is-bordered" gtm_event_label="ubuntu.com cloud overview" %}
 
 <section class="p-strip--x-light">
   <div class="row">

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
 {% include "takeovers/_kubernetes_webinar.html" %}
 
 
-{% include "shared-v1/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
+{% include "shared/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
 
 <section class="p-strip--light is-bordered">
   <div class="row u-align--center">

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -1,4 +1,4 @@
-{# example include- include "shared-v1/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" #}
+{# example include- include "shared/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" #}
 
 
 {% get_rss_feed rss_spotlight_url limit=1 as spotlight_feed %}


### PR DESCRIPTION
## Done

* moved news strip to /shared and deleted /shared-v1
* added .u-less-margin--bottom back to styles.scss

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/) and /cloud
- See that the news strip looks good
