### PR TITLE
Update resource row on digital-signage to new design for use with RTP

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -37,21 +37,21 @@
   </div>
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_left">
-      <img src="{{ ASSET_SERVER_URL }}51f2163c-050065fb-RHB.png?w=300" alt="" />
-      <h3>Building success with a Raspberry Pi!</h3>
-      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'webinar - Building success with a Raspberry Pi', 'eventValue' : '1' });">Watch the webinar<span hidden> Building success with a Raspberry Pi!</span></a></p>
+      <!-- rtp section start -->
+      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Webinar</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h2>
+      <!-- rtp section end -->
     </div>
 
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_center">
-      <img src="{{ ASSET_SERVER_URL }}1cd95f27-680e2dda-Data-triggered-content-_-4g-base-staton.png?w=300" alt="" />
-      <h3>Data-triggered content and 4G base stations</h3>
-      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });">Watch the webinar<span hidden> Data-triggered content and 4G base stations</span></a></p>
+      <!-- rtp section start -->
+      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Webinar</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Data-triggered content and 4G base stations</a></h2>
+      <!-- rtp section end -->
     </div>
 
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_right">
-      <img src="{{ ASSET_SERVER_URL }}d2abb0ff-01f0d584-CaseStudyCoverlarge.jpg?w=300" alt="" />
-      <h3>Open Source Digital Signage with Ubuntu</h3>
-      <p><a class="p-link--external" href="https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });">Download case study<span hidden> Open Source Digital Signage with Ubuntu</span></a></p>
+      <!-- rtp section start -->
+      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Case study</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspag' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });'><span hidden>Read the case study </span>Open Source Digital Signage with Ubuntu</a></h2>
+      <!-- rtp section end -->
     </div>
   </div>
 </div>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -38,19 +38,37 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Webinar</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h2>
+      <div class='p-heading-icon u-no-margin--bottom'>
+        <div class='p-heading-icon__header u-no-margin--bottom'>
+          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
+          <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Webinar</h3>
+        </div>
+      </div>
+      <h2 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h2>
       <!-- rtp section end -->
     </div>
 
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Webinar</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Data-triggered content and 4G base stations</a></h2>
+      <div class='p-heading-icon u-no-margin--bottom'>
+        <div class='p-heading-icon__header u-no-margin--bottom'>
+          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
+          <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Webinar</h3>
+        </div>
+      </div>
+      <h2 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Data-triggered content and 4G base stations</a></h2>
       <!-- rtp section end -->
     </div>
 
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Case study</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspag' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });'><span hidden>Read the case study </span>Open Source Digital Signage with Ubuntu</a></h2>
+      <div class='p-heading-icon u-no-margin--bottom'>
+        <div class='p-heading-icon__header u-no-margin--bottom'>
+          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
+          <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Case study</h3>
+        </div>
+      </div>
+      <h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspag' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });'><span hidden>Read the case study </span>Open Source Digital Signage with Ubuntu</a></h2>
       <!-- rtp section end -->
     </div>
   </div>


### PR DESCRIPTION
## Done

* updated resource strip to the new icon design
* updated the [copy doc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/digital-signage](http://0.0.0.0:8001/internet-of-things/digital-signage)
- compare to the copy doc and the design to the /server/maas page 'Learn about MAAS' section


## Issue / Card

Fixes #2140

## Screenshots

![image](https://user-images.githubusercontent.com/441217/29354165-81e38aa4-8264-11e7-8271-512a9e85ee89.png)
