### PR TITLE
Update plans and pricing page

### DIFF
--- a/static/sass/_pattern_table.scss
+++ b/static/sass/_pattern_table.scss
@@ -1,0 +1,7 @@
+@mixin ubuntu-p-tables {
+  .p-table {
+    &__cell--highlight {
+      background: $color-x-light;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -36,6 +36,7 @@
 @import 'pattern_strip-photos';
 @import 'pattern_ubuntu_intro';
 @import 'pattern_takeunders';
+@import 'pattern_table';
 
 @include ubuntu-p-buttons;
 @include ubuntu-p-site-search;
@@ -60,6 +61,7 @@
 @include ubuntu-p-strip-photos;
 @include ubuntu-p-ubuntu-intro;
 @include ubuntu-p-takeunders;
+@include ubuntu-p-tables;
 
 @import 'takeovers/enterprise-kubernetes';
 @include p-takeover-enterprise-kubernetes;

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -39,7 +39,7 @@
 </div>
 <div class="row">
   <div class="col-12">
-    <p class="u-padding-bottom--large"><small>* Ongoing <a href="#support-packages">enterprise support</a> for Kubernetes after 30 days is optional.</small></p>
+    <p class="u-padding-bottom--large"><small>* Ongoing enterprise support for Kubernetes after 30 days is optional.</small></p>
   </div>
 </div>
 <div class="row">

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -1,7 +1,7 @@
 <table style="width: 100%;">
   <tr>
-    <td>&nbsp;</td>
-    <th class="u-align--center">Ubuntu</th>
+    <td width="35%">&nbsp;</td>
+    <th width="15%" class="u-align--center">Ubuntu</th>
     <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for Kubernetes</th>
     <th class="p-table__cell--highlight u-align--center">BootStack</th>
   </tr>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -1,93 +1,99 @@
 <table style="width: 100%;">
   <tr>
     <td>&nbsp;</td>
-    <th class="u-align--center">Free</th>
-    <th class="u-align--center">Standard</th>
-    <th class="u-align--center">Advanced</th>
-    <th class="u-align--center">Fully Managed</th>
+    <th class="u-align--center">Ubuntu</th>
+    <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for Kubernetes</th>
+    <th class="p-table__cell--highlight u-align--center">BootStack</th>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <th class="p-table__cell--highlight u-align--center">Standard</th>
+    <th class="p-table__cell--highlight u-align--center">Advanced</th>
+    <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
   </tr>
   <tr>
     <th>Price per node (physical)</th>
     <td class="u-align--center">$0</td>
-    <td class="u-align--center">$600/year</td>
-    <td class="u-align--center">$1,200/year</td>
-    <td class="u-align--center">$4,380/year</td>
+    <td class="p-table__cell--highlight u-align--center">$600/year</td>
+    <td class="p-table__cell--highlight u-align--center">$1,200/year</td>
+    <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
   </tr>
   <tr>
     <th>Price per node (virtual)</th>
     <td class="u-align--center">$0</td>
-    <td class="u-align--center">$200/year</td>
-    <td class="u-align--center">$400/year</td>
-    <td class="u-align--center">$1,460/year</td>
+    <td class="p-table__cell--highlight u-align--center">$200/year</td>
+    <td class="p-table__cell--highlight u-align--center">$400/year</td>
+    <td class="p-table__cell--highlight u-align--center">$1,460/year</td>
   </tr>
   <tr>
     <th>Phone and web ticket support</th>
     <td class="u-align--center">None</td>
-    <td class="u-align--center">8am - 6pm on weekdays</td>
-    <td class="u-align--center">24 hours a day, everyday</td>
-    <td class="u-align--center">24 hours a day, everyday</td>
+    <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
+    <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+    <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
   </tr>
   <tr>
     <th>Industry-leading cloud operations tooling <br />(Ubuntu, MAAS, Juju, LXD)</th>
     <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>Deploy, run, scale, upgrade K8s</th>
     <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>Monitoring and logging</th>
     <td>&nbsp;</td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>Landscape Management</th>
     <td>&nbsp;</td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>Livepatch</th>
     <td>&nbsp;</td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>Knowledge Base</th>
     <td>&nbsp;</td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>High availability support</th>
     <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight">&nbsp;</td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>24x7 remote operations, smart alerts and proactive monitoring by Canonical’s cloud experts</th>
     <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight">&nbsp;</td>
+    <td class="p-table__cell--highlight">&nbsp;</td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
   <tr>
     <th>Disaster recovery</th>
     <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    <td class="p-table__cell--highlight">&nbsp;</td>
+    <td class="p-table__cell--highlight">&nbsp;</td>
+    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
   </tr>
 </table>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -1,10 +1,15 @@
 <table style="width: 100%;">
   <thead>
     <tr>
-      <th class="u-align--center" style="width: 40%;">&nbsp;</th>
-      <th class="u-align--center" style="width: 20%;">Free</th>
-      <th class="u-align--center" style="width: 20%;">Standard</th>
-      <th class="u-align--center" style="width: 20%;">Advanced</th>
+      <th style="width: 40%;">&nbsp;</th>
+      <th class="u-align--center" style="width: 20%;">Ubuntu</th>
+      <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for MAAS</th>
+    </tr>
+    <tr>
+      <th>&nbsp;</th>
+      <th class="u-align--center">Without support</th>
+      <th class="p-table__cell--highlight u-align--center" style="width: 20%;">Standard</th>
+      <th class="p-table__cell--highlight u-align--center" style="width: 20%;">Advanced</th>
     </tr>
   </thead>
 
@@ -12,73 +17,73 @@
     <tr>
       <td>Price per machine</td>
       <td class="u-align--center">$0</td>
-      <td class="u-align--center">$5 per month</td>
-      <td class="u-align--center">$10 per month</td>
+      <td class="p-table__cell--highlight u-align--center">$5 per month</td>
+      <td class="p-table__cell--highlight u-align--center">$10 per month</td>
     </tr>
 
     <tr>
       <td>Per region per year</td>
       <td class="u-align--center">-</td>
-      <td class="u-align--center">-</td>
-      <td class="u-align--center"><small>Unlimited machines $75,000</small></td>
+      <td class="p-table__cell--highlight u-align--center">-</td>
+      <td class="p-table__cell--highlight u-align--center"><small>Unlimited machines $75,000</small></td>
     </tr>
 
     <tr>
       <td>Phone and ticket support</td>
       <td class="u-align--center">None</td>
-      <td class="u-align--center">8am - 6pm on weekdays</td>
-      <td class="u-align--center">24 hours a day, everyday</td>
+      <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
     </tr>
 
     <tr>
       <td>Ubuntu and CentOS deployment</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
 
     <tr>
       <td>Landscape Management<br />
       (for the MAAS servers)</td>
       <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
 
     <tr>
       <td>Livepatch<br />
       (for the MAAS servers)</td>
       <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
 
     <tr>
       <td>Knowledge Base</td>
       <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
 
     <tr>
       <td>Windows, RHEL, SUSE, and custom image<br /> creation and deployment</td>
       <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
 
     <tr>
       <td>High availability (HA) support</td>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
 
     <tr>
       <td>&nbsp;</td>
       <td class="u-align--center"><a href="/download/server/provisioning" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Install MAAS', 'eventLabel' : 'Install MAAS - MAAS support table' : undefined });">Install MAAS&nbsp;&rsaquo;</a></td>
-      <td class="u-align--center"><a href="/server/maas/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - standard - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
-      <td class="u-align--center"><a href="/server/maas/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - advanced - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
+      <td class="p-table__cell--highlight u-align--center"><a href="/server/maas/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - standard - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
+      <td class="p-table__cell--highlight u-align--center"><a href="/server/maas/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - advanced - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
     </tr>
   </tbody>
 </table>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -91,6 +91,6 @@
     </table>
 
     <p><small>* Minimum of 12 supported nodes</small></p>
-    <p><small>** Small region: Up to 99 nodes, Medium region: 100-499 nodes; Large region: 500+ nodes</small></p>
+    <p class="u-no-margin--top"><small>** Small region: Up to 99 nodes, Medium region: 100-499 nodes; Large region: 500+ nodes</small></p>
   </div>
 </div>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -4,9 +4,14 @@
       <thead>
         <tr>
           <td style="width: 40%;">&nbsp;</td>
+          <td>MAAS</td>
+          <td colspan="2"></td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
           <th class="u-align--center" width="15%">Free</th>
-          <th class="p-table__cell--highlight u-align--center">Advanced support</th>
-          <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
+          <th class="p-table__cell--highlight u-align--center">Advanced</th>
+          <th class="p-table__cell--highlight u-align--center">Managed</th>
         </tr>
       </thead>
       <tbody>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -5,82 +5,82 @@
         <tr>
           <td style="width: 60%;">&nbsp;</td>
           <th class="u-align--center">Free</th>
-          <th class="u-align--center">Advanced support</th>
-          <th class="u-align--center">Fully Managed</th>
+          <th class="p-table__cell--highlight u-align--center">Advanced support</th>
+          <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>Price per machine *</td>
           <td class="u-align--center">$0</td>
-          <td class="u-align--center">$1,500/year</td>
-          <td class="u-align--center">$5,450/year</td>
+          <td class="p-table__cell--highlight u-align--center">$1,500/year</td>
+          <td class="p-table__cell--highlight u-align--center">$5,450/year</td>
         </tr>
         <tr>
           <td>Or, price per region per year **</td>
           <td class="u-align--center">-</td>
-          <td><small>Small: $95,000<br />Medium: $225,000<br />Large: $420,000</small></td>
-          <td class="u-align--center">-</td>
+          <td class="p-table__cell--highlight"><small>Small: $95,000<br />Medium: $225,000<br />Large: $420,000</small></td>
+          <td class="p-table__cell--highlight u-align--center">-</td>
         </tr>
         <tr>
           <td>Industry-leading cloud operations tooling<br />(Ubuntu, MAAS, Juju, LXD)</td>
           <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Deploy, run, scale, upgrade OpenStack</td>
           <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Landscape Management</td>
           <td></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Livepatch (all hosts and Ubuntu guests)</td>
           <td></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Knowledge Base</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>3TB of Ceph and/or Swift usable storage per node</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>24x7 phone and ticket support (all hosts and Ubuntu guests)</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>High availability (HA) support</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>24x7 remote operations, smart alerts and proactive monitoring by Canonical’s cloud experts</td>
           <td>&nbsp;</td>
-          <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Disaster recovery</td>
           <td>&nbsp;</td>
-          <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
       </tbody>
     </table>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -3,8 +3,8 @@
     <table>
       <thead>
         <tr>
-          <td style="width: 60%;">&nbsp;</td>
-          <th class="u-align--center">Free</th>
+          <td style="width: 40%;">&nbsp;</td>
+          <th class="u-align--center" width="15%">Free</th>
           <th class="p-table__cell--highlight u-align--center">Advanced support</th>
           <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
         </tr>
@@ -85,7 +85,7 @@
       </tbody>
     </table>
 
-    <p>* Minimum of 12 supported nodes</p>
-    <p>** Small region: Up to 99 nodes, Medium region: 100-499 nodes; Large region: 500+ nodes</p>
+    <p><small>* Minimum of 12 supported nodes</small></p>
+    <p><small>** Small region: Up to 99 nodes, Medium region: 100-499 nodes; Large region: 500+ nodes</small></p>
   </div>
 </div>

--- a/templates/shared/pricing/_storage-support.html
+++ b/templates/shared/pricing/_storage-support.html
@@ -1,8 +1,7 @@
 <table>
   <thead>
     <tr>
-      <td>&nbsp;</td>
-      <th class="u-align--center">Ubuntu Advantage Storage</th>
+      <th colspan="2">Ubuntu Advantage Storage</th>
     </tr>
   </thead>
   <tbody>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -4,53 +4,58 @@
       <thead>
         <tr>
           <td>&nbsp;</td>
-          <th class="u-align--center">Free</th>
-          <th class="u-align--center">Desktop Standard</th>
-          <th class="u-align--center">Desktop Advanced</th>
+          <th class="u-align--center">Ubuntu</th>
+          <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for desktops</th>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <th class="u-align--center">Without support</th>
+          <th class="p-table__cell--highlight u-align--center">Standard</th>
+          <th class="p-table__cell--highlight u-align--center">Advanced</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>Price per node (physical)</td>
           <td class="u-align--center">$0</td>
-          <td class="u-align--center">$150/year</td>
-          <td class="u-align--center">$300/year</td>
+          <td class="p-table__cell--highlight u-align--center">$150/year</td>
+          <td class="p-table__cell--highlight u-align--center">$300/year</td>
         </tr>
         <tr>
           <td>Phone and ticket support</td>
           <td class="u-align--center">None</td>
-          <td class="u-align--center">8am - 6pm on weekdays</td>
-          <td class="u-align--center">24 hours a day, everyday</td>
+          <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
+          <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
         </tr>
         <tr>
           <td>Download, install, run, use, update, secure, upgrade</td>
           <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Landscape Management</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Kernel Livepatch</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Knowledge Base</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
           <td>Ubuntu Legal Assurance programme</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
       </tbody>
     </table>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -1,97 +1,102 @@
-<table>
+<table class="p-table">
   <thead>
     <tr>
       <td>&nbsp;</td>
-      <th>Free</th>
-      <th class="u-align--center">Server Essential</th>
-      <th class="u-align--center">Server Standard</th>
-      <th class="u-align--center">Server Advanced</th>
+      <th class="u-align--center">Ubuntu</th>
+      <th class="p-table__cell--highlight u-align--center" colspan="3">Ubuntu Advantage for servers</th>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td class="u-align--center">Without support</td>
+      <td class="p-table__cell--highlight u-align--center">Server Essential</td>
+      <td class="p-table__cell--highlight u-align--center">Server Standard</td>
+      <td class="p-table__cell--highlight u-align--center">Server Advanced</td>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Price per node (physical)</td>
       <td class="u-align--center">$0</td>
-      <td class="u-align--center">$225/year</td>
-      <td class="u-align--center">$750/year</td>
-      <td class="u-align--center">$1,500/year</td>
+      <td class="p-table__cell--highlight u-align--center">$225/year</td>
+      <td class="p-table__cell--highlight u-align--center">$750/year</td>
+      <td class="p-table__cell--highlight u-align--center">$1,500/year</td>
     </tr>
     <tr>
       <td>Price per node (virtual)</td>
       <td class="u-align--center">$0</td>
-      <td class="u-align--center">$75/year</td>
-      <td class="u-align--center">$250/year</td>
-      <td class="u-align--center">$500/year</td>
+      <td class="p-table__cell--highlight u-align--center">$75/year</td>
+      <td class="p-table__cell--highlight u-align--center">$250/year</td>
+      <td class="p-table__cell--highlight u-align--center">$500/year</td>
     </tr>
     <tr>
       <td>Phone and ticket support</td>
       <td class="u-align--center">None</td>
-      <td class="u-align--center">None</td>
-      <td class="u-align--center">8am - 6pm on weekdays</td>
-      <td class="u-align--center">24 hours a day, everyday</td>
+      <td class="p-table__cell--highlight u-align--center">None</td>
+      <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
     </tr>
     <tr>
       <td>Download, install, run, use, update, secure, upgrade</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Landscape Management</td>
       <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Kernel Livepatch</td>
       <td></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Extended Security Maintenance</td>
       <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Knowledge Base</td>
       <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Ubuntu Legal Assurance programme</td>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Unlimited Ubuntu LXD guest support</td>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Unlimited Ubuntu KVM guest support</td>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
-      <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>FIPS-certified cryptographic modules</td>
       <td>&nbsp;</td>
-      <td>&nbsp;</td>
-      <td>&nbsp;</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
   </tbody>
 </table>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -74,7 +74,7 @@
     <div class="col-4 p-card">
       <h3>Consulting packages</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $2500 per day <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $2,500 per day <span style="font-size: 1rem;">*</span></p>
       </div>
       <div class="p-card__footer">
         <a href="#consulting">Learn more&nbsp;&rsaquo;</a>
@@ -154,7 +154,7 @@
   {% include "shared/pricing/_openstack-support.html" %}
   <div class="row">
     <div class="col-8">
-      <p><a href="https://buy.ubuntu.com/">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="https://buy.ubuntu.com/" class="p-link--external">Buy Ubuntu Advantage</a></p>
     </div>
   </div>
 </section>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -116,10 +116,6 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-deep u-no-padding--top">
-  {% include "shared/pricing/_ua-server-support-add-ons.html" %}
-</section>
-
 <section class="p-strip--x-light is-shallow u-no-padding--bottom">
   <div class="row" style="overflow-x: auto;">
     <div class="col-10">
@@ -127,6 +123,10 @@
       {% include "shared/pricing/_ua-desktop-support.html" %}
     </div>
   </div>
+</section>
+
+<section class="p-strip--x-light is-deep">
+  {% include "shared/pricing/_ua-server-support-add-ons.html" %}
 </section>
 
 <section class="p-strip--light is-deep is-bordered" id="maas">
@@ -187,7 +187,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-10" style="overflow-x: auto;">
+    <div class="col-12" style="overflow-x: auto;">
       {% include "shared/pricing/_kubernetes-enterprise-support.html" %}
     </div>
   </div>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -74,7 +74,7 @@
     <div class="col-4 p-card">
       <h3>Consulting packages</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $150 per year <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $2500 per day <span style="font-size: 1rem;">*</span></p>
       </div>
       <div class="p-card__footer">
         <a href="#consulting">Learn more&nbsp;&rsaquo;</a>
@@ -181,7 +181,7 @@
 <section class="p-strip--x-light is-deep is-bordered" id="kubernetes">
   <div class="row">
     <div class="col-8">
-      <h2>Enterprise support for Kubernetes</h2>
+      <h2>Kubernetes</h2>
       <p>Scale-out container management is top of mind for savvy cloud architects around the world.  Ubuntu is, by far, the world&rsquo;s leading platform for container-based workflows.  Canonical provides enterprise-caliber support for Kubernetes.</p>
       <p>For more information about Kubernetes support, <a href="/containers/contact-us">contact us&nbsp;&rsaquo;</a></p>
     </div>
@@ -205,7 +205,7 @@
 <section class="p-strip--x-light is-deep is-bordered" id="storage">
   <div class="row">
     <div class="col-8">
-      <h2>Enterprise support for Ceph and Swift Storage</h2>
+      <h2>Ceph and Swift Storage</h2>
       <p>Ubuntu Advantage Storage from Canonical embeds the proven open source software‐defined storage (SDS) technologies of Ceph and Swift into a 24x7 supported software solution with a unique usage-based pricing model.</p>
     </div>
   </div>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -20,7 +20,7 @@
 <section class="p-strip--light is-deep is-bordered">
   <div class="row u-padding-bottom">
     <div class="col-4 p-card">
-      <h3>Ubuntu Advantage</h3>
+      <h3>Server</h3>
       <div class="p-card__footer">
         <p class="p-heading--five">From $75 per year <span style="font-size: 1rem;">*</span></p>
       </div>
@@ -110,30 +110,29 @@
 <section class="p-strip--x-light is-shallow">
   <div class="row" style="overflow-x: auto;">
     <div class="col-10">
-      <h3>Ubuntu Advantage for servers</h3>
+      <h2>For servers</h2>
       {% include "shared/pricing/_ua-server-support.html" %}
     </div>
   </div>
 </section>
 
+<section class="p-strip--x-light is-deep u-no-padding--top">
+  {% include "shared/pricing/_ua-server-support-add-ons.html" %}
+</section>
+
 <section class="p-strip--x-light is-shallow u-no-padding--bottom">
   <div class="row" style="overflow-x: auto;">
     <div class="col-10">
-      <h3>Ubuntu Advantage for desktops</h3>
+      <h2>For desktops</h2>
       {% include "shared/pricing/_ua-desktop-support.html" %}
     </div>
   </div>
 </section>
 
-
-<section class="p-strip--x-light is-deep u-no-padding--top">
-  {% include "shared/pricing/_ua-server-support-add-ons.html" %}
-</section>
-
 <section class="p-strip--light is-deep is-bordered" id="maas">
   <div class="row">
     <div class="col-8">
-      <h2>Enterprise support for MAAS</h2>
+      <h2>MAAS</h2>
       <p>MAAS is freely available, open source software from Canonical. Many enterprises depend on MAAS to automate and optimize provisioning for production hardware.  Canonical offers Standard and Advanced support plans priced per-machine-per-month or, for large volume and public clouds with dynamic scale, we offer per-region pricing with flexible node ranges.</p>
     </div>
   </div>
@@ -148,14 +147,14 @@
 <section class="p-strip--x-light is-deep is-bordered" id="openstack">
   <div class="row">
     <div class="col-8">
-      <h2>Enterprise support for OpenStack</h2>
-      <p>Canonical provides support services, management tools, and the Cloud Archive which keeps thousands of businesses productive with their own local OpenStack clouds.  For large volume and public clouds with dynamic scale, we’re pleased to offer per-region pricing with flexible node ranges.</p>
+      <h2>OpenStack</h2>
+      <p>Canonical provides support services, management tools, and the Cloud Archive which keeps thousands of businesses productive with their own local OpenStack clouds.  For large volume and public clouds with dynamic scale, we&rsquo;re pleased to offer per-region pricing with flexible node ranges.</p>
     </div>
   </div>
   {% include "shared/pricing/_openstack-support.html" %}
   <div class="row">
     <div class="col-8">
-      <p><a href="/support/contact-us?product=cloud-plans-and-pricing">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="https://buy.ubuntu.com/">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -183,7 +182,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Enterprise support for Kubernetes</h2>
-      <p>Scale-out container management is top of mind for savvy cloud architects around the world.  Ubuntu is, by far, the world&rsaquo;s leading platform for container-based workflows.  Canonical provides enterprise-caliber support for Kubernetes.</p>
+      <p>Scale-out container management is top of mind for savvy cloud architects around the world.  Ubuntu is, by far, the world&rsquo;s leading platform for container-based workflows.  Canonical provides enterprise-caliber support for Kubernetes.</p>
       <p>For more information about Kubernetes support, <a href="/containers/contact-us">contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -232,7 +231,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Landscape Enterprise Systems Management</h2>
-      <p>Reduce your team&rsaquo;s efforts on day-to-day management with Landscape, the most cost-effective tool to support and monitor large and growing networks of desktops, servers and clouds.</p>
+      <p>Reduce your team&rsquo;s efforts on day-to-day management with Landscape, the most cost-effective tool to support and monitor large and growing networks of desktops, servers and clouds.</p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done
Updated the `/support/plans-and-pricing` page with the latest changes and some table highlighting.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support/plans-and-pricing](http://0.0.0.0:8001/support/plans-and-pricing)
- Check the content matches the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)
- Check that the new table cell highlight is ok

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2275
