### PR TITLE
Fix spelling of GNOME

### DIFF
--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu 17.10</h1>
-      <p>In April 2018, the next long-term support (LTS) release of Ubuntu will come with Gnome Shell as default.  Ubuntu 17.10 is the first release to include the new shell, so it’s a great way to preview the future of Ubuntu.</p>
+      <p>In April 2018, the next long-term support (LTS) release of Ubuntu will come with GNOME Shell as default.  Ubuntu 17.10 is the first release to include the new shell, so it’s a great way to preview the future of Ubuntu.</p>
       <p><a href="/download/desktop" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10</a></p>
     </div>
     <div class="col-6 u-hidden--small ">
@@ -28,7 +28,7 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3>Prepare early</h3>
-      <p>Get ready for Ubuntu 18.04, our next LTS release, and test out the new Gnome desktop.</p>
+      <p>Get ready for Ubuntu 18.04, our next LTS release, and test out the new GNOME desktop.</p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Fall in love again</h3>
@@ -78,7 +78,7 @@
       <ul class="p-matrix">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title">New Gnome desktop</h3>
+            <h3 class="p-matrix__title">New GNOME desktop</h3>
             <p class="p-matrix__desc">The biggest change is the desktop environment.  Ubuntu 17.10 is retiring Unity in favour of GNOME, version 3.26.1.</p>
           </div>
         </li>


### PR DESCRIPTION
Fixes #2322

QA
--

``` bash
ack -i '\b(gnome|Gnome)\b' templates
```

^ See that the only non-GNOME spellings are in URLs.