### PR TITLE
Feed check

### DIFF
--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -21,12 +21,16 @@
 
       {# insights news items #}
       <div class="row">
-        {% for item in insights_feed %}
-          <div class="col-3">
-            <h3 class="p-heading--four u-less-margin--bottom"><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ item.title|escapejs }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
-            <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
-          </div>
-        {% endfor %}
+        {% if insights_feed is False %}
+          Feed error.
+        {% else %}
+          {% for item in insights_feed %}
+            <div class="col-3">
+              <h3 class="p-heading--four u-less-margin--bottom"><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ item.title|escapejs }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
+              <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
+            </div>
+          {% endfor %}
+        {% endif %}
       </div>
     </div>
 

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -9,44 +9,58 @@
   {% get_rss_feed rss_news_url limit=4 as insights_feed %}
 {% endif %}
 
-<section class="{% if strip_classes %}{{strip_classes}}{% else %}p-strip is-deep is-bordered{% endif%}">
-  <div class="row {% if spotlight_feed %}p-divider{% endif %}">
-    <div class="{% if spotlight_feed %}col-9 p-divider__block{% else %}col-12{% endif %}">
-      {# insights heading #}
-      <h2 class="p-link--external p-heading--insights__title">
-        <a href="https://insights.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
-          Latest news from Insights
-        </a>
-      </h2>
+{% if insights_feed is False %}
+  <section class="p-strip is-deep is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2 class="p-link--external p-heading--insights__title">
+          <a href="https://insights.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link - feed error', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+            Latest news from Insights
+          </a>
+        </h2>
+        <div class="p-notification--negative">
+          <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as possible.</p>
+        </div>
+        <p>The latest Ubuntu news is available on the <a href="https://insights.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed message link - feed error', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });" class="p-link--external">Insights website</a>.</p>
+      </div>
+    </div>
+  </section>
+{% else %}
+  <section class="{% if strip_classes %}{{strip_classes}}{% else %}p-strip is-deep is-bordered{% endif%}">
+    <div class="row {% if spotlight_feed %}p-divider{% endif %}">
+      <div class="{% if spotlight_feed %}col-9 p-divider__block{% else %}col-12{% endif %}">
+        {# insights heading #}
+        <h2 class="p-link--external p-heading--insights__title">
+          <a href="https://insights.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+            Latest news from Insights
+          </a>
+        </h2>
 
-      {# insights news items #}
-      <div class="row">
-        {% if insights_feed is False %}
-          Feed error.
-        {% else %}
+        {# insights news items #}
+        <div class="row">
           {% for item in insights_feed %}
             <div class="col-3">
               <h3 class="p-heading--four u-less-margin--bottom"><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ item.title|escapejs }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
               <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
             </div>
           {% endfor %}
-        {% endif %}
+        </div>
       </div>
-    </div>
 
-    {# spotlight heading #}
-    {% if spotlight_feed %}
-      <div class="col-3 p-divider__block">
-        <h2 class="p-link--external p-heading--insights__title">
-          <a href="https://insights.ubuntu.com/tag/spotlight/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
-            Spotlight
-          </a>
-        </h2>
-        {% for item in spotlight_feed %}
-          <h3 class="p-heading--four u-less-margin--bottom"><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ item.title|escapejs }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
-          <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
-        {% endfor %}
-      </div>
-    {% endif %}
-  </div>
-</section>
+      {# spotlight heading #}
+      {% if spotlight_feed %}
+        <div class="col-3 p-divider__block">
+          <h2 class="p-link--external p-heading--insights__title">
+            <a href="https://insights.ubuntu.com/tag/spotlight/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+              Spotlight
+            </a>
+          </h2>
+          {% for item in spotlight_feed %}
+            <h3 class="p-heading--four u-less-margin--bottom"><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ item.title|escapejs }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
+            <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+  </section>
+{% endif %}

--- a/templates/templates/_further_reading_links.html
+++ b/templates/templates/_further_reading_links.html
@@ -4,12 +4,14 @@
     {% get_rss_feed "https://insights.ubuntu.com/feed/" limit=5 as feed %}
 {% endif %}
 
-<ul class='p-list'>
 {% if feed is False %}
-  Feed error.
+  <div class="p-notification--negative">
+    <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+  </div>
 {% else %}
-  {% for item in feed %}
-    <li class="p-list__item"><a href="{{item.link}}">{{item.title}}&nbsp;&rsaquo;</a></li>
-  {% endfor %}
+  <ul class='p-list'>
+    {% for item in feed %}
+      <li class="p-list__item"><a href="{{item.link}}">{{item.title}}&nbsp;&rsaquo;</a></li>
+    {% endfor %}
+  </ul>
 {% endif %}
-</ul>

--- a/templates/templates/_further_reading_links.html
+++ b/templates/templates/_further_reading_links.html
@@ -5,7 +5,11 @@
 {% endif %}
 
 <ul class='p-list'>
-{% for item in feed %}
+{% if feed is False %}
+  Feed error.
+{% else %}
+  {% for item in feed %}
     <li class="p-list__item"><a href="{{item.link}}">{{item.title}}&nbsp;&rsaquo;</a></li>
-{% endfor %}
+  {% endfor %}
+{% endif %}
 </ul>

--- a/webapp/templatetags/feeds.py
+++ b/webapp/templatetags/feeds.py
@@ -6,9 +6,15 @@ register = template.Library()
 
 @register.simple_tag
 def get_json_feed(feed_url, **kwargs):
-    return get_json_feed_content(feed_url, **kwargs)
+    try:
+        return get_json_feed_content(feed_url, **kwargs)
+    except:
+        return False
 
 
 @register.simple_tag
 def get_rss_feed(feed_url, **kwargs):
-    return get_rss_feed_content(feed_url, **kwargs)
+    try:
+        return get_rss_feed_content(feed_url, **kwargs)
+    except:
+        return False


### PR DESCRIPTION
## Done

 - Made the feed template tags return `False` to the template if loading the feed throws and error
 - Modified templates loading insights feeds 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
  - see that the insights news items load
- View the site locally in your web browser at: [http://0.0.0.0:8001/server](http://0.0.0.0:8001/server)
  - see that the "further reading" news items appear in the contextual footer.
- Edit `webapp/templatetags/feeds.py` and add `raise Exception('Simulate error')` as line 17
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
  - see that the insights news items do not load and that there is an error message
- View the site locally in your web browser at: [http://0.0.0.0:8001/server](http://0.0.0.0:8001/server)
  - see that the "further reading" news items do not load and that there is an error message