### PR TITLE
Changed date for previous short form agreement

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -355,8 +355,8 @@ legal:
       children:
         - title: JA
           path: /legal/short-terms/ja
-        - title: 2016-07-05
-          path: /legal/short-terms/2016-07-05
+        - title: 2016-06-24
+          path: /legal/short-terms/2016-06-24
         - title: 2016-05-20
           path: /legal/short-terms/2016-05-20
         - title: 2015-09-09

--- a/templates/legal/short-terms/2016-06-24.html
+++ b/templates/legal/short-terms/2016-06-24.html
@@ -1,6 +1,6 @@
 {% extends "legal/_base_legal.html" %}
 
-{% block title %}Short Form Services Agreement | 2016-07-05{% endblock %}
+{% block title %}Short Form Services Agreement | 2016-06-24{% endblock %}
 
 {% block meta_description %}Ubuntu and Canonical Legal - Short form services agreement{% endblock %}
 

--- a/templates/legal/short-terms/index.html
+++ b/templates/legal/short-terms/index.html
@@ -135,7 +135,7 @@
     <div class="col-4 p-card">
       <h3>Older versions</h3>
       <ul class="p-list">
-        <li class="p-list__item"><a href="/legal/short-terms/2016-07-05">05 July 2016&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/short-terms/2016-06-24">24 June 2016&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/short-terms/2016-05-20">20 May 2016&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/short-terms/2015-09-09">09 September 2015&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/short-terms/2015-06-24">24 June 2015&nbsp;&rsaquo;</a></li>


### PR DESCRIPTION
## Done

- Changed date for previous short form agreement to 24 June 2016

## QA

- Check that the date is changed to 24 June 2016 on /short-terms in nav bar and side bar
- Check that the link to the old short form agreement still works
