### PR TITLE
Update Landscape trial info

### DIFF
--- a/templates/shared/contextual_footers/_support_landscape.html
+++ b/templates/shared/contextual_footers/_support_landscape.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Try Landscape for free for 30 days</h3>
-  <p>For a limited period, you can try Landscape without subscribing to Ubuntu Advantage. Register for your 30 day free trial, to see the features for yourself.</p>
-  <p><a href="https://landscape.canonical.com/trial-registration" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'landscape.canonical.com trial', 'eventLabel' : 'Try Landscape for 30 days', 'eventValue' : undefined });">Try Landscape for free for 30 days&nbsp;&rsaquo;</a></p>
+  <h3 class="p-heading--four">Try Landscape for free</h3>
+  <p>At just 1&cent; per machine hour, you can use Landscape without subscribing to Ubuntu Advantage. Sign-up today and get a $100 free credit that is good for up to 60 days and see the features for yourself.</p>
+  <p><a href="https://landscape.canonical.com/signup" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'landscape.canonical.com trial', 'eventLabel' : 'Try Landscape for 30 days', 'eventValue' : undefined });">Get your $100 Landscape credit&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -3,7 +3,7 @@
 {% block title %}Plans and pricing | Support{% endblock %}
 {% block extra_body_class %}support-plans-and-pricing has-background{% endblock %}
 
-{% block meta_description %}You can access Landscape as a SaaS over the internet or as an application running on a server on premises behind your firewall. Both options are part of the Ubuntu Advantage service package, however you can try Landscape for free for 30 days, without committing to a subscription.{% endblock %}
+{% block meta_description %}A summary of all our support offerings. Ubuntu offers the best economics of any commercially supported Linux solution and the best community support.{% endblock %}
 
 {% block content %}
 <section class="p-strip is-deep is-bordered">
@@ -277,7 +277,7 @@
           </tr>
         </tbody>
       </table>
-      <p><a href="https://landscape.canonical.com/try-landscape" class="p-button--neutral"><span class="p-link--external">Try Landscape for 30 days free</span></a></p>
+      <p><a href="https://landscape.canonical.com/signup" class="p-button--neutral"><span class="p-link--external">Get a $100 credit for Landscape</span></a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

* update the contextual footer for the Landscape trial
* updated the /support/plans and pricing with the offer on the CTA
* updated the [copy doc - p&p](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#) and [copy doc - footers](https://docs.google.com/document/d/1kq0SPv-PAIfL9nHGxgNDpHhr5OplE2iNaZZiqG4RT48/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [plans and pricing](http://0.0.0.0:8001/support/plans-and-pricing) and [contextual footer](http://0.0.0.0:8001/support/esm)


## Issue / Card

Fixes #2000

## Screenshots

![image](https://user-images.githubusercontent.com/441217/27630917-cf90f4b8-5bee-11e7-9197-4fa016f9b143.png)

