### PR TITLE
Updated resource strip on robotics page to new design for RTP

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -41,19 +41,19 @@
   </div>
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_left">
-      <a href="https://pages.ubuntu.com/AerolionCS.html"><img src="{{ ASSET_SERVER_URL }}b370647c-sewage6-1.jpg" class="case-studies__image u-hidden--small col-12" alt="" /></a>
-      <p>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places. Add accessories and apps to a drone to create new industrial solutions.</p>
-      <p><a href="https://pages.ubuntu.com/AerolionCS.html" class="p-link--external">Download case study</a></p>
+      <!-- rtp section start -->
+      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Case study</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AerolionCS.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - left', 'eventLabel' : 'Case study - Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places', 'eventValue' : '1' });'><span hidden>Read the case study </span>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places</a></h2>
+      <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_center">
-      <a href="http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage"><img src="{{ ASSET_SERVER_URL }}bfb9384a-robotics_drone.png?w=768" class="case-studies__image u-hidden--small col-12" alt="S.L.A.M.dunk" /></a>
-      <p>Introducing S.L.A.M.dunk, the new drone development kit from Parrot. Build apps for the next generation of consumer and enterprise devices.</p>
-      <p><a href="http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage" class="p-link--external">Read more</a></p>
+      <!-- rtp section start -->
+      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Article</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h2>
+      <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_right">
-      <a href="http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/"><img src="{{ ASSET_SERVER_URL }}7dfcc747-ROSConSeoul.png?w=768" class="case-studies__image u-hidden--small col-12" alt="" /></a>
-      <p>ROScon &mdash; the robotics conference for developers and entrepreneurs.</p>
-      <p><a href="http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/" class="p-link--external">Read more</a></p>
+      <!-- rtp section start -->
+      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Article</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'Article - ROScon &mdash; the robotics conference for developers and entrepreneurs', 'eventValue' : '1' });'><span hidden>Read the article </span>ROScon &mdash; the robotics conference for developers and entrepreneurs</a></h2>
+      <!-- rtp section end -->
     </div>
   </div>
 </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -42,17 +42,35 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Case study</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AerolionCS.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - left', 'eventLabel' : 'Case study - Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places', 'eventValue' : '1' });'><span hidden>Read the case study </span>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places</a></h2>
+      <div class='p-heading-icon u-no-margin--bottom'>
+        <div class='p-heading-icon__header u-no-margin--bottom'>
+          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
+          <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Case study</h3>
+        </div>
+      </div>
+      <h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AerolionCS.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - left', 'eventLabel' : 'Case study - Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places', 'eventValue' : '1' });'><span hidden>Read the case study </span>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places</a></h2>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Article</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h2>
+      <div class='p-heading-icon u-no-margin--bottom'>
+        <div class='p-heading-icon__header u-no-margin--bottom'>
+          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
+          <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Article</h3>
+        </div>
+      </div>
+      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h2>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'><div class='p-heading-icon__header u-no-margin--bottom'><img class='p-heading-icon__img' src='https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' /><h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Article</h3></div></div><h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'Article - ROScon &mdash; the robotics conference for developers and entrepreneurs', 'eventValue' : '1' });'><span hidden>Read the article </span>ROScon &mdash; the robotics conference for developers and entrepreneurs</a></h2>
+      <div class='p-heading-icon u-no-margin--bottom'>
+        <div class='p-heading-icon__header u-no-margin--bottom'>
+          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
+          <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Article</h3>
+        </div>
+      </div>
+      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'Article - ROScon &mdash; the robotics conference for developers and entrepreneurs', 'eventValue' : '1' });'><span hidden>Read the article </span>ROScon &mdash; the robotics conference for developers and entrepreneurs</a></h2>
       <!-- rtp section end -->
     </div>
   </div>


### PR DESCRIPTION
## Done

* updated resource strip to the new icon design
* updated the [copy doc](https://docs.google.com/document/d/1g8XpVzDkAdFETrfZvOf5Q6WlYwHCBYQ8Y6TgTlyTEYc/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/robotics](http://0.0.0.0:8001/internet-of-things/robotics)
- compare to the copy doc and the design to the /server/maas page 'Learn about MAAS' section


## Issue / Card

Fixes #2140

## Screenshots

![image](https://user-images.githubusercontent.com/441217/29354219-c198abde-8264-11e7-9afb-5dc8c9ae01e7.png)

