### PR TITLE
update order on cloud overview

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -50,19 +50,23 @@
   </div>
 </section>
 
-<section class="p-strip--dark is-deep">
-  <div class="row u-equal-height">
+<section class="p-strip--accent is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h2>BootStack is a fully managed private cloud on OpenStack</h2>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-6">
-      <h2>OpenStack and containers office&nbsp;hours</h2>
-      <p class="u-align--center">
-        <img src="{{ ASSET_SERVER_URL }}b0e012b6-Openstack+Surgery+-+Dark+background.svg" alt="" class="u-hidden--medium u-hidden--large"/>
-      </p>
-      <p>Sign-up for a one-hour web session with an expert from Canonical.</p>
-      <p>Get help with Ubuntu OpenStack, Autopilot, Kubernetes, LXD, Juju and MAAS. Ask as many questions as you want.</p>
-      <p><a href="http://ubunt.eu/OpenStack_officehour" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Cloud overview', 'eventLabel' : 'Register now', 'eventValue' : undefined });">Register now</a></p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">We&rsquo;ll build an OpenStack cloud on your premises or hosted environment and operate it according to an agreed SLA</li>
+        <li class="p-list__item is-ticked">We&rsquo;ll train your staff to run it</li>
+        <li class="p-list__item is-ticked">When you&rsquo;re ready, we&rsquo;ll hand over the keys</li>
+      </ul>
+      <p><a class="p-link--inverted" href="/cloud/managed-cloud">Let us build, operate and transfer your cloud&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-align--center u-hidden--small">
-      <img src="{{ ASSET_SERVER_URL }}b0e012b6-Openstack+Surgery+-+Dark+background.svg" alt="" />
+      <img src="{{ ASSET_SERVER_URL }}466046c7-illustration-cloud-bootstack.svg?w=320" alt="" width="320" />
     </div>
   </div>
 </section>
@@ -105,23 +109,19 @@
   </div>
 </section>
 
-<section class="p-strip--accent is-deep">
-  <div class="row">
-    <div class="col-8">
-      <h2>BootStack is a fully managed private cloud on OpenStack</h2>
-    </div>
-  </div>
-  <div class="row">
+<section class="p-strip--dark is-deep">
+  <div class="row u-equal-height">
     <div class="col-6">
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">We&rsquo;ll build an OpenStack cloud on your premises or hosted environment and operate it according to an agreed SLA</li>
-        <li class="p-list__item is-ticked">We&rsquo;ll train your staff to run it</li>
-        <li class="p-list__item is-ticked">When you&rsquo;re ready, we&rsquo;ll hand over the keys</li>
-      </ul>
-      <p><a class="p-link--inverted" href="/cloud/managed-cloud">Let us build, operate and transfer your cloud&nbsp;&rsaquo;</a></p>
+      <h2>OpenStack and containers office&nbsp;hours</h2>
+      <p class="u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}b0e012b6-Openstack+Surgery+-+Dark+background.svg" alt="" class="u-hidden--medium u-hidden--large"/>
+      </p>
+      <p>Sign-up for a one-hour web session with an expert from Canonical.</p>
+      <p>Get help with Ubuntu OpenStack, Autopilot, Kubernetes, LXD, Juju and MAAS. Ask as many questions as you want.</p>
+      <p><a href="http://ubunt.eu/OpenStack_officehour" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Cloud overview', 'eventLabel' : 'Register now', 'eventValue' : undefined });">Register now</a></p>
     </div>
     <div class="col-6 u-align--center u-hidden--small">
-      <img src="{{ ASSET_SERVER_URL }}466046c7-illustration-cloud-bootstack.svg?w=320" alt="" width="320" />
+      <img src="{{ ASSET_SERVER_URL }}b0e012b6-Openstack+Surgery+-+Dark+background.svg" alt="" />
     </div>
   </div>
 </section>

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -229,7 +229,7 @@
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">BootStack for Kubernetes</h3>
       <p>Whether you want to orchestrate your container cluster on top of your OpenStack cloud or other substrate, we’ll build and operate it for you using the Canonical Distribution of Kubernetes. Focus on your applications not infrastructure.</p>
-      <p><a href="/cloud/kubernetes">Learn more about the Canonical Distribution of Kubernetes&nbsp;›</a></p>
+      <p><a href="/containers/kubernetes">Learn more about the Canonical Distribution of Kubernetes&nbsp;›</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

* swapped manage cloud and office hours blocks
* updated the [copy doc](https://docs.google.com/document/d/1mQjVXDcoP8ChOzRdmuI55BdXhbURD53qBNc2bgJhfhg/edit#heading=h.j462d721ndri) - which has a lot of foundation cloud text in it, so do not reference literally
* updated bad (redirected) k8s link on the /cloud/managed-cloud page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [cloud overview](http://0.0.0.0:8001/cloud/)
- check the link to k8s page on [managed cloud](http://0.0.0.0:8001/cloud/managed-cloud)

## Issues

Fixes #2036