### PR TITLE
Add ‘tell us your story’ takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_iot-business.html" %}
+{% include "takeovers/_tell-us-your-story.html" %}
 
 
 {% include "shared/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" %}

--- a/templates/takeovers/_tell-us-your-story.html
+++ b/templates/takeovers/_tell-us-your-story.html
@@ -1,0 +1,22 @@
+<section class="p-strip--accent is-dark is-deep">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-5">
+      <h1>What’s your Ubuntu story?</h1>
+      <p class="p-heading--five">Tell us how you use Ubuntu in your business and get featured on this page!</p>
+      <p class="u-align--center u-hidden--medium u-hidden--large u-padding-bottom--large">
+        <img class="u-vertically-spaced" src="{{ ASSET_SERVER_URL }}98943ac1-Ubuntu-story-illustration.svg" alt="" />
+      </p>
+      <p><a href="http://ubunt.eu/yourstory"
+      onclick="dataLayer.push({
+        'event' : 'GAEvent',
+        'eventCategory' : 'Homepage Link',
+        'eventAction' : 'Tell us your story - 08/2017',
+        'eventLabel' : 'Submit a story',
+        'eventValue' : undefined
+      });" class="p-button--brand">Submit a story</a></p>
+    </div>
+    <div class="u-hidden--small col-6 prefix-1">
+      <img src="{{ ASSET_SERVER_URL }}98943ac1-Ubuntu-story-illustration.svg" alt="" />
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

* built the 'tell us your story' homepage takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- compare to the [copy doc](https://docs.google.com/document/d/1rTHWfeuZbusH_nMBY2QJmoUSdKYTDQucLu1qYXZd_nU/edit) and [dropbox](https://www.dropbox.com/work/00_web_team/_ubuntu.com/takeovers/Ubuntu-story-07.2017/Exports?preview=Ubuntu-story-Takeover_desktop-final+.jpg)


## Issue / Card

Fixes https://github.com/ubuntudesign/www.ubuntu.com-design/issues/44

