### PR TITLE
fix links on /legal page

### DIFF
--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -57,7 +57,7 @@
           <div class="p-heading-icon__header">
             <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b06cbaa6-picto-canonical-warmgrey.svg" alt="" />
             <h3 class="p-heading-icon__title">
-              <a href="/legal/ubuntu-advantage">
+              <a href="/legal/contributors">
                 Contributors agreement&nbsp;&rsaquo;
               </a>
             </h3>
@@ -70,7 +70,7 @@
           <div class="p-heading-icon__header">
             <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/2a8cf960-picto-startfirst-warmgrey.svg" alt="" />
             <h3 class="p-heading-icon__title">
-              <a href="/legal/ubuntu-advantage">
+              <a href="/legal/bootstack">
                 BootStack terms&nbsp;&rsaquo;
               </a>
             </h3>
@@ -86,7 +86,7 @@
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0838729a-picto-bookmark-warmgrey.svg" alt="" />
           <h3 class="p-heading-icon__title">
-            <a href="/legal/ubuntu-advantage">
+            <a href="/legal/short-terms">
               Short terms&nbsp;&rsaquo;
             </a>
           </h3>

--- a/templates/legal/ubuntu-advantage/index.html
+++ b/templates/legal/ubuntu-advantage/index.html
@@ -9,7 +9,7 @@
     <div class="col-8">
       <h1>Ubuntu Advantage</h1>
       <p><a href="/support">Ubuntu Advantage</a> is Canonical&rsquo;s service package for Ubuntu. It offers tiered levels of support for desktop, server and cloud deployments. In this section, you can see our service description, but don&rsquo;t forget that there will still be some details in your customer agreement that are specific to your deployment.</p>
-      <p>If you&rsquo;re interested in support for an Ubuntu deployment or you&rsquo;re a reseller and you want to offer it to your customers, you can <a href="http://ubuntu.com/management/ubuntu-advantage">learn more about Ubuntu Advantage here</a>.</p>
+      <p>If you&rsquo;re interested in support for an Ubuntu deployment or you&rsquo;re a reseller and you want to offer it to your customers, you can <a href="/support">learn more about Ubuntu Advantage here</a>.</p>
     </div>
     <div class="col-4">
       <div class="u-align--center">


### PR DESCRIPTION
## Done

* James Troup noticed that the BootStack link was not correct on /legal
* turns out all the links were all going to the Ubuntu Advantage page
* fixed that, and a bad link on the /legal/ubuntu-advantage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [legal overview](http://0.0.0.0:8001/legal) and [ua page](http://0.0.0.0:8001/legal/ubuntu-advantage)
- See that the boxes links go to the correct secondary pages on the overview
- See that the second Ubuntu Advantage link in the intro on the Ubuntu Advantage page goes to Support