### PR TITLE
Maas pricing

### DIFF
--- a/templates/server/maas/index.html
+++ b/templates/server/maas/index.html
@@ -159,7 +159,7 @@
   </div>
 
   <div class="row">
-    <div class="col-10">
+    <div class="col-10" style="overflow-x: auto;">
       {% include "shared/_maas-support-pricing.html" %}
     </div>
   </div>

--- a/templates/shared/_maas-support-pricing.html
+++ b/templates/shared/_maas-support-pricing.html
@@ -13,7 +13,8 @@
       <td>Price per machine</td>
       <td class="u-align--center">$0</td>
       <td class="u-align--center">$5 per month</td>
-      <td class="u-align--center">$10 per month</td>
+      <td class="u-align--center">$10 per month<br />
+      <small>Or, unlimited machines $75,000 /year /region</small></td>
     </tr>
 
     <tr>

--- a/templates/shared/_maas-support-pricing.html
+++ b/templates/shared/_maas-support-pricing.html
@@ -19,7 +19,7 @@
     <tr>
       <td>Phone and ticket support</td>
       <td class="u-align--center">Community support only</td>
-      <td class="u-align--center">9am - 5pm on weekdays</td>
+      <td class="u-align--center">8am - 6pm on weekdays</td>
       <td class="u-align--center">24 hours a day, everyday</td>
     </tr>
 


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/server/maas](http://0.0.0.0:8001/server/maas)
- View the page in smaller viewports and see that the support pricing table has an x-scroll
