### PR TITLE
Replace youtube with vimeo video on /server/livepatch

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -116,7 +116,7 @@
     <div class="col-12">
       <h2>Install in under a minute</h2>
       <div class="u-embedded-media">
-        <iframe class="u-embedded-media__element" width="906" height="500" src="https://www.youtube.com/embed/9hvqFfwE4u0?rel=0&amp;&amp;hd=1" frameborder="0" allowfullscreen></iframe>
+        <iframe class="u-embedded-media__element" width="906" height="500" src="https://player.vimeo.com/video/225445183" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
       </div>
       <p class="u-vertically-spaced"><a href="/livepatch" class="p-link--external">Sign up for the Canonical Livepatch Service</a></p>
     </div>


### PR DESCRIPTION
## Done

* Replace youtube with vimeo video on /server/livepatch

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/server/livepatch](http://0.0.0.0:8001/server/livepatch)
- See that it looks and works the same, but with vimeo

## Issue / Card

Fixes #2096
