### PR TITLE
Add datasheet to /cloud/managed-cloud

### DIFF
--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -9,8 +9,8 @@
   <div class="row">
     <div class="u-equal-height">
       <div class="col-8">
-        <h1 class="p-heading--two">Fully managed OpenStack, by Canonical</h1>
-        <p>BootStack is the fastest path to a production private OpenStack cloud. Focus on your business while Canonical takes care of building and running your OpenStack cloud.</p>
+        <h1 class="p-heading--two">Fully managed cloud, by Canonical</h1>
+        <p>BootStack, the fully managed cloud service from Canonical is the fastest path to a production private OpenStack cloud. Focus on your business while Canonical takes care of building and running your OpenStack cloud.</p>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Fully managed cloud on your servers, at your location</li>
           <li class="p-list__item is-ticked">Built in three weeks using a proven reference architecture</li>
@@ -99,8 +99,8 @@
   <div class="row">
     <div class="u-equal-height">
       <div class="col-7">
-        <h2>Canonical secures the OpenStack&nbsp;majority</h2>
-        <p>Canonical, a founding member of OpenStack, provides security updates for most production OpenStack clouds worldwide.</p>
+        <h2>Security trusted by the OpenStack majority</h2>
+        <p>Canonical, a founding member of OpenStack, provides security updates for thousands production OpenStack clouds worldwide.</p>
         <p>The leading OpenStack and public cloud experts choose Ubuntu &mdash; that&rsquo;s why you should talk to us about efficient OpenStack operations at scale.</p>
       </div>
       <div class="col-4 prefix-1">
@@ -127,7 +127,7 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <h4>Managed OpenStack</h4>
+      <h4>Fully managed OpenStack</h4>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Controlled density and performance</li>
         <li class="p-list__item is-ticked">Containers for bare-metal speed</li>
@@ -154,7 +154,7 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
-      <h3 class="p-muted-heading u-align--center">BootStack helps these companies</h3>
+      <h3 class="p-muted-heading u-align--center">BootStack fully managed cloud customers</h3>
     </div>
   </div>
   <div class="row">
@@ -183,6 +183,12 @@
         </li>
         <li class="p-inline-images__item">
           <img src="{{ ASSET_SERVER_URL }}507a0979-Voidbridge.jpg" alt="Voidbridge" />
+        </li>
+        <li class="p-inline-images__item">
+          <img src="{{ ASSET_SERVER_URL }}7bf5e46b-fibernet-logo-sm-blk_260x47.png" alt="Fibernet Data Centers" />
+        </li>
+        <li class="p-inline-images__item">
+          <img src="{{ ASSET_SERVER_URL }}7dfdecc2-cogeco-logo_colour.png" alt="Cogeco Peer 1" />
         </li>
       </ul>
     </div>
@@ -309,7 +315,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><a href="/cloud/contact-us?product=managed-cloud" class="p-button--brand">Schedule a demo</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--brand">Schedule a demo</a></p>
     </div>
   </div>
 </section>
@@ -330,7 +336,7 @@
                 <span class="p-list-step__bullet">1</span>
                 We <strong>build</strong> your cloud
               </h3>
-              <p>Together, we <a href="cloud/foundation-cloud">design your OpenStack cloud</a> based on your hardware, scale, roadmap, applications and monitoring system. This happens on your site, in your datacentre or hosted at a third-party facility.</p>
+              <p>Together, we <a href="/cloud/foundation-cloud">design your OpenStack cloud</a> based on your hardware, scale, roadmap, applications and monitoring system. This happens on your site, in your datacentre or hosted at a third-party facility.</p>
             </div>
             <div class="col-6 u-align--center u-hidden--small">
               <img src="{{ ASSET_SERVER_URL }}4287c2b2-transfer.svg" alt="" width="134">
@@ -381,12 +387,11 @@
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Hosting partners</h3>
       <p><a href="https://insights.ubuntu.com/2017/04/18/unitas-global-and-canonical-provide-fully-managed-enterprise-openstack/" class="p-link--external">Unitas Global</a>, <a href="https://insights.ubuntu.com/2016/08/22/qts-and-canonical-unveil-private-fully-managed-openstack-cloud/" class="p-link--external">QTS</a> and <a href="https://insights.ubuntu.com/2016/07/05/e-shelter-and-canonical-launch-joint-managed-openstack-private-cloud/" class="p-link--external">eShelter</a> are certified partners, trained to handle the physical BootStack operations.</p>
-      <p><a class="p-link--external" href="https://insights.ubuntu.com/2016/08/22/qts-and-canonical-unveil-private-fully-managed-openstack-cloud/">Read the QTS press release</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Build services</h3>
       <p>We can build your cloud. Get started fast with our OpenStack reference architecture or a custom design to optimise your workloads.</p>
