### PR TITLE
Fix markup errors in site footer and UA service description.

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -62,8 +62,7 @@
             <li class="p-list__item"><span class="number">2.4.3</span> More information about kernel support can be found at <a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a></li>
             <li class="p-list__item" id="2-4-4"><span class="number">2.4.4</span> Kernel livepatching
               <ul>
-                <li class="p-list__item">The customer is entitled to a licence to use Canonical&#39;s kernel livepatch daemon, access to available kernel livepatches, and support for livepatches on all systems covered by Ubuntu Advantage, for which the livepatching features are available.
-                </li>
+                <li class="p-list__item">The customer is entitled to a licence to use Canonical&#39;s kernel livepatch daemon, access to available kernel livepatches, and support for livepatches on all systems covered by Ubuntu Advantage, for which the livepatching features are available.</li>
                 <li class="p-list__item">Canonical provides livepatches for High and Critical kernel CVEs. Note that some CVEs may be ineligible for livepatching due to technical limitations within the livepatching system.</li>
                 <li class="p-list__item">Canonical can not provide kernel support bug fixes as kernel livepatches.</li>
                 <li class="p-list__item">Kernel livepatching is available for generic and low latency 64-bit Intel/AMD 4.4 kernels on Ubuntu 16.04.</li>
@@ -113,7 +112,6 @@
         <li class="p-list__item"><a href="#ua-docker">Docker&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-kubernetes">Kubernetes&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-esm">ESM&nbsp;&rsaquo;</a></li>
-
         <li class="p-list__item"><a href="#ua-landscape-seats">Landscape Seats&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#tam">Technical Account Manager&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#dedicated-services-engineer">Dedicated Technical Account Manager&nbsp;&rsaquo;</a></li>
@@ -154,26 +152,25 @@
         <table>
           <caption>Table of business hours</caption>
           <thead>
-          <tr>
-            <th>Service</th>
-            <th>Business hours</th>
-          </tr>
-        </thead>
+            <tr>
+              <th>Service</th>
+              <th>Business hours</th>
+            </tr>
+          </thead>
           <tbody>
-          <tr>
-            <td>Ubuntu Advantage Server Essential<br /> Ubuntu Advantage Desktop Standard</td>
-            <td>Monday &dash; Friday 09:00 &dash; 17:00</td>
-          </tr>
-          <tr>
-            <td>Ubuntu Advantage Server Standard<br /> Ubuntu Advantage Virtual Guest Standard<br /> Ubuntu Advantage MAAS Standard</td>
-            <td>Monday &dash; Friday 08:00 &dash; 18:00</td>
-          </tr>
-          <tr>
-            <td>Ubuntu Advantage OpenStack<br />Ubuntu Advantage OpenStack Cloud Region<br /> Ubuntu Advantage Server Advanced<br /> Ubuntu Advantage Virtual Guest Advanced<br /> Ubuntu Advantage Ceph Storage<br /> Ubuntu Advantage Swift Storage<br /> Ubuntu
-              Advantage MAAS Advanced<br /> Ubuntu Advantage Switch<br /> Landscape on-premises<br /> Ubuntu Advantage Desktop Advanced<br />Ubuntu Advantage for Docker<br />The Canonical Distribution of Kubernetes<br /></td>
-            <td>Monday &dash; Friday 08:00 &dash; 18:00</td>
-          </tr>
-        </tbody>
+            <tr>
+              <td>Ubuntu Advantage Server Essential<br /> Ubuntu Advantage Desktop Standard</td>
+              <td>Monday &dash; Friday 09:00 &dash; 17:00</td>
+            </tr>
+            <tr>
+              <td>Ubuntu Advantage Server Standard<br /> Ubuntu Advantage Virtual Guest Standard<br /> Ubuntu Advantage MAAS Standard</td>
+              <td>Monday &dash; Friday 08:00 &dash; 18:00</td>
+            </tr>
+            <tr>
+              <td>Ubuntu Advantage OpenStack<br />Ubuntu Advantage OpenStack Cloud Region<br /> Ubuntu Advantage Server Advanced<br /> Ubuntu Advantage Virtual Guest Advanced<br /> Ubuntu Advantage Ceph Storage<br /> Ubuntu Advantage Swift Storage<br /> Ubuntu Advantage MAAS Advanced<br /> Ubuntu Advantage Switch<br /> Landscape on-premises<br /> Ubuntu Advantage Desktop Advanced<br />Ubuntu Advantage for Docker<br />The Canonical Distribution of Kubernetes<br /></td>
+              <td>Monday &dash; Friday 08:00 &dash; 18:00</td>
+            </tr>
+          </tbody>
         </table>
       </div>
       <div class="table__wrapper">
@@ -181,36 +178,36 @@
           <caption>Table of response times</caption>
           <thead>
             <tr>
-            <th>&nbsp;</th>
-            <th>Severity <br />Level 1</th>
-            <th>Severity <br />Level 2</th>
-            <th>Severity <br />Level 3</th>
-            <th>Severity <br />Level 4</th>
-          </tr>
+              <th>&nbsp;</th>
+              <th>Severity <br />Level 1</th>
+              <th>Severity <br />Level 2</th>
+              <th>Severity <br />Level 3</th>
+              <th>Severity <br />Level 4</th>
+            </tr>
           </thead>
           <tbody>
-        <tr>
-          <td>Ubuntu Advantage Server Essential<br /> Ubuntu Advantage Desktop Standard</td>
-          <td>1 business day</td>
-          <td>1 business day</td>
-          <td>2 business day</td>
-          <td>4 business days</td>
-        </tr>
-        <tr>
-          <td>Ubuntu Advantage Server Standard<br /> Ubuntu Advantage Virtual Guest Standard<br /> Ubuntu Advantage MAAS Standard</td>
-          <td>2 business hours</td>
-          <td>4 business hours</td>
-          <td>1 business day</td>
-          <td>2 business days</td>
-        </tr>
-        <tr>
-          <td>Ubuntu Advantage OpenStack<br /> Ubuntu Advantage OpenStack Cloud Region<br /> Ubuntu Advantage Server Advanced<br /> Ubuntu Advantage Virtual Guest Advanced<br /> Ubuntu Advantage Ceph Storage<br /> Ubuntu Advantage Swift Storage<br /> Ubuntu Advantage MAAS Advanced<br />            Ubuntu Advantage Switch<br /> Landscape on-premises<br /> Ubuntu Advantage Desktop Advanced<br />Ubuntu Advantage for Docker<br />The Canonical Distribution of Kubernetes</td>
-          <td>1 hour</td>
-          <td>4 business hours</td>
-          <td>6 business hours</td>
-          <td>1 business day</td>
-        </tr>
-      </tbody>
+            <tr>
+              <td>Ubuntu Advantage Server Essential<br /> Ubuntu Advantage Desktop Standard</td>
+              <td>1 business day</td>
+              <td>1 business day</td>
+              <td>2 business day</td>
+              <td>4 business days</td>
+            </tr>
+            <tr>
+              <td>Ubuntu Advantage Server Standard<br /> Ubuntu Advantage Virtual Guest Standard<br /> Ubuntu Advantage MAAS Standard</td>
+              <td>2 business hours</td>
+              <td>4 business hours</td>
+              <td>1 business day</td>
+              <td>2 business days</td>
+            </tr>
+            <tr>
+              <td>Ubuntu Advantage OpenStack<br /> Ubuntu Advantage OpenStack Cloud Region<br /> Ubuntu Advantage Server Advanced<br /> Ubuntu Advantage Virtual Guest Advanced<br /> Ubuntu Advantage Ceph Storage<br /> Ubuntu Advantage Swift Storage<br /> Ubuntu Advantage MAAS Advanced<br />Ubuntu Advantage Switch<br /> Landscape on-premises<br /> Ubuntu Advantage Desktop Advanced<br />Ubuntu Advantage for Docker<br />The Canonical Distribution of Kubernetes</td>
+              <td>1 hour</td>
+              <td>4 business hours</td>
+              <td>6 business hours</td>
+              <td>1 business day</td>
+            </tr>
+          </tbody>
         </table>
       </div>
     </div>
@@ -225,492 +222,491 @@
       </ol>
       <h2 id="assurance">5. Assurance</h2>
       <ol class="p-list">
-        <li class="p-list__item"><span class="number">5.1</span> The customer is entitled to participate in the Ubuntu Assurance Programme, subject to its terms and conditions. Canonical may update the Assurance Programme and its terms periodically. The current Ubuntu Assurance
-          Programme and its IP indemnification terms are available at our Ubuntu Assurance page: <a href="/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a>.</li>
+        <li class="p-list__item"><span class="number">5.1</span> The customer is entitled to participate in the Ubuntu Assurance Programme, subject to its terms and conditions. Canonical may update the Assurance Programme and its terms periodically. The current Ubuntu Assurance Programme and its IP indemnification terms are available at our Ubuntu Assurance page: <a href="/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a>.</li>
       </ol>
     </div>
   </div>
