### PR TITLE
Update get-feeds module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
-canonicalwebteam.get-feeds==0.1.2
+canonicalwebteam.get-feeds==0.1.5
 Django==1.11.1
 whitenoise==3.3.0
 django-yaml-redirects==0.5.3


### PR DESCRIPTION
To catch more types of errors.

QA
--

`./run` and check pages with feeds still load the feeds properly.