### PR TITLE
update /cloud/autopilot pricing

### DIFF
--- a/templates/cloud/openstack/autopilot.html
+++ b/templates/cloud/openstack/autopilot.html
@@ -73,7 +73,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <p>You can try OpenStack Autopilot for free, but you need to purchase Ubuntu Advantage when you use more than 10 machines.  Ubuntu Advantage is our enterprise management and support service. It gives you Landscape to monitor and manage your cloud, and access to 24x7 phone and email support.</p>
+      <p>You can try OpenStack Autopilot for free, but you need to purchase Ubuntu Advantage and Landscape On Premises when you use more than 10 machines.  Ubuntu Advantage is our enterprise management and support service. It gives you Landscape to monitor and manage your cloud, and access to 24x7 phone and email support.</p>
       <p><a class="p-button--brand" href="/cloud/plans-and-pricing">See Ubuntu Advantage pricing</a></p>
     </div>
     <div class="col-3 p-card--highlighted u-align--center">
@@ -81,7 +81,7 @@
       <p class="p-heading--five">Up to ten machines</p>
     </div>
     <div class="col-3 p-card--highlighted u-align--center">
-      <h3 title="USD">$750</h3>
+      <h3 title="USD">$1,500</h3>
       <p class="p-heading--five">Annually, per server</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

* update /cloud/autopilot pricing to 1500 from 750
* added the need to purchase Landscape On Premises as well
* updated the [copy doc](https://docs.google.com/document/d/1VmFtp_gEYvioRgGXbiQZpVGBhlJoIZAirLk6IOVUjUE/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/cloud/openstack/autopilot)
