### PR TITLE
Add links to the new Foundation Cloud Build page

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -20,7 +20,7 @@
       <h1>Build your cloud strategy with Ubuntu</h1>
       <p class="p-heading--five">70% of public cloud workloads and 54% of OpenStack clouds run on Ubuntu.<a href="#fn1" id="r1">*</a></p>
       <ul>
-        <li>Get us to build your solid cloud infrastructure and get it up and running in 3 weeks with Foundation Cloud Build</li>
+        <li>Get us to build your solid cloud infrastructure and get it up and running in 3 weeks with <a href="/cloud/foundation-cloud">Foundation Cloud Build</a></li>
         <li>Use <a href="/download/cloud/conjure-up">conjure-up</a> to easily create an OpenStack cloud using containers on a single machine</li>
         <li>Let us manage your production OpenStack cloud with <a href="/cloud/managed-cloud">BootStack</a></li>
         <li>Model and deploy applications to any cloud with <a href="/cloud/juju">Juju</a></li>

--- a/templates/cloud/openstack/index.html
+++ b/templates/cloud/openstack/index.html
@@ -45,7 +45,7 @@
         <p class="p-card__content"><strong>We will build you an OpenStack in three weeks</strong></p>
         <p class="p-card__content">Canonical offers training, consulting and support. Our engineers will build your production OpenStack cloud,  working alongside your team.</p>
         <p class="p-card__content">Tailor that OpenStack to your requirements with optional consulting services around networking, storage, hypervisors and cloud architecture.</p>
-        <p class="p-card__content"><a href="/cloud/contact-us?product=openstack">Contact us about Foundation Cloud Build&nbsp;&rsaquo;</a></p>
+        <p class="p-card__content"><a href="/cloud/foundation-cloud">Learn more about OpenStack Delivery &nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Added links to the new Foundation Cloud Build page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud](http://0.0.0.0:8001/cloud)
- See that the first bullet point in the hero now has a link
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud/openstack](http://0.0.0.0:8001/cloud/openstack)
- See that the `Consulting, Training and Enterprise Support` box now has a link to the FCB page