-  <div class="row" id="appendix-1">
+  <div class="row">
+    <div class="col-8" id="appendix-1">
+<h2 id="ua-appendix-1_support-scope">Appendix 1 - Support scope</h2>
+<h3 id="ua-openstack">Ubuntu Advantage OpenStack</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"OpenStack" means the cloud computing software known as "OpenStack" as distributed by Canonical with Ubuntu.</li>
+<li class="p-list__item">"OpenStack Packages" means packages relative to OpenStack present in the Ubuntu Main repository of the Ubuntu Archive, including updates to those packages delivered in the Ubuntu Cloud Archive. This includes Charms listed at <a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a></li>
+<li class="p-list__item">"Region" means a discrete OpenStack environment with dedicated API endpoints that typically shares only the Identity (Keystone) service with other Regions. An OpenStack Region must be contained within a single datacenter.</li>
+<li class="p-list__item">"Public Cloud" means a cloud environment in which third parties are able to create and manage guest instances.</li>
+<li class="p-list__item">"Cloud Guest" means an instance of Ubuntu Server not running in a Public Cloud.</li>
+<li class="p-list__item">"Full Stack Support" means addressing problems pertaining to user and operations-level OpenStack functionality, performance and availability.</li>
+<li class="p-list__item">"Bug-fix Support" means support for valid code bugs in OpenStack Packages only. This does not include troubleshooting of issues to determine if a bug is present.</li>
+<li class="p-list__item">"Valid Customizations" means configurations made through Horizon or the OpenStack API of the OpenStack Packages. For the avoidance of doubt, valid customizations do not include architectural changes that are not expressly executed or authorized by Canonical. Configuration options set during a Foundation OpenStack Build should be considered critical to the health of the Cloud. Any changes to these may render the cloud unsupported. Request for changes should be validated by Canonical to ensure continued support.</li>
+</ul>
+<p>Supported versions of OpenStack:</p>
+<ul>
+<li class="p-list__item">The version of OpenStack provided initially in the release of a Long Term Support (LTS) version of Ubuntu is supported for the entire lifecycle of that Ubuntu version.</li>
+<li class="p-list__item">Releases of OpenStack released after an LTS version of Ubuntu are available in the Ubuntu Cloud Archive. Each OpenStack release in the Ubuntu Cloud Archive is supported on an Ubuntu LTS version for a minimum of 18 months from the release date of the
+Ubuntu version that included the applicable OpenStack version.</li>
+<li class="p-list__item">The OpenStack release support schedule is available here <a href="http://www.ubuntu.com/info/release-end-of-life">http://www.ubuntu.com/info/release-end-of-life</a>.</li>
+</ul>
+<p>Support of OpenStack</p>
+<ul>
+<li class="p-list__item">OpenStack support requires each Region to consist of 12 or more supported nodes. All nodes that participate in the OpenStack environment must be covered under an active support agreement.</li>
+<li class="p-list__item">In addition to the hardware requirements laid out in <a href="#support-scope-hardware">Section 2.2</a>, hardware must meet the <a href="https://assets.ubuntu.com/v1/22beff77-Foundation+Cloud+Build+Hardware+Requirements.pdf">minimum criteria for Ubuntu OpenStack.</a></li>
+<li class="p-list__item">Full Stack Support of an OpenStack Cloud is only available when deployed via a Foundation OpenStack Build engagement.</li>
+<li class="p-list__item">
+<ul>
+<li class="p-list__item">Canonical will provide support for the charms deployed via a Foundation OpenStack Build.</li>
+<li class="p-list__item">For any deployments done under contract with Canonical, which results in customization of any Charms, customization will be valid for 90 days after the official release of the Charm which includes the customizations.</li>
+<li class="p-list__item">Support is included for all packages required to run OpenStack as deployed via the Foundation OpenStack Build engagement.</li>
+<li class="p-list__item">Upgrades of OpenStack components as part of the regular Ubuntu LTS maintenance cycle are supported.</li>
+<li class="p-list__item">Upgrades between versions of OpenStack (for instance, from OpenStack Newton to Mitaka) or versions of Ubuntu (for instance, from Ubuntu 14.04 LTS to Ubuntu 16.04 LTS), Juju and MAAS are supported as long as the upgrade is performed following a documented
+process as specified by Canonical as part of the Foundation OpenStack Build.</li>
+<li class="p-list__item">Addition of new cloud nodes and replacement of existing nodes with new nodes of equivalent capacity are both supported.</li>
+<li class="p-list__item">Full Stack Support excludes customizations which are not considered Valid Customizations.</li>
+<li class="p-list__item">Ubuntu Advantage Virtual Guest Advanced services for Cloud Guests.</li>
+</ul>
+</li>
+<li class="p-list__item">OpenStack clouds not deployed through a Foundation OpenStack Build are limited to Bug-fix Support.</li>
+</ul>
+<p>OpenStack support does not include support beyond Bug-fix Support during the deployment or configuration of an OpenStack cloud.</p>
+<p>Charms</p>
+<ul>
+<li class="p-list__item">Each charm version is supported for one year from the release date.</li>
+<li class="p-list__item">Canonical will not provide support for any charms that have been modified from the supported version found in in the page at <a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a>.</li>
+</ul>
+<p>Support for Ceph or Swift deployments of up to a total of 3 TB of usable storage per deployed node. This allowance can be used for Ubuntu Advantage Ceph, Ubuntu Advantage Swift or a combination of these.</p>
+<p>Licence to use available Canonical provided Microsoft-certified drivers in Windows Guest instances.</p>
+<p>Licence to use the Ceph Dash Monitoring tool.</p>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for workloads other than those required to run an OpenStack deployment.</li>
+<li class="p-list__item">Support for guest instances other than Cloud Guests.</li>
+</ul>
+<h3 id="ua-advantage-openstack-cloud-region">Ubuntu Advantage OpenStack Cloud Region</h3>
+<p>Ubuntu Advantage OpenStack Cloud Region is the same as Ubuntu Advantage OpenStack, except as follows:</p>
+<ul>
+<li class="p-list__item">Support is limited to a single region and a maximum number of nodes based upon the size of the Ubuntu Advantage OpenStack Cloud Region purchased.</li>
+<li class="p-list__item">Landscape on-premises is included</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for OpenStack projects or additional technologies not deployed via a Foundation OpenStack Build.</li>
+</ul>
+<h3 id="ua-server">Ubuntu Advantage Server</h3>
+<p>The scope of each particular offering (Essential, Standard, or Advanced) is defined below. The following items are not covered under any Ubuntu Advantage Server offerings.</p>
+<ul>
+<li class="p-list__item">Ceph</li>
+<li class="p-list__item">Swift</li>
+<li class="p-list__item">OpenStack</li>
+</ul>
+<h4>Summary of service offerings</h4>
+<div class="table__wrapper">
+<table>
+<thead>
+<tr>
+<th scope="col">Features</th>
+<th scope="col">Essential</th>
+<th scope="col">Standard</th>
+<th scope="col">Advanced</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>8x5 ticket support for the default packages in the Ubuntu Server image (see <a href="#response-times">Section 3</a>)</td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>Landscape Management (see <a href="#support-scope-landscape">Section 2.5</a>)</td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>Ubuntu Legal Assurance programme (see <a href="#assurance">Section 5</a>)</td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>Kernel livepatching (per Section <a href="#2-4-4">2.4.4</a> of this Service Description)</td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>Extended Security Maintenance (<a href="#service-offering-definitions">as defined in this section</a>)</td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>10x5 phone and ticket support for all packages in Ubuntu main (see <a href="#response-times">Section 3</a>), except as defined in <a href="#lxd-guest-support">this section</a></td>
+<td></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>Unlimited <a href="#lxd-guest-support">Ubuntu LXD guest support</a></td>
+<td></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>24x7 phone and ticket support for all packages in Ubuntu main (see <a href="#response-times">Section 3</a>) and Canonical-maintained packages in backports and universe, except as defined in <a href="#kvm-guest-support">this section</a></td>
+<td></td>
+<td></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+<tr>
+<td>Unlimited <a href="#kvm-guest-support">Ubuntu KVM guest support</a></td>
+<td></td>
+<td></td>
+<td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+</tr>
+</tbody>
+</table>
+</div>
+<h4 id="service-offering-definitions">Essential</h4>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Support for the packages found in the server/cloud image manifest.</li>
+<li class="p-list__item">Extended Security Maintenance for customers who have purchased a minimum of 100 Ubuntu Advantage Essential supported nodes.</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for packages not found in the server/cloud image manifest.</li>
+<li class="p-list__item">Support for issues other than bugs found in packages provided by the server/cloud image.</li>
+<li class="p-list__item">Access to telephone support.</li>
+</ul>
+<h4 id="lxd-guest-support">Standard</h4>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Ubuntu Advantage Virtual Guest Standard support for an unlimited number of Ubuntu LXD guests.</li>
+<li class="p-list__item">Extended Security Maintenance for Ubuntu</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for KVM-related packages and KVM guests.</li>
+<li class="p-list__item">Access to the Landscape systems management tool for Ubuntu LXD guests, except where covered by Landscape Seats or Landscape on-premises.</li>
+</ul>
+<h4 id="kvm-guest-support">Advanced</h4>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Ubuntu Advantage Virtual Guest Advanced support for an unlimited number of Ubuntu LXD and Ubuntu KVM guests.</li>
+<li class="p-list__item">Licence to use FIPS HMAC Checksum packages (if and when available) on the systems covered under Ubuntu Advantage Server Advanced.</li>
+<li class="p-list__item">Extended Security Maintenance for Ubuntu</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Access to the Landscape systems management tool for Ubuntu LXD or Ubuntu KVM guests, except where covered by Landscape Seats or Landscape on-premises.</li>
+</ul>
+<h3 id="ua-virtual-guest">Ubuntu Advantage Virtual Guest</h3>
+<ul>
+<li class="p-list__item">Services are provided for Ubuntu Server when installed and running in a virtualized environment on a physical host or in an Ubuntu Certified Public Cloud partner&#39;s environment. Certified Public Cloud partners can be found in the Ubuntu partner listing: <a href="https://partners.ubuntu.com/find-a-partner">https://partners.ubuntu.com/find-a-partner</a></li>
+<li class="p-list__item">Extended Security Maintenance for Ubuntu</li>
+<li class="p-list__item">
+Service excludes:
+<ul>
+<li class="p-list__item">Support for KVM-related packages and KVM guests.</li>
+<li class="p-list__item">Additional exclusions match those of the applicable Ubuntu Advantage Server service offering.</li>
+</ul>
+</li>
+</ul>
+<h3 id="ua-ceph-storage">Ubuntu Advantage Ceph Storage</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"Cluster" means a single Ceph installation in a single physical data center.</li>
+</ul>
+<p>Support is measured by the total amount of data stored in Ceph across all storage pools, measured in gigabytes. This excludes free space and all replication and erasure coding overhead.</p>
+<p>Customers who have purchased Ubuntu Advantage Ceph Storage for an unlimited amount of storage are limited to support in a single Cluster.</p>
+<p>Service additionally includes:</p>
+<ul>
+<li class="p-list__item">Support for all packages required to run a Ceph deployment.</li>
+<li class="p-list__item">Support for all servers necessary to meet the storage and replication requirements. This includes auxiliary (non-storage) nodes such as Ceph monitors.</li>
+<li class="p-list__item">Licence to use the Ceph Dash monitoring tool.</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for workloads other than those required to run a Ceph deployment.</li>
+</ul>
+<h3 id="ua-swift-storage">Ubuntu Advantage Swift Storage</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"Cluster" means a single Swift installation in a single physical data center.</li>
+</ul>
+<p>Support is measured by the total amount of data stored in Swift across all storage pools, measured in gigabytes. This excludes free space and all replication and erasure coding overhead.</p>
+<p>Customers who have purchased Ubuntu Advantage Swift Storage for an unlimited amount of storage are limited to support in a single Cluster.</p>
+<p>Service additionally includes:</p>
+<ul>
+<li class="p-list__item">Support for all packages required to run a Swift deployment.</li>
+<li class="p-list__item">Support for all servers necessary to meet the storage and replication requirements. This includes auxiliary (non-storage) nodes such as Swift monitors.</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for workloads other than those required to run a Swift deployment.</li>
+</ul>
+<h3 id="ua-maas">Ubuntu Advantage MAAS</h3>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Support for all servers required to host the MAAS environment following a documented MAAS deployment architecture.</li>
+<li class="p-list__item">Support for all packages required to run MAAS.</li>
+<li class="p-list__item">Support for the ability to boot machines using operating system images provided by Canonical.</li>
+<li class="p-list__item">Support for the tooling required to convert certified operating system images not provided by Canonical into MAAS images.</li>
+<li class="p-list__item">Support for the tooling required to properly implement a standard Highly-Available MAAS configuration.</li>
+<li class="p-list__item">Licence to use MAAS Custom Imaging tools.</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for workloads, packages and service components other than those required to run a MAAS deployment.</li>
+<li class="p-list__item">Support for the nodes deployed using MAAS.</li>
+<li class="p-list__item">Support for design and implementation details of a MAAS deployment.</li>
+</ul>
+<p>Supported versions of MAAS:</p>
+<ul>
+<li class="p-list__item">Versions of MAAS are supported on an LTS version of Ubuntu for a period of one year from the date it is released in the Ubuntu archives.</li>
+</ul>
+<h3 id="ua-switch">Ubuntu Advantage Switch</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"Whitebox Switch" means an x86 Broadcom ASIC based switch made by an ODM manufacturer for vendors to label and sell.</li>
+<li class="p-list__item">"BCOS" - An Ubuntu optimized version of a full featured Layer 2 and Layer 3 networking software from a Whitebox Switch.</li>
+</ul>
+<p>Services include:</p>
+<ul>
+<li class="p-list__item">Support for the specific version of Ubuntu required to run BCOS.</li>
+<li class="p-list__item">Support for the BCOS software.</li>
+</ul>
+<p>Services exclude:</p>
+<ul>
+<li class="p-list__item">Support for workloads other than those required to run BCOS.</li>
+<li class="p-list__item">Support for versions of the kernel other than those that are provided with the BCOS software.</li>
+<li class="p-list__item">Support for the physical hardware. Hardware support is provided by the vendor.</li>
+<li class="p-list__item">Landscape SaaS and Landscape on-premises</li>
+</ul>
+<h3 id="ua-desktop">Ubuntu Advantage Desktop</h3>
+<p>Services exclude:</p>
+<ul>
+<li class="p-list__item">Virtual machines</li>
+<li class="p-list__item">Machine containers</li>
+<li class="p-list__item">Application containers</li>
+<li class="p-list__item">Dual-booting (cohabitating with other operating systems)</li>
+<li class="p-list__item">Peripherals which are not certified to work with Ubuntu</li>
+<li class="p-list__item">Support for non-desktop packages</li>
+<li class="p-list__item">Community flavours of Ubuntu</li>
+</ul>
+<h4 id="ua-desktop-standard">Standard</h4>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Basic network authentication and connectivity using sssd, winbind, network-manager, and network-manager related plugins in the Ubuntu Main repository</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Developer tools</li>
+<li class="p-list__item">Support for packages not in the base Ubuntu desktop image</li>
+</ul>
+<h4 id="ua-desktop-advanced">Advanced</h4>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Desktop provisioning with Canonical tools</li>
+</ul>
+
+<h3 id="ua-docker">Ubuntu Advantage for Docker</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"Docker" means the software known as Docker Enterprise Edition Basic as published by Docker, Inc.</li>
+</ul>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Support for the host machine running Ubuntu.</li>
+<li class="p-list__item">Support for all packages required to run Docker as found in the Docker package archives.</li>
+<li class="p-list__item">Support for an unlimited number of Docker containers.</li>
+<li class="p-list__item">Ubuntu Advantage Virtual Guest Advanced services for Docker containers running Ubuntu and installed from official sources.</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support for workloads other than those required to run Docker on the host machine.</li>
+<li class="p-list__item">Landscape seats for Docker containers.</li>
+</ul>
+<p>Releases of Docker are supported as defined on Docker&rsquo;s website at: <a href="https://success.docker.com/Policies/Maintenance_Lifecycle">https://success.docker.com/Policies/Maintenance_Lifecycle</a></p>
+<h3 id="ua-kubernetes">The Canonical Distribution of Kubernetes</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"Canonical Distribution of Kubernetes" means Kubernetes deployed using Juju and the official Canonical-Kubernetes bundle on bare metal, cloud guests, or virtual machines.</li>
+<li class="p-list__item">"Deployment" means the process of deploying the Canonical Distribution of Kubernetes. A deployment is considered successful once Juju reports all applications in a "started" state.</li>
+<li class="p-list__item">"Upgrade" means the process of upgrading Kubernetes between versions. An upgrade is considered successful once Juju reports all applications in a "started" state. Canonical will provide support for valid bugs encountered during
+the Upgrade process.</li>
+<li class="p-list__item">"Support" means break-fix support and answering basic questions about Kubernetes. Deployment and Upgrade assistance, as well as configuration and optimization of Kubernetes fall outside the scope of support.</li>
+</ul>
+<p>Minimum deployment of the Canonical Distribution of Kubernetes is the base configuration of the Canonical-Kubernetes bundle. Support must be purchased for all nodes in the supported Kubernetes environment.</p>
+<p>Supported versions of Kubernetes include the current stable version of Kubernetes and the most recent previous version as listed:</p>
+<ul>
+<li class="p-list__item"><a href="https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions">https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions</a></li>
+</ul>
+<p>Support is limited to the software packages and Charms necessary for running the Canonical Distribution of Kubernetes.</p>
+<p>For any deployment of the Canonical Distribution of Kubernetes carried out by Canonical while under contract for this deployment, which result in the customization of any Charms, the customization will be supported for 90 days after the official release of the Charm which includes the customizations.</p>
+<h3 id="ua-esm">Extended Security Maintenance</h3>
+<p>Extended Security Maintenance includes available High and Critical CVE fixes for a number of server packages in the Ubuntu Main Repository through 28 April 2019. A complete list of packages included in Extended Security Maintenance can be found at: <a href="https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages">https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages</a>
+</p>
+<p>Extended Security Maintenance is included for 64-bit x86 AMD/Intel installations.</p>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Bug fixes for packages in the end of life release, unless a bug was created by an Extended Security Maintenance security update.</li>
+<li class="p-list__item">Security fixes for packages not found in the Maintained Packages list.</li>
+<li class="p-list__item">Security fixes for CVEs that are not High or Critical</li>
+</ul>
+<p>Extended Security Maintenance does not guarantee secure software or fixes to all High or Critical CVEs.</p>
+<h3 id="ua-landscape-seats">Landscape Seats</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"Seats" means the ability to register Virtual Machines in Landscape SaaS or Landscape on-premises.</li>
+<li class="p-list__item">"Virtual Machines" means Ubuntu Server installed and running in a virtualized environment.</li>
+</ul>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Seats running on systems covered by the Ubuntu Advantage service.</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support beyond that of the packages required to install and run the Landscape Client.</li>
+</ul>
+<h3 id="tam">Technical Account Manager</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"TAM" means a Canonical support engineer who works remotely to personally collaborate with the customer&#39;s staff and management.</li>
+</ul>
+<p>Canonical will enhance its support offering by providing a TAM, who will perform the following services for up to 10 hours per week during the term of service:</p>
+<ul>
+<li class="p-list__item">Provide support and best-practice advice on platform and configurations covered by the applicable Ubuntu Advantage services.</li>
+<li class="p-list__item">Participate in review calls every other week at mutually agreed times addressing the customer&#39;s operational issues.</li>
+<li class="p-list__item">Organise multi-vendor issue coordination through TSANet or Canonical&#39;s direct partnerships where applicable. When the root cause is identified, the TAM will work with the vendor for that sub-system, working to resolve the case through their normal support process.</li>
+</ul>
+<p>Canonical will hold a quarterly service review meeting with the customer to assess service performance and determine areas of improvement.</p>
+<p>The TAM will visit the customer&#39;s site annually for on-site technical review.</p>
+<p>The TAM is available to respond to support cases during the TAM&#39;s working hours. Outside of such hours, support will be provided per the Ubuntu Advantage Support Process.</p>
+<h3 id="dedicated-services-engineer">Dedicated Technical Account Manager</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"DTAM" means a Canonical support engineer dedicated to work full-time remotely for a single customer.</li>
+</ul>
+<p>Canonical will enhance its support offering by providing a DTAM, who will perform the following services during local business hours for up to 40 hours per week (subject to Canonical leave policies) during the term of service:</p>
+<ul>
+<li class="p-list__item">Provide support and best-practice advice on platform and configurations covered by the applicable Ubuntu Advantage services.</li>
+<li class="p-list__item">Act as the primary point of contact for all support requests originating from the customer department for which the DTAM is responsible.</li>
+<li class="p-list__item">Manage support escalations and prioritization in accordance with Canonical&#39;s standard support response definitions and customer needs.</li>
+<li class="p-list__item">Participate in regular review calls addressing the customer&#39;s operational issues.</li>
+<li class="p-list__item">Organise multi-vendor issue coordination through TSANet or Canonical&#39;s direct partnerships where applicable. When the root cause is identified, the DTAM will work with the vendor for that sub-system, working to resolve the case through their
+normal support process.</li>
+<li class="p-list__item">Attend applicable Canonical internal training and development activities (in-person and remote).</li>
+</ul>
+<p>Canonical will hold a quarterly service review meeting with the customer to assess service performance and determine areas of improvement.</p>
+<p>The DTAM is available to respond to support cases during the DTAM&#39;s working hours. Outside of business hours, support will be provided per the Ubuntu Advantage Support Process.</p>
+<h3 id="landscape-on-premises">Landscape on-premises</h3>
+<p>Definitions:</p>
+<ul>
+<li class="p-list__item">"Landscape on-premises" means Canonical&#39;s Landscape system management software installed on the customer&#39;s hardware.</li>
+</ul>
+<p>Service includes:</p>
+<ul>
+<li class="p-list__item">Licence to download and install a single instance of Landscape on-premises.</li>
+<li class="p-list__item">Ability to use Landscape on-premises management and monitoring services for machines (whether physical or virtual) for which the customer has purchased Ubuntu Advantage services.</li>
+</ul>
+<p>Deployment methods:</p>
+<ul>
+<li class="p-list__item">When installed using the "Quickstart" install method, support is included for the machine on which Landscape on-premises is installed.</li>
+<li class="p-list__item">When installed using a manual install method, support is included for up to two servers on which Landscape on-premises is installed.</li>
+<li class="p-list__item">When deployed using Juju, the "dense deployment" method will be supported.</li>
+</ul>
+<p>Service excludes:</p>
+<ul>
+<li class="p-list__item">Support beyond that of the Landscape on-premises packages.</li>
+</ul>
+<p>Supported versions of Landscape on-premises:</p>
+<ul>
+<li class="p-list__item">Each release of Landscape on-premises will be supported for 1 year from its release date.</li>
+</ul>
+<!-- / Appendix 1 -->
+</div>
+  </div>
+
+  <div class="row" id="appendix-2">
     <div class="col-8">
