### PR TITLE
Growing your cloud

### DIFF
--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -27,7 +27,7 @@
         <li class="p-list__item is-ticked">Role-based access</li>
         <li class="p-list__item is-ticked">Informative monitoring</li>
       </ul>
-      <p><a class="p-link--external" href="https://landscape.canonical.com/">Learn more about Landscape&nbsp;&rsaquo;</a></p>
+      <p><a class="p-link--external" href="https://landscape.canonical.com/">Learn more about Landscape</a></p>
     </div>
     <div class="col-5 p-hero__item u-hidden--small">
       <img class="p-hero__image" src="{{ ASSET_SERVER_URL }}65274d19-landscape-screenshot.png?op=region&amp;rect=0,0,1324,450&amp;w=500" alt="screenshot of Landscape" />

--- a/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
+++ b/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
@@ -2,5 +2,5 @@
   <h3 class="p-heading--four">Growing your cloud?</h3>
   <p>Ubuntu Advantage enterprise support agreements cover OpenStack and include the Landscape licenses needed for the Autopilot in larger cloud deployments.</p>
   <p><a href="https://buy.ubuntu.com/" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Shop for Ubuntu Advantage', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">Buy now</a></p>
-  <p>Or <a href="/support/contact-us?product=contextual-footer-landscape" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Contact-us management', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">or, contact us&nbsp;&rsaquo;</a></p>
+  <p>Or, <a href="/support/contact-us?product=contextual-footer-landscape" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Contact-us management', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">contact us&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

Remove repeated ‘or’ from 'Growing your cloud?’ in contextual footer
Remove chevron from external link in 'Landscape: Server management’ cat on /cloud/plans-and-pricing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Go to [https://www.ubuntu.com/cloud/openstack](https://www.ubuntu.com/cloud/openstack) and you’ll see in the contextual footer that there is an extra ‘or’ in the 'Growing your cloud?’ section, then go to [http://0.0.0.0:8001/cloud/openstack](http://0.0.0.0:8001/cloud/openstack) and see that it’s gone
- Go to the ‘Landscape: Server management’ section of [https://ubuntu.com/cloud/plans-and-pricing](https://ubuntu.com/cloud/plans-and-pricing) and note the chevron on the 'Learn more about Landscape’ external link, then go to  [http://0.0.0.0:8001/cloud/plans-and-pricing](http://0.0.0.0:8001/cloud/plans-and-pricing) and see that it’s gone

