### PR TITLE
Update trainling link to Hastexo

### DIFF
--- a/templates/cloud/training.html
+++ b/templates/cloud/training.html
@@ -23,7 +23,7 @@
       <h2>OpenStack Fundamentals</h2>
       <h3>Online training by Hastexo</h3>
       <p>Independent providers of online OpenStack training materials, certified by&nbsp;Canonical.</p>
-      <p><a href="https://academy.hastexo.com/courses/course-v1:hastexo+hx201+201610-juju/about" class="p-link--external">OpenStack 101 by Hastexo</a></p>
+      <p><a href="https://store.hastexo.com/catalogue/cloud-fundamentals-for-openstack_2/" class="p-link--external">OpenStack Fundamentals by Hastexo</a></p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

* updated the link and text
* did NOT update the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit#heading=h.1ycyiqb9j91) as things are still moving with the offering

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [training page](http://0.0.0.0:8001/cloud/training)
- see that is links to [this page](https://store.hastexo.com/catalogue/cloud-fundamentals-for-openstack_2/)


## Issue / Card

Fixes #2044

