### PR TITLE
Fix neutral buttons on accented backgrounds.

### DIFF
--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -9,4 +9,8 @@
   .p-strip--accent .p-link--external {
     color: $color-x-light;
   }
+
+  .p-strip--accent .p-button--neutral .p-link--external {
+    color: $color-dark;
+  }
 }


### PR DESCRIPTION
## Done

Stopped neutral buttons from being white text on whit background when placed on accented strips

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/containers](http://0.0.0.0:8001/containers)
- See that the button "Download the whitepaper" is now visible.


## Issue / Card
Fixes #2317 