### PR TITLE
Moved secondary footer to footer container

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -10,8 +10,7 @@
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          {% include 'templates/_footer_item.html' with section=nav_sections.server %}
-          {% include 'templates/_footer_item.html' with section=nav_sections.containers %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.server %} {% include 'templates/_footer_item.html' with section=nav_sections.containers %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
@@ -21,8 +20,7 @@
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          {% include 'templates/_footer_item.html' with section=nav_sections.core %}
-          {% include 'templates/_footer_item.html' with section=nav_sections.iot %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.core %} {% include 'templates/_footer_item.html' with section=nav_sections.iot %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
@@ -36,12 +34,7 @@
         </ul>
       </div>
     </nav>
-  </div>
-  <div class="row">
-    <div class="nav-global-footer"></div>
-  </div>
-  <hr class="p-footer__divider" />
-  <div class="row">
+    <hr class="p-footer__divider" />
     <div class="p-footer--secondary">
       <div class="col-7">
         <nav>
@@ -98,9 +91,9 @@
     </div>
 
     <script>
-    /* Add the page to the report a bug link */
-    var bugLink = document.querySelector('#report-a-bug');
-    bugLink.href += '?body=%0a%0a%0a---%0a*Reported%20from:%20' + location.href + '*';
+      /* Add the page to the report a bug link */
+      var bugLink = document.querySelector('#report-a-bug');
+      bugLink.href += '?body=%0a%0a%0a---%0a*Reported%20from:%20' + location.href + '*';
     </script>
     <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
   </div>


### PR DESCRIPTION
## Done

* moved the secondary footer to inside the footer container
* removed the old div for the global nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- see that the secondary footer looks correct - mostly like [this](https://github.com/ubuntudesign/www.ubuntu.com-design/blob/master/Footer-mobile-final-close.jpg) minus the position of the global nav 

## Issue / Card

Fixes #2139

