### PR TITLE
Bumped juju-cards version to 1.5.0

### DIFF
--- a/templates/cloud/juju.html
+++ b/templates/cloud/juju.html
@@ -223,5 +223,5 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.4.0.js"></script>
+<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.5.0.js"></script>
 {% endblock footer_extra %}

--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -204,5 +204,5 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.4.0.js"></script>
+<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.5.0.js"></script>
 {% endblock footer_extra %}


### PR DESCRIPTION
## Done

Updated juju-cards include script to version 1.5.0

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Go to [http://0.0.0.0:8001/containers/kubernetes](http://0.0.0.0:8001/containers/kubernetes) and click the 'Deploy now' button on the Juju card.
- You should be redirected to http://jujucharms.com/new/...
- Repeat for cards on [http://0.0.0.0:8001/cloud/juju](http://0.0.0.0:8001/cloud/juju)

## Screenshots

Before: Link to demo.jujucharms.com
<img width="1213" alt="screen shot 2017-07-04 at 14 36 45" src="https://user-images.githubusercontent.com/479384/27834121-8f4af1e0-60cd-11e7-968a-5122a7ca542c.png">

After: Link to jujucharms.com/new
<img width="1214" alt="screen shot 2017-07-04 at 14 56 22" src="https://user-images.githubusercontent.com/479384/27834143-a597cedc-60cd-11e7-9b6b-17d92b712ab4.png">
