### PR TITLE
Remove utm from homepage

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -49,7 +49,7 @@
 
     <div class="col-5">
       <!-- MARKETO FORM -->
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save?utm_source=ubuntu.com&utm_medium=Download-provisioning&utm_campaign=MAAS_ebook" method="post" id="mktoForm_1862">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save?source=ubuntu.com&medium=Download-provisioning&campaign=MAAS_ebook" method="post" id="mktoForm_1862">
         <fieldset>
           <ul class="p-list">
 

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -38,7 +38,7 @@
           <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Case study</h3>
         </div>
       </div>
-      <h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AzetiCS.html?utm_campaign=Device_FY17_IOT&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=azeticasestudy' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - left', 'eventLabel' : 'Case study - Azeti uses Ubuntu Core to improve deployment operations and security', 'eventValue' : '1' });'><span hidden>Read the case study </span>Azeti uses Ubuntu Core to improve deployment operations and security</a></h2>
+      <h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AzetiCS.html?campaign=Device_FY17_IOT&amp;medium=edgegatewaycontentblock&amp;source=ubuntuwebsite&amp;content=azeticasestudy' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - left', 'eventLabel' : 'Case study - Azeti uses Ubuntu Core to improve deployment operations and security', 'eventValue' : '1' });'><span hidden>Read the case study </span>Azeti uses Ubuntu Core to improve deployment operations and security</a></h2>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_center">
@@ -60,7 +60,7 @@
           <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>White paper</h3>
         </div>
       </div>
-      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&amp;amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=eclipsewhitepaper' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'White paper - The Eclipse IoT Working Group outlines the three required software stacks', 'eventValue' : '1' });'><span hidden>Read the white paper </span>The Eclipse IoT Working Group outlines the three required software stacks</a></h2>
+      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'White paper - The Eclipse IoT Working Group outlines the three required software stacks', 'eventValue' : '1' });'><span hidden>Read the white paper </span>The Eclipse IoT Working Group outlines the three required software stacks</a></h2>
       <!-- rtp section end -->
     </div>
   </div>
@@ -164,7 +164,7 @@
     <div class="col-6 p-divider__block">
       <h2>Simple development and distribution for ISVs and SIs</h2>
       <p>Independent software vendors and system integrators develop with the familiar environment and use the wealth of libraries available in Ubuntu. With Ubuntu Core you can easily manage the software you distribute. Use the Ubuntu Store to reach new customers.</p>
-      <p><a class="p-link--external p-link--inverted" href="http://snapcraft.io/?utm_campaign=Device_FY17_IOT&amp;utm_medium=gatewaysolutioncta&amp;utm_source=ubuntuwebsite&amp;utm_content=isvandis">Find out more about&nbsp;snaps</a></p>
+      <p><a class="p-link--external p-link--inverted" href="http://snapcraft.io/">Find out more about&nbsp;snaps</a></p>
     </div>
   </div>
 </section>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -59,7 +59,7 @@
           <h3 class='p-heading-icon__title p-heading--muted' style='color: #666;'>Article</h3>
         </div>
       </div>
-      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/?utm_source=roboticspage&utm_medium=latestnewsblock&utm_campaign=device-roboticspage' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h2>
+      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h2>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_right">
@@ -112,7 +112,7 @@
     <div class="col-12">
       <h2>Ubuntu runs on the robotic platforms that matter</h2>
       <p>Want to run Ubuntu Core on your hardware or write apps for an IoT device?</p>
-      <p><a class="p-link--external" href="https://developer.ubuntu.com/en/snappy/?utm_campaign=device-fy17-iot-vertical-robotics-webpage&utm_medium=partnerhardwarelink&utm_source=ubunturobotics">Learn more</a></p>
+      <p><a class="p-link--external" href="https://developer.ubuntu.com/en/snappy/">Learn more</a></p>
     </div>
   </div>
   <div class="row">

--- a/templates/server/maas/index.html
+++ b/templates/server/maas/index.html
@@ -90,7 +90,7 @@
             <h3 class="p-heading-icon__title p-heading-icon__title--muted p-heading--muted">Ebook</h3>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/eBook-MAAS.html?utm_source=maas_page&utm_medium=Banner&utm_campaign=MAAS_ebook&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Download the eBook - What you need to know about server provisioning', 'eventValue' : undefined });">What you need to know about server provisioning</a></h2>
