### PR TITLE
Fixed ubuntu intro images cutting off on small screens

### DIFF
--- a/static/sass/_pattern_ubuntu_intro.scss
+++ b/static/sass/_pattern_ubuntu_intro.scss
@@ -33,9 +33,12 @@
       float: left;
       text-align: center;
       width: 100%;
+      padding-left: 0;
+      margin-left: 0;
 
       @media only screen and (min-width: $breakpoint-medium + 1) {
         margin: 0;
+        padding-left: 1rem;
         padding-bottom: 0;
       }
     }
@@ -53,13 +56,16 @@
         background: 0;
       }
 
+      @media only screen and (max-width: 667px) and (orientation: landscape) {
+        width: 20%;
+      }
 
       @media only screen and (max-width: $breakpoint-medium) {
         width: 32%;
       }
 
-      @media only screen and (max-width: 667px) and (orientation: landscape) {
-        width: 20%;
+      @media only screen and (max-width: $breakpoint-small) {
+        width: 45%;
       }
 
       @media only screen and (min-width: $breakpoint-medium) {


### PR DESCRIPTION
## Done

- Fixed intro images getting cut off on small screens
- Added media query to p-ubuntu-intro__list-item for small screens, changing width to 45%
- Set padding-left and margin-left to 0 by default

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that the intro images are not cut off when viewed on a small screen (width < 620px)

## Issue / Card

Fixes #1481 

## Screenshots

**Current Look**
![current](https://user-images.githubusercontent.com/25733845/31081089-997547dc-a782-11e7-81c4-e89ab68a8d29.png)

**Suggested Fix**
![suggested](https://user-images.githubusercontent.com/25733845/31081105-a17edcae-a782-11e7-842b-6ce3db9e225c.png)

**Alternative Fix**
![alternative](https://user-images.githubusercontent.com/25733845/31081116-abb39e44-a782-11e7-9520-e3a1e1b52617.png)
