### PR TITLE
Reverted takeunder to previous one

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -96,7 +96,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="u-equal-height">
-      {% include "takeovers/takeunders/_iot-business-report-08-2017.html" %}
+      {% include "takeovers/takeunders/_kubernetes.html" %}
       {% include "takeovers/takeunders/_stuck-stack.html" %}
     </div>
   </div>


### PR DESCRIPTION
## Done

Changed the IoT takeunder to the previous K8s one

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the bottom left takeunder is now about K8s
