### PR TITLE
Upgrade to using canonicalwebteam.yaml-redirects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.yaml-deleted-paths==0.1.0
 canonicalwebteam.get-feeds==0.1.5
 Django==1.11.1
 whitenoise==3.3.0
-django-yaml-redirects==0.5.3
+canonicalwebteam.yaml-redirects==1.0.2
 django-asset-server-url==0.1
 django-template-finder-view==0.3
 django-static-root-finder==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
+canonicalwebteam.yaml-redirects==1.0.2
 canonicalwebteam.get-feeds==0.1.5
 Django==1.11.1
 whitenoise==3.3.0
-canonicalwebteam.yaml-redirects==1.0.2
 django-asset-server-url==0.1
 django-template-finder-view==0.3
 django-static-root-finder==0.3.1

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,14 +1,14 @@
 # Third party modules
 from django.conf.urls import url
-from django_yaml_redirects import load_redirects
 from canonicalwebteam import yaml_deleted_paths
+from canonicalwebteam import yaml_redirects
 from ubuntudesign.gsa.views import SearchView
 
 # Local code
 from .views import UbuntuTemplateFinder, DownloadView
 
 
-urlpatterns = load_redirects()
+urlpatterns = yaml_redirects.create_views()
 urlpatterns += yaml_deleted_paths.create_views()
 urlpatterns += [
     url(


### PR DESCRIPTION
Use the new shiny `canonicalwebteam.yaml-redirects` version 1.0.0.

QA
--

``` bash
./run
```

Check redirects still work as expected.