### PR TITLE
Add ids for RTP and AB testing on iot resources row section

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -36,20 +36,22 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_left">
       <img src="{{ ASSET_SERVER_URL }}51f2163c-050065fb-RHB.png?w=300" alt="" />
       <h3>Building success with a Raspberry Pi!</h3>
-      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=">Watch the webinar<span hidden> Building success with a Raspberry Pi!</span></a></p>
+      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'webinar - Building success with a Raspberry Pi', 'eventValue' : '1' });">Watch the webinar<span hidden> Building success with a Raspberry Pi!</span></a></p>
     </div>
-    <div class="col-4 p-divider__block">
+
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_center">
       <img src="{{ ASSET_SERVER_URL }}1cd95f27-680e2dda-Data-triggered-content-_-4g-base-staton.png?w=300" alt="" />
       <h3>Data-triggered content and 4G base stations</h3>
-      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar">Watch the webinar<span hidden> Data-triggered content and 4G base stations</span></a></p>
+      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });">Watch the webinar<span hidden> Data-triggered content and 4G base stations</span></a></p>
     </div>
-    <div class="col-4 p-divider__block">
+
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_right">
       <img src="{{ ASSET_SERVER_URL }}d2abb0ff-01f0d584-CaseStudyCoverlarge.jpg?w=300" alt="" />
       <h3>Open Source Digital Signage with Ubuntu</h3>
-      <p><a class="p-link--external" href="https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspage">Download case study<span hidden> Open Source Digital Signage with Ubuntu</span></a></p>
+      <p><a class="p-link--external" href="https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });">Download case study<span hidden> Open Source Digital Signage with Ubuntu</span></a></p>
     </div>
   </div>
 </div>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -30,17 +30,17 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_left">
       <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png?h=75" alt="" />
       <p>Azeti uses Ubuntu Core to improve deployment operations and security for a wide range of industries.</p>
       <p><a class="p-link--external" href="https://pages.ubuntu.com/AzetiCS.html?utm_campaign=Device_FY17_IOT&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=azeticasestudy">Read the case study</a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_center">
       <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png?h=75" alt="" />
       <p>Watch CloudPlugs define Industry 4.0, the convergence of information and operations.</p>
       <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs">Watch the webinar</a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_right">
       <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg?h=75" alt="" />
       <p>The Eclipse IoT Working Group outlines the three software stacks required for IoT.</p>
       <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&amp;amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=eclipsewhitepaper">Read the white paper</a></p>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -31,17 +31,17 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_left">
       <a href="https://pages.ubuntu.com/AerolionCS.html"><img src="{{ ASSET_SERVER_URL }}b370647c-sewage6-1.jpg" class="case-studies__image u-hidden--small col-12" alt="" /></a>
       <p>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places. Add accessories and apps to a drone to create new industrial solutions.</p>
       <p><a href="https://pages.ubuntu.com/AerolionCS.html" class="p-link--external">Download case study</a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_center">
       <a href="http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage"><img src="{{ ASSET_SERVER_URL }}bfb9384a-robotics_drone.png?w=768" class="case-studies__image u-hidden--small col-12" alt="S.L.A.M.dunk" /></a>
       <p>Introducing S.L.A.M.dunk, the new drone development kit from Parrot. Build apps for the next generation of consumer and enterprise devices.</p>
       <p><a href="http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage" class="p-link--external">Read more</a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_right">
       <a href="http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/"><img src="{{ ASSET_SERVER_URL }}7dfcc747-ROSConSeoul.png?w=768" class="case-studies__image u-hidden--small col-12" alt="" /></a>
       <p>ROScon &mdash; the robotics conference for developers and entrepreneurs.</p>
       <p><a href="http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/" class="p-link--external">Read more</a></p>


### PR DESCRIPTION
## Done

* added the ids for the RTPing and AB testing of the resources row on the iot vertical pages
* added GA events for the AB testing of the resources row

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [dig signage](http://0.0.0.0:8001/internet-of-things/digital-signage), [robotics](http://0.0.0.0:8001/internet-of-things/robotics) and [gateways](http://0.0.0.0:8001/internet-of-things/gateways)
- look at the code - no visual changes

