### PR TITLE
Remove duplicate links from vanilla upgrade

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -304,9 +304,6 @@
       <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - consulting packages CTA' : undefined });">Contact us</a>&#8195;<a href="https://assets.ubuntu.com/v1/Enterprise-Canonical-Kubernetes.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - consulting packages CTA' : undefined });">Download the datasheet</a></p>
     </div>
   </div>
-  <div class="row">
-    <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - consulting packages CTA' : undefined });">Contact us</a>&#8195;<a href="{{ ASSET_SERVER_URL }}b35eca50-Enterprise-Kubernetes-datasheet.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - consulting packages CTA' : undefined });">Download the datasheet</a></p>
-  </div>
 </section>
 
 <section class="p-strip is-bordered">


### PR DESCRIPTION
## Done

Removed the duplicate set of links/buttons under Kubernetes consulting packages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- See that there is only one version of the link block containing "Download the datasheet"