-      <p><a class="p-link--external" href="">OpenStack build service&nbsp;&rsaquo;</a></p>
+      <p><a href="/cloud/foundation-cloud">OpenStack build service&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Fully managed Kubernetes</h3>
@@ -399,7 +404,7 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Enable containers</h3>
-      <p>Use <a href="">Linux Containers Project</a>, LXD, for pure-container guests in OpenStack. Faster to launch, with zero latency and amazing quality of service, LXD guests are a bridge between VMs and Docker.</p>
+      <p>Use <a href="https://linuxcontainers.org/" class="p-link--external">Linux Containers Project</a>, LXD, for pure-container guests in OpenStack. Faster to launch, with zero latency and amazing quality of service, LXD guests are a bridge between VMs and Docker.</p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Add Docker</h3>
@@ -407,7 +412,7 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Custom integration</h3>
-      <p>Integrate your OpenStack with existing storage SANs, network and SDN controllers, authentication systems like LDAP or Active Directory, and monitoring systems using our <a href="">professional services and consulting</a> teams.</p>
+      <p>Integrate your OpenStack with existing storage SANs, network and SDN controllers, authentication systems like LDAP or Active Directory, and monitoring systems using our <a href="/cloud/foundation-cloud">professional services and consulting</a> teams.</p>
     </div>
   </div>
 </section>

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -116,13 +116,7 @@
     <div class="col-8">
       <h2>Fits your hybrid cloud strategy</h2>
       <p>We recommend a hybrid cloud strategy. Canonical is a leading partner for all major public clouds, so we deliver neutral advice for both private and public operations. The right location for a workload should be driven by economics, not habit.</p>
-      <p>Give yourself the freedom to choose.</p>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-12">
-      <p class="u-padding-bottom--large">The right location for a workload should be driven by economics, not habit.</p>
+      <p class="u-padding-bottom--large">Give yourself the freedom to choose.</p>
     </div>
   </div>
   <div class="row u-equal-height">

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -12,15 +12,18 @@
         <h1 class="p-heading--two">Fully managed OpenStack, by Canonical</h1>
         <p>BootStack is the fastest path to a production private OpenStack cloud. Focus on your business while Canonical takes care of building and running your OpenStack cloud.</p>
         <ul class="p-list">
-          <li class="p-list__item is-ticked">Runs on your servers, at your location, but managed by Canonical, 24/7</li>
-          <li class="p-list__item is-ticked">Built using a proven reference architecture, get up and running within 3 weeks</li>
+          <li class="p-list__item is-ticked">Fully managed cloud on your servers, at your location</li>
+          <li class="p-list__item is-ticked">Built in three weeks using a proven reference architecture</li>
           <li class="p-list__item is-ticked">Customise the architecture in iterations based on workloads</li>
-          <li class="p-list__item is-ticked">Get an SLA for the cloud and focus on your business applications</li>
+          <li class="p-list__item is-ticked">Enterprise class SLA for the cloud </li>
           <li class="p-list__item is-ticked">Your team has access to all machines at all times</li>
-          <li class="p-list__item is-ticked">Integrate with your monitoring systems</li>
+          <li class="p-list__item is-ticked">Monitoring and log management integration</li>
           <li class="p-list__item is-ticked">When you&rsquo;re ready, we will hand over the keys</li>
         </ul>
-        <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--brand">Let&rsquo;s discuss your OpenStack requirements</a></p>
+        <p>
+          <a href="{{ ASSET_SERVER_URL }}3465457b-Bootstack_datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Bootstack datasheet - Top CTA' : undefined });" class="p-button--brand">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=cloud-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Bootstack - Top CTA' : undefined });" class="p-button--neutral">Talk to us</a>
+        </p>
+
       </div>
       <div class="col-4 u-vertically-center u-align--center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="OpenStack logo" />
@@ -63,16 +66,16 @@
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header u-no-margin--bottom">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/3769b4a7-webinar-icon.svg" />
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
             <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Learn why private open cloud makes financial&nbsp;sense</a></h2>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Why private open cloud makes financial&nbsp;sense</a></h2>
         </div>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header u-no-margin--bottom">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/3769b4a7-webinar-icon.svg" />
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
             <h3 class="p-heading-icon__title p-heading-icon__title--muted  p-muted-heading">Webinar</h3>
           </div>
           <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Cloudbase-webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Run Windows workloads on BootStack', 'eventValue' : undefined });">Run Windows workloads on BootStack</a></h2>
@@ -81,10 +84,10 @@
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header u-no-margin--bottom">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/3769b4a7-webinar-icon.svg" />
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
             <h3 class="p-heading-icon__title p-heading-icon__title--muted  p-muted-heading">Webinar</h3>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Supermicro_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Build a hyperconverged cloud with BootStack and Supermicro', 'eventValue' : undefined });"> Build a hyperconverged cloud with BootStack and&nbsp;Supermicro</a></h2>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Supermicro_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Build a hyperconverged cloud with BootStack and Supermicro', 'eventValue' : undefined });">Hyperconverged cloud with BootStack and&nbsp;Supermicro</a></h2>
         </div>
       </div>
     </div>
