### PR TITLE
Update link to webinar on /containers/kubernetes

### DIFF
--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -38,7 +38,7 @@
       <img src="{{ ASSET_SERVER_URL }}7fbdce8e-validate-k8s-video.png?w=300" alt="Webinar title slide" />
       <h3 class="p-heading--four">Validating and testing your Kubernetes cluster</h3>
       <p>Learn why testing your cluster&rsquo;s health is important and how saves you time.</p>
-      <p><a class="p-link--external" href="https://pages.ubuntu.com/03.UpgradingK8sclusters_LPOn-demandwebinar.html?utm_source=ubuntu.com&utm_medium=website&utm_campaign=On-demand%20webinar%20--%20Painless%20Kubernetes%20upgrades"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Validating Kubernetes', 'eventLabel' : 'Watch now', 'eventValue' : undefined });">Watch now</a></p>
+      <p><a class="p-link--external" href="https://pages.ubuntu.com/02.Validatingtestingk8sclusterwebinar_LPOn-demandwebinar.html?utm_source=ubuntu.com&utm_medium=website&utm_campaign=On-demand%20webinar%20--%20Validating%20k8s%20cluster"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Validating Kubernetes', 'eventLabel' : 'Watch now', 'eventValue' : undefined });">Watch now</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <img src="{{ ASSET_SERVER_URL }}bd9fb1f1-painless-k8s-video.png?w=300" alt="Webinar title slide" />


### PR DESCRIPTION
## Done

* updated link to the ‘Validating and testing your Kubernetes cluster’ webinar on /containers/kubernetes
* updated the [copy doc](https://docs.google.com/document/d/1VMu4i8rJHW7BXKiOiy36XVFsihVxrNEMzUHn3X2XabI/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/containers/kubernetes)
* see that the webinar titled ‘Validating and testing your Kubernetes cluster’ goes to https://pages.ubuntu.com/02.Validatingtestingk8sclusterwebinar_LPOn-demandwebinar.html

## Issue / Card

Fixes #2047

