### PR TITLE
Make cookie message disappear with link in footer

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -8,7 +8,7 @@ core.cookiePolicy = function() {
     switch(stateChange) {
       case 'open':
         var range = document.createRange();
-        var cookieNode = range.createContextualFragment('<div class="p-notification p-notification--floating cookie-policy"><p class="p-notification--floating__content">We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>. <a href="?cp=close" class="p-notification--floating__close js-close">Close</a></p></div>');
+        var cookieNode = range.createContextualFragment('<div class="p-notification p-notification--floating cookie-policy"><p class="p-notification--floating__content">We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself. To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>. <a href="?cp=close" class="p-notification--floating__close js-close">Close</a></p></div>');
         document.body.insertBefore(cookieNode, document.body.lastChild);
         document.querySelector('footer.p-footer').classList.add('has-cookie');
         window.setTimeout(function() {

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -11,6 +11,12 @@ core.cookiePolicy = function() {
         var cookieNode = range.createContextualFragment('<div class="p-notification p-notification--floating cookie-policy"><p class="p-notification--floating__content">We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>. <a href="?cp=close" class="p-notification--floating__close js-close">Close</a></p></div>');
         document.body.insertBefore(cookieNode, document.body.lastChild);
         document.querySelector('footer.p-footer').classList.add('has-cookie');
+        window.setTimeout(function() {
+          state('close');
+        }, 10000);
+        window.addEventListener('unload', function() {
+          state('close');
+        });
         document.querySelector('.cookie-policy .js-close').addEventListener('click', function(e) {
           e.preventDefault();
           state('close');

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -70,6 +70,9 @@
               <a class="p-link--soft" accesskey="8" href="/legal"><small>Legal information</small></a>
             </li>
             <li class="p-inline-list__item">
+              <a class="p-link--soft" accesskey="9" href="/legal/terms-and-policies/privacy-policy"><small>Cookie policy</small></a>
+            </li>
+            <li class="p-inline-list__item">
               <a class="p-link--soft" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" id="report-a-bug"><small>Report a bug on this site</small></a>
             </li>
           </ul>


### PR DESCRIPTION
## Done

* updated the cookie message
* added a 'cookie policy' link in the footer
* added a 10 sec timeout on the cookie box that sets the _cookie_accepted cookie
* added an unload event  that sets the _cookie_accepted cookie
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
1. unset _cookie_accepted cookie
2. wait 10 seconds and the message disappears - see that _cookie_accepted cookie is set
3. unset _cookie_accepted cookie
4. within 10 seconds, navigate to a new page, see no cookie message, see that _cookie_accepted cookie is set

## Issue / Card

![image](https://user-images.githubusercontent.com/441217/27488730-fef66b92-582f-11e7-83c6-e5a74fac8c41.png)

