### PR TITLE
Use the same environment headers as snapcraft.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ RUN pip3 install --upgrade pip
 RUN pip3 install gunicorn
 
 # Set git commit ID
-ARG commit_id
-ENV COMMIT_ID=$commit_id
+ARG COMMIT_ID
+ENV COMMIT_ID=$COMMIT_ID
+RUN test -n "${COMMIT_ID}"
 
 # Import code, install code dependencies
 WORKDIR /srv

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
 import os
+import socket
 import yaml
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -31,8 +32,8 @@ ALLOWED_HOSTS = ['*']
 DEBUG = os.environ.get('DJANGO_DEBUG', 'false').lower() == 'true'
 
 CUSTOM_HEADERS = {
-    'X-commit-ID': os.getenv('COMMIT_ID'),
-    'X-k8s-pod': os.getenv('K8S_POD_NAME')
+    'X-Commit-ID': os.getenv('COMMIT_ID'),
+    'X-Hostname': socket.gethostname()
 }
 
 USE_X_FORWARDED_HOST = True


### PR DESCRIPTION
Unify www.ubuntu.com's HTTP headers for environment information with those provided in snapcraft.io:
https://github.com/canonical-websites/snapcraft.io/pull/78

This PR ~also adds~ *no longer adds* updates from run script v2.1.1: https://github.com/canonical-webteam/generator-canonical-webteam/pull/43. ~Feel free to review that too if you wish.~

QA
--

Check the built image has the correct headers:

``` bash
$ docker build --build-arg COMMIT_ID=`git rev-parse HEAD` --tag u.c .  # Build the image
$ docker run --rm --name throwaway -ti -d -p 80:80 u.c  # Run the image in the background
$ curl -sI localhost | grep 'X-'  # Check the headers of the response for "commit"
X-Commit-ID: ab279404423effe21454323ab35
X-Hostname: 70cb5292e2eb
$ docker kill throwaway  # Kill the background image
```