### PR TITLE
Update /desktop/education hero text

### DIFF
--- a/templates/desktop/contact-us.html
+++ b/templates/desktop/contact-us.html
@@ -4,9 +4,14 @@
 {% block meta_description %}Fast, easy and quick to deploy, switching to Ubuntu has never been easier{% endblock %}
 
 {% block content %}
+  {% if product == 'desktop-education' %}
+    {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your school or university? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html" %}
 
-{% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your organisation? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html" %}
+  {% else %}
 
+    {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your organisation? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html" %}
+
+  {% endif %}
 {% endblock content %}
 {% block footer_extra %}
 <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -11,7 +11,7 @@
     <div class="col-12 suffix-5">
       <div class="p-card--overlay">
         <h1>Ubuntu for education</h1>
-        <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators. Institutions can deploy Ubuntu for free or call upon Canonical commercial services and products to manage large device fleets.</p>
+        <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators. Institutions can deploy Ubuntu for free or can use Canonical&rsquo;s commercial services and products to manage your Ubuntu desktop, cloud and server deployments.</p>
         <p class="u-no-margin--top">
           <a href="/desktop/contact-us?product=desktop-education" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us for commercial support - Hero CTA' : undefined });">Contact us for commercial support</a>
           <a href="/download/desktop" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download now', 'eventLabel' : 'Download now - Hero CTA' : undefined });">Download now</a>
@@ -94,7 +94,7 @@
         <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}476dda79-italc-icon.png" alt="iTalc icon" />
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">iTalc</h3>
-          <p class="p-matrix__desc">IT tool which allows teachers to manage individual computers within school’s network.</p>
+          <p class="p-matrix__desc">IT tool which allows teachers to manage individual computers within school&rsquo;s network.</p>
         </div>
       </li>
       <li class="p-matrix__item last-row">

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -11,7 +11,7 @@
     <div class="col-12 suffix-5">
       <div class="p-card--overlay">
         <h1>Ubuntu for education</h1>
-        <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators. Institutions can deploy Ubuntu for free or can use Canonical&rsquo;s commercial services and products to manage your Ubuntu desktop, cloud and server deployments.</p>
+        <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators. Institutions can deploy Ubuntu for free or can use Canonical&rsquo;s commercial services and products to manage Ubuntu desktop, cloud and server deployments.</p>
         <p class="u-no-margin--top">
           <a href="/desktop/contact-us?product=desktop-education" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us for commercial support - Hero CTA' : undefined });">Contact us for commercial support</a>
           <a href="/download/desktop" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download now', 'eventLabel' : 'Download now - Hero CTA' : undefined });">Download now</a>

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -11,8 +11,11 @@
     <div class="col-12 suffix-5">
       <div class="p-card--overlay">
         <h1>Ubuntu for education</h1>
-        <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators.</p>
-        <p><a href="/desktop/contact-us?product=desktop-education" class="p-button--brand">Contact us</a></p>
+        <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators. Institutions can deploy Ubuntu for free or call upon Canonical commercial services and products to manage large device fleets.</p>
+        <p class="u-no-margin--top">
+          <a href="/desktop/contact-us?product=desktop-education" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us for commercial support - Hero CTA' : undefined });">Contact us for commercial support</a>
+          <a href="/download/desktop" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download now', 'eventLabel' : 'Download now - Hero CTA' : undefined });">Download now</a>
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

* Update /desktop/education hero text and added a new secondary CTA
* Contexualised the contact-us page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: - [education page](http://0.0.0.0:8001/desktop/education) and [contact us page](http://0.0.0.0:8001/desktop/contact-us?product=desktop-education)
- compare to the [copy doc](https://docs.google.com/document/d/1cwTA8lXgMAAHR8w79hJOHjyu84O0b9LmEM_jtRAeGSU/edit?ts=59d6459e#)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/31236984-aa14b8aa-a9c3-11e7-8bcc-3b598baa6f8e.png)
