### PR TITLE
Reinstate partner feeds

### DIFF
--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -51,14 +51,7 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <h2 class="p-heading--muted u-align--center">A selection of our cloud partners</h2>
-    <ul id="cloud-partners" class="p-inline-images">
-      {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Certified%20Public%20Cloud&programme__name=Charm%20Partner%20Programme&programme__name=OpenStack&featured=true" limit=10 as cloud_partners %} {% for partner in cloud_partners %}
-      <li class="p-inline-images__item">
-        <img class="p-inline-images__image" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-      </li>
-      {% endfor %}
-    </ul>
+    {% include "shared/_partner-logos.html" with title="A selection of our cloud partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme__name=Certified%20Public%20Cloud&programme__name=Charm%20Partner%20Programme&programme__name=OpenStack&featured=true" feed_item_limit=10 %}
     <div class="col-12">
       <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?programme=openstack&amp;programme=charm-partner-programme&amp;programme=certified-public-cloud" class="p-link--external">See all our cloud partners</a></p>
     </div>

--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -49,6 +49,22 @@
   </div>
 </section>
 
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2 class="p-heading--muted u-align--center">A selection of our cloud partners</h2>
+    <ul id="cloud-partners" class="p-inline-images">
+      {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Certified%20Public%20Cloud&programme__name=Charm%20Partner%20Programme&programme__name=OpenStack&featured=true" limit=10 as cloud_partners %} {% for partner in cloud_partners %}
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__image" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+      </li>
+      {% endfor %}
+    </ul>
+    <div class="col-12">
+      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?programme=openstack&amp;programme=charm-partner-programme&amp;programme=certified-public-cloud" class="p-link--external">See all our cloud partners</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light">
   <div class="row">
     <div class="col-4 u-align--center">

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -126,6 +126,22 @@
   </div>
 </div>
 
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">Partnering with industry leaders</h2>
+      <ul class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Containers" limit=10 as container_partners %}
+        {% for partner in container_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" title="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+
 <div class="p-strip--light is-deep">
   <div class="row">
     <div class="u-equal-height">

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -129,15 +129,7 @@
 <div class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">Partnering with industry leaders</h2>
-      <ul class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Containers" limit=10 as container_partners %}
-        {% for partner in container_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" title="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
+      {% include "shared/_partner-logos.html" with title="Partnering with industry leaders" json_feed_url="http://partners.ubuntu.com/partners.json?technology__name=Containers" feed_item_limit=10 %}
     </div>
   </div>
 </div>

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -23,15 +23,7 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">A selection of our desktop partners</h2>
-      <ul id="hardware-partners" class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" limit=10 as desktop_partners %}
-        {% for partner in desktop_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
+      {% include "shared/_partner-logos.html" with title="A selection of our desktop partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" feed_item_limit=10 %}
       <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?service-offered=hardware-manufacturer" class="p-link--external">See all of our desktop partners</a></p>
     </div>
   </div>

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -20,6 +20,23 @@
   </div>
 </section>
 
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">A selection of our desktop partners</h2>
+      <ul id="hardware-partners" class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" limit=10 as desktop_partners %}
+        {% for partner in desktop_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?service-offered=hardware-manufacturer" class="p-link--external">See all of our desktop partners</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light">
   <div class="row">
     <div class="col-12">

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -51,18 +51,7 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">IoT gateway partners on Ubuntu Core</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <ul id="edge-gateway-partners" class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Edge%20Gateway" limit=10 as edge_gateway_partners %} {% for partner in edge_gateway_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
+      {% include "shared/_partner-logos.html" with title="IoT gateway partners on Ubuntu Core" json_feed_url="http://partners.ubuntu.com/partners.json?technology__name=Edge%20Gateway" feed_item_limit=10 %}
       <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=edge-gateway" class="p-link--external">See all of our gateway partners</a></p>
     </div>
   </div>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -48,6 +48,26 @@
   </div>
 </section>
 
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">IoT gateway partners on Ubuntu Core</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <ul id="edge-gateway-partners" class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Edge%20Gateway" limit=10 as edge_gateway_partners %} {% for partner in edge_gateway_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=edge-gateway" class="p-link--external">See all of our gateway partners</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -16,16 +16,8 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">Join the robotics trailblazers on Ubuntu</h2>
-      <ul id="public-cloud-partners" class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Robotics" limit=10 as public_cloud_partners %}
-        {% for partner in public_cloud_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
-      <p><a href="http://partners.ubuntu.com/find-a-partner?technology=robotics" class="p-link--external">See all of our robotics partners</a></p>
+      {% include "shared/_partner-logos.html" with title="Join the robotics trailblazers on Ubuntu" json_feed_url="http://partners.ubuntu.com/partners.json?technology__name=Robotics" feed_item_limit=10 %}
+      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=robotics" class="p-link--external">See all of our robotics partners</a></p>
     </div>
   </div>
 </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -13,6 +13,23 @@
   </div>
 </div>
 
+<div class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">Join the robotics trailblazers on Ubuntu</h2>
+      <ul id="public-cloud-partners" class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Robotics" limit=10 as public_cloud_partners %}
+        {% for partner in public_cloud_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p><a href="http://partners.ubuntu.com/find-a-partner?technology=robotics" class="p-link--external">See all of our robotics partners</a></p>
+    </div>
+  </div>
+</div>
+
 <div class="p-strip--accent is-bordered">
   <div class="row">
     <div class="col-10 prefix-1">

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -204,6 +204,41 @@
   </div>
 </div>
 
+
+<div class="p-strip--x-light is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">A selection of our hardware partners</h2>
+      <ul class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" limit=10 as hardware_partners %}
+        {% for partner in hardware_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a class="p-link--external" href="https://certification.ubuntu.com">View all certified hardware partners</a></p>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip--x-light is-deep">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">A selection of our software partners</h2>
+      <ul class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=OpenStack&service-offered=softwarecontent-publisher" limit=10 as software_partners %}
+        {% for partner in software_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a class="p-link--external" href="/partners/certified-software">View all certified software partners</a></p>
+    </div>
+  </div>
+</div>
+
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
 
 {% endblock content %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -208,15 +208,7 @@
 <div class="p-strip--x-light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">A selection of our hardware partners</h2>
-      <ul class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" limit=10 as hardware_partners %}
-        {% for partner in hardware_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
+      {% include "shared/_partner-logos.html" with title="A selection of our hardware partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" feed_item_limit=10 %}
       <p class="u-align--center"><a class="p-link--external" href="https://certification.ubuntu.com">View all certified hardware partners</a></p>
     </div>
   </div>
@@ -225,15 +217,7 @@
 <div class="p-strip--x-light is-deep">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">A selection of our software partners</h2>
-      <ul class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=OpenStack&service-offered=softwarecontent-publisher" limit=10 as software_partners %}
-        {% for partner in software_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
+      {% include "shared/_partner-logos.html" with title="A selection of our software partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme__name=OpenStack&service-offered=softwarecontent-publisher" feed_item_limit=10 %}
       <p class="u-align--center"><a class="p-link--external" href="/partners/certified-software">View all certified software partners</a></p>
     </div>
   </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -227,15 +227,7 @@
 <div class="p-strip is-deep is-bordered" style="padding-top: 2rem;">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">A selection of our public cloud partners</h2>
-      <ul id="public-cloud-partners" class="p-inline-images">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme=certified-public-cloud&featured=true" limit=10 as public_cloud_partners %}
-        {% for partner in public_cloud_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
+      {% include "shared/_partner-logos.html" with title="A selection of our public cloud partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme=certified-public-cloud&featured=true" feed_item_limit=10 %}
       <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud" class="p-link--external">See all of our public cloud partners</a></p>
     </div>
   </div>
@@ -255,15 +247,7 @@
 <div class="p-strip is-deep is-bordered" style="padding-top: 2rem;">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--muted u-align--center">A selection of our big data partners</h2>
-      <ul id="big-data-partners" class="p-inline-images no-margin dynamic-logos">
-        {% get_json_feed "http://partners.ubuntu.com/partners.json?service_offered__name=Big+data" limit=10 as big_data_partners %}
-        {% for partner in big_data_partners %}
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
-        </li>
-        {% endfor %}
-      </ul>
+      {% include "shared/_partner-logos.html" with title="A selection of our big data partners" json_feed_url="http://partners.ubuntu.com/partners.json?service_offered__name=Big+data" feed_item_limit=10 %}
       <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?service-offered=big-data" class="p-link--external">See all of our big data partners</a></p>
     </div>
   </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -224,6 +224,23 @@
   </div>
 </div>
 
+<div class="p-strip is-deep is-bordered" style="padding-top: 2rem;">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">A selection of our public cloud partners</h2>
+      <ul id="public-cloud-partners" class="p-inline-images">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?programme=certified-public-cloud&featured=true" limit=10 as public_cloud_partners %}
+        {% for partner in public_cloud_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud" class="p-link--external">See all of our public cloud partners</a></p>
+    </div>
+  </div>
+</div>
+
 <div class="p-strip is-deep" style="padding-bottom: 2rem;">
   <div class="row">
     <div class="col-8">
@@ -231,6 +248,23 @@
       <h3>Speed and simplicity, on bare metal or in the cloud</h3>
       <p>With its new rapid deployment tools, Ubuntu significantly speeds up the installation of server instances on bare metal. And our service orchestration tool, Juju, makes deploying big data services surprisingly simple &mdash; on bare metal or in the cloud. That&rsquo;s why vendors like 10gen, Cloudera, Couchbase, DataStax, Hortonworks, LexisNexis and Map-R partner with us.</p>
       <p><a href="/cloud">Learn more about Ubuntu Cloud&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-deep is-bordered" style="padding-top: 2rem;">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--muted u-align--center">A selection of our big data partners</h2>
+      <ul id="big-data-partners" class="p-inline-images no-margin dynamic-logos">
+        {% get_json_feed "http://partners.ubuntu.com/partners.json?service_offered__name=Big+data" limit=10 as big_data_partners %}
+        {% for partner in big_data_partners %}
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?service-offered=big-data" class="p-link--external">See all of our big data partners</a></p>
     </div>
   </div>
 </div>

--- a/templates/shared/_partner-logos.html
+++ b/templates/shared/_partner-logos.html
@@ -1,0 +1,18 @@
+
+
+{% get_json_feed json_feed_url limit=feed_item_limit as partners %}
+
+{% if partners is False %}
+  <div class="p-notification--negative">
+    <p class="p-notification__response"><span class="p-notification__status">Error:</span>Our partner logos failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as possible.</p>
+  </div>
+{% else %}
+  {% if title %}<h2 class="p-heading--muted u-align--center">{{title}}</h2>{% endif %}
+  <ul id="cloud-partners" class="p-inline-images">
+    {% for partner in partners %}
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}" />
+      </li>
+    {% endfor %}
+  </ul>
+{% endif %}


### PR DESCRIPTION
## Done

Added an error message in the event of partners logo feeds going down and reinstated the previously-removed logo blocks.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/gateways](http://0.0.0.0:8001/internet-of-things/gateways)
- See that a logo block loads
- Fake a feed error by editing `webapp/templatetags/feeds.py` and adding `raise Exception('test')` as line 10
- Go back to [http://0.0.0.0:8001/internet-of-things/gateways](http://0.0.0.0:8001/internet-of-things/gateways) in your browser and see that the error message now appears.


## Issue / Card

Fixes #2073 

## Screenshots

![error](https://user-images.githubusercontent.com/118614/28325812-c293cc84-6bd6-11e7-8b5c-e6b354e1ecfd.png)

