### PR TITLE
Migrate font license pages from font.ubuntu.com

### DIFF
--- a/templates/legal/terms-and-policies/font-licence/faq.html
+++ b/templates/legal/terms-and-policies/font-licence/faq.html
@@ -1,0 +1,79 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}Ubuntu font FAQs{% endblock %}
+
+{% block content %}
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu Font Family Licensing&nbsp;FAQ</h1>
+      <h2>Stylistic Foundations</h2>
+      <p>The Ubuntu Font Family is the <em>first time</em> that a libre typeface has been designed professionally and <em>explicitly</em> with the intent of developing a public and long-term community-based development process.</p>
+      <p>When developing an open project, it is generally necessary to have firm foundations: a font needs to maintain harmony within itself even across many type designers and writing systems. For the <a href="http://font.ubuntu.com/" class="p-link--external">Ubuntu Font Family</a>, the process has been guided with the type foundry Dalton Maag setting the project up with firm stylistic foundation covering several left-to-right scripts: Latin, Greek and Cyrillic; and right-to-left scripts: Arabic and Hebrew (due in 2011).</p>
+      <p>With this starting point the community will, under the supervision of <a href="http://www.canonical.com/">Canonical</a> and <a href="http://www.daltonmaag.com/" class="p-link--external">Dalton Maag</a>, be able to build on the existing font sources to expand their character coverage. Ultimately everybody will be able to use the Ubuntu Font Family in their own written languages across the whole of Unicode (and this will take some time!).</p>
+      <h2>Licensing</h2>
+      <p>The licence chosen by any free software project is one of the foundational decisions that sets out how derivatives and contributions can occur, and in turn what kind of community will form around the project.</p>
+      <p>Using a licence that is compatible with other popular licences is a powerful constraint because of the <a href="http://en.wikipedia.org/wiki/Network_effect" class="p-link--external">network effects</a>: the freedom to share improvements between projects allows free software to reach high-quality over time. Licence-proliferation leads to many incompatible licences, undermining the network effect, the freedom to share and ultimately making the libre movement that Ubuntu is a part of less effective. For all kinds of software, writing a new licence is <strong>not</strong> to be taken lightly and is a choice that needs to be thoroughly justified if this path is taken.</p>
+      <p>Today it is not clear to Canonical what the best licence for a font project like the Ubuntu Font Family is: one that starts life designed by professionals and continues with the full range of community development, from highly commercial work in new directions to curious beginners' experimental contributions. The fast and steady pace of the Ubuntu release cycle means that an <strong>interim</strong> libre licence has been necessary to enable the consideration of the font family as part of Ubuntu 10.10 operating system release.</p>
+      <p>Before taking any decision on licensing, Canonical as sponsor and backer of the project has reviewed the many existing licenses used for libre/open fonts and <strong>engaged the stewards of the most popular licenses in detailed discussions</strong>.  The current interim licence is the <strong>first step</strong> in progressing the state-of-the-art in licensing for libre/open font development.</p>
+      <p>The public discussion must now involve everyone in the (comparatively new) area of the libre/open font community; including font users, software freedom advocates, open source supporters and existing libre font developers.  Most importantly, the minds and wishes of professional type designers considering entering the free software business community must be taken on board.</p>
+      <p>Conversations and discussion has taken place, privately, with individuals from the following groups (generally speaking personally on behalf of themselves, rather than their affiliations):</p>
+      <ul>
+        <li><a href="http://scripts.sil.org/" class="p-link--external">SIL International</a></li>
+        <li><a href="http://openfontlibrary.org/" class="p-link--external">Open Font Library</a></li>
+        <li><a href="http://www.softwarefreedom.org/" class="p-link--external">Software Freedom Law Center</a></li>
+        <li><a href="http://code.google.com/webfonts" class="p-link--external">Google Font API</a></li>
+      </ul>
+      <h2 id="embedding">Document embedding</h2>
+      <p>One issue highlighted early on in the survey of existing font licences is that of document embedding. Almost all font licences, both free and unfree, permit embedding a font into a document to a certain degree.</p>
+      <p>Embedding a font with other works that make up a document creates a "combined work" and copyleft would normally require the whole document to be distributed under the terms of the font licence.  As beautiful as the font might be, such a licence makes a font too restrictive for useful general purpose digital publishing.</p>
+      <p>The situation is not entirely unique to fonts and is encountered also with tools such as GNU Bison: a vanilla GNU GPL licence would require anything generated <em>with</em> Bison to be made available under the terms of the GPL as well. To avoid this, Bison is <a href="http://www.gnu.org/licenses/gpl-faq.html#CanIUseGPLToolsForNF" class="p-link--external">published with an additional permission</a> to the GPL which allows the output of Bison to be made available under any licence.</p>
+      <p>The conflict between licensing of fonts and licensing of documents, is addressed in two popular libre font licences, the SIL OFL and GNU GPL:</p>
+      <ul>
+        <li><strong><a href="http://scripts.sil.org/OFL_web" class="p-link--external">SIL Open Font Licence</a></strong>: When OFL fonts are embedded in a document, the OFL's terms do not apply to that document. <small>(See <a href="http://scripts.sil.org/OFL-FAQ_web" class="p-link--external">OFL-FAQ</a> for details.</small></li>
+        <li><strong><a href="http://www.gnu.org/licenses/gpl-faq.html#FontException" class="p-link--external">GPL Font Exception</a></strong>: The situation is resolved by granting an <em>additional permission</em> to allow documents to not be covered by the GPL.  <small>(The exception is being reviewed).</small></li>
+      </ul>
+      <p>The Ubuntu Font Family must also resolve this conflict, ensuring that if the font is embedded and then extracted it is once again clearly under the terms of its libre licence.</p>
+      <h2>Long-term licensing</h2>
+      <p>Those individuals involved, especially from Ubuntu and Canonical, are interested in finding a long-term libre licence that finds broad favour across the whole libre/open font community. The deliberation during the past months has been on how to licence the Ubuntu Font Family in the <em>short-term</em>, while knowingly encouraging everyone to pursue a <em>long-term</em> goal.</p>
+      <ul>
+        <li><strong><a href="https://launchpad.net/~uff-contributors" class="p-link--external">Copyright assignment will be required</a></strong> so that the Ubuntu Font Family's licensing can be progressively expanded to one (or more) licences, as best practice continues to evolve within the libre/open font community.</li>
+        <li><strong>Canonical will support and fund</strong> legal work on libre font licensing. It is recognised that the cost and time commitments required are likely to be significant. We invite other capable parties to join in supporting this activity.</li>
+      </ul>
+      <p>The GPL version 3 (GPLv3) will be used for Ubuntu Font Family build scripts and the CC-BY-SA for associated documentation and non-font content: all items which do not end up embedded in general works and documents.</p>
+      <h2>Ubuntu Font Licence</h2>
+      <p>For the <strong>short-term only</strong>, the initial licence is the <a href="{{ ASSET_SERVER_URL }}81e5605d-ubuntu-font-licence-1.0.txt" class="p-link--external">Ubuntu Font License</a> (UFL). This is loosely inspired from the work on the SIL OFL&nbsp;1.1, and seeks to clarify the issues that arose during discussions and legal review, from the perspective of the backers, Canonical Ltd. Those already using established licensing models such as the GPL, OFL or Creative Commons licensing should have no worries about continuing to use them.  The Ubuntu Font Licence (UFL) and the SIL Open Font Licence (SIL OFL) are <em>not</em> identical and should <em>not</em> be confused with each other. Please read the terms precisely. The UFL is only intended as an interim license, and the overriding aim is to support the creation of a more suitable and generic libre font licence. As soon as such a licence is developed, the Ubuntu Font Family will migrate to it&mdash;made possible by copyright assignment in the interium. Between the OFL&nbsp;1.1, and the UFL&nbsp;1.0, the following changes are made to produce the Ubuntu Font Licence:</p>
+      <ul>
+        <li>
+          <strong>Clarification:</strong>
+          <ol>
+            <li>Document embedding <em>(see <a href="#embedding">embedding section</a> above)</em>.</li>
+            <li>Apply at point of distribution, instead of receipt</li>
+            <li>Author vs. copyright holder disambiguation (type designers are authors, with the copyright holder normally being the funder)</li>
+            <li>Define "Propagate" (for internationalisation, similar to the GPLv3)</li>
+            <li>Define "Substantially Changed"</li>
+            <li>Trademarks are explicitly not transferred</li>
+            <li>Refine renaming requirement</li>
+          </ol>
+        </li>
+        <li>
+          <strong>Streamlining:</strong>
+          <ol>
+            <li>Remove "not to be sold separately" clause</li>
+            <li>Remove "Reserved Font Name(s)" declaration</li>
+          </ol>
+        </li>
+      </ul>
+      <p>A visual demonstration of how these points were implemented can be found in the accompanying coloured diff between SIL OFL&nbsp;1.1 and the Ubuntu Font Licence&nbsp;1.0: <a href="/legal/terms-and-policies/font-licence/ofl-1.1-ufl-1.0.diff">ofl-1.1-ufl-1.0.diff</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <h3>Other resources</h3>
+      <ul class="p-list">
+        <li class="p-list__item"><a href="/legal/terms-and-policies/font-licence">Ubuntu font licence&nbsp;›</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/legal/terms-and-policies/font-licence/index.html
+++ b/templates/legal/terms-and-policies/font-licence/index.html
@@ -1,0 +1,87 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}Ubuntu font licence{% endblock %}
+
+{% block content %}
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu font licence</h1>
+      <h2>Version 1.0</h2>
+      <h3>Preamble</h3>
+      <p>This licence allows the licensed fonts to be used, studied, modified and redistributed freely. The fonts, including any derivative works, can be bundled, embedded, and redistributed provided the terms of this licence are met. The fonts and derivatives, however, cannot be released under any other licence. The requirement for fonts to remain under this licence does not require any document created using the fonts or their derivatives to be published under this licence, as long as the primary purpose of the document is not to be a vehicle for the distribution of the fonts.</p>
+
+      <h3>Definitions</h3>
+      <p>"Font Software" refers to the set of files released by the Copyright Holder(s) under this licence and clearly marked as such. This may include source files, build scripts and documentation.</p>
+      <p>"Original Version" refers to the collection of Font Software components as received under this licence.</p>
+      <p>"Modified Version" refers to any derivative made by adding to, deleting, or substituting — in part or in whole — any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.</p>
+      <p>"Copyright Holder(s)" refers to all individuals and companies who have a copyright ownership of the Font Software.</p>
+      <p>"Substantially Changed" refers to Modified Versions which can be easily identified as dissimilar to the Font Software by users of the Font Software comparing the Original Version with the Modified Version.</p>
+      <p>To "Propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification and with or without charging a redistribution fee), making available to the public, and in some countries other activities as well.</p>
+
+      <h3>Permission &amp; Conditions</h3>
+      <p>This licence does not grant any rights under trademark law and all such rights are reserved.</p>
+      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to propagate the Font Software, subject to the below conditions:</p>
+
+      <ol>
+        <li>Each copy of the Font Software must contain the above copyright notice and this licence. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.</li>
+        <li>The font name complies with the following:
+          <ol>
+            <li>The Original Version must retain its name, unmodified.</li>
+            <li>Modified Versions which are Substantially Changed must be renamed to avoid use of the name of the Original Version or similar names entirely.</li>
+            <li>Modified Versions which are not Substantially Changed must be renamed to both
+              <ol>
+                <li>retain the name of the Original Version and</li>
+                <li>add additional naming elements to distinguish the Modified Version from the Original Version. The name of such Modified Versions must be the name of the Original Version, with "derivative X" where X represents the name of the new work, appended to that name.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>The name(s) of the Copyright Holder(s) and any contributor to the Font Software shall not be used to promote, endorse or advertise any Modified Version, except
+          <ol>
+            <li>as required by this licence,</li>
+            <li>to acknowledge the contribution(s) of the Copyright Holder(s) or</li>
+            <li>with their explicit written permission.</li>
+          </ol>
+        </li>
+        <li>The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this licence, and must not be distributed under any other licence. The requirement for fonts to remain under this licence does not affect any document created using the Font Software, except any version of the Font Software extracted from a document created using the Font Software may only be distributed under this licence.</li>
+      </ol>
+
+      <h3>Termination</h3>
+      <p>This licence becomes null and void if any of the above conditions are not met.</p>
+
+      <h3>Disclaimer</h3>
+      <p>THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.</p>
+      <p><a href="{{ ASSET_SERVER_URL }}81e5605d-ubuntu-font-licence-1.0.txt" class="p-link--external">Ubuntu Font Licence Version 1.0 (plain text)</a></p>
+    </div>
+    <div class="col-4 p-card">
+      <h3>Other resources</h3>
+      <ul class="p-list">
+        <li class="p-list__item"><a href="/legal/terms-and-policies/font-licence/faq">Ubuntu font FAQs&nbsp;›</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Ubuntu Font Licence &mdash; Further information</h2>
+      <p>The Ubuntu Font Family is presently distributed under the Ubuntu Font Licence.  This means you can use the font in much the same way as you would use any other font (open or proprietary).  The <em>open</em> means that in the long run, the font can continue to be expanded, because the raw source code (design files) for the font itself are available to those who are interested.</p>
+      <p>You are most welcome to use the Ubuntu Font Family, in your documents, graphic designs, logos, or company stationary.  We'd like as many people as possible to have a better quality reading experience everyday.</p>
+
+      <h2>For those wishing to alter or expand the font itself</h2>
+      <p>The present Ubuntu Font Licence 1.0 is loosely inspired from the <a href="http://scripts.sil.org/OFL" class="p-link--external">SIL Open Font Licence (OFL)</a> version 1.1. Using the Ubuntu Font Licence 1.0 is an interim solution and the choice of licence will likely change as alternative licences become available in the future.</p>
+      <p>Note that the Ubuntu Font Licence and the SIL Open Font Licence are not identical (<a href="/legal/terms-and-policies/font-licence/ofl-1.1-ufl-1.0.diff">view the differences</a>) and should not be confused with each other. Please read the terms precisely and <a href="/legal/terms-and-policies/font-licence/faq">read through the FAQ</a> for more details.</p>
+      <p>In order to properly license your font derivative under the Ubuntu Font Licence you should:</p>
+      <ul class="p-list">
+        <li class="p-list__item">Add your copyright information into the dedicated placeholders in <a href="{{ ASSET_SERVER_URL }}1e2338ad-copyright.txt" class="p-link--external">copyright.txt</a> at the top of your file tree, modelled on the example included in this tree. (Never remove existing copyright notices.)</li>
+        <li class="p-list__item">Include a copy of the <a href="{{ ASSET_SERVER_URL }}81e5605d-ubuntu-font-licence-1.0.txt" class="p-link--external">ubuntu-font-licence-1.0.txt</a> from this tree</li>
+        <li class="p-list__item">Put the text from copyright.txt with the placeholders properly filled-in at the top of any files, to be explicit about ownership and licensing for those files in particular. Fonts in both object and sources have dedicated metadata fields to hold author and licence details, you should make use of these to include the relevant information.</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/legal/terms-and-policies/font-licence/ofl-1.1-ufl-1.0.diff.html
+++ b/templates/legal/terms-and-policies/font-licence/ofl-1.1-ufl-1.0.diff.html
@@ -1,0 +1,150 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}Ubuntu font licence{% endblock %}
+
+{% block content %}
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>Differences between the Ubuntu Font Licence and the SIL Open Font Licence</h1>
+      <pre>
+<del>Copyright (c) &lt;dates&gt;, &lt;Copyright Holder&gt; (&lt;URL|email&gt;),
+with Reserved Font Name &lt;Reserved Font Name&gt;.
+Copyright (c) &lt;dates&gt;, &lt;additional Copyright Holder&gt; (&lt;URL|email&gt;),
+with Reserved Font Name &lt;additional Reserved Font Name&gt;.
+Copyright (c) &lt;dates&gt;, &lt;additional Copyright Holder&gt; (&lt;URL|email&gt;).
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+<a href="http://scripts.sil.org/OFL">http://scripts.sil.org/OFL</a>
+</del>
+---------------------------------------------------------------
+<del>SIL OPEN</del> <ins>UBUNTU</ins> FONT LICEN<u>C</u>E Version <ins>1.0</ins> <del>1.1 - 26 February 2007</del>
+---------------------------------------------------------------
+
+PREAMBLE
+<del>The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.</del>
+
+<ins><span class="moved">Th</span>is licence</ins> <del><span class="moved">Th</span>e OFL</del> allows the licensed fonts to be used, studied, modified
+and redistributed freely <del>as long as they are not sold by themselves</del>. The fonts,
+including any derivative works, can be bundled, embedded, <ins class="moved">and</ins> redistributed
+<del><span class="moved">and</span>/or sold with any software</del> provided <ins>the terms of this licence are met</ins>
+<del>that any reserved names are not used by derivative works</del>. The fonts and
+derivatives, however, cannot be released under any other <del>type of</del> licen<u>c</u>e.
+The requirement for fonts to remain under this licen<u>c</u>e does not <ins>require</ins>
+<del>apply to</del> any document created using the fonts or their derivatives
+<ins>to be published under this licence, as long as the primary purpose of
+the document is not to be a vehicle for the distribution of the fonts</ins>.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this licen<u>c</u>e and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+<del>"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).</del>
+
+"Original Version" refers to the collection of Font Software components
+as <ins>received under this licence</ins> <del>distributed by the Copyright Holder(s)</del>.
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to
+a new environment.
+
+"<del>Author</del> <ins>Copyright Holder(s)</ins>" refers to <ins>all individuals and companies
+<span class="moved">who</span> have a copyright ownership of</ins> <del>any designer, engineer, programmer,
+technical writer or other person <span class="moved">who</span> contributed to</del> the Font Software.
+
+<ins>"Substantially Changed" refers to Modified Versions which can be easily
+identified as dissimilar to the Font Software by users of the Font
+Software comparing the Original Version with the Modified Version.
+
+To "Propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy. Propagation includes copying,
+distribution (with or without modification and with or without charging
+a redistribution fee), making available to the public, and in some
+countries other activities as well.</ins>
+
+PERMISSION & CONDITIONS
+<ins>This licence does not grant any rights under trademark law and all such
+rights are reserved.</ins>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to <del>use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of</del> <ins>propagate</ins>
+the Font Software, subject to the <ins>below</ins> <del>following</del> conditions:
+
+<del>1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.</del>
+
+<ins>1<span class="moved">)</span></ins> <del>2<span class="moved">)</span> Original or Modified Versions <span class="moved">of the Font Software</span> may be
+bundled, redistributed and/or sold with any software, provided that</del>
+<u>E</u>ach copy <ins><span class="moved">of the Font Software</span> must</ins> contain<del>s</del> the above copyright
+notice and this licen<u>c</u>e. These can be included either as stand-alone
+text files, human-readable headers or in the appropriate machine-
+readable metadata fields within text or binary files as long as those
+fields can be easily viewed by the user.
+
+<ins>2<span class="moved">)</span> T<span class="moved">he font name</span> complies with <span class="moved">the</span> following:
+(a) The Original Version must retain its name, unmodified.
+(b) <span class="moved">Modified Version</span>s which are Substantially Changed must be renamed to
+avoid <span class="moved">use</span> <span class="moved">of</span> the n<span class="moved">ame</span> <span class="moved">of the</span> Original Version or similar names entirely.
+(c) <span class="moved">Modified Version</span>s which are not Substantially Changed must be
+renamed to both (i) retain the name of <span class="moved">the</span> Original Version and (ii) add
+additional naming elements to distinguish the <span class="moved">Modified Version</span> from the
+Original Version. T<span class="moved">he name</span> of such <span class="moved">Modified Version</span>s must be <span class="moved">the name</span> of
+the Original Version, with "derivative X" where X re<span class="moved">present</span>s <span class="moved">the name</span> of
+<span class="moved">the</span> new work, appended to that name.</ins>
+
+<del>3<span class="moved">)</span> No <span class="moved">Modified Version</span> <span class="moved">of <span class="moved">the</span></span> Font Software may <span class="moved">use</span> <span class="moved">the</span> Reserved Font
+N<span class="moved">ame</span>(s) unless explicit written permission is granted by <span class="moved">the</span> corresponding
+Copyright Holder. This restriction only applies to t<span class="moved">he</span> primary <span class="moved">font name</span>
+as <span class="moved">present</span>ed to <span class="moved">the</span> users.</del>
+
+<ins>3<span class="moved">)</span></ins> <del>4<span class="moved">)</span></del> The name(s) of the Copyright Holder(s) <ins>and any contributor to</ins>
+<del>or the Author(s) of</del> the Font Software shall not be used to promote, endorse
+or advertise any Modified Version, except <ins>(i) as required by this licence,
+(ii)</ins> to acknowledge the contribution(s) of the Copyright Holder(s)
+<del>and the Author(s)</del> or <ins>(iii)</ins> with their explicit written permission.
+
+<ins>4<span class="moved">)</span></ins> <del>5<span class="moved">)</span></del> The Font Software, modified or unmodified, in part or in whole, must
+be distributed entirely under this licen<u>c</u>e, and must not be distributed
+under any other licen<u>c</u>e. The requirement for fonts to remain under this
+licen<u>c</u>e does not <ins>affect</ins> <del>apply to</del> any document created using the Font Software<ins>,
+except any version of the Font Software extracted from a document created
+using the Font Software may only be distributed under this licence</ins>.
+
+TERMINATION
+This licen<u>c</u>e becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+      </pre>
+    </div>
+    <div class="col-4 p-card">
+      <h3>Other resources</h3>
+      <ul class="p-list">
+        <li class="p-list__item"><a href="/legal/terms-and-policies/font-licence">Ubuntu font licence&nbsp;›</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -85,8 +85,12 @@
         <p>This is a legal agreement between Canonical and users of the Juju-as-a-Service Beta.</p>
         <p><a href="/legal/terms-and-policies/jaas-beta-terms-of-service">View JAAS Beta Terms of Service&nbsp;&rsaquo;</a></p>
       </div>
+      <div class="col-6 p-card">
+        <h3>Ubuntu font licence</h3>
+        <p>This is a licence which allows the licensed fonts to be used, studied, modified and redistributed freely.</p>
+        <p><a href="/legal/terms-and-policies/font-licence">View font licence&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </div>
-
 {% endblock content %}


### PR DESCRIPTION
## Done

Migrated some pages to from font.ubuntu.com to /legal

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/terms-and-policies](http://0.0.0.0:8001/legal/terms-and-policies)
- See that there is a new section for "Ubuntu font licence"
- Follow that link
- See the font licence
- Check the links on the page, including the sidebar with the FAQ page