-      <h2 id="ua-appendix-1_support-scope">Appendix 1 - Support scope</h2>
-      <h3 id="ua-openstack">Ubuntu Advantage OpenStack</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"OpenStack" means the cloud computing software known as "OpenStack" as distributed by Canonical with Ubuntu.</li>
-        <li class="p-list__item">"OpenStack Packages" means packages relative to OpenStack present in the Ubuntu Main repository of the Ubuntu Archive, including updates to those packages delivered in the Ubuntu Cloud Archive. This includes Charms listed at <a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a></li>
-        <li class="p-list__item">"Region" means a discrete OpenStack environment with dedicated API endpoints that typically shares only the Identity (Keystone) service with other Regions. An OpenStack Region must be contained within a single datacenter.</li>
-        <li class="p-list__item">"Public Cloud" means a cloud environment in which third parties are able to create and manage guest instances.</li>
-        <li class="p-list__item">"Cloud Guest" means an instance of Ubuntu Server not running in a Public Cloud.</li>
-        <li class="p-list__item">"Full Stack Support" means addressing problems pertaining to user and operations-level OpenStack functionality, performance and availability.</li>
-        <li class="p-list__item">"Bug-fix Support" means support for valid code bugs in OpenStack Packages only. This does not include troubleshooting of issues to determine if a bug is present.</li>
-        <li class="p-list__item">"Valid Customizations" means configurations made through Horizon or the OpenStack API of the OpenStack Packages. For the avoidance of doubt, valid customizations do not include architectural changes that are not expressly executed or authorized by Canonical. Configuration options set during a Foundation OpenStack Build should be considered critical to the health of the Cloud. Any changes to these may render the cloud unsupported. Request for changes should be validated by Canonical to ensure continued support.</li>
-      </ul>
-      <p>Supported versions of OpenStack:</p>
-      <ul>
-        <li class="p-list__item">The version of OpenStack provided initially in the release of a Long Term Support (LTS) version of Ubuntu is supported for the entire lifecycle of that Ubuntu version.</li>
-        <li class="p-list__item">Releases of OpenStack released after an LTS version of Ubuntu are available in the Ubuntu Cloud Archive. Each OpenStack release in the Ubuntu Cloud Archive is supported on an Ubuntu LTS version for a minimum of 18 months from the release date of the
-          Ubuntu version that included the applicable OpenStack version.</li>
-        <li class="p-list__item">The OpenStack release support schedule is available here <a href="http://www.ubuntu.com/info/release-end-of-life">http://www.ubuntu.com/info/release-end-of-life</a>.</li>
-      </ul>
-      <p>Support of OpenStack</p>
-      <ul>
-        <li class="p-list__item">OpenStack support requires each Region to consist of 12 or more supported nodes. All nodes that participate in the OpenStack environment must be covered under an active support agreement.</li>
-        <li class="p-list__item">In addition to the hardware requirements laid out in <a href="#support-scope-hardware">Section 2.2</a>, hardware must meet the <a href="https://assets.ubuntu.com/v1/22beff77-Foundation+Cloud+Build+Hardware+Requirements.pdf">minimum criteria for Ubuntu OpenStack.</a></li>
-        <li class="p-list__item">Full Stack Support of an OpenStack Cloud is only available when deployed via a Foundation OpenStack Build engagement.</li>
-        <li class="p-list__item">
-          <ul>
-            <li class="p-list__item">Canonical will provide support for the charms deployed via a Foundation OpenStack Build.</li>
-            <li class="p-list__item">For any deployments done under contract with Canonical, which results in customization of any Charms, customization will be valid for 90 days after the official release of the Charm which includes the customizations.</li>
-            <li class="p-list__item">Support is included for all packages required to run OpenStack as deployed via the Foundation OpenStack Build engagement.</li>
-            <li class="p-list__item">Upgrades of OpenStack components as part of the regular Ubuntu LTS maintenance cycle are supported.</li>
-            <li class="p-list__item">Upgrades between versions of OpenStack (for instance, from OpenStack Newton to Mitaka) or versions of Ubuntu (for instance, from Ubuntu 14.04 LTS to Ubuntu 16.04 LTS), Juju and MAAS are supported as long as the upgrade is performed following a documented
-              process as specified by Canonical as part of the Foundation OpenStack Build.</li>
-            <li class="p-list__item">Addition of new cloud nodes and replacement of existing nodes with new nodes of equivalent capacity are both supported.</li>
-            <li class="p-list__item">Full Stack Support excludes customizations which are not considered Valid Customizations.</li>
-            <li class="p-list__item">Ubuntu Advantage Virtual Guest Advanced services for Cloud Guests.</li>
-          </ul>
-        </li>
-        <li class="p-list__item">OpenStack clouds not deployed through a Foundation OpenStack Build are limited to Bug-fix Support.</li>
-      </ul>
-      <p>OpenStack support does not include support beyond Bug-fix Support during the deployment or configuration of an OpenStack cloud.</p>
-      <p>Charms</p>
-      <ul>
-        <li class="p-list__item">Each charm version is supported for one year from the release date.</li>
-        <li class="p-list__item">Canonical will not provide support for any charms that have been modified from the supported version found in in the page at <a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a>.</li>
-      </ul>
-      <p>Support for Ceph or Swift deployments of up to a total of 3 TB of usable storage per deployed node. This allowance can be used for Ubuntu Advantage Ceph, Ubuntu Advantage Swift or a combination of these.</p>
-      <p>Licence to use available Canonical provided Microsoft-certified drivers in Windows Guest instances.</p>
-      <p>Licence to use the Ceph Dash Monitoring tool.</p>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for workloads other than those required to run an OpenStack deployment.</li>
-        <li class="p-list__item">Support for guest instances other than Cloud Guests.</li>
-      </ul>
-      <h3 id="ua-advantage-openstack-cloud-region">Ubuntu Advantage OpenStack Cloud Region</h3>
-      <p>Ubuntu Advantage OpenStack Cloud Region is the same as Ubuntu Advantage OpenStack, except as follows:</p>
-      <ul>
-        <li class="p-list__item">Support is limited to a single region and a maximum number of nodes based upon the size of the Ubuntu Advantage OpenStack Cloud Region purchased.</li>
-        <li class="p-list__item">Landscape on-premises is included</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for OpenStack projects or additional technologies not deployed via a Foundation OpenStack Build.</li>
-      </ul>
-      <h3 id="ua-server">Ubuntu Advantage Server</h3>
-      <p>The scope of each particular offering (Essential, Standard, or Advanced) is defined below. The following items are not covered under any Ubuntu Advantage Server offerings.</p>
-      <ul>
-        <li class="p-list__item">Ceph</li>
-        <li class="p-list__item">Swift</li>
-        <li class="p-list__item">OpenStack</li>
-      </ul>
-      <h4>Summary of service offerings</h4>
+      <h2 id="ua-support-process">Appendix 2 - Ubuntu Advantage Support&nbsp;Process</h2>
+      <h3 id="ua-support-service-initiation">1. Service initiation</h3>
+      <ol class="p-list">
+        <li class="p-list__item"><span class="number">1.1</span> Upon commencement of the services, Canonical will provide access for a single technical representative to Landscape, the support portal and the online knowledge base.</li>
+        <li class="p-list__item"><span class="number">1.2</span> The customer -- through their initial technical representative -- may select their chosen technical representatives to interface with Canonical based on the number of systems under support as represented in the table below. These technical representatives will hold credentials to the support portal and will act as primary points of contact for support requests.</li>
+      </ol>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
       <div class="table__wrapper">
         <table>
