### PR TITLE
Add redirect and update plans and pricing page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -66,6 +66,7 @@ aboutus/trademarkpolicy\./?: "/legal/terms-and-policies/intellectual-property-po
 aboutus/trademarkpolicy\.Kind/?: "/legal/terms-and-policies/intellectual-property-policy"
 aboutus/trademarkpolicy/?: "/legal/terms-and-policies/intellectual-property-policy"
 advantage/?: "/support/plans-and-pricing"
+pricing/?: "/support/plans-and-pricing"
 android/?: "/mobile"
 arm/?: "http://partners.ubuntu.com/arm"
 assesment-terms/?: "/legal"

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -13,8 +13,14 @@
       <td>Price per machine</td>
       <td class="u-align--center">$0</td>
       <td class="u-align--center">$5 per month</td>
-      <td class="u-align--center">$10 per month<br />
-      <small>Or, unlimited machines $75,000 /year /region</small></td>
+      <td class="u-align--center">$10 per month</td>
+    </tr>
+
+    <tr>
+      <td>Per region per year</td>
+      <td class="u-align--center">-</td>
+      <td class="u-align--center">-</td>
+      <td class="u-align--center"><small>Unlimited machines $75,000</small></td>
     </tr>
 
     <tr>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -18,9 +18,9 @@
         </tr>
         <tr>
           <td>Or, price per region per year **</td>
-          <td>-</td>
+          <td class="u-align--center">-</td>
           <td><small>Small: $95,000<br />Medium: $225,000<br />Large: $420,000</small></td>
-          <td>-</td>
+          <td class="u-align--center">-</td>
         </tr>
         <tr>
           <td>Industry-leading cloud operations tooling<br />(Ubuntu, MAAS, Juju, LXD)</td>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col-6">
       <h1>Plans and pricing</h1>
-      <p>Ubuntu is always free to download, install, run, and upgrade.  Free community support is available in the following ways <a href="https://usn.ubuntu.com/usn/">Ubuntu Security Notices</a>, <a href="http://askubuntu.com">AskUbuntu</a>, <a href="http://ubuntuforums.org">UbuntuForums</a>, <a href="http://launchpad.net/ubuntu">Launchpad</a>, <a href="http://planet.ubuntu.com">PlanetUbuntu</a>, <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC</a> and through <a href="https://lists.ubuntu.com">Mailing Lists</a>.</p>
+      <p>Ubuntu is always free to download, install, run, and upgrade. Free community support is available from <a href="https://usn.ubuntu.com/usn/">Ubuntu Security Notices</a>, <a href="http://askubuntu.com">AskUbuntu</a>, <a href="http://ubuntuforums.org">UbuntuForums</a>, <a href="http://launchpad.net/ubuntu">Launchpad</a>, <a href="http://planet.ubuntu.com">PlanetUbuntu</a>, <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC</a> and through <a href="https://lists.ubuntu.com">Mailing Lists</a>.</p>
       <p>For enterprises with production workloads Canonical offers the following suite of Ubuntu Advantage tools, services and support packages.</p>
     </div>
   </div>
@@ -20,7 +20,7 @@
 <section class="p-strip--light is-deep is-bordered">
   <div class="row u-padding-bottom">
     <div class="col-4 p-card">
-      <h3>Ubuntu Support</h3>
+      <h3>Ubuntu Advantage</h3>
       <div class="p-card__footer">
         <p class="p-heading--five">From $75 per year <span style="font-size: 1rem;">*</span></p>
       </div>
@@ -84,7 +84,7 @@
 
   <div class="row">
     <div class="col-12">
-      <p><small>* Minimum spend applies</small></p>
+      <p><small>* Minimums apply</small></p>
     </div>
   </div>
 </section>
@@ -107,20 +107,20 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-shallow u-no-padding--bottom">
-  <div class="row" style="overflow-x: auto;">
-    <div class="col-10">
-      <h3>Ubuntu Advantage for desktops</h3>
-      {% include "shared/pricing/_ua-desktop-support.html" %}
-    </div>
-  </div>
-</section>
-
 <section class="p-strip--x-light is-shallow">
   <div class="row" style="overflow-x: auto;">
     <div class="col-10">
       <h3>Ubuntu Advantage for servers</h3>
       {% include "shared/pricing/_ua-server-support.html" %}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--x-light is-shallow u-no-padding--bottom">
+  <div class="row" style="overflow-x: auto;">
+    <div class="col-10">
+      <h3>Ubuntu Advantage for desktops</h3>
+      {% include "shared/pricing/_ua-desktop-support.html" %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Add redirect and update the plans and pricing page.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support/plans-and-pricing](http://0.0.0.0:8001/support/plans-and-pricing)
- Check that the copy matches the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/).
- Go to /pricing and see that is redirects to /support/plans-and-pricing

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2262
