### PR TITLE
Fix misspelling of Cassandra on the snappy page

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -58,7 +58,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}476aaa77-cassandra.svg" alt="icon">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Casandra</h3>
+            <h3 class="p-matrix__title">Cassandra</h3>
           </div>
         </li>
         <li class="p-matrix__item">


### PR DESCRIPTION
## Done
Updated Casandra to Cassandra n the

## QA
- Check the code is ok

## Details
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2032