### PR TITLE
17.10 page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -112,6 +112,8 @@ desktop:
       path: /desktop/partners
     - title: Snappy
       path: /desktop/snappy
+    - title: Ubuntu 17.10
+      path: /desktop/1710
 
     - title: Contact us
       path: /desktop/contact-us

--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -20,8 +20,8 @@
 <section class="p-strip--light is-bordered">
   <div class="row p-divider u-equal-height">
     <div class="col-4 p-divider__block">
-      <h3>Latest edition</h3>
-      <p>Try Ubuntu 17.10 get all the latest software and enhancements.</p>
+      <h3>Get the latest edition</h3>
+      <p>Ubuntu 17.10 comes with the newest software enhancements and nine months of security and maintenance updates.</p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Prepare early</h3>

--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -12,7 +12,7 @@
     <div class="col-6">
       <h1>Ubuntu 17.10</h1>
       <p>In April 2018, the next Long-term release of Ubuntu, will come with the Gnome shell as default.  Ubuntu 17.10 will be the first release to include the new shell and is a great way to preview the future of Ubuntu.</p>
-      <p><a href="/download/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10&nbsp;&rsaquo;</a></p>
+      <p><a href="/download/desktop" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10</a></p>
     </div>
   </div>
 </section>

--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -1,0 +1,178 @@
+{% extends "desktop/base_desktop.html" %}
+
+{% block title %}Ubuntu 17.10{% endblock %}
+{% block meta_description %}Fast, secure and stylishly simple, the Ubuntu operating system is used by 50 million people worldwide every day.{% endblock %}
+
+{% block extra_body_class %}1710{% endblock %}
+
+{% block content %}
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h1>Ubuntu 17.10</h1>
+      <p>In April 2018, the next Long-term release of Ubuntu, will come with the Gnome shell as default.  Ubuntu 17.10 will be the first release to include the new shell and is a great way to preview the future of Ubuntu.</p>
+      <p><a href="/download/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row p-divider u-equal-height">
+    <div class="col-4 p-divider__block">
+      <h3>Latest edition</h3>
+      <p>Try Ubuntu 17.10 get all the latest software and enhancements.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3>Prepare early</h3>
+      <p>Get ready for Ubuntu 18.04, our next LTS release and test out the new Gnome desktop.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3>Fall in love again</h3>
+      <p>New desktop experience, same ease of use, reliability and huge choice of software.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Meet Ubuntu 17.10</h2>
+      <p>Take the tour and learn about the new Ubuntu.</p>
+      <div class="u-embedded-media">
+        <iframe class="u-embedded-media__element" width="640" height="480" src="https://player.vimeo.com/video/236987486" frameborder="0" allowfullscreen></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <h2>Get started</h2>
+  </div>
+  <div class="row">
+    <div class="col-4 p-card u-align--center">
+      <p><a href="https://wiki.ubuntu.com/ArtfulAardvark/ReleaseNotes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Release notes', 'eventLabel' : 'Release notes - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}df54bb6a-document-open-icon.svg" alt="" style="max-height: 47px;" /></a></p>
+      <h4 class="u-no-margin--bottom"><a href="https://wiki.ubuntu.com/ArtfulAardvark/ReleaseNotes" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Release notes', 'eventLabel' : 'Release notes - get started' : undefined });">Release notes</a></h4>
+    </div>
+    <div class="col-4 p-card u-align--center">
+      <p><a href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Read the docs', 'eventLabel' : 'Read the docs - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}df54bb6a-document-open-icon.svg" alt="" style="max-height: 47px;" /></a></p>
+      <h4 class="u-no-margin--bottom"><a href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Read the docs', 'eventLabel' : 'Read the docs - get started' : undefined });">Installation tutorial</a></h4>
+    </div>
+    <div class="col-4 p-card u-align--center">
+      <p><a href="https://community.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Community Hub', 'eventLabel' : 'Community Hub - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}5913cd4c-visit-site-icon.svg" alt="" style="max-height: 47px;" /></a></p>
+      <h4 class="u-no-margin--bottom"><a href="https://community.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Community Hub', 'eventLabel' : 'Community Hub - get started' : undefined });">Community Hub</a></h4>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>Features and changes</h2>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <ul class="p-matrix">
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">New Gnome desktop</h3>
+            <p class="p-matrix__desc">The biggest change is the desktop environment.  Ubuntu 17.10 is retiring Unity in favour of GNOME, version 3.26.1.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">New Wayland</h3>
+            <p class="p-matrix__desc">The default display server is Wayland, but can also run x.org as a session or on systems that cannot support Wayland.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">New on screen keyboard</h3>
+            <p class="p-matrix__desc">The new Caribou on screen keyboard is paving the way to future touchscreen laptop experience.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Same user experience</h3>
+            <p class="p-matrix__desc">The familiar Ubuntu experience – from desktop layout to key shortcuts – remains unchanged thanks to themes and extensions.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Familiar dock</h3>
+            <p class="p-matrix__desc">The dock that has been a staple feature of Ubuntu since 11.04 is still here but can now be moved around left, right or bottom.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">More customisation</h3>
+            <p class="p-matrix__desc">The new settings application lets you easily explore all the possibilities and features of the new desktop.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Kernel</h3>
+            <p class="p-matrix__desc">Ubuntu 17.10 features the Linux kernel 4.13.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Seamless</h3>
+            <p class="p-matrix__desc">Upgrading to Ubuntu 17.10 should be seamless from Ubuntu 16.04 LTS and 17.04.</p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Swap</h3>
+            <p class="p-matrix__desc">The swap is now a file, not a partition that will scale to what your system needs, making it easier to install Ubuntu on any machine.</p>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep is-bordered">
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}908ee6a0-help.svg" alt="" />
+          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Help</h3>
+        </div>
+      </div>
+      <h2 class="p-heading--four"><a class="p-link--external" href="https://launchpad.net/ubuntu/artful/+bugs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : '1710 report bug', 'eventLabel' : 'Help make 18.04 better by raising bugs', 'eventValue' : undefined });">Help make 18.04 better by raising bugs</a></h2>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
+          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Article</h3>
+        </div>
+      </div>
+      <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/12/ubuntu-desktop-gnome-extensions-poll-results/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventLabel' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventValue' : undefined });">The making of 17.10 &mdash; Choosing your preferred GNOME Extensions</a></h2>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5913cd4c-visit-site-icon.svg" alt="" />
+          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">News</h3>
+        </div>
+      </div>
+      <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Stay in touch with the latest Ubuntu desktop news', 'eventLabel' : 'Stay in touch with the latest Ubuntu desktop news', 'eventValue' : undefined });">Stay in touch with the latest Ubuntu desktop news</a></h2>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Download now!</h2>
+      <p><a href="/download/desktop" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - Bottom CTA' : undefined });">Get Ubuntu 17.10</a></p>
+    </div>
+  </div>
+</section>
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_download" second_item="_support-image" third_item="_desktop_flavours" %}
+
+{% endblock content %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,6 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
+
 {% with latest_release_name="ArtfulAardvark" latest_release="17.10" latest_release_full='17.10' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,6 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-
 {% with latest_release_name="ArtfulAardvark" latest_release="17.10" latest_release_full='17.10' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

Added a new 17.10 page with requisite nav configuration.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/1710](http://0.0.0.0:8001/desktop/1710)
- Check the content against the [copydoc](https://docs.google.com/document/d/1AE41rdko6D9ilW7UVkUO0fG2LfODhTlb2-ODladOapQ/edit#)

Note: There are some vertical padding issues with headings that are being fixed as part of a vanilla update.