+          <caption>Table of machines under support</caption>
           <thead>
             <tr>
-              <th scope="col">Features</th>
-              <th scope="col">Essential</th>
-              <th scope="col">Standard</th>
-              <th scope="col">Advanced</th>
+              <th>Number of machines under Ubuntu Advantage support</th>
+              <th>Technical representatives</th>
             </tr>
           </thead>
-        <tbody>
-          <tr>
-            <td>8x5 ticket support for the default packages in the Ubuntu Server image (see <a href="#response-times">Section 3</a>)</td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>Landscape Management (see <a href="#support-scope-landscape">Section 2.5</a>)</td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>Ubuntu Legal Assurance programme (see <a href="#assurance">Section 5</a>)</td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>Kernel livepatching (per Section <a href="#2-4-4">2.4.4</a> of this Service Description)</td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>Extended Security Maintenance (<a href="#service-offering-definitions">as defined in this section</a>)</td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>10x5 phone and ticket support for all packages in Ubuntu main (see <a href="#response-times">Section 3</a>), except as defined in <a href="#lxd-guest-support">this section</a></td>
-            <td></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>Unlimited <a href="#lxd-guest-support">Ubuntu LXD guest support</a></td>
-            <td></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>24x7 phone and ticket support for all packages in Ubuntu main (see <a href="#response-times">Section 3</a>) and Canonical-maintained packages in backports and universe, except as defined in <a href="#kvm-guest-support">this section</a></td>
-            <td></td>
-            <td></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
-            <td>Unlimited <a href="#kvm-guest-support">Ubuntu KVM guest support</a></td>
-            <td></td>
-            <td></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-        </tbody>
-      </table>
-      </div>
-      <h4 id="service-offering-definitions">Essential</h4>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Support for the packages found in the server/cloud image manifest.</li>
-        <li class="p-list__item">Extended Security Maintenance for customers who have purchased a minimum of 100 Ubuntu Advantage Essential supported nodes.</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for packages not found in the server/cloud image manifest.</li>
-        <li class="p-list__item">Support for issues other than bugs found in packages provided by the server/cloud image.</li>
-        <li class="p-list__item">Access to telephone support.</li>
-      </ul>
-      <h4 id="lxd-guest-support">Standard</h4>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Ubuntu Advantage Virtual Guest Standard support for an unlimited number of Ubuntu LXD guests.</li>
-        <li class="p-list__item">Extended Security Maintenance for Ubuntu</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for KVM-related packages and KVM guests.</li>
-        <li class="p-list__item">Access to the Landscape systems management tool for Ubuntu LXD guests, except where covered by Landscape Seats or Landscape on-premises.</li>
-      </ul>
-      <h4 id="kvm-guest-support">Advanced</h4>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Ubuntu Advantage Virtual Guest Advanced support for an unlimited number of Ubuntu LXD and Ubuntu KVM guests.</li>
-        <li class="p-list__item">Licence to use FIPS HMAC Checksum packages (if and when available) on the systems covered under Ubuntu Advantage Server Advanced.</li>
-        <li class="p-list__item">Extended Security Maintenance for Ubuntu</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Access to the Landscape systems management tool for Ubuntu LXD or Ubuntu KVM guests, except where covered by Landscape Seats or Landscape on-premises.</li>
-      </ul>
-      <h3 id="ua-virtual-guest">Ubuntu Advantage Virtual Guest</h3>
-      <ul>
-        <li class="p-list__item">Services are provided for Ubuntu Server when installed and running in a virtualized environment on a physical host or in an Ubuntu Certified Public Cloud partner&#39;s environment. Certified Public Cloud partners can be found in the Ubuntu partner listing: <a href="https://partners.ubuntu.com/find-a-partner">https://partners.ubuntu.com/find-a-partner</a></li>
-        <li class="p-list__item">Extended Security Maintenance for Ubuntu</li>
-        <li class="p-list__item">
-          Service excludes:
-          <ul>
-            <li class="p-list__item">Support for KVM-related packages and KVM guests.</li>
-            <li class="p-list__item">Additional exclusions match those of the applicable Ubuntu Advantage Server service offering.</li>
-          </ul>
-        </li>
-      </ul>
-      <h3 id="ua-ceph-storage">Ubuntu Advantage Ceph Storage</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"Cluster" means a single Ceph installation in a single physical data center.</li>
-      </ul>
-      <p>Support is measured by the total amount of data stored in Ceph across all storage pools, measured in gigabytes. This excludes free space and all replication and erasure coding overhead.</p>
-      <p>Customers who have purchased Ubuntu Advantage Ceph Storage for an unlimited amount of storage are limited to support in a single Cluster.</p>
-      <p>Service additionally includes:</p>
-      <ul>
-        <li class="p-list__item">Support for all packages required to run a Ceph deployment.</li>
-        <li class="p-list__item">Support for all servers necessary to meet the storage and replication requirements. This includes auxiliary (non-storage) nodes such as Ceph monitors.</li>
-        <li class="p-list__item">Licence to use the Ceph Dash monitoring tool.</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for workloads other than those required to run a Ceph deployment.</li>
-      </ul>
-      <h3 id="ua-swift-storage">Ubuntu Advantage Swift Storage</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"Cluster" means a single Swift installation in a single physical data center.</li>
-      </ul>
-      <p>Support is measured by the total amount of data stored in Swift across all storage pools, measured in gigabytes. This excludes free space and all replication and erasure coding overhead.</p>
-      <p>Customers who have purchased Ubuntu Advantage Swift Storage for an unlimited amount of storage are limited to support in a single Cluster.</p>
-      <p>Service additionally includes:</p>
-      <ul>
-        <li class="p-list__item">Support for all packages required to run a Swift deployment.</li>
-        <li class="p-list__item">Support for all servers necessary to meet the storage and replication requirements. This includes auxiliary (non-storage) nodes such as Swift monitors.</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for workloads other than those required to run a Swift deployment.</li>
-      </ul>
-      <h3 id="ua-maas">Ubuntu Advantage MAAS</h3>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Support for all servers required to host the MAAS environment following a documented MAAS deployment architecture.</li>
-        <li class="p-list__item">Support for all packages required to run MAAS.</li>
-        <li class="p-list__item">Support for the ability to boot machines using operating system images provided by Canonical.</li>
-        <li class="p-list__item">Support for the tooling required to convert certified operating system images not provided by Canonical into MAAS images.</li>
-        <li class="p-list__item">Support for the tooling required to properly implement a standard Highly-Available MAAS configuration.</li>
-        <li class="p-list__item">Licence to use MAAS Custom Imaging tools.</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for workloads, packages and service components other than those required to run a MAAS deployment.</li>
-        <li class="p-list__item">Support for the nodes deployed using MAAS.</li>
-        <li class="p-list__item">Support for design and implementation details of a MAAS deployment.</li>
-      </ul>
-      <p>Supported versions of MAAS:</p>
-      <ul>
-        <li class="p-list__item">Versions of MAAS are supported on an LTS version of Ubuntu for a period of one year from the date it is released in the Ubuntu archives.</li>
-      </ul>
-      <h3 id="ua-switch">Ubuntu Advantage Switch</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"Whitebox Switch" means an x86 Broadcom ASIC based switch made by an ODM manufacturer for vendors to label and sell.</li>
-        <li class="p-list__item">"BCOS" - An Ubuntu optimized version of a full featured Layer 2 and Layer 3 networking software from a Whitebox Switch.</li>
-      </ul>
-      <p>Services include:</p>
-      <ul>
-        <li class="p-list__item">Support for the specific version of Ubuntu required to run BCOS.</li>
-        <li class="p-list__item">Support for the BCOS software.</li>
-      </ul>
-      <p>Services exclude:</p>
-      <ul>
-        <li class="p-list__item">Support for workloads other than those required to run BCOS.</li>
-        <li class="p-list__item">Support for versions of the kernel other than those that are provided with the BCOS software.</li>
-        <li class="p-list__item">Support for the physical hardware. Hardware support is provided by the vendor.</li>
-        <li class="p-list__item">Landscape SaaS and Landscape on-premises</li>
-      </ul>
-      <h3 id="ua-desktop">Ubuntu Advantage Desktop</h3>
-      <p>Services exclude:</p>
-      <ul>
-        <li class="p-list__item">Virtual machines</li>
-        <li class="p-list__item">Machine containers</li>
-        <li class="p-list__item">Application containers</li>
-        <li class="p-list__item">Dual-booting (cohabitating with other operating systems)</li>
-        <li class="p-list__item">Peripherals which are not certified to work with Ubuntu</li>
-        <li class="p-list__item">Support for non-desktop packages</li>
-        <li class="p-list__item">Community flavours of Ubuntu</li>
-      </ul>
-      <h4 id="ua-desktop-standard">Standard</h4>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Basic network authentication and connectivity using sssd, winbind, network-manager, and network-manager related plugins in the Ubuntu Main repository</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Developer tools</li>
-        <li class="p-list__item">Support for packages not in the base Ubuntu desktop image</li>
-      </ul>
-      <h4 id="ua-desktop-advanced">Advanced</h4>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Desktop provisioning with Canonical tools</li>
-      </ul>
-
-      <h3 id="ua-docker">Ubuntu Advantage for Docker</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"Docker" means the software known as Docker Enterprise Edition Basic as published by Docker, Inc.</li>
-      </ul>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Support for the host machine running Ubuntu.</li>
-        <li class="p-list__item">Support for all packages required to run Docker as found in the Docker package archives.</li>
-        <li class="p-list__item">Support for an unlimited number of Docker containers.</li>
-        <li class="p-list__item">Ubuntu Advantage Virtual Guest Advanced services for Docker containers running Ubuntu and installed from official sources.</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support for workloads other than those required to run Docker on the host machine.</li>
-        <li class="p-list__item">Landscape seats for Docker containers.</li>
-      </ul>
-      <p>Releases of Docker are supported as defined on Docker&rsquo;s website at: <a href="https://success.docker.com/Policies/Maintenance_Lifecycle">https://success.docker.com/Policies/Maintenance_Lifecycle</a></p>
-      <h3 id="ua-kubernetes">The Canonical Distribution of Kubernetes</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"Canonical Distribution of Kubernetes" means Kubernetes deployed using Juju and the official Canonical-Kubernetes bundle on bare metal, cloud guests, or virtual machines.</li>
-        <li class="p-list__item">"Deployment" means the process of deploying the Canonical Distribution of Kubernetes. A deployment is considered successful once Juju reports all applications in a "started" state.</li>
-        <li class="p-list__item">"Upgrade" means the process of upgrading Kubernetes between versions. An upgrade is considered successful once Juju reports all applications in a "started" state. Canonical will provide support for valid bugs encountered during
-          the Upgrade process.</li>
-        <li class="p-list__item">"Support" means break-fix support and answering basic questions about Kubernetes. Deployment and Upgrade assistance, as well as configuration and optimization of Kubernetes fall outside the scope of support.</li>
-      </ul>
-      <p>Minimum deployment of the Canonical Distribution of Kubernetes is the base configuration of the Canonical-Kubernetes bundle. Support must be purchased for all nodes in the supported Kubernetes environment.</p>
-      <p>Supported versions of Kubernetes include the current stable version of Kubernetes and the most recent previous version as listed:</p>
-      <ul>
-        <li class="p-list__item"><a href="https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions">https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions</a></li>
-      </ul>
-      <p>Support is limited to the software packages and Charms necessary for running the Canonical Distribution of Kubernetes.</p>
-      <p>For any deployment of the Canonical Distribution of Kubernetes carried out by Canonical while under contract for this deployment, which result in the customization of any Charms, the customization will be supported for 90 days after the official release of the Charm which includes the customizations.</p>
-      <h3 id="ua-esm">Extended Security Maintenance</h3>
-      <p>Extended Security Maintenance includes available High and Critical CVE fixes for a number of server packages in the Ubuntu Main Repository through 28 April 2019. A complete list of packages included in Extended Security Maintenance can be found at: <a href="https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages">https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages</a>
-      </p>
-      <p>Extended Security Maintenance is included for 64-bit x86 AMD/Intel installations.</p>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Bug fixes for packages in the end of life release, unless a bug was created by an Extended Security Maintenance security update.</li>
-        <li class="p-list__item">Security fixes for packages not found in the Maintained Packages list.</li>
-        <li class="p-list__item">Security fixes for CVEs that are not High or Critical</li>
-      </ul>
-      <p>Extended Security Maintenance does not guarantee secure software or fixes to all High or Critical CVEs.</p>
-      <h3 id="ua-landscape-seats">Landscape Seats</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"Seats" means the ability to register Virtual Machines in Landscape SaaS or Landscape on-premises.</li>
-        <li class="p-list__item">"Virtual Machines" means Ubuntu Server installed and running in a virtualized environment.</li>
-      </ul>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Seats running on systems covered by the Ubuntu Advantage service.</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support beyond that of the packages required to install and run the Landscape Client.</li>
-      </ul>
-      <h3 id="tam">Technical Account Manager</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"TAM" means a Canonical support engineer who works remotely to personally collaborate with the customer&#39;s staff and management.</li>
-      </ul>
-      <p>Canonical will enhance its support offering by providing a TAM, who will perform the following services for up to 10 hours per week during the term of service:</p>
-      <ul>
-        <li class="p-list__item">Provide support and best-practice advice on platform and configurations covered by the applicable Ubuntu Advantage services.</li>
-        <li class="p-list__item">Participate in review calls every other week at mutually agreed times addressing the customer&#39;s operational issues.</li>
-        <li class="p-list__item">Organise multi-vendor issue coordination through TSANet or Canonical&#39;s direct partnerships where applicable. When the root cause is identified, the TAM will work with the vendor for that sub-system, working to resolve the case through their normal support process.</li>
-      </ul>
-      <p>Canonical will hold a quarterly service review meeting with the customer to assess service performance and determine areas of improvement.</p>
-      <p>The TAM will visit the customer&#39;s site annually for on-site technical review.</p>
-      <p>The TAM is available to respond to support cases during the TAM&#39;s working hours. Outside of such hours, support will be provided per the Ubuntu Advantage Support Process.</p>
-      <h3 id="dedicated-services-engineer">Dedicated Technical Account Manager</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"DTAM" means a Canonical support engineer dedicated to work full-time remotely for a single customer.</li>
-      </ul>
-      <p>Canonical will enhance its support offering by providing a DTAM, who will perform the following services during local business hours for up to 40 hours per week (subject to Canonical leave policies) during the term of service:</p>
-      <ul>
-        <li class="p-list__item">Provide support and best-practice advice on platform and configurations covered by the applicable Ubuntu Advantage services.</li>
-        <li class="p-list__item">Act as the primary point of contact for all support requests originating from the customer department for which the DTAM is responsible.</li>
-        <li class="p-list__item">Manage support escalations and prioritization in accordance with Canonical&#39;s standard support response definitions and customer needs.</li>
-        <li class="p-list__item">Participate in regular review calls addressing the customer&#39;s operational issues.</li>
-        <li class="p-list__item">Organise multi-vendor issue coordination through TSANet or Canonical&#39;s direct partnerships where applicable. When the root cause is identified, the DTAM will work with the vendor for that sub-system, working to resolve the case through their
-          normal support process.</li>
-        <li class="p-list__item">Attend applicable Canonical internal training and development activities (in-person and remote).</li>
-      </ul>
-      <p>Canonical will hold a quarterly service review meeting with the customer to assess service performance and determine areas of improvement.</p>
-      <p>The DTAM is available to respond to support cases during the DTAM&#39;s working hours. Outside of business hours, support will be provided per the Ubuntu Advantage Support Process.</p>
-      <h3 id="landscape-on-premises">Landscape on-premises</h3>
-      <p>Definitions:</p>
-      <ul>
-        <li class="p-list__item">"Landscape on-premises" means Canonical&#39;s Landscape system management software installed on the customer&#39;s hardware.</li>
-      </ul>
-      <p>Service includes:</p>
-      <ul>
-        <li class="p-list__item">Licence to download and install a single instance of Landscape on-premises.</li>
-        <li class="p-list__item">Ability to use Landscape on-premises management and monitoring services for machines (whether physical or virtual) for which the customer has purchased Ubuntu Advantage services.</li>
-      </ul>
-      <p>Deployment methods:</p>
-      <ul>
-        <li class="p-list__item">When installed using the "Quickstart" install method, support is included for the machine on which Landscape on-premises is installed.</li>
-        <li class="p-list__item">When installed using a manual install method, support is included for up to two servers on which Landscape on-premises is installed.</li>
-        <li class="p-list__item">When deployed using Juju, the "dense deployment" method will be supported.</li>
-      </ul>
-      <p>Service excludes:</p>
-      <ul>
-        <li class="p-list__item">Support beyond that of the Landscape on-premises packages.</li>
-      </ul>
-      <p>Supported versions of Landscape on-premises:</p>
-      <ul>
-        <li class="p-list__item">Each release of Landscape on-premises will be supported for 1 year from its release date.</li>
-      </ul>
-      <!-- / Appendix 1 -->
-    </div>
-    <div class="row" id="appendix-2">
-      <div class="col-8">
-        <h2 id="ua-support-process">Appendix 2 - Ubuntu Advantage Support&nbsp;Process</h2>
-        <h3 id="ua-support-service-initiation">1. Service initiation</h3>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">1.1</span> Upon commencement of the services, Canonical will provide access for a single technical representative to Landscape, the support portal and the online knowledge base.</li>
-          <li class="p-list__item"><span class="number">1.2</span> The customer -- through their initial technical representative -- may select their chosen technical representatives to interface with Canonical based on the number of systems under support as represented in the table below. These technical representatives will hold credentials to the support portal and will act as primary points of contact for support requests.</li>
-        </ol>
+          <tbody>
+            <tr>
+              <td>1-20</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>21-50</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>51-250</td>
+              <td>6</td>
+            </tr>
+            <tr>
+              <td>251-1000</td>
+              <td>9</td>
+            </tr>
+            <tr>
+              <td>1001-5000</td>
+              <td>12</td>
+            </tr>
+            <tr>
+              <td>5001+</td>
+              <td>15</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
-    <div class="row">
-      <div class="col-8">
-        <div class="table__wrapper">
-          <table>
-        <caption>Table of machines under support</caption>
-        <thead>
-          <tr>
-            <th>Number of machines under Ubuntu Advantage support</th>
-            <th>Technical representatives</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>1-20</td>
-            <td>2</td>
-          </tr>
-          <tr>
-            <td>21-50</td>
-            <td>3</td>
-          </tr>
-          <tr>
-            <td>51-250</td>
-            <td>6</td>
-          </tr>
-          <tr>
-            <td>251-1000</td>
-            <td>9</td>
-          </tr>
-          <tr>
-            <td>1001-5000</td>
-            <td>12</td>
-          </tr>
-          <tr>
-            <td>5001+</td>
-            <td>15</td>
-          </tr>
-        </tbody>
-      </table>
-        </div>
-      </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <ol class="p-list">
+        <li class="p-list__item"><span class="number">1.3</span> The customer may change their specified technical representatives at any time by submitting a support request via the support portal.</li>
+      </ol>
+      <h3 id="ua-support-submitting-support-requests">2. Submitting support requests</h3>
+      <ol class="p-list">
+        <li class="p-list__item"><span class="number">2.1</span> The customer may open a support request once the customer account has been provisioned within the support portal.</li>
+        <li class="p-list__item"><span class="number">2.2</span> The customer may submit support cases through the support portal or by contacting the support team by telephone, unless otherwise noted.</li>
+        <li class="p-list__item"><span class="number">2.3</span> A support case should consist of a single discrete problem, issue, or request.</li>
+        <li class="p-list__item"><span class="number">2.4</span> Cases are assigned a ticket number and responded to automatically. All correspondence not entered directly into the case, including emails and telephone calls, will be logged into the case with a timestamp for quality assurance.</li>
+        <li id="ua-support-submitting-support-requests-2-5"><span class="number">2.5</span> When reporting a case, the customer should provide an impact statement to help Canonical determine appropriate severity level. Customers with multiple concurrent support cases may be asked to prioritize cases according to severity of business impact.</li>
+        <li class="p-list__item"><span class="number">2.6</span> The customer is expected to provide all information requested by Canonical as we work to resolve the case.</li>
+        <li class="p-list__item"><span class="number">2.7</span> Canonical will keep a record of each case within the support portal enabling the customer to track and respond to all current cases and allowing for review of historical cases.</li>
+      </ol>
+      <h3 id="ua-support-severity-levels">3. Support severity levels</h3>
+      <ol class="p-list">
+        <li class="p-list__item"><span class="number">3.1</span> Once a support request is opened, a Canonical Support Engineer will validate the case information and determine the severity level, working with the customer to assess the urgency of the case.</li>
+        <li class="p-list__item"><span class="number">3.2</span> Response times will be as set forth in the Service Description for the applicable service offering.</li>
+        <li class="p-list__item"><span class="number">3.3</span> When setting the severity level, Canonical&#39;s Support Team will use the definitions as stated below:</li>
+      </ol>
     </div>
