### PR TITLE
Update juju-cards to v1.6.0

### DIFF
--- a/templates/cloud/juju.html
+++ b/templates/cloud/juju.html
@@ -223,5 +223,5 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.5.0.js"></script>
+<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.6.0.js"></script>
 {% endblock footer_extra %}

--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -204,5 +204,5 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.5.0.js"></script>
+<script async src="{{ ASSET_SERVER_URL }}juju-cards-v1.6.0.js"></script>
 {% endblock footer_extra %}


### PR DESCRIPTION
## Done
Upgraded juju-cards from 1.5.0 to 1.6.0.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/containers/kubernetes](http://0.0.0.0:8001/containers/kubernetes)
- Scroll down to the juju-card in the Production features section
- Check the Deploy with juju button links to /new/

## Issue / Card

Fixes https://github.com/juju/juju-gui/issues/3048
