### PR TITLE
Remove brand-color from links

### DIFF
--- a/static/sass/_settings_colors.scss
+++ b/static/sass/_settings_colors.scss
@@ -1,4 +1,3 @@
 $color-brand:             #e95420;
 $color-brand-light:       lighten($color-brand, 10%);
 $color-brand-dark:        darken($color-brand, 10%);
-$color-link:              $color-brand;

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -58,7 +58,7 @@
       <div class="col-6 suffix-1">
         <h2>Intel<sup>&reg;</sup> Compute Stick with&nbsp;Ubuntu</h2>
         <p>Ubuntu is now being offered preloaded on the Intel Compute Stick which enables users to transform their display into a fully functional computer. Just plug the Intel Compute Stick into any HDMI TV or monitor and you're ready to work, play or access media.</p>
-        <p><a href="http://www.intel.com/content/www/us/en/compute-stick/intel-compute-stick.html" class="p-link--external">Learn more</a></p>
+        <p><a href="http://www.intel.com/content/www/us/en/compute-stick/intel-compute-stick.html" class="p-link--inverted p-link--external">Learn more</a></p>
       </div>
       <div class="col-6 u-align--center">
         <img src="{{ ASSET_SERVER_URL }}847fdd06-image-intelonastick-device.png" alt="Intel Compute Stick" />


### PR DESCRIPTION
## Done
Removed the bespoke link color, making them all Vanilla default.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Click through pages and check there are no issues