-    <div class="row">
-      <div class="col-8">
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">1.3</span> The customer may change their specified technical representatives at any time by submitting a support request via the support portal.</li>
-        </ol>
-        <h3 id="ua-support-submitting-support-requests">2. Submitting support requests</h3>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">2.1</span> The customer may open a support request once the customer account has been provisioned within the support portal.</li>
-          <li class="p-list__item"><span class="number">2.2</span> The customer may submit support cases through the support portal or by contacting the support team by telephone, unless otherwise noted.</li>
-          <li class="p-list__item"><span class="number">2.3</span> A support case should consist of a single discrete problem, issue, or request.</li>
-          <li class="p-list__item"><span class="number">2.4</span> Cases are assigned a ticket number and responded to automatically. All correspondence not entered directly into the case, including emails and telephone calls, will be logged into the case with a timestamp for quality assurance.
-          </li>
-          <li id="ua-support-submitting-support-requests-2-5"><span class="number">2.5</span> When reporting a case, the customer should provide an impact statement to help Canonical determine appropriate severity level. Customers with multiple concurrent support cases may be asked to prioritize cases
-            according to severity of business impact.</li>
-          <li class="p-list__item"><span class="number">2.6</span> The customer is expected to provide all information requested by Canonical as we work to resolve the case.</li>
-          <li class="p-list__item"><span class="number">2.7</span> Canonical will keep a record of each case within the support portal enabling the customer to track and respond to all current cases and allowing for review of historical cases.</li>
-        </ol>
-        <h3 id="ua-support-severity-levels">3. Support severity levels</h3>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">3.1</span> Once a support request is opened, a Canonical Support Engineer will validate the case information and determine the severity level, working with the customer to assess the urgency of the case.</li>
-          <li class="p-list__item"><span class="number">3.2</span> Response times will be as set forth in the Service Description for the applicable service offering.</li>
-          <li class="p-list__item"><span class="number">3.3</span> When setting the severity level, Canonical&#39;s Support Team will use the definitions as stated below:</li>
-        </ol>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <table>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <table>
         <tbody>
           <tr>
             <th><strong>Severity Level 1</strong><br /> Core functionality not available</th>