@@ -112,7 +115,8 @@
   <div class="row">
     <div class="col-8">
       <h2>Fits your hybrid cloud strategy</h2>
-      <p>We recommend a hybrid cloud strategy. Canonical is a leading partner for all major public clouds, so we deliver neutral advice for both private and public operations. Give yourself the freedom to choose.</p>
+      <p>We recommend a hybrid cloud strategy. Canonical is a leading partner for all major public clouds, so we deliver neutral advice for both private and public operations. The right location for a workload should be driven by economics, not habit.</p>
+      <p>Give yourself the freedom to choose.</p>
     </div>
   </div>
 
@@ -141,7 +145,7 @@
         <li class="p-list__item is-ticked">Choice of providers</li>
         <li class="p-list__item is-ticked">OPEX as needed</li>
         <li class="p-list__item is-ticked">Network isolation</li>
-        <li class="p-list__item is-ticked">Risk of noisy neighbours</li>
+        <li class="p-list__item is-ticked">Potential for uneven cloud performance</li>
       </ul>
     </div>
   </div>
@@ -313,7 +317,7 @@
 <section class="p-strip strip-light is-bordered">
   <div class="row">
     <div class="col-12 u-padding-bottom--x-large">
-      <h2>Get BootStack &mdash; managed OpenStack in 3 steps</h2>
+      <h2>Get BootStack &mdash; OpenStack managed cloud in 3 steps</h2>
     </div>
   </div>
   <div class="row">
@@ -326,7 +330,7 @@
                 <span class="p-list-step__bullet">1</span>
                 We <strong>build</strong> your cloud
               </h3>
-              <p>Together, we <a href="">design your OpenStack cloud</a> based on your hardware, scale, roadmap, applications and monitoring system. This happens on your site, in your datacentre or hosted at a third-party facility.</p>
+              <p>Together, we <a href="cloud/foundation-cloud">design your OpenStack cloud</a> based on your hardware, scale, roadmap, applications and monitoring system. This happens on your site, in your datacentre or hosted at a third-party facility.</p>
             </div>
             <div class="col-6 u-align--center u-hidden--small">
               <img src="{{ ASSET_SERVER_URL }}4287c2b2-transfer.svg" alt="" width="134">
@@ -381,11 +385,11 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Build services</h3>
-      <p>We can build your cloud. Get started fast with our <a href="">OpenStack reference architecture</a> or a custom design to optimise your workloads.</p>
+      <p>We can build your cloud. Get started fast with our OpenStack reference architecture or a custom design to optimise your workloads.</p>
       <p><a class="p-link--external" href="">OpenStack build service&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Managed Kubernetes</h3>
+      <h3 class="p-heading--four">Fully managed Kubernetes</h3>
       <p>Canonical will <a href="">build, operate and transfer a Kubernetes cluster</a> for you, on bare metal, OpenStack, VMware or public cloud.</p>
       <p><a href="/cloud/kubernetes">Canonical Kubernetes&nbsp;&rsaquo;</a></p>
     </div>

--- a/templates/cloud/shared/_openstack-pie-chart.html
+++ b/templates/cloud/shared/_openstack-pie-chart.html
@@ -1,7 +1,7 @@
 {% comment %} might want to add this image instead of the chart - {{ ASSET_SERVER_URL }}845e046c-partner-openstack.png
 {% endcomment %}
 <figure id="ubuntu-pie" class="ubuntu-pie"></figure>
-<p class="u-no-margin--bottom"><small>OpenStack deployments with more than 1,000 cores, <a href="https://www.openstack.org/assets/survey/April2017SurveyReport.pdf" class="external">OpenStack survey &mdash; April 2017 [PDF 10.6MB]</a></small></p>
+<p class="u-no-margin--bottom"><small>Ubuntu powers 55% of OpenStack in production. Source: <a href="https://www.openstack.org/assets/survey/April2017SurveyReport.pdf" class="external">OpenStack survey &mdash; April 2017 [PDF 10.6MB]</a></small></p>
 
 
 <script src="{{ ASSET_SERVER_URL }}3c99518b-d3-version3.5.6.min.js"></script>
@@ -13,8 +13,8 @@ function drawChart() {
   var width = document.querySelector('#ubuntu-pie').offsetWidth;
 
   var dataset = [
-    { label: 'ubuntu', count: 54, left: (width / 2.75), top: -5 },
-    { label: 'other', count: 46, left: -(width / 2.75), top: -5 }
+    { label: 'ubuntu', count: 55, left: (width / 2.75), top: -5 },
+    { label: 'other', count: 45, left: -(width / 2.75), top: -5 }
   ];
   var height = width;
   var radius = Math.min(width, height) / 2;


### PR DESCRIPTION
## Done

* Add datasheet to /cloud/managed-cloud
* Added many Mark Baker text changes that I found in the document
* Fixed or removed EMPTY HREFs!!!
* Used {{ ASSET_SERVER_URL }} instead of actual link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/cloud/managed-cloud)
- compare to the [copy doc](https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit#)
