### PR TITLE
Add 'Try it now' link to K8s page

### DIFF
--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -12,7 +12,8 @@
         <h2>Enterprise Kubernetes, anywhere</h2>
         <p>In partnership with Google, Canonical now delivers a &lsquo;pure <abbr title="Kubernetes">K8s</abbr>&rsquo; experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.</p>
         <p>The Canonical Distribution of Kubernetes works across all major public clouds and private infrastructure, enabling your teams to operate Kubernetes clusters on demand, anywhere.</p>
-        <p><a href="/containers/contact-us?product=containers-kubernetes">Talk to us about your container management strategy&nbsp;&rsaquo;</a></p>
+        <p><a href="https://conjure-up.io/" class="p-button--brand"><span class="p-link--external">Try it now&nbsp;</span></a></p>
+        <p><a href="/containers/contact-us?product=containers-kubernetes">Talk to us about Kubernetes&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-vertically-center u-align--center">
         <img src="{{ ASSET_SERVER_URL }}dba11aee-kubernetes.svg" width="220" alt="" />


### PR DESCRIPTION
## Done

Added a new button to the kubernetes page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/containers/kubernetes](http://0.0.0.0:8001/containers/kubernetes)
- See that there's now a CTA in the hero
- Check against the [copydoc](https://docs.google.com/document/d/1VMu4i8rJHW7BXKiOiy36XVFsihVxrNEMzUHn3X2XabI/edit#)

## Issue / Card

Fixes #2065 