### PR TITLE
testing, please don't merge

### DIFF
--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -8,7 +8,7 @@
 <div class="p-strip--light is-deep">
   <div class="row">
     <div class="col-10">
-      <h1>Get a production cloud with OpenStack Autopilot</h1>
+      <h1>Get a production cloud with OpenStack Autopilot for $2000</h1>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

* updated autopilot page to include pricing
* also update the [copy doc](google.com)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [autopilot](http://0.0.0.0:8001/cloud/openstack/autopilot)
- see that the h1 now has the price per the copy doc

## Issue / Card

Fixes #2023 

