### PR TITLE
add context to forms

### DIFF
--- a/templates/about/contact-us/index.html
+++ b/templates/about/contact-us/index.html
@@ -20,7 +20,7 @@
         <li>Spain <a href="tel:+34 900 833872">+34 900 833872</a></li>
         <li>UK and rest of world <a href="tel:+44 800 0588704">+44 800 0588704</a></li>
       </ul>
-      <p>Or <a href="/about/contact-us/form">contact us</a> at Canonical to discuss support, training or technical consulting and we will get in touch with you within two working days.</p>
+      <p>Or <a href="/about/contact-us/form?product=generic-contact-us">contact us</a> at Canonical to discuss support, training or technical consulting and we will get in touch with you within two working days.</p>
     </div>
   </div>
   <div class="row">

--- a/templates/cloud/contact-us.html
+++ b/templates/cloud/contact-us.html
@@ -2,25 +2,35 @@
 {% block title %}Contact us | Ubuntu Cloud{% endblock %}
 
 {% block content %}
-  <section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
-    <div class="strip-inner-wrapper">
-      {% if product == 'cloud-training' %}
-        {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training" %}
-      {% elif product == 'cloud-training-classroom' %}
-        {% include "shared/_cloud-contact-us-form.html" with  h1="Register for Ubuntu OpenStack Training" intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we’ll get back to you with available dates and locations." formid="1261" lpId="2161" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-classroom" %}
-      {% elif product == 'cloud-training-onsite' %}
-        {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1223" lpId="1973" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-onsite" %}
-      {% elif product == 'cloud-training-server-admin' %}
-        {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-server-admin" %}
-      {% elif product == 'storage' %}
-        {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/cloud/thank-you?product=storage" %}
-      {% elif product == 'managed-cloud' %}
-        {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/cloud/thank-you?product=managed-cloud" %}
-      {% else %}
-        {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about the cloud" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/cloud/thank-you' %}
-      {% endif %}
-    </div>
-  </section>
+  {% if product == 'cloud-training' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training" %}
+
+  {% elif product == 'cloud-training-classroom' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Register for Ubuntu OpenStack Training" intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we’ll get back to you with available dates and locations." formid="1261" lpId="2161" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-classroom" %}
+
+  {% elif product == 'cloud-training-onsite' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1223" lpId="1973" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-onsite" %}
+
+  {% elif product == 'cloud-training-server-admin' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-server-admin" %}
+
+  {% elif product == 'storage' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/cloud/thank-you?product=storage" %}
+
+  {% elif product == 'managed-cloud' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/cloud/thank-you?product=managed-cloud" %}
+
+  {% else %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about the cloud" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/cloud/thank-you' %}
+
+  {% endif %}
 {% endblock content %}
 
 {% block footer_extra %}

--- a/templates/cloud/contact-us.html
+++ b/templates/cloud/contact-us.html
@@ -18,13 +18,17 @@
 
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-server-admin" %}
 
-  {% elif product == 'storage' %}
+  {% elif product == 'cloud-storage' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/cloud/thank-you?product=storage" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-storage" %}
 
-  {% elif product == 'managed-cloud' %}
+  {% elif product == 'cloud-managed-cloud' or product == 'contextual-footer-cloud-managed-cloud' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/cloud/thank-you?product=managed-cloud" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-managed-cloud" %}
+
+  {% elif product == 'cloud' or product == 'contextual-footer-cloud' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about the cloud" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/cloud/thank-you' %}
 
   {% else %}
 

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -17,7 +17,7 @@
           <div class="col-7">
             <p>BootStack is a managed service where the world-class team at Canonical build and operate your OpenStack cloud either on-premises or hosted.</p>
             <p>We provide the in-house expertise to stand-up and scale your cloud. And, when you&rsquo;re ready, we will hand over operational control.</p>
-            <p><a href="/cloud/contact-us?product=managed-cloud" class="p-button--brand">Schedule a demo</a></p>
+            <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--brand">Schedule a demo</a></p>
           </div>
         </div>
       </div>
@@ -121,7 +121,7 @@
   </div>
   <div class="row">
     <div class="col-12 u-padding-bottom--x-large">
-      <p><a href="/cloud/contact-us?product=managed-cloud" class="p-button--neutral">Schedule a demo</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--neutral">Schedule a demo</a></p>
     </div>
   </div>
 </section>

--- a/templates/cloud/openstack/index.html
+++ b/templates/cloud/openstack/index.html
@@ -57,7 +57,7 @@
       <div class="col-6 p-card">
         <h3 class="p-card__title">Get a customised cloud</h3>
         <p class="p-card__content">Our engineers can tailor OpenStack to support your specific requirements and cloud applications.</p>
-        <p class="p-card__content"><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
+        <p class="p-card__content"><a href="/cloud/contact-us?product=openstack">Contact us&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -142,7 +142,7 @@
         <li class="p-list__item is-ticked">Repeatable deployment</li>
         <li class="p-list__item is-ticked">Hardware selection support</li>
       </ul>
-      <p><a href="/cloud/contact-us">Contact us about your custom engineering needs&nbsp;&rsaquo;</a></p>
+      <p><a href="/cloud/contact-us?product=openstack">Contact us about your custom engineering needs&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 prefix-1">
       <blockquote class="p-pull-quote">

--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -89,7 +89,7 @@
     <div class="col-8">
       <h2>Become a cloud partner</h2>
       <p>To learn more about becoming a charm, Ubuntu certified public cloud or Ubuntu OpenStack partner, please contact us today.</p>
-      <p><a href="http://partners.ubuntu.com/contact-us?product=partners" class="p-button--brand">Get in touch</a></p>
+      <p><a href="http://partners.ubuntu.com/contact-us" class="p-button--brand">Get in touch</a></p>
       <p>or <a href="http://partners.ubuntu.com/partnering-with-us" class="p-link--external">learn more about partnering with us</a></p>
     </div>
   </div>

--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -89,7 +89,7 @@
     <div class="col-8">
       <h2>Become a cloud partner</h2>
       <p>To learn more about becoming a charm, Ubuntu certified public cloud or Ubuntu OpenStack partner, please contact us today.</p>
-      <p><a href="http://partners.ubuntu.com/contact-us" class="p-button--brand">Get in touch</a></p>
+      <p><a href="http://partners.ubuntu.com/contact-us?product=partners" class="p-button--brand">Get in touch</a></p>
       <p>or <a href="http://partners.ubuntu.com/partnering-with-us" class="p-link--external">learn more about partnering with us</a></p>
     </div>
   </div>

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -79,7 +79,7 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <p><a href="/management/contact-us">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/management/contact-us?product=cloud-plans-and-pricing">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -109,7 +109,7 @@
           <td>$0.05</td>
         </tr>
       </table>
-      <p><a href="/cloud/openstack/managed-cloud/contact-us">Schedule a BootStack demo&nbsp;&rsaquo;</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-plans-and-pricing">Schedule a BootStack demo&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -119,7 +119,7 @@
     <div class="col-7">
       <h2>Consulting</h2>
       <p>Need greater customisation? We have helped the world&rsquo;s leading telcos and service providers take their OpenStack clouds from concept all the way to production. We have an extensive portfolio of services to help you build and support an Extreme OpenStack cloud.</p>
-      <p><a href="/cloud/contact-us">Contact us to discuss your needs&nbsp;&rsaquo;</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-plans-and-pricing">Contact us to discuss your needs&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center">
       <img src="{{ ASSET_SERVER_URL }}3ba54a27-picto-contact-midaubergine.svg" width="200" alt="" />

--- a/templates/cloud/storage.html
+++ b/templates/cloud/storage.html
@@ -10,7 +10,7 @@
       <div class="col-6">
         <h1>Ubuntu&nbsp;Advantage&nbsp;Storage</h1>
         <p>Ubuntu Advantage Storage from Canonical embeds the proven software&dash;defined storage (<abbr title="Software&dash;defined storage">SDS</abbr>) technologies of Ceph, NexentaEdge, Swift and SwiftStack, into a 24x7&dash;supported software solution with a unique metered pricing model.</p>
-        <p><a class="p-button--brand" href="/cloud/contact-us?product=storage">Request a demo</a></p>
+        <p><a class="p-button--brand" href="/cloud/contact-us?product=cloud-storage">Request a demo</a></p>
       </div>
       <div class="col-6 prefix-1 u-align--center u-vertically-center u-hidden--small">
         <img class="hero-image" width="100%" src="{{ ASSET_SERVER_URL }}c2d50399-storage.svg" alt="Lots of server pictos in a cloud" />
@@ -104,7 +104,7 @@
                 <p>Legacy storage solutions are often priced per&dash;node or according to total disk capacity. This can lead to a penalty for good practices such as high durability&nbsp;replication.</p>
                 <p>Ubuntu Advantage Storage is different. Our pricing is based on the amount of data you record in your storage pool, regardless of how it is written or how much disk space is used.</p>
                 <p>Ubuntu Advantage Storage means you don&rsquo;t have to pay for replicas or empty space.</p>
-                <p><a href="/cloud/contact-us?product=storage">Find out how much you can save&nbsp;&rsaquo;</a></p>
+                <p><a href="/cloud/contact-us?product=cloud-storage">Find out how much you can save&nbsp;&rsaquo;</a></p>
               </div>
               <div class="col-6 u-align--center">
                 <img src="{{ ASSET_SERVER_URL }}d8555ed7-storage-diagram-jy.png" alt="" />
@@ -124,7 +124,7 @@
                   <li class="p-list__item is-ticked">World&dash;class support from Canonical, experts in large&dash;scale, multi&dash;site&dash;replicated deployments.</li>
                   <li class="p-list__item is-ticked">Built with Ubuntu {{ lts_release_full }} with five years of support for every component in the stack.</li>
                 </ul>
-                <p><a class="p-button--neutral" href="/cloud/contact-us?product=storage">Request a demo</a></p>
+                <p><a class="p-button--neutral" href="/cloud/contact-us?product=cloud-storage">Request a demo</a></p>
               </div>
             </div>
           </section>

--- a/templates/cloud/training.html
+++ b/templates/cloud/training.html
@@ -127,7 +127,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">From 6 February 2017</dd>
       </dl>
-      <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/cloud/contact-us?proudct=cloud-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -137,7 +137,7 @@
     <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
-      <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-training">Contact us&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hidden--small">
       <img src="{{ ASSET_SERVER_URL }}9b170f06-picto-help-orange.svg" width="135" alt="" />

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -3,7 +3,17 @@
 
 
 {% block content %}
+  {% if product == 'containers-docker' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Docker Engine on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
+  {% elif product == 'containers-kubernetes' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Canonical Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
+  {% elif product == 'containers-lxd' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about LXD" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
+  {% elif product == 'containers-overview' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about containers on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
+  {% else %}
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about containers" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
+  {% endif %}
 {% endblock content %}
 
 {% block footer_extra %}

--- a/templates/containers/docker-ubuntu.html
+++ b/templates/containers/docker-ubuntu.html
@@ -15,7 +15,7 @@
         <h2>Integrated support service with enterprise&nbsp;SLAs</h2>
         <p>Docker Engine is a lightweight container runtime with robust tooling that builds and runs your container. Over 65% of all Docker-based scale out operations run on Ubuntu.</p>
         <p>Canonical works closely with Docker Inc. to deliver an integrated Docker Enterprise Edition offering on Ubuntu. This partnership provides customers with the fastest and easiest path for support of Ubuntu and Docker Engine in enterprise Docker operations.</p>
-        <p><a href="/containers/contact-us?product=docker">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
+        <p><a href="/containers/contact-us?product=containers-docker">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-vertically-center u-align--center">
         <img src="{{ ASSET_SERVER_URL }}fe637cb5-docker.svg" width="220" alt="" />
@@ -75,7 +75,7 @@
           <li class="p-list__item is-ticked">Canonical provides Level 1 and Level 2 technical support for Docker Enterprise Edition and are backed by Docker Inc. for Level 3 support</li>
           <li class="p-list__item is-ticked">Canonical also ensures global availability of secure  Ubuntu images on Docker Hub</li>
         </ul>
-        <p><a href="/containers/contact-us?product=docker">Talk to our container team&nbsp;&rsaquo;</a></p>
+        <p><a href="/containers/contact-us?product=containers-docker">Talk to our container team&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-align--center u-vertically-center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}9f035e4a-picto-support-orange.svg" width="200" alt="" />

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -12,7 +12,7 @@
         <h1>Containers</h1>
         <h2>Ubuntu is the number one platform for containers</h2>
         <p>From LXD to Kubernetes to Docker, Canonical has partnered with industry leaders to offer a full range of technologies and services to run containers at scale on public, private and hybrid or bare metal clouds.<p>
-          <p><a href="/containers/contact-us">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
+          <p><a href="/containers/contact-us?product=containers-overview">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-5 u-align--center u-hidden--small">
           <img class="u-float--right" src="{{ ASSET_SERVER_URL }}a9aff224-Containers-illustration.svg" width="350" alt="" />
@@ -155,7 +155,7 @@
           <li class="p-list__item is-ticked">Kernel livepatching to ensure you have the latest kernel security&nbsp;updates</li>
         </ul>
         <p><a href="https://buy.ubuntu.com/" class="p-button--brand"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
-        <p>Or <a href="/containers/contact-us">contact us&nbsp;&rsaquo;</a></p>
+        <p>Or <a href="/containers/contact-us?product=containers-overview">contact us&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-align--right u-vertically-center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}11da76f5-image-management.svg" style="width: 80%;" width="288" height="155" />

--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -12,7 +12,7 @@
         <h2>Enterprise Kubernetes, anywhere</h2>
         <p>In partnership with Google, Canonical now delivers a &lsquo;pure <abbr title="Kubernetes">K8s</abbr>&rsquo; experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.</p>
         <p>The Canonical Distribution of Kubernetes works across all major public clouds and private infrastructure, enabling your teams to operate Kubernetes clusters on demand, anywhere.</p>
-        <p><a href="/containers/contact-us?product=kubernetes">Talk to us about your container management strategy&nbsp;&rsaquo;</a></p>
+        <p><a href="/containers/contact-us?product=containers-kubernetes">Talk to us about your container management strategy&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-vertically-center u-align--center">
         <img src="{{ ASSET_SERVER_URL }}dba11aee-kubernetes.svg" width="220" alt="" />
@@ -177,7 +177,7 @@
         <p>We also offer consulting services and customisation for larger organisations to integrate Kubernetes with existing infrastructure.</p>
         <p>For customers needing a fully managed Kubernetes, Canonical will deploy and operate your cluster remotely, and hand over to your own team as soon as they are familiar with the operational practices under the hood.</p>
         <p>To discuss your requirement connect with a member of the Canonical team.</p>
-        <p><a href="/containers/contact-us?product=kubernetes" class="p-button--brand">Contact us</a></p>
+        <p><a href="/containers/contact-us?product=containers-kubernetes" class="p-button--brand">Contact us</a></p>
       </div>
     </div>
   </div>

--- a/templates/containers/lxd.html
+++ b/templates/containers/lxd.html
@@ -11,7 +11,7 @@
         <h1>The LXD container hypervisor</h1>
         <h2>10x the density of ESX, 25% faster, zero latency</h2>
         <p>Move your Linux VMs straight to containers, easily, without modifying the apps or administration processes. Canonical&rsquo;s LXD is a pure-container hypervisor that runs unmodified Linux guest operating systems with VM-style operations at incredible speed and density.</p>
-        <p><a href="/containers/contact-us?product=lxd">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
+        <p><a href="/containers/contact-us?product=containers-lxd">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}f581fd89-lxd_takeover.png" width="260" alt="LXD" />
@@ -207,7 +207,7 @@
         <p>We also offer consulting services and customisation for larger organisations to integrate LXD with existing infrastructure.</p>
         <p>To discuss your requirement connect with a member of the Canonical team.</p>
         <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
-        <p><a href="/containers/contact-us?product=lxd">Contact us&nbsp;&rsaquo;</a></p>
+        <p><a href="/containers/contact-us?product=containers-lxd">Contact us&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-3 prefix-1 u-vertically-center u-hidden--small">
         <img src="https://assets.ubuntu.com/v1/9f035e4a-picto-support-orange.svg" width="200" />

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -187,7 +187,7 @@
       <div class="col-8">
         <h2>Let&rsquo;s work together</h2>
         <p>Talk to us if you are thinking about using Ubuntu Core for your next project.</p>
-        <p><a href="/core/contact-us" class="p-button--brand">Get in touch</a></p>
+        <p><a href="/core/contact-us?product=core-overview" class="p-button--brand">Get in touch</a></p>
       </div>
       <div class="col-2 u-align--center u-vertically-align u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="140" alt="" />

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -12,7 +12,7 @@
       <div class="p-card--overlay">
         <h1>Ubuntu for education</h1>
         <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators.</p>
-        <p><a href="/desktop/contact-us" class="p-button--brand">Contact us</a></p>
+        <p><a href="/desktop/contact-us?product=desktop-education" class="p-button--brand">Contact us</a></p>
       </div>
     </div>
   </div>

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -10,7 +10,7 @@
     <div class="col-6">
       <h1>Ubuntu for enterprise</h1>
       <p>On the desktop, Ubuntu has been widely adopted by small and large enterprises because of its ease of use, speed, apps, security model, management tools and low cost of ownership.</p>
-      <p><a href="/desktop/contact-us" class="p-button--brand">Contact us</a></p>
+      <p><a href="/desktop/contact-us?product=desktop-enterprise" class="p-button--brand">Contact us</a></p>
       <p><a href="https://buy.ubuntu.com" class="p-link--external">Buy Ubuntu Advantage</a></p>
     </div>
     <div class="col-6 u-vertically-center u-hidden--small">

--- a/templates/desktop/government.html
+++ b/templates/desktop/government.html
@@ -9,7 +9,7 @@
     <div class="col-6">
       <h1>Ubuntu for government</h1>
       <p>Ubuntu provides central and local government departments with secure, open source, cost-effective, accessible computing on an extensive range of certified hardware.</p>
-      <p><a href="/desktop/contact-us" class="p-button--neutral">Contact us</a></p>
+      <p><a href="/desktop/contact-us?product=desktop-government" class="p-button--neutral">Contact us</a></p>
     </div>
   </div>
 </section>

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -142,7 +142,7 @@
       <h2>Considering buying new devices with Ubuntu?</h2>
       <p>An increasing number of private and public entities are migrating to Ubuntu, as it offers a robust solution with equivalent performance to other proprietary systems but at a much lower cost. Canonical is ready to share best practices with organisations wishing to deploy Ubuntu.</p>
       <p>We have extensive experience helping companies worldwide. We have registered global deployments of over two million computers. Canonical can help to meet this growing demand by supporting organisations who are inviting requests for tender.</p>
-      <p><a href="https://www.ubuntu.com/desktop/tenders/contact-us" class="p-button--neutral">Contact us about your tender</a></p>
+      <p><a href="https://www.ubuntu.com/desktop/tenders/contact-us?product=desktop-partners" class="p-button--neutral">Contact us about your tender</a></p>
       <p><a href="https://insights.ubuntu.com/2015/04/17/tendering-with-ubuntu/" class="p-link--external p-link--inverted">Learn more about tendering with Ubuntu</a></p>
     </div>
   </div>

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -231,7 +231,7 @@
           <div class="col-12">
             <h2>Need more help?</h2>
             <p>Let our cloud experts help you take the next step.</p>
-            <p><a href="/cloud/contact-us?product=autopilot">Contact us&nbsp;&rsaquo;</a></p>
+            <p><a href="/cloud/contact-us?product=cloud-autopilot">Contact us&nbsp;&rsaquo;</a></p>
             <p>Already a Landscape Dedicated Server customer? Upgrading is simple, see the instructions in the <a href="https://help.landscape.canonical.com/LDS/ReleaseNotes" class="p-link--external">release notes</a>.</p>
           </div>
         </div>

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -231,7 +231,7 @@
           <div class="col-12">
             <h2>Need more help?</h2>
             <p>Let our cloud experts help you take the next step.</p>
-            <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
+            <p><a href="/cloud/contact-us?product=autopilot">Contact us&nbsp;&rsaquo;</a></p>
             <p>Already a Landscape Dedicated Server customer? Upgrading is simple, see the instructions in the <a href="https://help.landscape.canonical.com/LDS/ReleaseNotes" class="p-link--external">release notes</a>.</p>
           </div>
         </div>

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -42,7 +42,7 @@
         <div class="col-12">
           <h2>Need more help?</h2>
           <p>Let our cloud experts help you take the next step.</p>
-          <p><a href="/cloud/contact-us" class="p-button--neutral">Contact us</a></p>
+          <p><a href="/cloud/contact-us?product=cloud-overview" class="p-button--neutral">Contact us</a></p>
           <p>Already a Landscape Dedicated Server customer? Upgrading is simple, see the instructions in the <a href="https://help.landscape.canonical.com/LDS/ReleaseNotes" class="p-link--external">release notes</a>.</p>
         </div>
       </div>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -55,7 +55,7 @@
       <h3>Commercially supported and ready to deploy today</h3>
       <p>Pair your ARM server deployment with enterprise-grade 24x7 support with Ubuntu Advantage to get the SLA-backed  assurance that you are fully covered by our system and architecture experts &mdash; no matter what comes up.</p>
       <p>Built for cutting-edge hardware, from the HP Moonshot range to standard form-factor certified systems, Ubuntu and ARM Server provide truly compelling economics for cloud-scale deployment.</p>
-      <p><a href="/server/contact-us">Contact us about your ARM server plans&nbsp;&rsaquo;</a></p>
+      <p><a href="/server/contact-us?product=server-arm">Contact us about your ARM server plans&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -206,7 +206,7 @@
     <div class="col-7">
       <h2>Let&rsquo;s work together</h2>
       <p class="clear">Talk to us if you are thinking about using Ubuntu Core for your next Internet of Things project.</p>
-      <p><a href="/internet-of-things/contact-us" class="p-button--neutral">Get in touch</a></p>
+      <p><a href="/internet-of-things/contact-us?product=iot-overview" class="p-button--neutral">Get in touch</a></p>
     </div>
   </div>
 </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -109,7 +109,7 @@
       <h3>Still no luck?</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked"><a href="/">Visit the Ubuntu homepage</a></li>
-        <li class="p-list__item is-ticked"><a href="/contact-us">Contact us</a></li>
+        <li class="p-list__item is-ticked"><a href="/desktop/contact-us?product=search-page">Contact us</a></li>
       </ul>
     </div>
   </div>

--- a/templates/server/contact-us.html
+++ b/templates/server/contact-us.html
@@ -1,14 +1,34 @@
 {% extends "server/base_server.html" %}
 {% block title %}Contact us | Ubuntu Server{% endblock %}
-{% block meta_description %}Contact Canonical about Ubuntu Server{% endblock %}
+{% block meta_description %}Contact us about Ubuntu Server about Ubuntu Server{% endblock %}
 
 
 {% block content %}
-<div class="p-strip">
-  <div class="row">
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact Canonical"   intro_text="Considering Ubuntu Server for your business?"  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
-  </div>
- </section>
+  {% if product == 'server-overview' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
+
+  {% elif product == 'server-hyperscale' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server for hyperscale"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
+
+  {% elif product == 'server-management' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Advantage support"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
+
+  {% elif product == 'server-maas' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about MAAS and server provisioning"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
+
+  {% elif product == 'contextual-footer-maas' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about MAAS and server provisioning"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
+
+  {% else %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
+
+{% endif %}
 
 {% endblock content %}
 

--- a/templates/server/contact-us.html
+++ b/templates/server/contact-us.html
@@ -16,7 +16,7 @@
 
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Advantage support"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
 
-  {% elif product == 'server-maas' %}
+  {% elif product == 'server-maas' or product == 'contextual-footer-server-maas' %}
 
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about MAAS and server provisioning"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
 

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -155,7 +155,7 @@
   </div>
   <div class="row">
     <div class="col-8 suffix-4">
-      <p><a href="/server/contact-us">Contact us about hyperscale&nbsp;&rsaquo;</a></p>
+      <p><a href="/server/contact-us?product=server-hyperscale">Contact us about hyperscale&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -206,7 +206,7 @@
       <div class="p-card">
         <h3 class="p-card__title">Get in touch</h3>
         <p class="p-card__content">Speak to our technical support team about your server requirements.</p>
-        <p class="p-card__content"><a class="p-button--brand" href="/server/contact-us">Contact us</a></p>
+        <p class="p-card__content"><a class="p-button--brand" href="/server/contact-us?product=server-overview">Contact us</a></p>
       </div>
     </div>
   </div>

--- a/templates/server/maas.html
+++ b/templates/server/maas.html
@@ -195,7 +195,7 @@
             <li class="p-list__item is-ticked">All operating systems</li>
             <li class="p-list__item is-ticked">9 to 5 support on weekdays (US and Europe only)</li>
           </ul>
-          <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
+          <p><a href="/server/contact-us?product=server-maas">Contact us&nbsp;&rsaquo;</a></p>
         </footer>
       </div>
       <div class="col-4 p-card">
@@ -208,7 +208,7 @@
             <li class="p-list__item is-ticked">All operating systems</li>
             <li class="p-list__item is-ticked">24/7 support</li>
           </ul>
-          <p><a href="/cloud/contact-us">Contact us&nbsp;&rsaquo;</a></p>
+          <p><a href="/server/contact-us?product=server-maas">Contact us&nbsp;&rsaquo;</a></p>
         </footer>
       </div>
     </div>

--- a/templates/server/management.html
+++ b/templates/server/management.html
@@ -66,7 +66,7 @@
   <div class="row">
     <div class="col-10">
       {% include "shared/_ubuntu_advantage_cloud_virtual_guests.html" %}
-      <p><a href="/support/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/support/contact-us?product=server-management">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/shared/contextual_footers/_cloud_bootstack.html
+++ b/templates/shared/contextual_footers/_cloud_bootstack.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Want a fully managed private cloud?</h3>
   <p>BootStack is your OpenStack private cloud with our experts responsible for design, deployment and availability.</p>
-  <p><a href="/cloud/openstack/managed-cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'BootStack', 'eventLabel' : 'Want a fully managed private cloud?', 'eventValue' : undefined });">Get BootStack&nbsp;&rsaquo;</a></p>
+  <p><a href="/cloud/contact-us?product=contextual-footer-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'BootStack', 'eventLabel' : 'Want a fully managed private cloud?', 'eventValue' : undefined });">Get BootStack&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_cloud_bootstack.html
+++ b/templates/shared/contextual_footers/_cloud_bootstack.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Want a fully managed private cloud?</h3>
   <p>BootStack is your OpenStack private cloud with our experts responsible for design, deployment and availability.</p>
-  <p><a href="/cloud/contact-us?product=contextual-footer-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'BootStack', 'eventLabel' : 'Want a fully managed private cloud?', 'eventValue' : undefined });">Get BootStack&nbsp;&rsaquo;</a></p>
+  <p><a href="/cloud/contact-us?product=contextual-footer-cloud-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'BootStack', 'eventLabel' : 'Want a fully managed private cloud?', 'eventValue' : undefined });">Get BootStack&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared/contextual_footers/_cloud_contact_us.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Get in touch</h3>
   <p>Contact us for more information or to discuss your specific needs.</p>
-  <p><a class="p-button--neutral" href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us</a></p>
+  <p><a class="p-button--neutral" href="/cloud/contact-us?product=contextual-footer-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us</a></p>
 </div>

--- a/templates/shared/contextual_footers/_desktop_contact_us.html
+++ b/templates/shared/contextual_footers/_desktop_contact_us.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Talk to us today</h3>
   <p>Ready to discuss how Ubuntu could benefit your organisation?</p>
-  <p><a class="p-button--neutral" href="/desktop/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Desktop contact-us', 'eventLabel' : 'Talk to us today', 'eventValue' : undefined });">Get in touch</a></p>
+  <p><a class="p-button--neutral" href="/desktop/contact-us?product=contextual-footer-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Desktop contact-us', 'eventLabel' : 'Talk to us today', 'eventValue' : undefined });">Get in touch</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
+++ b/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
@@ -2,5 +2,5 @@
   <h3 class="p-heading--four">Need more licenses?</h3>
   <p>Have you built your Ubuntu OpenStack cloud and need more licenses?  You&rsquo;ll need to purchase Ubuntu Advantage.</p>
   <p><a href="https://buy.ubuntu.com/" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Shop for Ubuntu Advantage', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">Buy now</a></p>
-  <p>Or <a href="/support/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Contact-us management', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">contact our sales team&nbsp;&rsaquo;</a></p>
+  <p>Or <a href="/support/contact-us?product=contextual-footer-landscape" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Contact-us management', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">contact our sales team&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_maas_experts.html
+++ b/templates/shared/contextual_footers/_maas_experts.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Talk to our experts</h3>
   <p>Canonical makes MAAS amazing and we help people run critical infrastructure at scale with it. Contact us for more information or to discuss your specific&nbsp;needs.</p>
-  <p><a href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'download server provisioning page', 'eventLabel' : 'contact us', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
+  <p><a href="/server/contact-us?product=contextual-footer-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'download server provisioning page', 'eventLabel' : 'contact us', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_maas_experts.html
+++ b/templates/shared/contextual_footers/_maas_experts.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Talk to our experts</h3>
   <p>Canonical makes MAAS amazing and we help people run critical infrastructure at scale with it. Contact us for more information or to discuss your specific&nbsp;needs.</p>
-  <p><a href="/server/contact-us?product=contextual-footer-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'download server provisioning page', 'eventLabel' : 'contact us', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
+  <p><a href="/server/contact-us?product=contextual-footer-server-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'download server provisioning page', 'eventLabel' : 'contact us', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_server_contact_us.html
+++ b/templates/shared/contextual_footers/_server_contact_us.html
@@ -1,6 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ubuntu Advantage for business</h3>
   <p>Get professional support {% if level_2 == 'management' %}with Ubuntu Advantage{% else %}for Ubuntu Server{% endif %} from Canonical.</p>
-  <p><a href="https://buy.ubuntu.com" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'Ubuntu Advantage store', 'eventValue' : undefined });"><span class="external">Visit the store</span></a></p>
+  <p><a href="https://buy.ubuntu.com" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'Ubuntu Advantage store', 'eventValue' : undefined });"><span class="p-link--external">Visit the store</span></a></p>
   <p><a href="/server/contact-us?product=contextual-footer-ua" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'For business', 'eventValue' : undefined });">Get in touch&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_server_contact_us.html
+++ b/templates/shared/contextual_footers/_server_contact_us.html
@@ -2,5 +2,5 @@
   <h3 class="p-heading--four">Ubuntu Advantage for business</h3>
   <p>Get professional support {% if level_2 == 'management' %}with Ubuntu Advantage{% else %}for Ubuntu Server{% endif %} from Canonical.</p>
   <p><a href="https://buy.ubuntu.com" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'Ubuntu Advantage store', 'eventValue' : undefined });"><span class="external">Visit the store</span></a></p>
-  <p><a href="/server/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'For business', 'eventValue' : undefined });">Get in touch&nbsp;&rsaquo;</a></p>
+  <p><a href="/server/contact-us?product=contextual-footer-ua" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'For business', 'eventValue' : undefined });">Get in touch&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_support_contact_us.html
+++ b/templates/shared/contextual_footers/_support_contact_us.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Contact us today</h3>
   <p>Landscape is part of the Ubuntu Advantage service package, delivered by Canonical. To talk to a member of our team about the benefits it could bring to your organisation.</p>
-  <p><a href="/support/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'support contact-us', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us today</a></p>
+  <p><a href="/support/contact-us?product=contextual-footer-landscape" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'support contact-us', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us today</a></p>
 </div>

--- a/templates/support/contact-us.html
+++ b/templates/support/contact-us.html
@@ -7,7 +7,7 @@
 <section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
     <div class="strip-inner-wrapper">
 
-  {% include "shared/_cloud-contact-us-form.html" with  h1="Contact Canonical"   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch."  formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you"  %}
+  {% include "shared/_cloud-contact-us-form.html" with  h1="Contact Canonical about Ubuntu Advantage"   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch."  formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you"  %}
 
     </div>
 </section>

--- a/templates/support/contact-us.html
+++ b/templates/support/contact-us.html
@@ -4,13 +4,9 @@
 
 
 {% block content %}
-<section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
-    <div class="strip-inner-wrapper">
 
   {% include "shared/_cloud-contact-us-form.html" with  h1="Contact Canonical about Ubuntu Advantage"   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch."  formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you"  %}
 
-    </div>
-</section>
 {% endblock content %}
 
 {% block footer_extra %}

--- a/templates/support/esm.html
+++ b/templates/support/esm.html
@@ -64,7 +64,7 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <p><a href="/support/contact-us">Any questions, contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/support/contact-us?product=server-esm">Any questions, contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>
@@ -93,7 +93,7 @@
     </div>
     <div class="col-8">
       <h2>Get ESM for Ubuntu 12.04</h2>
-      <p>If you would like to discuss ESM for Ubuntu 12.04 please <a href="/support/contact-us">get in touch</a>.</p>
+      <p>If you would like to discuss ESM for Ubuntu 12.04 please <a href="/support/contact-us?product=server-esm">get in touch</a>.</p>
       <p>Or <a href="https://buy.ubuntu.com" class="p-link--external">visit the Ubuntu Advantage store</a></p>
     </div>
   </div>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -106,12 +106,12 @@
     <div class="col-4 p-divider__block">
       <h4>Talk to a member of our team</h4>
       <p>We can recommend a support package that best suits the needs of your organisation. </p>
-      <p>Ask on <a href="/support/contact-us" class="p-link--external">Contact us</a></p>
+      <p>Ask on <a href="/support/contact-us?product=support-overview" class="p-link--external">Contact us</a></p>
     </div>
   </div>
   <div class="row">
     <div class="col-8">
-      <p><a href="/support/contact-us" class="p-button--brand">Any questions, contact us</a></p>
+      <p><a href="/support/contact-us?product=support-overview" class="p-button--brand">Any questions, contact us</a></p>
     </div>
   </div>
 </div>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -26,7 +26,7 @@
       <h2>Ubuntu Advantage</h2>
       <p>Ubuntu Advantage is the professional package of tooling, technology and expertise from Canonical, helping organisations around the world to manage their Ubuntu deployments. It includes access to Landscape, the systems management tool for using Ubuntu at scale, as well as 24x7 telephone and web support and the option of dedicated Canonical support engineers. Ubuntu Advantage tiers are based on the size of your deployment and the support levels you need.</p>
       <p><a href="https://buy.ubuntu.com" class="p-button--neutral"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
-      <p><a href="/support/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/support/contact-us?product=support-plans-and-pricing">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="row u-equal-height">


### PR DESCRIPTION
## Done

* it looks bigger than it is, sensible defaults are everywhere and will help with GA tracking
* added ‘?product=<name>’ to every contact-us form
* update server, container contact us to be more  contextual
* moved maas to use server/contact-us, not /cloud anymore

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
  - [/about/contact-us](http://0.0.0.0:8001/about/contact-us)
  - [/cloud/openstack](http://0.0.0.0:8001/cloud/openstack)
  - [/cloud/partners](http://0.0.0.0:8001/cloud/partners)
  - [/cloud/plans-and-pricing](http://0.0.0.0:8001/cloud/plans-and-pricing)
  - [/cloud/storage](http://0.0.0.0:8001/cloud/storage)
  - [/cloud/training](http://0.0.0.0:8001/cloud/training)
  - [/containers/contact-us](http://0.0.0.0:8001/containers/contact-us)
  - [/containers/docker-ubuntu](http://0.0.0.0:8001/containers/docker-ubuntu)
  - [/containers/](http://0.0.0.0:8001/containers/)
  - [/containers/kubernetes](http://0.0.0.0:8001/containers/kubernetes)
  - [/containers/lxd](http://0.0.0.0:8001/containers/lxd)
  - [/core](http://0.0.0.0:8001/core)
  - [/desktop/education](http://0.0.0.0:8001/desktop/education)
  - [/desktop/enterprise](http://0.0.0.0:8001/desktop/enterprise)
  - [/desktop/government](http://0.0.0.0:8001/desktop/government)
  - [/desktop/partners](http://0.0.0.0:8001/desktop/partners)
  - [/download/cloud/autopilot](http://0.0.0.0:8001/download/cloud/autopilot)
  - [/download/cloud/](http://0.0.0.0:8001/download/cloud/)
  - [/download/server/arm](http://0.0.0.0:8001/download/server/arm)
  - [/internet-of-things](http://0.0.0.0:8001/internet-of-things)
  - [/search](http://0.0.0.0:8001/search)
  - [/server/contact-us](http://0.0.0.0:8001/server/contact-us)
  - [/server/hyperscale](http://0.0.0.0:8001/server/hyperscale)
  - [/server/](http://0.0.0.0:8001/server/)
  - [/server/maas](http://0.0.0.0:8001/server/maas)
  - [/server/management](http://0.0.0.0:8001/server/management)
  - [/support/contact-us](http://0.0.0.0:8001/support/contact-us)
  - [/support/esm](http://0.0.0.0:8001/support/esm)
  - [/support](http://0.0.0.0:8001/support)
  - [/support/plans-and-pricing](http://0.0.0.0:8001/support/plans-and-pricing)
- click on any contact us page and see that it goes to one.	
