### PR TITLE
Migrated the autopilot page to vanilla v1

### DIFF
--- a/templates/cloud/openstack/autopilot.html
+++ b/templates/cloud/openstack/autopilot.html
@@ -6,137 +6,136 @@
 
 {% block meta_description %}Autopilot is an automated tool from Canonical that makes the deployment and management of OpenStack clouds much easier.{% endblock meta_description %}
 
+{% block extra_body_class %}has-background{% endblock %}
 
 {% block content %}
 
-<section class="row row-hero strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="six-col">
-            <h1>OpenStack Autopilot</h1>
-            <p class="intro">The Canonical OpenStack installer is the easiest way to build a reference architecture OpenStack private cloud.</p>
-            <ul class="list-ticks--compact">
-                <li>Fully automated install and operations</li>
-                <li>Choice of storage and SDN technologies</li>
-                <li>Highest performance cloud architecture</li>
-                <li>Add hardware at any time to scale up</li>
-                <li>Works on all major vendor servers</li>
-                <li>Free to all support customers</li>
-                <li>From 5 servers upwards, your cloud grows on demand</li>
-            </ul>
-            <p>By automating every step of the deployment, management, operations and update process, the Canonical OpenStack Autopilot brings the cost of OpenStack into line with public cloud alternatives. Stand up your private cloud without any dedicated staff. This is the OpenStack most large-scale operators have chosen.</p>
-            <p>
-                <a class="button--primary" href="/download/cloud/autopilot">
-                    Get Autopilot
-                </a>
-            </p>
-        </div>
+<section class="p-strip--x-light is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h1>OpenStack Autopilot</h1>
+      <p>The Canonical OpenStack installer is the easiest way to build a reference architecture OpenStack private cloud.</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Fully automated install and operations</li>
+        <li class="p-list__item is-ticked">Choice of storage and SDN technologies</li>
+        <li class="p-list__item is-ticked">Highest performance cloud architecture</li>
+        <li class="p-list__item is-ticked">Add hardware at any time to scale up</li>
+        <li class="p-list__item is-ticked">Works on all major vendor servers</li>
+        <li class="p-list__item is-ticked">Free to all support customers</li>
+        <li class="p-list__item is-ticked">From 5 servers upwards, your cloud grows on demand</li>
+      </ul>
+      <p>By automating every step of the deployment, management, operations and update process, the Canonical OpenStack Autopilot brings the cost of OpenStack into line with public cloud alternatives. Stand up your private cloud without any dedicated staff. This is the OpenStack most large-scale operators have chosen.</p>
+      <p><a class="p-button--brand" href="/download/cloud/autopilot">Get Autopilot</a></p>
     </div>
+    <div class="col-5 p-hero__item u-hidden--small">
+      <img class="p-hero__image" src="{{ ASSET_SERVER_URL }}b72144a5-cloud_landscape_components.png?w=675" alt="screenshot of Landscape" />
+    </div>
+  </div>
 </section>
 
 <!-- main window -->
-<section class="row no-border no-padding-bottom autopilot-dynamic" id="autopilot-main">
-    <div class="strip-inner-wrapper">
-        <h2>Autopilot in action</h2>
-        <div class="twelve-col">
-            <div class="video-container">
-                <iframe width="453" height="255" src="https://www.youtube.com/embed/RiEZB1-83wQ" frameborder="0" allowfullscreen></iframe>
-            </div>
-        </div>
+<section class="p-strip--light is-deep u-no-padding--bottom">
+  <div class="row">
+    <h2>Autopilot in action</h2>
+    <div class="col-12">
+      <div class="u-embedded-media">
+        <iframe width="453" height="255" src="https://www.youtube.com/embed/RiEZB1-83wQ" frameborder="0" allowfullscreen class="u-embedded-media__element"></iframe>
+      </div>
     </div>
+  </div>
 </section>
 
