### PR TITLE
Fix up internal and external links on alternative downloads

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -24,9 +24,9 @@
       <h2>Network installer</h2>
       <p>The network installer lets you install Ubuntu over the network. This is useful, for example, if you have an old machine with a non-bootable CD-ROM or a computer that can&rsquo;t run the graphical interface-based installer, either because they don&rsquo;t meet the minimum requirements for the live CD/DVD or because they require extra configuration before  the graphical desktop can be used, or if you want to install Ubuntu on a large number of computers at once.</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked"><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/{{latest_release}}/">Download the network installer for {{latest_release_full}}</a></li>
-        <li class="p-list__item is-ticked"><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/16.04/">Download the network installer for 16.04 LTS</a></li>
-        <li class="p-list__item is-ticked"><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
+        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{latest_release}}/">Download the network installer for {{latest_release_full}}</a></li>
+        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/16.04/">Download the network installer for 16.04 LTS</a></li>
+        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
       </ul>
     </div>
   </div>
@@ -44,28 +44,28 @@
     <div class="col-4">
       <h3 class="p-link--external"><span>Ubuntu {{latest_release}}</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)</a></li>
       </ul>
     </div>
     <div class="col-4">
       <h3 class="p-link--external"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Server (64-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Server (32-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Server (32-bit)</a></li>
       </ul>
     </div>
     <div class="col-4">
       <h3 class="p-link--external"><span>Ubuntu 14.04.5 LTS</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-amd64.iso.torrent">Ubuntu 14.04.5 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-i386.iso.torrent">Ubuntu 14.04.5 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso.torrent">Ubuntu 14.04.5 Server (64-bit)&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-i386.iso.torrent">Ubuntu 14.04.5 Server (32-bit)&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-amd64.iso.torrent">Ubuntu 14.04.5 Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-i386.iso.torrent">Ubuntu 14.04.5 Desktop (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso.torrent">Ubuntu 14.04.5 Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-i386.iso.torrent">Ubuntu 14.04.5 Server (32-bit)</a></li>
       </ul>
     </div>
   </div>
@@ -83,19 +83,19 @@
   <div class="row">
     <div class="col-12">
       <ul class="p-list--divided is-trisected">
-        <li class="p-list__item"><a  href="http://mirror.waia.asn.au/ubuntu-releases/">Australia &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland &rsaquo;</a></li>
-        <li class="p-list__item"><a href="ftp://ftp.free.fr/mirrors/ftp.ubuntu.com/releases/">France &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://de.releases.ubuntu.com/">Germany &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://ftp.ntua.gr/pub/linux/ubuntu-releases-dvd">Greece &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://ftp.heanet.ie/pub/ubuntu-cdimage/releases">Ireland &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://nl.archive.ubuntu.com/ubuntu-cdimages">Netherlands &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://mirror.yandex.ru/ubuntu-cdimage/releases">Russian Federation &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://ubuntu.cica.es/releases/">Spain &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://ftp.acc.umu.se/mirror/cdimage.ubuntu.com/releases">Sweden &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://tw.archive.ubuntu.com/ubuntu-cd/">Taiwan &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/releases">United Kingdom &rsaquo;</a></li>
-        <li class="p-list__item"><a href="http://mirror.pnl.gov/releases/">United States &rsaquo;</a></li>
+        <li class="p-list__item"><a  href="http://mirror.waia.asn.au/ubuntu-releases/">Australia</a></li>
+        <li class="p-list__item"><a href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland</a></li>
+        <li class="p-list__item"><a href="ftp://ftp.free.fr/mirrors/ftp.ubuntu.com/releases/">France</a></li>
+        <li class="p-list__item"><a href="http://de.releases.ubuntu.com/">Germany</a></li>
+        <li class="p-list__item"><a href="http://ftp.ntua.gr/pub/linux/ubuntu-releases-dvd">Greece</a></li>
+        <li class="p-list__item"><a href="http://ftp.heanet.ie/pub/ubuntu-cdimage/releases">Ireland</a></li>
+        <li class="p-list__item"><a href="http://nl.archive.ubuntu.com/ubuntu-cdimages">Netherlands</a></li>
+        <li class="p-list__item"><a href="http://mirror.yandex.ru/ubuntu-cdimage/releases">Russian Federation</a></li>
+        <li class="p-list__item"><a href="http://ubuntu.cica.es/releases/">Spain</a></li>
+        <li class="p-list__item"><a href="http://ftp.acc.umu.se/mirror/cdimage.ubuntu.com/releases">Sweden</a></li>
+        <li class="p-list__item"><a href="http://tw.archive.ubuntu.com/ubuntu-cd/">Taiwan</a></li>
+        <li class="p-list__item"><a href="http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/releases">United Kingdom</a></li>
+        <li class="p-list__item"><a href="http://mirror.pnl.gov/releases/">United States</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done

* Fix up internal and external links on alternative downloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/download/alternative-downloads)
- note that lists with external headers do NOT have &nbsp;&rsaquo;
- note that lists with external links and no headers to have the external icon

