### PR TITLE
Add border to the end of the navigation

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -40,7 +40,7 @@
     .p-navigation__links {
 
       &:last-of-type {
-        border-right: 0;
+        border-right: 1px solid $color-brand-light;
       }
 
       .p-navigation__link {


### PR DESCRIPTION
## Done
Added a right border to the navigation on large screens.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that the navigation has a border on the right
- Check small screens


## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/1699
