### PR TITLE
Use v0.1.7 of canonicalwebteam.get-feeds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
 canonicalwebteam.yaml-redirects==1.0.2
-canonicalwebteam.get-feeds==0.1.5
+canonicalwebteam.get-feeds==0.1.7
 Django==1.11.1
 whitenoise==3.3.0
 django-asset-server-url==0.1


### PR DESCRIPTION
Just to be on the latest version.

QA
--

`./run`, check feeds still load