+        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Download the eBook - What you need to know about server provisioning', 'eventValue' : undefined });">What you need to know about server provisioning</a></h2>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon u-no-margin--bottom">
@@ -99,7 +99,7 @@
             <h3 class="p-heading-icon__title p-heading-icon__title--muted p-heading--muted">Video</h3>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?utm_source=maas_page&utm_medium=Banner&utm_campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h2>
+        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?source=maas_page&medium=Banner&campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h2>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon u-no-margin--bottom">
@@ -108,7 +108,7 @@
             <h3 class="p-heading-icon__title p-heading-icon__title--muted p-heading--muted">Webinar</h3>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?utm_source=maas_page&utm_medium=Banner&utm_campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h2>
+        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?source=maas_page&medium=Banner&campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h2>
       </div>
     </div>
   </div>

--- a/templates/shared/contextual_footers/_iot_for_developers.html
+++ b/templates/shared/contextual_footers/_iot_for_developers.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">For developers</h3>
   <p>Ubuntu Core delivers security, reliable updates and much more.</p>
-  <p><a href="http://developer.ubuntu.com/en/snappy/?utm_campaign=Device_FY17_IOT&utm_medium=iotthankyoupage&utm_source=ubuntuwebsite&utm_content=seedeveloperinformation" class="p-link--external">Learn about Ubuntu Core for developers</a></p>
+  <p><a href="http://developer.ubuntu.com/en/snappy/" class="p-link--external">Learn about Ubuntu Core for developers</a></p>
 </div>

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -18,7 +18,7 @@
           class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
       </li>
     </ul>
-    <input type="hidden" name="utm_source" class="mktoField  mktoFormCol" value="">
+    <input type="hidden" name="source" class="mktoField  mktoFormCol" value="ubuntu.com">
     <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True">
     <input type="hidden" name="returnURL" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
     <input type="hidden" name="retURL" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />

--- a/templates/takeovers/_core.html
+++ b/templates/takeovers/_core.html
@@ -6,7 +6,7 @@
                 <img src="{{ ASSET_SERVER_URL }}763a9500-IOT_overview_graphic.svg" alt="" class="row-hero__image" />
             </div>
             <p>Get Ubuntu Core 16, the tiny, transactional version of Ubuntu that is secure, stable and upgradable remotely.</p>
-            <p><a class="button--primary row-hero__cta" href="/core?utm_campaign=Device_FY17_IOT-16launch&utm_medium=takeover&utm_source=ubuntuwebsite">Get started</a></p>
+            <p><a class="button--primary row-hero__cta" href="/core">Get started</a></p>
         </div>
         <div class="six-col last-col equal-height__item equal-height__align-vertically not-for-small">
             <img src="{{ ASSET_SERVER_URL }}763a9500-IOT_overview_graphic.svg" alt="" class="row-hero__image" />

--- a/templates/takeovers/_enterprise-kubernetes.html
+++ b/templates/takeovers/_enterprise-kubernetes.html
@@ -8,7 +8,7 @@
           <img src="{{ ASSET_SERVER_URL }}465244ee-K8s-illustration.svg" alt="" />
         </p>
         <p><a href="https://www.brighttalk.com/webcast/6793/278341?utm_source=ubuntu.com&amp;utm_medium=takeover" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Enterprise Kubernetes takeover - 12-09-2017', 'eventLabel' : 'Sign up to the webinar', 'eventValue' : undefined });" class="p-button--neutral"><span class="p-link--external">Sign up to the webinar</span></a></p>
-        <p class="u-no-margin--bottom"><a href="/containers/kubernetes?utm_source=ubuntu.com&amp;utm_medium=takeover" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Enterprise Kubernetes takeover - 12-09-2017', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-link--inverted">Find out more&nbsp;&rsaquo;</a></p>
+        <p class="u-no-margin--bottom"><a href="/containers/kubernetes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Enterprise Kubernetes takeover - 12-09-2017', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-link--inverted">Find out more&nbsp;&rsaquo;</a></p>
       </div>
       <div class="u-hidden--small col-7 prefix-1 u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}465244ee-K8s-illustration.svg" alt="" />

--- a/templates/takeovers/_maas_may_2017.html
+++ b/templates/takeovers/_maas_may_2017.html
@@ -5,8 +5,8 @@
       <h1>Maximise hardware efficiency</h1>
       <p class="p-heading--five">Build your data centre with <abbr title="Metal as a Service">MAAS</abbr>.</p>
       <div class="u-visible--small u-hidden--medium u-hidden--large u-padding-bottom--large"><img src="{{ ASSET_SERVER_URL }}3fb3f433-MAAS-takeover-illustration.svg" alt="MAAS service blocks illustration" /></div>
