### PR TITLE
Fix usn redirects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
-canonicalwebteam.yaml-redirects==1.0.2
 canonicalwebteam.get-feeds==0.1.7
 Django==1.11.1
 whitenoise==3.3.0
+django-yaml-redirects==0.5.3
 django-asset-server-url==0.1
 django-template-finder-view==0.3
 django-static-root-finder==0.3.1

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,14 +1,14 @@
 # Third party modules
 from django.conf.urls import url
+from django_yaml_redirects import load_redirects
 from canonicalwebteam import yaml_deleted_paths
-from canonicalwebteam import yaml_redirects
 from ubuntudesign.gsa.views import SearchView
 
 # Local code
 from .views import UbuntuTemplateFinder, DownloadView
 
 
-urlpatterns = yaml_redirects.create_views()
+urlpatterns = load_redirects()
 urlpatterns += yaml_deleted_paths.create_views()
 urlpatterns += [
     url(


### PR DESCRIPTION
Some redirects are broken, e.g.: https://www.ubuntu.com/usn/usn-3381-2

Fix by reverting "Upgrade to using canonicalwebteam.yaml-redirects"

This reverts commit 453b2afefb264b6cf37f438cf10568301f8f7009.

QA
--

`./run`, then `curl -I http://127.0.0.1:8001/usn/usn-3381-2` and check it redirects somewhere sensible.