### PR TITLE
Bump LTS variable to 16.04.3

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -87,7 +87,7 @@
 <section class="p-strip is-bordered is-shallow">
   <div class="row">
     <div class="col-12">
-      <h2>Ubuntu Server 16.04.1 LTS for OpenStack</h2>
+      <h2>Ubuntu Server {{ lts_release_full_with_point }} for OpenStack</h2>
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Supported for five years by Canonical</li>
         <li class="p-list__item is-ticked">ZFS support for LXD OpenStack hosts</li>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ZestyZapus" latest_release="17.04" latest_release_full='17.04' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.2" lts_release_full='16.04 LTS' lts_release_with_point="16.04.2" lts_release_full_with_point='16.04.2 <abbr title="Long-term support">LTS</abbr>' lts_openstack_version="Mitaka" latest_openstack_version="Ocata" %}
+{% with latest_release_name="ZestyZapus" latest_release="17.04" latest_release_full='17.04' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_openstack_version="Mitaka" latest_openstack_version="Ocata" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

Updated the LTS variable with the latest point release

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Check a page that makes use of the variable, e.g.: [http://0.0.0.0:8001/download/desktop](http://0.0.0.0:8001/download/desktop)
- Check that 16.04.2 is replaced with 16.04.3 


## Issue / Card

Fixes #2113