### PR TITLE
Add K8s certified logo to /kubernetes page

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -6,11 +6,14 @@
 
 {% block content %}
 <section class="p-strip is-bordered">
-  <div class="row">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-8">
       <h1>Kubernetes for the enterprise</h1>
       <p>This is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.</p>
       <p class="u-no-margin--top"><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?_ga=2.25375934.2035833349.1504518498-2070601899.1473694436" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Hero CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/containers/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Hero CTA' : undefined });">Talk to us about Kubernetes</a></p>
+    </div>
+    <div class="col-4 u-align--center u-hidden--small">
+      <img src="{{ ASSET_SERVER_URL }}7c230fc3-kubernetes_certified_service_provider_logo.png?w=300" alt="Kubernetes Certified Service Provider" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

* added the Kubernetes Certified Service Provider logo to the banner of the /kubernetes page per Dustin’s request in the [copy doc](https://docs.google.com/a/canonical.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit?usp=sharing)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/kubernetes)
- see the new logo

## Screenshots

![image](https://user-images.githubusercontent.com/441217/30648991-4a938b98-9e17-11e7-874f-e544dc0c6426.png)
