### PR TITLE
Remove bower components when cleaned

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
     "build": "node-sass --include-path node_modules static/sass --output static/css",
     "watch": "node-sass --include-path node_modules --source-map true --watch static/sass --output static/css",
-    "clean": "rm -rf node_modules yarn-error.log static/css cache.sqlite"
+    "clean": "rm -rf node_modules yarn-error.log static/css static/components cache.sqlite"
   },
   "keywords": [
     "website",


### PR DESCRIPTION
## Done
Add bower components to the clean script

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run `./run clean` and check `ls static` does not have a component directory
