### PR TITLE
Update appendix 1 toc on service-description page

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -94,18 +94,19 @@
 
       <h3><a href="#appendix-1">Appendix 1 - Support scope&nbsp;&rsaquo;</a></h3>
       <ol class="p-list">
-        <li class="p-list__item"><a href="#ua-openstack">OpenStack&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-advantage-openstack-cloud-region">OpenStack Cloud Region&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-server">Server&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-virtual-guest">Virtual Guest&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-ceph-storage">Ceph Storage&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-swift-storage">Swift Storage&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-maas">MAAS&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-switch">Switch&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-desktop">Desktop&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-docker">Docker&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-kubernetes">Kubernetes&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="#ua-esm">ESM&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-openstack">Ubuntu Advantage OpenStack&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-advantage-openstack-cloud-region">Ubuntu Advantage OpenStack Cloud Region&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-server">Ubuntu Advantage Server&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-virtual-guest">Ubuntu Advantage Virtual Guest&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-ceph-storage">Ubuntu Advantage Ceph Storage&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-swift-storage">Ubuntu Advantage Swift Storage&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-maas">Ubuntu Advantage MAAS&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-switch">Ubuntu Advantage Switch&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-desktop">Ubuntu Advantage Desktop&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-docker">Ubuntu Advantage for Docker&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-kubernetes">The Canonical Distribution of Kubernetes&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-esm">Extended Security Maintenance&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="#ua-livepatch">Canonical Livepatch Service&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-landscape-seats">Landscape Seats&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#tam">Technical Account Manager&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#dedicated-services-engineer">Dedicated Technical Account Manager&nbsp;&rsaquo;</a></li>
@@ -553,7 +554,7 @@ the Upgrade process.</li>
 <li class="p-list__item">Security fixes for CVEs that are not High or Critical</li>
 </ul>
 <p>Extended Security Maintenance does not guarantee secure software or fixes to all High or Critical CVEs.</p>
-<h3>Canonical Livepatch Service</h3>
+<h3 id="ua-livepatch">Canonical Livepatch Service</h3>
 <p>Canonical Livepatch Service includes a license to use Canonical&rsquo;s kernel livepatch daemon, access to available kernel livepatches, and support for livepatches on all systems covered by Livepatch for which the livepatching features are available.</p>
 <p>Canonical provides livepatches for High and Critical kernel CVEs. Note that some CVEs may be ineligible for livepatching due to technical limitations within the livepatching system.</p>
 <p>Canonical can not provide kernel support bug fixes as kernel livepatches.</p>


### PR DESCRIPTION
## Done

* updated appendix 1 toc on service-description page using actual titles

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description)
- Make sure the Appendix 1 links work, especially livepatch

## Issue / Card

Fixes #2204

## Screenshots

![image](https://user-images.githubusercontent.com/441217/30534358-c4c6df50-9c55-11e7-8f7d-776a3322949f.png)

