### PR TITLE
Fix the incorrect URL to Screenly

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -125,7 +125,7 @@
     <div class="u-equal-height u-padding-bottom">
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-          <a href="https://www.screenlyapp.com/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}5917a214-logo-screenly.png" alt="Screenly logo" /></a>
+          <a href="https://www.screenly.io/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}5917a214-logo-screenly.png" alt="Screenly logo" /></a>
         </header>
         <h3 class="p-card__title">Screenly</h3>
         <p class="p-card__content">The world's most popular digital signage player for the Raspberry Pi.</p>


### PR DESCRIPTION
## Done
Fix the incorrect URL to Screenly

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/digital-signage](http://0.0.0.0:8001/internet-of-things/digital-signage)
- Scroll down to the Screenly logo and click the link
- It should take you to https://www.screenly.io

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2269
