### PR TITLE
Remove class breaking takeunders.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -93,7 +93,7 @@
 </section>
 
 {# strip takeunders #}
-<section class="p-strip p-takeunder">
+<section class="p-strip">
   <div class="row">
     <div class="u-equal-height">
       {% include "takeovers/takeunders/_iot-02-2017.html" %}


### PR DESCRIPTION
## Done

Recent changes broke the spacing around the takeunder strip. I removed the .p-takeunder class, which is no longer needed on the wrapping .p-strip

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the takeunders strip now has normal strip pattern padding.

[Demo](http://www.ubuntu.com-takeunder-fix.demo.haus/)