### PR TITLE
Corrects grammar and punctuation errors on desktop/1710 page.

### DIFF
--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu 17.10</h1>
-      <p>In April 2018, the next Long-term release of Ubuntu, will come with the Gnome shell as default.  Ubuntu 17.10 will be the first release to include the new shell and is a great way to preview the future of Ubuntu.</p>
+      <p>In April 2018, the next long-term support (LTS) release of Ubuntu will come with Gnome Shell as default.  Ubuntu 17.10 is the first release to include the new shell, so it’s a great way to preview the future of Ubuntu.</p>
       <p><a href="/download/desktop" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10</a></p>
     </div>
     <div class="col-6 u-hidden--small ">
@@ -28,7 +28,7 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3>Prepare early</h3>
-      <p>Get ready for Ubuntu 18.04, our next LTS release and test out the new Gnome desktop.</p>
+      <p>Get ready for Ubuntu 18.04, our next LTS release, and test out the new Gnome desktop.</p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Fall in love again</h3>
@@ -90,8 +90,8 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title">New on screen keyboard</h3>
-            <p class="p-matrix__desc">The new Caribou on screen keyboard is paving the way to future touchscreen laptop experience.</p>
+            <h3 class="p-matrix__title">New on-screen keyboard</h3>
+            <p class="p-matrix__desc">The new Caribou on-screen keyboard is paving the way to future touchscreen laptop experience.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -103,7 +103,7 @@
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">Familiar dock</h3>
-            <p class="p-matrix__desc">The dock that has been a staple feature of Ubuntu since 11.04 is still here but can now be moved around left, right or bottom.</p>
+            <p class="p-matrix__desc">The dock that has been a staple feature of Ubuntu since 11.04 is still here, but it can now be moved to the left, right or bottom.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -127,7 +127,7 @@
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">Swap</h3>
-            <p class="p-matrix__desc">The swap is now a file, not a partition that will scale to what your system needs, making it easier to install Ubuntu on any machine.</p>
+            <p class="p-matrix__desc">The swap is now a file that scales to what your system needs, rather than a partition, making it easier to install Ubuntu on any machine.</p>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Done

- “Long-term release of Ubuntu,” > “long-term support (LTS) release of Ubuntu”
- “the Gnome shell” > “Gnome Shell”
- Ubuntu 17.10 will be” > “Ubuntu 17.10 is” since it’s released already
- puts a comma in the final long sentence in the intro
- Adds missing comma after secondary clause “our next LTS release”
- fixes odd phrase “moved around left” > “moved to the left”
- Fixes misleading text about swap file vs. partition: it’s the file that scales automatically, not the partition

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/1710](http://0.0.0.0:8001/desktop/1710)

## Issue / Card

- #2324