### PR TITLE
Fix retrieval of mirror list

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -90,11 +90,7 @@ Thank you for your contribution
   var architecture = '{{ architecture }}';
 
   // Mirrors for this country
-  var mirrors = {
-    {
-      mirror_list | safe
-    }
-  };
+  var mirrors = {{ mirror_list|safe }};
 
   if (version && architecture && architecture != 'amd64+mac') {
     dataLayer.push({


### PR DESCRIPTION
## Done

Fixed retrieval of mirror list in desktop download page. This fixes a bug where the Ubuntu download would not start automatically.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Navigate to the desktop download page, and the download should start automatically.

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2049