@@ -731,80 +727,79 @@
           </tr>
         </tbody>
       </table>
-      </div>
     </div>
-    <div class="row">
-      <div class="col-8">
-        <h3 id="ua-support-hotfixes">4. Hotfixes</h3>
-        <p>To temporarily resolve critical support cases, Canonical may provide a version of the affected software (e.g. package) that applies a patch. Such versions are referred to as &#8220;hotfixes&#8221;. Hotfixes provided by Canonical are valid until 90 days after the corresponding patch has been incorporated into a release of the software in the Ubuntu Archives. However, if a patch is rejected by the applicable upstream project, the hotfix will be no longer be supported and the case will remain open.
-        </p>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h3 id="ua-support-hotfixes">4. Hotfixes</h3>
+      <p>To temporarily resolve critical support cases, Canonical may provide a version of the affected software (e.g. package) that applies a patch. Such versions are referred to as &#8220;hotfixes&#8221;. Hotfixes provided by Canonical are valid until 90 days after the corresponding patch has been incorporated into a release of the software in the Ubuntu Archives. However, if a patch is rejected by the applicable upstream project, the hotfix will be no longer be supported and the case will remain open.</p>
 
-        <h3 id="ua-support-languages">5. Languages</h3>
-        <p>Canonical will provide support in English. Other languages may be available at certain times.</p>
-        <h3 id="ua-support-remote-sessions">6. Remote sessions</h3>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">6.1</span> Canonical may offer to access the customer&#39;s supported system using a remote access service. In such case, Canonical will determine which remote access service to use.</li>
-        </ol>
-        <h3 id="ua-support-regions">7. Support regions</h3>
-        <p>Canonical may provide services from any location, including but not limited to the following countries:</p>
-        <ul>
-          <li class="p-list__item">Australia</li>
-          <li class="p-list__item">Brazil</li>
-          <li class="p-list__item">Canada</li>
-          <li class="p-list__item">Chile</li>
-          <li class="p-list__item">China</li>
-          <li class="p-list__item">Croatia</li>
-          <li class="p-list__item">Finland</li>
-          <li class="p-list__item">France</li>
-          <li class="p-list__item">Germany</li>
-          <li class="p-list__item">Hungary</li>
-          <li class="p-list__item">Ireland</li>
-          <li class="p-list__item">Italy</li>
-          <li class="p-list__item">Japan</li>
-          <li class="p-list__item">Norway</li>
-          <li class="p-list__item">Poland</li>
-          <li class="p-list__item">South Korea</li>
-          <li class="p-list__item">Spain</li>
-          <li class="p-list__item">Sweden</li>
-          <li class="p-list__item">Taiwan</li>
-          <li class="p-list__item">Turkey</li>
-          <li class="p-list__item">United Kingdom</li>
-          <li class="p-list__item">United States of America</li>
-        </ul>
-      </div>
-      <!-- / Appendix 2 -->
+      <h3 id="ua-support-languages">5. Languages</h3>
+      <p>Canonical will provide support in English. Other languages may be available at certain times.</p>
+      <h3 id="ua-support-remote-sessions">6. Remote sessions</h3>
+      <ol class="p-list">
+        <li class="p-list__item"><span class="number">6.1</span> Canonical may offer to access the customer&#39;s supported system using a remote access service. In such case, Canonical will determine which remote access service to use.</li>
+      </ol>
+      <h3 id="ua-support-regions">7. Support regions</h3>
+      <p>Canonical may provide services from any location, including but not limited to the following countries:</p>
+      <ul>
+        <li class="p-list__item">Australia</li>
+        <li class="p-list__item">Brazil</li>
+        <li class="p-list__item">Canada</li>
+        <li class="p-list__item">Chile</li>
+        <li class="p-list__item">China</li>
+        <li class="p-list__item">Croatia</li>
+        <li class="p-list__item">Finland</li>
+        <li class="p-list__item">France</li>
+        <li class="p-list__item">Germany</li>
+        <li class="p-list__item">Hungary</li>
+        <li class="p-list__item">Ireland</li>
+        <li class="p-list__item">Italy</li>
+        <li class="p-list__item">Japan</li>
+        <li class="p-list__item">Norway</li>
+        <li class="p-list__item">Poland</li>
+        <li class="p-list__item">South Korea</li>
+        <li class="p-list__item">Spain</li>
+        <li class="p-list__item">Sweden</li>
+        <li class="p-list__item">Taiwan</li>
+        <li class="p-list__item">Turkey</li>
+        <li class="p-list__item">United Kingdom</li>
+        <li class="p-list__item">United States of America</li>
+      </ul>
     </div>
