### PR TITLE
Added link to 17.10 page from /download/desktop

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -50,6 +50,7 @@
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months of security and maintenance updates.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{latest_release}} release notes</a></p>
+          <p class="p-card__content"><a href="/desktop/1710" class="p-link--external">Find out more about {{latest_release}}</a></p>
           <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
         </div>
         <div class="col-4">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -50,7 +50,7 @@
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months of security and maintenance updates.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{latest_release}} release notes</a></p>
-          <p class="p-card__content"><a href="/desktop/1710">Find out more about {{latest_release}}&nbsp;›</a></p>
+          <p class="p-card__content"><a href="/desktop/1710">Find out more about {{latest_release}}&nbsp;&rsaquo;</a></p>
           <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
         </div>
         <div class="col-4">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -50,7 +50,7 @@
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months of security and maintenance updates.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{latest_release}} release notes</a></p>
-          <p class="p-card__content"><a href="/desktop/1710" class="p-link--external">Find out more about {{latest_release}}</a></p>
+          <p class="p-card__content"><a href="/desktop/1710">Find out more about {{latest_release}}&nbsp;›</a></p>
           <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
         </div>
         <div class="col-4">


### PR DESCRIPTION
## Done

- Added link to 17.10 page from /download/desktop as per [copydoc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit#)


## QA

- Check that there is a link to /desktop/1710 on the /download/desktop page
- Check that it directs to the new page about 17.10


## Issue / Card

Fixes #2298 
