### PR TITLE
Corrected incorrect spelling of Licensing

### DIFF
--- a/templates/about/about-ubuntu/licensing.html
+++ b/templates/about/about-ubuntu/licensing.html
@@ -7,7 +7,7 @@
 <section class="p-strip is-deep">
   <div class="row">
     <div class="col-8">
-      <h1>Licencing</h1>
+      <h1>Licensing</h1>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

Corrected "Licencing" to "Licensing" on the licensing page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about/about-ubuntu/licensing](http://0.0.0.0:8001/about/about-ubuntu/licensing)
- See that the H1 is now correctly spelled.


## Issue / Card

Fixes #1827