### PR TITLE
fix breadcrumb, second and third nav

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -99,6 +99,7 @@
 
     @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
       border-top: 1px solid $color-mid-light;
+      white-space: nowrap;
     }
 
     &__row {
@@ -172,6 +173,7 @@
 
       @media (min-width: $breakpoint-medium) {
         margin-left: $sp-large;
+        vertical-align: top;
       }
     }
 
@@ -189,6 +191,7 @@
       background: $color-light;
       border-bottom: 1px solid $color-mid-light;
       padding: $sp-x-small 0 $sp-small;
+      white-space: nowrap;
 
       .p-breadcrumbs__item {
         margin-bottom: 0;
@@ -314,6 +317,8 @@
   }
 
   .nav-tertiary__menu {
+    white-space: normal;
+    width: 90%;
 
     .p-inline-list__item {
       font-size: .875rem;
@@ -321,7 +326,7 @@
 
     @media (max-width: $breakpoint-medium - 1) {
       .p-inline-list__item {
-        padding: 0 $sp-x-small;
+        padding: 0 $sp-x-small 0 0;
       }
     }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -90,6 +90,14 @@
     padding: 0;
   }
 
+  .p-breadcrumbs {
+
+    // medium size - avoid overflow
+    @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+      width: 90%;
+    }
+  }
+
   // .nav-secondary override
   .nav-secondary {
 
@@ -295,7 +303,6 @@
   }
 
   // tertiary navigation
-
   .p-breadcrumbs__link {
 
     & + .second-level-nav,

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -318,7 +318,7 @@
 
   .nav-tertiary__menu {
     white-space: normal;
-    width: 90%;
+    width: 85%;
 
     .p-inline-list__item {
       font-size: .875rem;

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -124,6 +124,7 @@
               <li class="p-breadcrumbs__item">
                 <a class="p-breadcrumbs__link" href="{{ breadcrumbs.section.path }}">{{ breadcrumbs.section.title }}</a>
 
+                {% if breadcrumbs.children %}
                 <ul class="nav-secondary__menu p-inline-list">
                   {% for child in breadcrumbs.children %}
                     <li class="{% if breadcrumbs.grandchildren %}p-breadcrumbs__item{% else %}p-inline-list__item{% endif %}">
@@ -131,19 +132,20 @@
                         class="{% if breadcrumbs.grandchildren %}p-breadcrumbs__link{% else %}p-inline-list__link{% endif %} {% if child.active %}is-active{% endif %}"
                         href="{{ child.path }}"
                       >{{ child.title }}</a>
-                    </li>
-                  {% endfor %}
-                </ul>
 
-                {% if breadcrumbs.grandchildren %}
-                  <ul class="nav-tertiary__menu p-inline-list">
-                    {% for grandchild in breadcrumbs.grandchildren %}
-                      <li class="p-inline-list__item">
-                        <a class="p-inline-list__link {% if grandchild.active %}is-active{% endif %}" href="{{ grandchild.path }}">{{ grandchild.title }}</a>
-                      </li>
+                      {% if breadcrumbs.grandchildren %}
+                        <ul class="nav-tertiary__menu p-inline-list">
+                          {% for grandchild in breadcrumbs.grandchildren %}
+                            <li class="p-inline-list__item">
+                              <a class="p-inline-list__link {% if grandchild.active %}is-active{% endif %}" href="{{ grandchild.path }}">{{ grandchild.title }}</a>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      {% endif %}{# end if breadcrumbs.grandchildren #}
+                    </li>
                     {% endfor %}
                   </ul>
-                {% endif %}
+                  {% endif %}{# end if breadcrumbs.children #}
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Done

* fixed the nesting of the lists
* used white-space, vertical-align and widths to make lists stay together

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [test of long nav 1](http://0.0.0.0:8001/about/about-ubuntu/our-philosophy) and [test of long nav 2](http://0.0.0.0:8001/legal/terms-and-policies/privacy-policy)

## Issue / Card

* Fixes #1954 - Breadcrumbs misaligned on small screen on ubuntu chrome
* Fixes #1931 - Breadcrumbs broken in S screen (live)
* Fixes #1765 - Make sure 2nd level item with children is correctly aligned

## Screenshots

full width
![image](https://user-images.githubusercontent.com/441217/27843484-03ebc1b2-610c-11e7-8422-dd1e126a366f.png)

medium width
![image](https://user-images.githubusercontent.com/441217/27843488-1b89eb82-610c-11e7-88e0-1d130acb3454.png)

small width
![image](https://user-images.githubusercontent.com/441217/27843496-2959b5a8-610c-11e7-8d5c-087fd14aed81.png)
