### PR TITLE
change server nav order

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -46,14 +46,14 @@ server:
   children:
     - title: Overview
       path: /server
-    - title: Server management
-      path: /server/management
+    - title: Server provisioning
+      path: /server/maas
     - title: Hyperscale
       path: /server/hyperscale
     - title: Livepatch
       path: /server/livepatch
-    - title: Server provisioning
-      path: /server/maas
+    - title: Server management
+      path: /server/management
 
     - title: Contact us
       path: /server/contact-us


### PR DESCRIPTION
## Done

* update per [brief](https://docs.google.com/document/d/1tZHdGlabAl8e54ZSlAB1SdbIQOe3IoWNBjMbGr5A36c/edit?ts=58877331)
* new order
 * Overview
 * Server provisioning
 * Hyperscale
 * Livepatch
 * Server management

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the order is change in the dropdown, footer and on the server page itself
