### PR TITLE
Fixed padding/spacing on mobile nav

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -17,7 +17,7 @@
     & &__toggle--open,
     & &__toggle--close {
       @media (max-width: $breakpoint-medium) {
-        top: .75rem;
+        top: .875rem;
       }
     }
 
@@ -69,6 +69,14 @@
           &:last-of-type,
           &:nth-last-child(2) {
             border-bottom: 1px solid $color-mid-light;
+          }
+
+          > a {
+            padding: $sp-small $sp-medium;
+
+            &.is-active {
+              background-color: $color-mid-light;
+            }
           }
         }
 
@@ -154,7 +162,7 @@
           color: $color-dark;
           display: inline-block;
           margin-bottom: $sp-x-small;
-          padding: $sp-x-small;
+          padding: $sp-small $sp-medium;
           width: 100%;
         }
       }
@@ -165,7 +173,8 @@
         .p-inline-list__item {
           float: left;
           margin-right: 0;
-          padding-left: $sp-xx-small;
+          margin-top: 0;
+          padding-left: $sp-x-small;
           width: 50%;
 
           .is-active {

--- a/static/sass/_pattern_site_search.scss
+++ b/static/sass/_pattern_site_search.scss
@@ -19,7 +19,7 @@
 
   .p-site-search {
     float: right;
-    margin: $sp-small 0;
+    margin: .875rem 0;
     position: absolute;
     right: $sp-large * 3;
 
@@ -67,6 +67,11 @@
       border: 0;
       box-shadow: none;
       margin-top: 0;
+
+      @media (max-width: $breakpoint-medium - 1) {
+        border-bottom: 1px solid #cdcdcd;
+      }
+      
     }
 
     &__button {


### PR DESCRIPTION
## Done

- Changed padding on secondary nav to be in line with Ubuntu logo
- Vertically aligned magnifying glass icon and 'Menu' to be in the centre
- Active breadcrumb link is now $color-mid-light (similar to before Vanilla update) as opposed to the same colour


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that the padding on the secondary nav on small screens looks good


## Issue / Card

Fixes #1893 

## Screenshots

**Original**
![www ubuntu com-cloud iphone 6](https://user-images.githubusercontent.com/25733845/31283328-2a4af23e-aaad-11e7-9cbc-2588afe7c94a.png)


**Suggested**
![0 0 0 0-8001-cloud iphone 6](https://user-images.githubusercontent.com/25733845/31283336-304f89a6-aaad-11e7-955d-0c2054d1355f.png)


