### PR TITLE
Update the hours of standard support

### DIFF
--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -23,7 +23,7 @@
   <tr>
     <th>Phone and web ticket support</th>
     <td class="u-align--center">None</td>
-    <td class="u-align--center">9am - 5pm on weekdays</td>
+    <td class="u-align--center">8am - 6pm on weekdays</td>
     <td class="u-align--center">24 hours a day, everyday</td>
     <td class="u-align--center">24 hours a day, everyday</td>
   </tr>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -19,7 +19,7 @@
         <tr>
           <td>Phone and ticket support</td>
           <td class="u-align--center">None</td>
-          <td class="u-align--center">9am - 5pm on weekdays</td>
+          <td class="u-align--center">8am - 6pm on weekdays</td>
           <td class="u-align--center">24 hours a day, everyday</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Done
Simply updated the support hours for standard support in the plans and pricing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support/plans-and-pricing](http://0.0.0.0:8001/support/plans-and-pricing)
- Check all support timing is `8am - 6pm` instead of `9am - 5pm`
- Updated the copy doc: https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit
