### PR TITLE
Add Enterprise Kubernetes takeover

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 
 //settings
-@import '_settings_colors';
+@import 'settings_colors';
 
 // custom mixins
 @import 'mixins/full-width-breakout';
@@ -59,6 +59,9 @@
 @include ubuntu-p-strip-photos;
 @include ubuntu-p-ubuntu-intro;
 @include ubuntu-p-takeunders;
+
+@import 'takeovers/enterprise-kubernetes';
+@include p-takeover-enterprise-kubernetes;
 
 // **************************
 // Bug fixes

--- a/static/sass/takeovers/_enterprise-kubernetes.scss
+++ b/static/sass/takeovers/_enterprise-kubernetes.scss
@@ -1,0 +1,18 @@
+@mixin p-takeover-enterprise-kubernetes {
+  $color-kubernetes: #326ce5;
+
+  .p-takeover--enterprise-kubernetes {
+    background-color: $color-kubernetes;
+
+    @media (min-width: $breakpoint-medium) {
+      background-image: url('#{$assets-path}fea46439-backgroundx2.png?w=984');
+      background-size: cover;
+      margin: $sp-x-large;
+      width: auto;
+    }
+
+    @media (min-width: 1200px) {
+      background-image: url('#{$assets-path}fea46439-backgroundx2.png?w=2000');
+    }
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block takeover_body_class %}homepage-iot-business{% endblock takeover_body_class %}
+{% block takeover_body_class %}homepage-enterprise-kubernetes{% endblock takeover_body_class %}
 
 {% block head_extra %}
   <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
@@ -8,7 +8,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_iot-business.html" %}
+{% include "takeovers/_enterprise-kubernetes.html" %}
 
 
 {% include "shared/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,7 +96,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="u-equal-height">
-      {% include "takeovers/takeunders/_kubernetes.html" %}
+      {% include "takeovers/takeunders/_iot-business-report-08-2017.html" %}
       {% include "takeovers/takeunders/_stuck-stack.html" %}
     </div>
   </div>

--- a/templates/takeovers/_enterprise-kubernetes.html
+++ b/templates/takeovers/_enterprise-kubernetes.html
@@ -1,4 +1,4 @@
-<section class="p-strip--image is-dark is-deep p-takeover--enterprise-kubernetes" style="">
+<section class="p-strip--image is-dark is-deep p-takeover--enterprise-kubernetes">
   <div class="row">
     <div class="u-equal-height u-vertically-center">
       <div class="col-5 u-no-margin--bottom">

--- a/templates/takeovers/_enterprise-kubernetes.html
+++ b/templates/takeovers/_enterprise-kubernetes.html
@@ -1,0 +1,18 @@
+<section class="p-strip--image is-dark is-deep p-takeover--enterprise-kubernetes" style="">
+  <div class="row">
+    <div class="u-equal-height u-vertically-center">
+      <div class="col-5 u-no-margin--bottom">
+        <h1>Want a private Kubernetes?</h1>
+        <p>Buy our specialist consulting packages and we will build you one in the cloud or on-premises.</p>
+        <p class="u-hidden u-visible--small">
+          <img src="{{ ASSET_SERVER_URL }}465244ee-K8s-illustration.svg" alt="" />
+        </p>
+        <p><a href="https://www.brighttalk.com/webcast/6793/278341?utm_source=ubuntu.com&amp;utm_medium=takeover" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Enterprise Kubernetes takeover - 12-09-2017', 'eventLabel' : 'Sign up to the webinar', 'eventValue' : undefined });" class="p-button--neutral"><span class="p-link--external">Sign up to the webinar</span></a></p>
+        <p class="u-no-margin--bottom"><a href="/containers/kubernetes?utm_source=ubuntu.com&amp;utm_medium=takeover" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Enterprise Kubernetes takeover - 12-09-2017', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-link--inverted">Find out more&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="u-hidden--small col-7 prefix-1 u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}465244ee-K8s-illustration.svg" alt="" />
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

Added a new homepage takeover for Enterprise k8s and switched the kubernetes takeunder for an IoT one.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check all viewports, the [design](https://www.dropbox.com/sh/u0oux5t7nmat5la/AABa8IH1qkRbYYKiCS5lu5Yya/Kubernetes-2017.09.07?dl=0&preview=Takeover-large-screen.png) and the [brief](https://docs.google.com/document/d/12qtyp7fOukhf_V_yG207FidQT8FqWp8naPby3o2sESs/edit?ts=599c2105#)