### PR TITLE
Remove link shortener for thank-you page in form for iot newsletter

### DIFF
--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -20,8 +20,8 @@
     </ul>
     <input type="hidden" name="utm_source" class="mktoField  mktoFormCol" value="">
     <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True">
-    <input type="hidden" name="returnURL" value="http://ubunt.eu/i1jy52" />
-    <input type="hidden" name="retURL" value="http://ubunt.eu/i1jy52" />
+    <input type="hidden" name="returnURL" value="https://www.ubuntu.com/internet-of-things/thank-you" />
+    <input type="hidden" name="retURL" value="https://www.ubuntu.com/internet-of-things/thank-you" />
   </form>
   <script>
     $("#mktoForm_1670").validate({


### PR DESCRIPTION
## Done

* Removed the link shortener and therefore the session breaking utm informattoin for thank-you page fields on the iot newsletter contextual footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
- [iot overview](http://0.0.0.0:8001/internet-of-things
- [iot dig signage](http://0.0.0.0:8001/internet-of-things/digital-signage
- [iot robotics](http://0.0.0.0:8001/internet-of-things/robotics
- [iot gateways](http://0.0.0.0:8001/internet-of-things/gateways

## Issue / Card

Fixes #2208

