### PR TITLE
Fixed footer nav on small screens

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -32,6 +32,19 @@
       @media only screen and (min-width: $breakpoint-medium) {
         border: 0;
       }
+
+      &.u-clearfix {
+        @media only screen and (max-width: $breakpoint-medium - 1) {
+          padding-bottom: 0;
+        }
+      }
+
+      &-col.col-2 {
+        @media only screen and (max-width: $breakpoint-medium - 1) {
+          margin-top: 0;
+        }
+      }
+
     }
 
     &__divider {
@@ -54,6 +67,10 @@
       display: block;
       margin-bottom: 0;
 
+      @media only screen and (max-width: $breakpoint-medium - 1px) {
+        margin-top: 0;
+      }
+
       + .p-footer__item {
         @media only screen and (min-width: $breakpoint-medium) {
           margin-top: $sp-large;
@@ -69,7 +86,7 @@
       background-size: 13px 13px;
       border-top: 1px solid $color-mid-light;
       font-size: .8125rem;
-      padding: $sp-small 0;
+      padding: $sp-medium 0;
 
       @media only screen and (min-width: $breakpoint-medium) {
         background: none;
@@ -164,12 +181,16 @@
       li {
         margin-bottom: 0;
 
+        @media only screen and (max-width: $breakpoint-medium) {
+          margin-top: 0;
+        }
+
         a {
           border-top: 1px solid $color-mid-light;
           color: $color-dark;
           display: block;
           font-size: .8125rem;
-          padding: $sp-small $sp-small $sp-small $sp-medium;
+          padding: $sp-medium $sp-small $sp-medium;
 
           @media only screen and (min-width: $breakpoint-medium) {
             border: 0;
@@ -189,6 +210,10 @@
 
     @media only screen and (min-width: $breakpoint-medium) {
       padding: 0;
+    }
+
+    @media only screen and (max-width: $breakpoint-medium - 1px) {
+      margin-top: 0;
     }
 
     a:hover {


### PR DESCRIPTION
## Done

- Changed footer nav on small screens to be evenly spaced and padded
- Removed unnecessary bottom padding on small screens
- Changed vertical padding from $sp-small to $sp-medium


## QA

- Check that the footer nav looks good on small screens
- Check that the footer nav on large screens has not been affected accidentally
- Check the CSS specificity (is it too specific?)


## Issue / Card

Fixes #2249 


## Screenshots

**Original**
![original](https://user-images.githubusercontent.com/25733845/31127876-04c812b0-a848-11e7-870f-86b33d071149.png)


**Suggested**
![suggested](https://user-images.githubusercontent.com/25733845/31127891-113181b2-a848-11e7-9954-5dbd35536a16.png)
