### PR TITLE
Update the latest release variables to 17.10 Artful Aardvark

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ZestyZapus" latest_release="17.04" latest_release_full='17.04' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_openstack_version="Mitaka" latest_openstack_version="Ocata" %}
+{% with latest_release_name="ArtfulAardvark" latest_release="17.10" latest_release_full='17.10' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_openstack_version="Mitaka" latest_openstack_version="Ocata" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

Updated the variables in which we store the latest Ubuntu release

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Check that headings, link text and URLs on the following pages are correctly updated:
- [/download/server](http://0.0.0.0:8001/download/server)
- [/download/desktop](http://0.0.0.0:8001/download/desktop)/download/desktop
- [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads)
- [/download/server/linux-one](http://0.0.0.0:8001/download/server/linux-one)
- [/download/server/power8](http://0.0.0.0:8001/download/server/power8)
- [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads)

## Issue / Card

Fixes #2278 
