### PR TITLE
update cpc partners on _guest-list.html

### DIFF
--- a/templates/cloud/shared/_guest-list.html
+++ b/templates/cloud/shared/_guest-list.html
@@ -41,10 +41,10 @@
     </div>
     <div class="col-4 p-card">
       <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
-        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}d584bd83-logo-vmware.svg" alt="VMware logo" height="35" />
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}ff936628-rackspace.svg" alt="Rackspace logo" height="35" />
       </header>
-      <h3 class="p-card__title u-hidden">VMware</h3>
-      <p class="p-card__content"><a class="p-link--external" href="https://solutionexchange.vmware.com/store/products/ubuntu-12-04-lts--2#.VA_9Dq2zDsa">Get started on VMware</a></p>
+      <h3 class="p-card__title u-hidden">Rackspace</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://www.rackspace.com/openstack/public/getting-started">Get started on Rackspace</a></p>
     </div>
   </div>
 </div>
@@ -52,17 +52,17 @@
   <div class="u-equal-height">
     <div class="col-4 p-card">
       <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
-        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}7cd13ce0-vexxhost-logo-01.svg?w=275" alt="Vexxhost logo" />
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}3f403c1f-logo.svg" alt="Packet logo" />
       </header>
-      <h3 class="p-card__title u-hidden">Vexxhost</h3>
-      <p class="p-card__content"><a class="p-link--external" href="https://vexxhost.com/public-cloud/">Get started on Vexxhost</a></p>
+      <h3 class="p-card__title u-hidden">Packet</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://www.packet.net/">Get started on Packet</a></p>
     </div>
     <div class="col-4 p-card">
       <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">
-        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}43c55d04-logo-brightbox.svg?w=275" alt="Brightbox logo" height="35" />
+        <img style="max-width: 150px;" src="{{ ASSET_SERVER_URL }}939e0279-citycloud-logo.svg" alt="citycloud logo" height="35" />
       </header>
-      <h3 class="p-card__title u-hidden">Brightbox</h3>
-      <p class="p-card__content"><a class="p-link--external" href="https://www.brightbox.com/">Get started on Brightbox</a></p>
+      <h3 class="p-card__title u-hidden">citycloud</h3>
+      <p class="p-card__content"><a class="p-link--external" href="https://www.citycloud.com/">Get started on citycloud</a></p>
     </div>
     <div class="col-4 p-card">
       <header class="p-card__header u-align--center u-vertically-center" style="min-height: 8rem;">


### PR DESCRIPTION
## Done

* updated our CPC partners per bug #2009

Please keep these partners:

- AWS
- Azure
- Google
- Oracle
- Softlayer
- T-Systems

Please add (replacing the remaining partners with):

- Rackspace
- Packet
- CityCloud

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/cloud/public-cloud)
- compare to the [copy doc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit) *note - order not imporant*


## Issue / Card

Fixes #2009

## Screenshots

![image](https://user-images.githubusercontent.com/441217/27627340-59099ab2-5be3-11e7-9177-7ab251a0d3f5.png)