-<section class="row no-border">
-    <div class="strip-inner-wrapper">
-        <h2>Build an OpenStack cloud with Autopilot</h2>
-        <div class="six-col">
-            <h4>Experience OpenStack at its best</h4>
-            <p>OpenStack Autopilot is the world&rsquo;s easiest dynamic OpenStack installer. It handles every aspect of your cloud both during installation, expansion, and everyday operations.</p>
-            <p>
-                <a class="button--primary" href="/download/cloud">
-                Get Autopilot
-                </a>
-            </p>
-        </div>
-        <div class="six-col last-col">
-            <h4>Requirements for Autopilot:</h4>
-            <ul class="list-ticks--compact">
-                <li>At least six machines with two disks</li>
-                <li>One machine with two network interfaces (NICs)</li>
-                <li>A dedicated switch to create a private cloud LAN</li>
-                <li>Internet access through a router on that LAN</li>
-            </ul>
-        </div>
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <h2>Build an OpenStack cloud with Autopilot</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h4>Experience OpenStack at its best</h4>
+      <p>OpenStack Autopilot is the world&rsquo;s easiest dynamic OpenStack installer. It handles every aspect of your cloud both during installation, expansion, and everyday operations.</p>
+      <p><a class="p-button--neutral" href="/download/cloud">Get Autopilot</a></p>
     </div>
+    <div class="col-6">
+      <h4>Requirements for Autopilot:</h4>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">At least six machines with two disks</li>
+        <li class="p-list__item is-ticked">One machine with two network interfaces (NICs)</li>
+        <li class="p-list__item is-ticked">A dedicated switch to create a private cloud LAN</li>
+        <li class="p-list__item is-ticked">Internet access through a router on that LAN</li>
+      </ul>
+    </div>
+  </div>
 </section>
 
-<section class="row strip-dark row-cost no-border">
-    <div class="strip-inner-wrapper">
-        <h2>How much does it cost?</h2>
-        <div class="six-col">
-            <p>You can try OpenStack Autopilot for free, but you need to purchase
-                Ubuntu Advantage when you use more than 10 machines.  Ubuntu Advantage
-                is our enterprise management and support service. It gives you Landscape
-                to monitor and manage your cloud, and access to 24x7 phone and email support.</p>
-                <p>
-                    <a class="button--primary" href="/cloud/plans-and-pricing">
-                        See Ubuntu Advantage pricing
-                    </a>
-                </p>
-            </div>
-
-            <div class="three-col box align-center">
-                <h3 class="caps">Free</h3>
-                <p class="intro">Up to ten machines</p>
-            </div>
-
-            <div class="three-col last-col box align-center">
-                <h3 title="USD">$750</h3>
-                <p class="intro">Annually, per server</p>
-            </div>
+<section class="p-strip--accent is-deep">
+  <div class="row">
+    <h2>How much does it cost?</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>You can try OpenStack Autopilot for free, but you need to purchase Ubuntu Advantage when you use more than 10 machines.  Ubuntu Advantage is our enterprise management and support service. It gives you Landscape to monitor and manage your cloud, and access to 24x7 phone and email support.</p>
+      <p><a class="p-button--brand" href="/cloud/plans-and-pricing">See Ubuntu Advantage pricing</a></p>
     </div>
+    <div class="col-3 p-card--highlighted u-align--center">
+      <h3>FREE</h3>
+      <p class="p-heading--five">Up to ten machines</p>
+    </div>
+    <div class="col-3 p-card--highlighted u-align--center">
+      <h3 title="USD">$750</h3>
+      <p class="p-heading--five">Annually, per server</p>
+    </div>
+  </div>
 </section>
 
