### PR TITLE
adding an id anchor for press release

### DIFF
--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<div class="p-strip--light is-bordered">
+<div id="enterprise" class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>Enterprise Kubernetes packages</h2>


### PR DESCRIPTION
## Done

* added a #enterprise anchor to the new strip

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/containers/kubernetes#enterprise](http://0.0.0.0:8001/containers/kubernetes#enterprise)
- see that it moves to the start of that section

