### PR TITLE
Revert the 'Tell us your story' takeover back to the 'IoT business' one

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_tell-us-your-story.html" %}
+{% include "takeovers/_iot-business.html" %}
 
 
 {% include "shared/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" %}


### PR DESCRIPTION
## Done

Switch the "Tell us your story" takeover back to the old IoT one

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the IoT takeover is now visible.