-    <div class="row">
-      <div class="col-8">
-        <div class="p-top"><a href="#service-description" class="p-top__link">Back to top</a></div>
-      </div>
+    <!-- / Appendix 2 -->
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <div class="p-top"><a href="#service-description" class="p-top__link">Back to top</a></div>
     </div>
-    <div class="row" id="appendix-3">
-      <div class="col-8">
-        <h2 id="ua-escalation">Appendix 3 - Ubuntu Advantage Management Escalation</h2>
-        <p>In the event of an unsatisfactory service of any kind, there are several ways to escalate this situation to Canonical management.</p>
-        <h3>Feedback at end of case</h3>
-        <p>When a case is closed, a survey will be emailed to the case owner concerning overall experience with Canonical&#39;s support. All surveys are reviewed by management.</p>
-        <h3>Ask for a Peer Review</h3>
-        <p>As a normal business practice, Canonical performs peer reviews on a percentage of all cases. Customers can specifically request a peer review on a case within the case comments or by calling the phone number listed in the support portal. An impartial engineer will be assigned to review the case and provide feedback.</p>
-        <h3>Management escalation</h3>
-        <p>Non-urgent needs:</p>
-        <ul>
-          <li class="p-list__item">Please request a management escalation within the case itself. A manager will be contacted to review the case and post a response within 1 business day.</li>
-        </ul>
-        <p>Urgent needs</p>
-        <ul>
-          <li class="p-list__item">You may escalate to Canonical&#39;s Support &amp; Technical Services Manager by emailing <a href="mailto:%73%75%70%70%6F%72%74%2D%6D%61%6E%61%67%65%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">support-manager@canonical.com</a>.</li>
-          <li class="p-list__item">If you require further escalation, you may email Canonical&#39;s Support &amp; Technical Services Director at <a href="mailto:%6F%70%65%72%61%74%69%6F%6E%73%2D%64%69%72%65%63%74%6F%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">operations-director@canonical.com</a>.</li>
-        </ul>
-      </div>
-      <!-- / Appendix 3 -->
+  </div>
+  <div class="row" id="appendix-3">
+    <div class="col-8">
+      <h2 id="ua-escalation">Appendix 3 - Ubuntu Advantage Management Escalation</h2>
+      <p>In the event of an unsatisfactory service of any kind, there are several ways to escalate this situation to Canonical management.</p>
+      <h3>Feedback at end of case</h3>
+      <p>When a case is closed, a survey will be emailed to the case owner concerning overall experience with  Canonical&#39;s support. All surveys are reviewed by management.</p>
+      <h3>Ask for a Peer Review</h3>
+      <p>As a normal business practice, Canonical performs peer reviews on a percentage of all cases. Customers can specifically request a peer review on a case within the case comments or by calling the phone number listed in the support portal. An impartial engineer will be assigned to review the case and provide feedback.</p>
+      <h3>Management escalation</h3>
+      <p>Non-urgent needs:</p>
+      <ul>
+        <li class="p-list__item">Please request a management escalation within the case itself. A manager will be contacted to review the case and post a response within 1 business day.</li>
+      </ul>
+      <p>Urgent needs</p>
+      <ul>
+        <li class="p-list__item">You may escalate to Canonical&#39;s Support &amp; Technical Services Manager by emailing <a href="mailto:%73%75%70%70%6F%72%74%2D%6D%61%6E%61%67%65%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">support-manager@canonical.com</a>.</li>
+        <li class="p-list__item">If you require further escalation, you may email Canonical&#39;s Support &amp; Technical Services Director at <a href="mailto:%6F%70%65%72%61%74%69%6F%6E%73%2D%64%69%72%65%63%74%6F%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">operations-director@canonical.com</a>.</li>
+      </ul>
     </div>
-    <div class="row">
-      <div class="col-8">
-        <p><a href="#service-description" class="p-top__link">Back to top</a></p>
-      </div>
+    <!-- / Appendix 3 -->
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p><a href="#service-description" class="p-top__link">Back to top</a></p>
     </div>
   </div>
 </div>
+
 {% endblock content %}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -36,6 +36,7 @@
         </ul>
       </div>
     </nav>
+  </div>
   <div class="row">
     <div class="nav-global-footer"></div>
   </div>


### PR DESCRIPTION
## Done

Fixed markup errors in the markup 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/ubuntu-advantage/service-description](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description)
- Check that the nav links to the appendices work.