### PR TITLE
Update the k8s try it now link to the new tutorial

### DIFF
--- a/templates/containers/kubernetes.html
+++ b/templates/containers/kubernetes.html
@@ -12,7 +12,7 @@
         <h2>Enterprise Kubernetes, anywhere</h2>
         <p>In partnership with Google, Canonical now delivers a &lsquo;pure <abbr title="Kubernetes">K8s</abbr>&rsquo; experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.</p>
         <p>The Canonical Distribution of Kubernetes works across all major public clouds and private infrastructure, enabling your teams to operate Kubernetes clusters on demand, anywhere.</p>
-        <p><a href="https://docs.ubuntu.com/conjure-up/en/walkthrough" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Containers Kubernetes - try now', 'eventLabel' : 'Try it now', 'eventValue' : undefined });"><span class="p-link--external">Try it now&nbsp;</span></a></p>
+        <p><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Containers Kubernetes - try now', 'eventLabel' : 'Try it now', 'eventValue' : undefined });"><span class="p-link--external">Try it now&nbsp;</span></a></p>
         <p><a href="/containers/contact-us?product=containers-kubernetes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Containers Kubernetes - talk to us', 'eventLabel' : 'Talk to us about Kubernetes', 'eventValue' : undefined });">Talk to us about Kubernetes&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-vertically-center u-align--center">


### PR DESCRIPTION
## Done

Updated the "Try it now" link on /containers/kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/containers/kubernetes](http://0.0.0.0:8001/containers/kubernetes)
- Click the "Try it now" button and see that you are taken to the new tutorials.ubuntu.com tutorial