### PR TITLE
Add environmental HTTP headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV LANG C.UTF-8
 RUN pip3 install --upgrade pip
 RUN pip3 install gunicorn
 
+# Set git commit ID
+ARG commit_id
+ENV COMMIT_ID=$commit_id
+
 # Import code, install code dependencies
 WORKDIR /srv
 ADD . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+Django==1.11.1
+canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
 canonicalwebteam.get-feeds==0.1.7
-Django==1.11.1
 whitenoise==3.3.0
 django-yaml-redirects==0.5.3
 django-asset-server-url==0.1

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -30,6 +30,11 @@ FEED_TIMEOUT = 2
 ALLOWED_HOSTS = ['*']
 DEBUG = os.environ.get('DJANGO_DEBUG', 'false').lower() == 'true'
 
+CUSTOM_HEADERS = {
+    'X-commit-ID': os.getenv('COMMIT_ID'),
+    'X-k8s-pod': os.getenv('K8S_POD_NAME')
+}
+
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 ROOT_URLCONF = 'webapp.urls'
@@ -54,6 +59,7 @@ SEARCH_SERVER_URL = 'http://10.22.112.8/search'
 SEARCH_TIMEOUT = 10
 
 MIDDLEWARE_CLASSES = [
+    'canonicalwebteam.custom_response_headers.Middleware',
     'unslashed.middleware.RemoveSlashMiddleware',
 ]
 


### PR DESCRIPTION
Set up the application to it will return information about its running environment as HTTP headers:

- `X-commit-ID`: Should display the current commit ID of the version of the code that is running
- `X-k8s-pod`: Should display the name of the kubernetes pod that processed the request

These two headers coupled together will allow us to have absolute certainty about whether all or parts of a kubernetes environment are running a particular version of the code.

QA
--

This can be tested locally in two ways:

**Using ./run**

``` bash
$ # Setup some dummy environment variables
$ echo "COMMIT_ID=adummycommit" >> .env
$ echo "K8S_POD_NAME=afakepodname" >> .env
 
$ # Run the site in the background
$ ./run serve --detach
...

$ # Check the response headers
$ curl -Is 127.0.0.1:8001
HTTP/1.0 200 OK
...
X-commit-ID: adummycommit
X-k8s-pod: afakepodname

$ # Stop the running site
$ ./run stop
```

**By building a docker image**

``` bash
$ # Build the docker image passing a dummy commit ID
$ docker build --build-arg commit_id=adummycommit -t www.ubuntu.com .

$ # Run the docker image, passing an extra environment variabel
$ docker run --name headers-test --detach --tty --interactive --publish 8101:80 --env K8S_POD_NAME=afakepodname www.ubuntu.com

$ # Check the headers
$ curl -Is 127.0.0.1:8101
HTTP/1.1 200 OK
Server: gunicorn/19.7.1
...
X-commit-ID: adummycommit
X-k8s-pod: afakepodname

$ # Stop the container
$ docker kill headers-test
```

Check you see the expected headers in both cases.