-      <p><a href="https://pages.ubuntu.com/eBook-MAAS.html?utm_source=ubuntu.com&amp;utm_medium=takeover&amp;utm_campaign=MAAS_eBook " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Maas takeover - 26-05-2017', 'eventLabel' : 'Download the eBook', 'eventValue' : undefined });" class="p-button--brand">Download the eBook</a></p>
-      <p><a href="https://www.ubuntu.com/server/maas?utm_source=ubuntu.com&amp;utm_medium=takeover&amp;utm_campaign=MAAS_eBook" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MAAS takeover', 'eventLabel' : 'Learn more about MAAS', 'eventValue' : undefined });">Learn more about MAAS &rsaquo;</a></p>
+      <p><a href="https://pages.ubuntu.com/eBook-MAAS.html?source=ubuntu.com&amp;medium=takeover&amp;campaign=MAAS_eBook " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Maas takeover - 26-05-2017', 'eventLabel' : 'Download the eBook', 'eventValue' : undefined });" class="p-button--brand">Download the eBook</a></p>
+      <p><a href="/server/maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MAAS takeover', 'eventLabel' : 'Learn more about MAAS', 'eventValue' : undefined });">Learn more about MAAS &rsaquo;</a></p>
     </div>
     <div class="u-hidden--small col-6 u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}3fb3f433-MAAS-takeover-illustration.svg" alt="MAAS service blocks illustration" />

--- a/templates/takeovers/takeunders/_iot-02-2017.html
+++ b/templates/takeovers/takeunders/_iot-02-2017.html
@@ -5,7 +5,7 @@
         <img class="" src="{{ ASSET_SERVER_URL }}f9b91fa8-iot-whitepaper.svg" width="145" alt="" />
       </div>
       <div class="col-8">
-        <h3><a href="https://pages.ubuntu.com/IoT-Security-whitepaper.html?utm_source=Takeunder&amp;utm_campaign=3)%20Device_FY17_IOT_IoTSecurityWhitepaper&amp;utm_medium=Banner" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'IoT security white paper takeunder', 'eventLabel' : 'The latest on IoT security', 'eventValue' : undefined });">The latest information on IoT security&nbsp;&rsaquo;</a></h3>
+        <h3><a href="https://pages.ubuntu.com/IoT-Security-whitepaper.html?source=Takeunder&amp;campaign=3)%20Device_FY17_IOT_IoTSecurityWhitepaper&amp;medium=Banner" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'IoT security white paper takeunder', 'eventLabel' : 'The latest on IoT security', 'eventValue' : undefined });">The latest information on IoT security&nbsp;&rsaquo;</a></h3>
         <p>Get rid of security vulnerabilities with help from our newest white&nbsp;paper.</p>
       </div>
     </div>

--- a/templates/takeovers/takeunders/_iot-business-report-08-2017.html
+++ b/templates/takeovers/takeunders/_iot-business-report-08-2017.html
@@ -5,7 +5,7 @@
         <img class="" src="{{ ASSET_SERVER_URL }}cebe4366-iot-orange-icon.svg" width="175" alt="" />
       </div>
       <div class="col-8">
-        <h3><a href="https://pages.ubuntu.com/IOT_IoTReport2017.html?utm_source=Takeunder&amp;utm_campaign=FY18_IOT_IoTReport&amp;utm_medium=website" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'IoT business model takeunder - 08/2017', 'eventLabel' : 'FY18_IOT_IoTReport', 'eventValue' : undefined });">How to pick a winning IoT business model&nbsp;&rsaquo;</a></h3>
+        <h3><a href="https://pages.ubuntu.com/IOT_IoTReport2017.html?source=Takeunder&amp;campaign=FY18_IOT_IoTReport&amp;medium=website" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'IoT business model takeunder - 08/2017', 'eventLabel' : 'FY18_IOT_IoTReport', 'eventValue' : undefined });">How to pick a winning IoT business model&nbsp;&rsaquo;</a></h3>
         <p>Monetising IoT investments, maximising IoT skills and addressing IoT security.</p>
       </div>
     </div>


### PR DESCRIPTION
## Done

* utm_* get strings start a new google session, so we lose track of people with them
  * changed get strings to pages.ubuntu.com links to remove the 'utm_' as marketo doesn't care what the name is
  * removed the entire utm_* get strings from all other internal sites

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/) and other sites in this PR
- see that the bottom left takeunder still works
