### PR TITLE
Remove OIL strip from /cloud/partners

### DIFF
--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -38,29 +38,13 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2>Ubuntu OpenStack Interoperability Lab</h2>
-      <p>Ubuntu is the world&rsquo;s most popular choice for OpenStack clouds. And as more new solutions are developed for OpenStack, interoperability between components becomes increasingly important. With the Ubuntu OpenStack Interoperability Lab, we test
-        and integrate your hardware and software rigorously, to ensure all components can be combined reliably in real-world deployments. </p>
-      <p><a href="http://partners.ubuntu.com/partner-programmes/openstack">Learn more about the Ubuntu OpenStack Interoperability Lab&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-card--highlighted u-float--right">
-      <h2 class="p-card__title"><a title="Download the Ubuntu OpenStack factsheet" href="https://insights.ubuntu.com/2013/08/29/ubuntu-openstack-factsheet/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'OpenStack Factsheet', 'eventLabel' : 'from ubuntu.com/cloud/partners', 'eventValue' : undefined });">Ubuntu OpenStack</a></h2>
-      <p class="p-card__content">What makes up Ubuntu OpenStack? And how do all the parts fit together?</p>
-      <p class="p-card__category">Factsheet</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-4 suffix-1 prefix-1">
-      <img src="{{ ASSET_SERVER_URL }}69dadbd3-logo-premiercloudpartner.svg" alt="" />
-    </div>
-    <div class="col-8">
       <h2>World leading public cloud partners</h2>
       <p>If you operate a public cloud or you&rsquo;re considering launching one, the Ubuntu certified public cloud programme lets you make certified, secure and up to date Ubuntu images available to your users, along with the opportunity to sell management,
         monitoring and commercial support from Canonical &mdash; all of which represent additional revenue opportunities.</p>
       <p><a href="http://partners.ubuntu.com/partner-programmes/public-cloud">Learn more about the Ubuntu certified public cloud programme&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 suffix-1 prefix-1">
+      <img src="{{ ASSET_SERVER_URL }}69dadbd3-logo-premiercloudpartner.svg" alt="" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

* remove OIL strip from /cloud/partners
* updated the [copy doc](https://docs.google.com/document/d/1J2AxzOkFgkXyV7C7VO7ZJ0urzbEtrqRYCRt1SL64f3I/edit#heading=h.kvgycom0sgyc)
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/cloud/partners](http://0.0.0.0:8001/cloud/partners)

## Issue / Card

Email from Samantha Jian-Pielak:

Hi Thibaut, Peter,

> The OIL program is terminated. We should have all the references removed from our website. I know it's still here: https://www.ubuntu.com/cloud/partners, but I don't know where else it could be.
> 
> Thanks,
> Samantha