### PR TITLE
Add Foundation Cloud Build to the pricing table

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -61,6 +61,7 @@
   /// Temporary fix until vanilla-brochure-theme is updated to 1.0.9
   .p-card__header {
     border-bottom: 1px solid $color-mid-light;
+    margin: 0 0 $sp-x-small;
 
     &.no-border {
       border: none;

--- a/templates/cloud/plans-and-pricing.html
+++ b/templates/cloud/plans-and-pricing.html
@@ -69,6 +69,48 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
+      <h2>Foundation Cloud Build</h2>
+      <p>There are two packages available. For most organisations, Foundation Cloud Build will deliver solid cloud infrastructure that just works. For organisations that require greater flexibility in implementation or specific storage technologies, Foundation Cloud Plus offers more options.</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="p-card col-4">
+      <div class="p-card__header">
+        <h3 class="p-heading--five">Foundation Cloud Build</h3>
+        <p class="p-heading--two">$75,000 <span class="p-heading--six">one-off fee</span></p>
+      </div>
+      <p class="p-card__content">Consultants build an OpenStack cloud infrastructure in your datacentre.</p>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__header">
+        <h3 class="p-heading--five">Foundation Cloud Plus</h3>
+        <p class="p-heading--two">$150,000 <span class="p-heading--six">one-off fee</span></p>
+      </div>
+      <p class="p-card__content">Consultants build an OpenStack cloud infrastructure in your datacentre with some customisations that you define.</p>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__header">
+        <h3 class="p-heading--five">Add-ons</h3>
+        <p class="p-heading--two">From $25,000</p>
+      </div>
+      <p class="p-card__content">Such as:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Additional hypervisors</li>
+        <li class="p-list__item is-ticked">Complex networking</li>
+        <li class="p-list__item is-ticked">Disaster recovery integration</li>
+      </ul>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p><a href="/cloud/foundation-cloud">Learn more about Foundation Cloud Build&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
       <h2>Ubuntu Advantage for OpenStack</h2>
       <p>Ubuntu Advantage for OpenStack plans are delivered through Ubuntu Advantage, a professional package of integrated management tooling and enterprise class support. It includes access to Landscape, the systems management tool for using Ubuntu at scale,
         as well as 24x7 telephone support, online support library and legal assurance.</p>


### PR DESCRIPTION
## Done

Added the price table for Foundation Cloud Build

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud/plans-and-pricing](http://0.0.0.0:8001/cloud/plans-and-pricing)
- Check the `Foundation Cloud Build` section against the [copydoc](https://docs.google.com/document/d/1yZ7wClcmxGCqMyyyBJLO66Z3YlpT-4soWLFmJ6uXeMM/edit#)
