### PR TITLE
update link to

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -31,7 +31,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Popular snaps</h2>
-      <p>To find snaps you can check out <a class="p-link--external" href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a> or just use the command line to install any of these great snaps:</p>
+      <p>To find snaps you can check out <a class="p-link--external" href="https://uappexplorer.com/snaps">uappexplorer.com</a> or just use the command line to install any of these great snaps:</p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

* update link to uappexplorer on /desktop/snappy
* updated the [copy doc](https://docs.google.com/document/d/19EIGiQ4FLfWVQczBgAqj5lIcWGnM0GmVGWggFIXcHt0/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/desktop/snappy)
- See that the link has changed in 'Popular snaps'


## Issue / Card

Fixes #2020
