### PR TITLE
Remove duplicate section number

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -61,7 +61,7 @@
             <li class="p-list__item"><span class="number">2.4.1</span> The kernel provided initially in the release of a long-term support (LTS) version of Ubuntu is supported for the entire lifecycle of the LTS.</li>
             <li class="p-list__item"><span class="number">2.4.2</span> Hardware enablement (HWE) kernels provide support for newer hardware in an LTS release and are released in conjunction with the non-LTS Ubuntu releases. HWE kernels are supported until the next LTS point release.</li>
             <li class="p-list__item"><span class="number">2.4.3</span> More information about kernel support can be found at <a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a></li>
-            <li class="p-list__item" id="2-4-4"><span class="number">2.4.4</span>2.4.4 Access to Canonical Livepatch Service is included with all support offerings, unless otherwise noted.</li>
+            <li class="p-list__item" id="2-4-4"><span class="number">2.4.4</span> Access to Canonical Livepatch Service is included with all support offerings, unless otherwise noted.</li>
           </ol>
         </li>
         <li id="support-scope-landscape"><span class="number">2.5</span> Landscape


### PR DESCRIPTION
## Done

Removed duplicate number in copy.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/ubuntu-advantage/service-description](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description)
- See that `2.4.4` isn't duplicated.


## Issue / Card

Fixes #2089 
