### PR TITLE
add foundation k8s offer to /containers/kubernetes page

### DIFF
--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -7,8 +7,8 @@
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Docker Engine on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% elif product == 'containers-kubernetes' %}
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Canonical Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes' %}
-    {% elif product == 'containers-kubernetes-foundation' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical's enterprise Kubernetes packages" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation' %}
+  {% elif product == 'containers-kubernetes-foundation' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical's enterprise Kubernetes packages" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation' %}
   {% elif product == 'containers-lxd' %}
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about LXD" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% elif product == 'containers-overview' %}

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -6,7 +6,9 @@
   {% if product == 'containers-docker' %}
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Docker Engine on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% elif product == 'containers-kubernetes' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Canonical Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Canonical Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes' %}
+    {% elif product == 'containers-kubernetes-foundation' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical's enterprise Kubernetes packages" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation' %}
   {% elif product == 'containers-lxd' %}
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about LXD" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% elif product == 'containers-overview' %}

--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -168,18 +168,40 @@
 
 <div class="p-strip--light is-bordered">
   <div class="row">
+    <div class="col-8">
+      <h2>Enterprise Kubernetes packages</h2>
+      <p>Canonical has two Kubernetes offerings, one to get you up and running quickly with a smaller setup and a predefined architecture and another that includes bare-metal environments or custom integrations, with loads of optional add ons to customise Kubernetes to your exact requirements. Every Kubernetes we build is future-proof with automated upgrades to newer versions on demand.</p>
+    </div>
+  </div>
+  <div class="row">
     <div class="u-equal-height">
-      <div class="col-4 u-vertically-center u-hidden--small">
-        <img src="{{ ASSET_SERVER_URL }}9f035e4a-picto-support-orange.svg" width="200" alt="" />
+      <div class="col-6 p-card">
+        <h3 class="p-card__title">Kubernetes Explorer</h3>
+        <p class="p-card__content">Empower your devops with a reference architecture VM-based Kubernetes deployment together with on-site training and consulting.</p>
+        <p class="p-card__content">What’s included</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">High availability Kubernetes, deployed on cloud or VMware</li>
+          <li class="p-list__item is-ticked"> Reference architecture</li>
+          <li class="p-list__item is-ticked">8 hours hands-on, web-based training</li>
+          <li class="p-list__item is-ticked">30 days of phone support</li>
+        </ul>
       </div>
-      <div class="col-8">
-        <h2>Support and customisation services</h2>
-        <p>Enterprise support for Kubernetes is provided by Canonical in partnership with Google where customers gain access to a global pool of knowledge and expertise.</p>
-        <p>We also offer consulting services and customisation for larger organisations to integrate Kubernetes with existing infrastructure.</p>
-        <p>For customers needing a fully managed Kubernetes, Canonical will deploy and operate your cluster remotely, and hand over to your own team as soon as they are familiar with the operational practices under the hood.</p>
-        <p>To discuss your requirement connect with a member of the Canonical team.</p>
-        <p><a href="/containers/contact-us?product=containers-kubernetes" class="p-button--brand">Contact us</a></p>
+      <div class="col-6 p-card">
+        <h3 class="p-card__title">Kubernetes Discoverer</h3>
+        <p class="p-card__content">Maximise efficiency with a customized production grade Kubernetes architecture, built by Canonical’s container experts and your team, together.</p>
+        <p class="p-card__content">What’s included</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">High availability Kubernetes, deployed on bare metal servers, cloud or VMware</li>
+          <li class="p-list__item is-ticked">Custom Kubernetes architecture optimised for your workloads</li>
+          <li class="p-list__item is-ticked">4 days hands-on, in-person training</li>
+          <li class="p-list__item is-ticked">Workload analysis covering web, AI/ machine learning, blockchain, serverless and more</li>
+          <li class="p-list__item is-ticked">Continuous Integration and Delivery (CI/CD) for one code repo</li>
+          <li class="p-list__item is-ticked">30 days of phone support</li>
+        </ul>
       </div>
+    </div>
+    <div class="col-8">
+      <p><a href="http://ubunt.eu/k8s-datasheet" class="p-button--brand is-inline" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'ubuntu.com', 'eventAction' : 'resource  download', 'eventLabel' : 'k8s foundation datasheet download', 'eventValue' : undefined });">Download the datasheet</a> <a href="/containers/contact-us?product=containers-kubernetes-foundation">or, contact us.</a></p>
     </div>
   </div>
 </div>

--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -158,7 +158,7 @@
         <li class="p-list__item is-ticked">Optional: Elastic Stack for Insights with Beats log collection and monitoring and analysis and visualisation with Elasticsearch and Kibana</li>
         <li class="p-list__item is-ticked">Optional: Ceph for filesystem and block storage</li>
       </ul>
-      <p><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Datasheet_Canonical-kubernetes_28.09.16_WEB.pdf" class="p-link--external">Learn more in the Canonical Distribution of Kubernetes&nbsp;datasheet</a></p>
+      <p><a href="http://ubunt.eu/k8s-datasheet" class="p-link--external">Learn more in the Canonical Distribution of Kubernetes&nbsp;datasheet</a></p>
     </div>
     <div class="col-6">
       <div class="juju-card" data-id="canonical-kubernetes"></div>

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -6,7 +6,7 @@
 {% block content %}
 {% if product == 'containers-kubernetes' %}
   {% include "shared/_thank_you.html" with thanks_context="enquiring about the Canonical Distribution of Kubernetes" %}
-{% elsif product == 'containers-kubernetes-foundation' %}
+{% elif product == 'containers-kubernetes-foundation' %}
     {% include "shared/_thank_you.html" with thanks_context="enquiring about the Enterprise Kubernetes Packages" %}
 {%  else %}
   {% include "shared/_thank_you.html" with thanks_context="enquiring about containers" %}

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -4,7 +4,13 @@
 
 
 {% block content %}
+{% if product == 'containers-kubernetes' %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about the Canonical Distribution of Kubernetes" %}
+{% elsif product == 'containers-kubernetes-foundation' %}
+    {% include "shared/_thank_you.html" with thanks_context="enquiring about the Enterprise Kubernetes Packages" %}
+{%  else %}
   {% include "shared/_thank_you.html" with thanks_context="enquiring about containers" %}
+{% endif %}
 {% endblock content %}
 
 {% block footer_extra %}


### PR DESCRIPTION
## Done

* add foundation k8s offer to /containers/kubernetes page
* updated contact-us to use new form for k8s and the datasheet
* updated thank-you for new form and the same form with a datasheet variant

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/containers/kubernetes)
* compare to the [copy doc](https://docs.google.com/document/d/1VMu4i8rJHW7BXKiOiy36XVFsihVxrNEMzUHn3X2XabI/edit#heading=h.tehvkk10lyod)
