### PR TITLE
Fix the snappy refresh all command

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -147,7 +147,7 @@
       <p>To update all your snaps:</p>
 
 <pre>
-<code>sudo snap refresh all</code>
+<code>sudo snap refresh</code>
 </pre>
 
       <p>To revert a snap to the previously installed version:</p>


### PR DESCRIPTION
## Done

Removed `all` from the refresh all snaps command.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/snappy](http://0.0.0.0:8001/desktop/snappy)
- Check the command is just `sudo snap refresh`


## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2070
