### PR TITLE
Implement the basics of 410 deleted pages

### DIFF
--- a/deleted.yaml
+++ b/deleted.yaml
@@ -1,0 +1,3 @@
+mobile/?:
+    message: "This page has been removed"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 canonicalwebteam.versioned_static==1.0.2
+canonicalwebteam.yaml-deleted-paths==0.1.0
 Django==1.11.1
 whitenoise==3.3.0
 django-yaml-redirects==0.5.3

--- a/templates/410.html
+++ b/templates/410.html
@@ -12,7 +12,7 @@
       <div class="col-6 u-vertically-center">
         <div>
           <h1>410: Page deleted</h1>
-          <p class="p-heading--four">This page has been removed.</p>
+          <p class="p-heading--four">{{ message }}</p>
         </div>
       </div>
     </div>

--- a/templates/410.html
+++ b/templates/410.html
@@ -1,0 +1,21 @@
+{% extends "templates/one-column.html" %}
+{% block title %}404: Page not found{% endblock %}
+{% block extra_body_class %}error-page error404{% endblock %}
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 u-vertically-center u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}bcdcf2c8-image-404.svg?w=365" alt="Error owl" width="365" />
+      </div>
+      <div class="col-6 u-vertically-center">
+        <div>
+          <h1>410: Page deleted</h1>
+          <p class="p-heading--four">This page has been removed.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,12 +1,15 @@
 # Third party modules
 from django.conf.urls import url
 from django_yaml_redirects import load_redirects
+from canonicalwebteam import yaml_deleted_paths
 from ubuntudesign.gsa.views import SearchView
 
 # Local code
 from .views import UbuntuTemplateFinder, DownloadView
 
+
 urlpatterns = load_redirects()
+urlpatterns += yaml_deleted_paths.create_views()
 urlpatterns += [
     url(
         r'^(?P<template>download/(desktop|server|cloud)/thank-you)$',


### PR DESCRIPTION
Fixes https://github.com/ubuntudesign/web-squad/issues/66

Create the infrastructure for serving 410 pages based on a list maintained in a YAML file.

The bulk of the functionality is over in https://github.com/canonical-webteam/yaml-deleted-paths.

QA
--

`./run` and visit `http://0.0.0.0:8001/mobile/` - check it says "page deleted" with a message, and that the status is `410`.

Also check out the code in https://github.com/canonical-webteam/yaml-deleted-paths.