### PR TITLE
Update livepatch datasheet on /server/livepatch

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -102,7 +102,7 @@
       </div>
       <div class="col-4">
         <div class="p-card--highlighted  u-float--right">
-          <h2 class="p-card__title"><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/20161017_LivePatching_DS_.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/server/livepatch', 'eventValue' : undefined });">Livepatch overview&nbsp;&rsaquo;</a></h2>
+          <h2 class="p-card__title"><a href="{{ ASSET_SERVER_URL }}ac3aa269-DS_Canonical_Livepatch_Service_screen-AW_08.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/server/livepatch', 'eventValue' : undefined });">Livepatch overview&nbsp;&rsaquo;</a></h2>
           <p class="p-card__content">Download the datasheet for more technical details and FAQs on the Canonical Livepatch Service.</p>
           <p class="p-card__category">Datasheet</p>
         </div>


### PR DESCRIPTION
## Done

* updated datasheet
* updated the [copy doc](https://docs.google.com/a/canonical.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit?usp=sharing)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [livepatch page](http://0.0.0.0:8001/server/livepatch) and see the new pdf

## Issue / Card

Fixes #2158