-<section class="row no-border">
-    <div class="strip-inner-wrapper">
-        <div class="nine-col">
-            <h2>How Autopilot works</h2>
-        </div>
-        <div class="six-col append-six">
-            <h3>Before you start</h3>
-            <p>You need to get at least six machines to run OpenStack and you need to install Ubuntu Server on one of them.</p>
-        </div>
-        <div class="six-col append-one">
-            <ol class="list-stepped">
-                <li class="list-stepped__item">
-                    <h3 class="list-stepped__title">Use MAAS to register your machines</h3>
-                    <p>Using MAAS, you setup the rest of the servers and define your network.</p>
-                </li>
-                <li class="list-stepped__item">
-                    <h3 class="list-stepped__title">Build your cloud with Autopilot</h3>
-                    <p>Select your OpenStack configuration. Choose your hypervisor (KVM or LXD), networking (Open vSwitch) and storage components (Ceph, Swift or iSCSI). Add your hardware and install.</p>
-                </li>
-                <li class="list-stepped__item">
-                    <h3 class="list-stepped__title">Start using your cloud</h3>
-                    <p>Using the OpenStack dashboard create users and virtual machines and try out your cloud</p>
-                </li>
-                <li class="list-stepped__item">
-                    <h3 class="list-stepped__title">Monitor and scale out</h3>
-                    <p>Using Autopilot&rsquo;s dashboard, you can monitor your cloud utilisation and add hardware to scale-out as needed.</p>
-                </li>
-            </ol>
-            <p>
-                <a href="/download/cloud" class="button--primary">
-                    Build your own cloud now
-                </a>
-            </p>
-        </div>
-        <div class="prepend-one four-col last-col">
-            <img src="{{ ASSET_SERVER_URL }}4455ef04-autopilot-diagram.svg" alt="Autopilot diagram" width="100%" />
-        </div>
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-6">
+      <h2>How Autopilot works</h2>
     </div>
+  </div>
+  <div class="row">
+    <div class="col-7 suffix-1">
+      <h3>Before you start</h3>
+      <p>You need to get at least six machines to run OpenStack and you need to install Ubuntu Server on one of them.</p>
+      <ol class="p-list-step">
+        <li class="p-list-step__item u-padding-bottom--x-large">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Use MAAS to register your machines
+          </h4>
+          <p>Using MAAS, you setup the rest of the servers and define your network.</p>
+        </li>
+        <li class="p-list-step__item u-padding-bottom--x-large">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Build your cloud with Autopilot
+          </h4>
+          <p>Select your OpenStack configuration. Choose your hypervisor (KVM or LXD), networking (Open vSwitch) and storage components (Ceph, Swift or iSCSI). Add your hardware and install.</p>
+        </li>
+        <li class="p-list-step__item u-padding-bottom--x-large">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">3</span>
+            Start using your cloud
+          </h4>
+          <p>Using the OpenStack dashboard create users and virtual machines and try out your cloud</p>
+        </li>
+        <li class="p-list-step__item u-padding-bottom">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Monitor and scale out
+          </h4>
+          <p>Using Autopilot&rsquo;s dashboard, you can monitor your cloud utilisation and add hardware to scale-out as needed.</p>
+        </li>
+      </ol>
+      <p><a href="/download/cloud" class="p-button--brand">Build your own cloud now</a></p>
+    </div>
+    <div class="col-4">
+      <img src="{{ ASSET_SERVER_URL }}4455ef04-autopilot-diagram.svg" alt="Autopilot diagram" width="100%" />
+    </div>
+  </div>
 </section>
 
-    {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
 
 
-    {% endblock content %}
+{% endblock content %}


### PR DESCRIPTION
## Done

Migrated /cloud/openstack/autopilot to v1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud/openstack/autopilot](http://0.0.0.0:8001/cloud/openstack/autopilot)
- Check in all pages and that it has been migrated to the [spec](https://www.dropbox.com/work/00_web_team/_ubuntu.com/new%20projects/vanilla%20update/Patterns%20inventory/2.%20Cloud?preview=cloud-openstack-autopilot.png)

## Issue / Card

Fixes #2004 