### PR TITLE
Feeds should timeout quicker - 2 seconds

### DIFF
--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -25,6 +25,8 @@ INSTALLED_APPS = [
 WHITENOISE_MAX_AGE = 31557600
 WHITENOISE_ALLOW_ALL_ORIGINS = False
 
+FEED_TIMEOUT = 2
+
 ALLOWED_HOSTS = ['*']
 DEBUG = os.environ.get('DJANGO_DEBUG', 'false').lower() == 'true'
 


### PR DESCRIPTION
Fixes #2129

QA
--

`./run` - check feeds still work.

Break a couple of feed URLs, check they time out nice and fast and show the page with errors where the feed should be.