### PR TITLE
Add the new colour theory

### DIFF
--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -10,7 +10,7 @@
     color: $color-x-light;
   }
 
-  .p-strip--accent .p-button--neutral .p-link--external {
+  [class^='p-strip'] .p-button--neutral .p-link--external {
     color: $color-dark;
   }
 }

--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -13,17 +13,4 @@
   .p-strip--accent .p-button--neutral .p-link--external {
     color: $color-dark;
   }
-
-  .p-button--brand,
-  .p-button--brand[type='submit'] {
-    @include button-pattern (
-      $button-background-color: $color-positive,
-      $button-border-color: $color-positive,
-      $button-text-color: $color-x-light,
-      $button-hover-background-color: darken($color-positive, 10%),
-      $button-hover-border-color: darken($color-positive, 10%),
-      $button-disabled-background-color: $color-positive,
-      $button-disabled-border-color: $color-positive
-    );
-  }
 }

--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -13,4 +13,17 @@
   .p-strip--accent .p-button--neutral .p-link--external {
     color: $color-dark;
   }
+
+  .p-button--brand,
+  .p-button--brand[type='submit'] {
+    @include button-pattern (
+      $button-background-color: $color-positive,
+      $button-border-color: $color-positive,
+      $button-text-color: $color-x-light,
+      $button-hover-background-color: darken($color-positive, 10%),
+      $button-hover-border-color: darken($color-positive, 10%),
+      $button-disabled-background-color: $color-positive,
+      $button-disabled-border-color: $color-positive
+    );
+  }
 }

--- a/static/sass/_settings_colors.scss
+++ b/static/sass/_settings_colors.scss
@@ -2,6 +2,5 @@ $color-brand:             #e95420;
 $color-accent-background: #2c001e;
 $color-brand-light:       lighten($color-brand, 10%);
 $color-brand-dark:        darken($color-brand, 10%);
-$color-link:              $color-brand;
 $color-navigation-background: $color-brand;
 

--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -10,7 +10,7 @@
       <div class="col-8">
         <h1>Foundation Cloud Build &mdash; your fast track to success</h1>
         <p>Building an OpenStack cloud requires domain expertise, cloud know-how, and detailed platform knowledge. After years of deploying, upgrading, and supporting OpenStack clouds, Canonical created Foundation Cloud Build, a fixed-price cloud with a proven reference architecture that Canonical will deploy for you on your premises.</p>
-        <p><a href="https://insights.ubuntu.com/wp-content/uploads/9ee0/Datasheet_Foundation-cloud-build_02.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Top CTA' : undefined });" class="p-button--brand">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - Top CTA' : undefined });" class="p-button--neutral">Talk to us</a></p>
+        <p><a href="https://insights.ubuntu.com/wp-content/uploads/9ee0/Datasheet_Foundation-cloud-build_02.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Top CTA' : undefined });" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - Top CTA' : undefined });" class="p-button--neutral">Talk to us</a></p>
       </div>
     </div>
   </section>
@@ -185,7 +185,7 @@
     <div class="row">
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
-        <p class="u-no-margin--top"><a href="https://insights.ubuntu.com/wp-content/uploads/9ee0/Datasheet_Foundation-cloud-build_02.17.pdf" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA' : undefined });">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="https://insights.ubuntu.com/wp-content/uploads/9ee0/Datasheet_Foundation-cloud-build_02.17.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA' : undefined });">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -17,7 +17,7 @@
     <div class="col-10">
       <h1>The standard OS for cloud computing</h1>
       <p class="p-heading--five">70% of public cloud workloads and 54% of OpenStack clouds<a href="#fn1" id="r1">*</a></p>
-      <p><a href="/download/cloud" class="p-button--brand">Install OpenStack</a></p>
+      <p><a href="/download/cloud" class="p-button--positive">Install OpenStack</a></p>
     </div>
   </div>
 </section>

--- a/templates/cloud/juju.html
+++ b/templates/cloud/juju.html
@@ -11,7 +11,7 @@
     <div class="col-6">
       <h1><img src="{{ ASSET_SERVER_URL }}7e21b535-logo-juju.svg" width="131" height="54" alt="Juju" /></h1>
       <p>Model, configure and manage services with Juju and deploy to all major public and private clouds with only a few commands. Hundreds of preconfigured services available in the Juju store.</p>
-      <p><a class="p-button--brand" href="https://jujucharms.com/">Get started</a></p>
+      <p><a class="p-button--positive" href="https://jujucharms.com/">Get started</a></p>
     </div>
   </div>
   <div class="row">
@@ -210,7 +210,7 @@
   <div class="row">
     <div class="col-6">
       <h2>Get started</h2>
-      <p ><a href="https://jujucharms.com/jaas" class="p-button--brand"><span class="p-link--external">Try the JAAS beta today</span></a></p>
+      <p ><a href="https://jujucharms.com/jaas" class="p-button--positive"><span class="p-link--external">Try the JAAS beta today</span></a></p>
     </div>
     <div class="col-6 u-hidden--small u-hidden--medium">
       <img src="{{ ASSET_SERVER_URL }}8149d09f-Service+View+-+zoom.png?h=332" class="u-image-position--top u-image-position--right" alt="" />

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -21,7 +21,7 @@
           <li class="p-list__item is-ticked">When you&rsquo;re ready, we will hand over the keys</li>
         </ul>
         <p>
-          <a href="{{ ASSET_SERVER_URL }}3465457b-Bootstack_datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Bootstack datasheet - Top CTA' : undefined });" class="p-button--brand">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=cloud-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Bootstack - Top CTA' : undefined });" class="p-button--neutral">Talk to us</a>
+          <a href="{{ ASSET_SERVER_URL }}3465457b-Bootstack_datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Bootstack datasheet - Top CTA' : undefined });" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=cloud-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Bootstack - Top CTA' : undefined });" class="p-button--neutral">Talk to us</a>
         </p>
 
       </div>
@@ -309,7 +309,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--brand">Schedule a demo</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--positive">Schedule a demo</a></p>
     </div>
   </div>
 </section>
@@ -366,7 +366,7 @@
           </div>
         </li>
       </ol>
-      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--brand">Free quote and architecture assessment</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--positive">Free quote and architecture assessment</a></p>
     </div>
   </div>
 </section>
@@ -413,7 +413,7 @@
 <section class="p-strip is-shallow u-no-padding--top">
   <div class="row">
     <div class="col-12">
-      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--brand">Let&rsquo;s discuss your requirements</a></p>
+      <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--positive">Let&rsquo;s discuss your requirements</a></p>
     </div>
   </div>
 </section>

--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -66,7 +66,7 @@
     <div class="col-8">
       <h2>Become a cloud partner</h2>
       <p>To learn more about becoming a charm, Ubuntu certified public cloud or Ubuntu OpenStack partner, please contact us today.</p>
-      <p><a href="http://partners.ubuntu.com/contact-us" class="p-button--brand">Get in touch</a></p>
+      <p><a href="http://partners.ubuntu.com/contact-us" class="p-button--positive">Get in touch</a></p>
       <p>or <a href="http://partners.ubuntu.com/partnering-with-us" class="p-link--external">learn more about partnering with us</a></p>
     </div>
   </div>

--- a/templates/cloud/storage.html
+++ b/templates/cloud/storage.html
@@ -10,7 +10,7 @@
       <div class="col-6">
         <h1>Ubuntu&nbsp;Advantage&nbsp;Storage</h1>
         <p>Ubuntu Advantage Storage from Canonical embeds the proven software&dash;defined storage (<abbr title="Software&dash;defined storage">SDS</abbr>) technologies of Ceph, NexentaEdge, Swift and SwiftStack, into a 24x7&dash;supported software solution with a unique metered pricing model.</p>
-        <p><a class="p-button--brand" href="/cloud/contact-us?product=cloud-storage">Request a demo</a></p>
+        <p><a class="p-button--positive" href="/cloud/contact-us?product=cloud-storage">Request a demo</a></p>
       </div>
       <div class="col-6 prefix-1 u-align--center u-vertically-center u-hidden--small">
         <img class="hero-image" width="100%" src="{{ ASSET_SERVER_URL }}c2d50399-storage.svg" alt="Lots of server pictos in a cloud" />

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -146,7 +146,7 @@
           <li class="p-list__item is-ticked">IP assurance for your Ubuntu environment</li>
           <li class="p-list__item is-ticked">Kernel livepatching to ensure you have the latest kernel security&nbsp;updates</li>
         </ul>
-        <p><a href="https://buy.ubuntu.com/" class="p-button--brand"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
+        <p><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
         <p>Or <a href="/containers/contact-us?product=containers-overview">contact us&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-align--right u-vertically-center u-hidden--small">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -14,7 +14,7 @@
       <!-- small screen version -->
       <img class="u-visible--small u-hidden--medium u-hidden--large" src="{{ ASSET_SERVER_URL }}53163a88-IOT_core_infographic.svg?w=300" width="300" alt="" style="margin: 4rem 0;"/>
       <p>Ubuntu Core is a tiny, transactional version of Ubuntu for IoT devices and large container deployments. It runs a new breed of super-secure, remotely upgradeable Linux app packages known as snaps &dash; and it&rsquo;s trusted by leading IoT players, from chipset vendors to device makers and system integrators.</p>
-      <p><a class="p-button--brand" href="http://developer.ubuntu.com/en/snappy/start/?from=corepage"><span class="p-link--external">Download Ubuntu Core</span></a></p>
+      <p><a class="p-button--positive" href="http://developer.ubuntu.com/en/snappy/start/?from=corepage"><span class="p-link--external">Download Ubuntu Core</span></a></p>
       <p><a class="p-link--external" href="http://snapcraft.io/?from=corepage">Learn more about snaps</a></p>
     </div>
     <div class="col-6 u-hidden--small">
@@ -187,7 +187,7 @@
       <div class="col-8">
         <h2>Let&rsquo;s work together</h2>
         <p>Talk to us if you are thinking about using Ubuntu Core for your next project.</p>
-        <p><a href="/core/contact-us?product=core-overview" class="p-button--brand">Get in touch</a></p>
+        <p><a href="/core/contact-us?product=core-overview" class="p-button--positive">Get in touch</a></p>
       </div>
       <div class="col-2 u-align--center u-vertically-align u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="140" alt="" />

--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -12,7 +12,7 @@
     <div class="col-6">
       <h1>Ubuntu 17.10</h1>
       <p>In April 2018, the next long-term support (LTS) release of Ubuntu will come with GNOME Shell as default.  Ubuntu 17.10 is the first release to include the new shell, so it’s a great way to preview the future of Ubuntu.</p>
-      <p><a href="/download/desktop" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10</a></p>
+      <p><a href="/download/desktop" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10</a></p>
     </div>
     <div class="col-6 u-hidden--small ">
       <img src="{{ ASSET_SERVER_URL }}0ace706d-LAPTOP%402x.png?w=654" alt="Laptop running Ubuntu 17.10, showing insights.ubuntu.com" />
@@ -171,7 +171,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Download now!</h2>
-      <p><a href="/download/desktop" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - Bottom CTA' : undefined });">Get Ubuntu 17.10</a></p>
+      <p><a href="/download/desktop" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - Bottom CTA' : undefined });">Get Ubuntu 17.10</a></p>
     </div>
   </div>
 </section>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -10,7 +10,7 @@
       <div class="col-6">
         <h1>Ubuntu Desktop for&nbsp;developers</h1>
         <p>Whether you&rsquo;re a mobile app developer, an engineering manager, a music or video editor or a financial analyst with large-scale models to run &mdash; in fact, anyone in need of a powerful machine for your work &mdash; Ubuntu is the ideal platform.</p>
-        <p><a href="/download/desktop/" class="p-button--brand">Get Ubuntu now</a></p>
+        <p><a href="/download/desktop/" class="p-button--positive">Get Ubuntu now</a></p>
       </div>
       <div class="col-6 u-vertically-center u-hidden--small">
         <img class="u-visible--large u-hidden--medium u-image-position--top" src="{{ ASSET_SERVER_URL }}2e62cdb4-desktop-developer-hero.png?w=600" alt="" style="top: 105px; left: 50%;" />

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -13,7 +13,7 @@
         <h1>Ubuntu for education</h1>
         <p>With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators. Institutions can deploy Ubuntu for free or can use Canonical&rsquo;s commercial services and products to manage Ubuntu desktop, cloud and server deployments.</p>
         <p class="u-no-margin--top">
-          <a href="/desktop/contact-us?product=desktop-education" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us for commercial support - Hero CTA' : undefined });">Contact us for commercial support</a>
+          <a href="/desktop/contact-us?product=desktop-education" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us for commercial support - Hero CTA' : undefined });">Contact us for commercial support</a>
           <a href="/download/desktop" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download now', 'eventLabel' : 'Download now - Hero CTA' : undefined });">Download now</a>
         </p>
       </div>

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -10,7 +10,7 @@
     <div class="col-6">
       <h1>Ubuntu for enterprise</h1>
       <p>On the desktop, Ubuntu has been widely adopted by small and large enterprises because of its ease of use, speed, apps, security model, management tools and low cost of ownership.</p>
-      <p><a href="/desktop/contact-us?product=desktop-enterprise" class="p-button--brand">Contact us</a></p>
+      <p><a href="/desktop/contact-us?product=desktop-enterprise" class="p-button--positive">Contact us</a></p>
       <p><a href="https://buy.ubuntu.com" class="p-link--external">Buy Ubuntu Advantage</a></p>
     </div>
     <div class="col-6 u-vertically-center u-hidden--small">

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -36,7 +36,7 @@
     <div class="col-6">
       <h1>Features</h1>
       <p>Enjoy the simplicity of Ubuntu&rsquo;s intuitive interface. Fast, secure and with thousands of apps to choose from &mdash; for everything you want to do, Ubuntu has what you need.</p>
-      <p><a href="/download/desktop" class="p-button--brand">Download Ubuntu</a></p>
+      <p><a href="/download/desktop" class="p-button--positive">Download Ubuntu</a></p>
     </div>
     <div class="col-6 u-vertically-center u-hidden--small">
       <img class="u-visible--large u-hidden--medium u-image-position--top" src="{{ ASSET_SERVER_URL }}9fe68ee3-desktop-features-hero.png?w=600" alt="" style="top: 70px; left: 50%;" />

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -15,7 +15,7 @@
       <div class="p-card--overlay">
         <h1>Ubuntu for desktops</h1>
         <p>Learn how the Ubuntu desktop operating system powers millions of PCs and laptops around the world.</p>
-        <p><a href="/download/desktop" class="p-button--brand">Download Ubuntu</a></p>
+        <p><a href="/download/desktop" class="p-button--positive">Download Ubuntu</a></p>
         <p><a href="/desktop/features">Take a look&nbsp;&rsaquo;</a></p>
       </div>
     </div>

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -12,7 +12,7 @@
       <h1>A &lsquo;snap&rsquo; is a universal Linux package</h1>
       <p>Snaps work on any distribution or device. Snaps are faster to install, easier to create, safer to run, and they update automatically and transactionally so your app is always fresh and never broken.</p>
       <p>The public collection of snaps includes the latest and best apps from GitHub and beyond, so you have the whole world of Linux apps at your fingertips.</p>
-      <p><a class="p-button--brand" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
+      <p><a class="p-button--positive" href="http://snapcraft.io/docs/core"><span class="external">Get started with snaps</span></a></p>
     </div>
     <div class="col-5 prefix-1 suffix-2">
       <ul class="p-list p-list--imgstack u-hidden--small">

--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -119,7 +119,7 @@
           <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you?version={{ version }}&amp;architecture={{ architecture }}">
 
           <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
-          <button type="submit" class="contribute__submit p-button--brand" tabindex="9">Pay with PayPal</button> {% if start_download %}
+          <button type="submit" class="contribute__submit p-button--positive" tabindex="9">Pay with PayPal</button> {% if start_download %}
           <a href="/download/desktop/thank-you?version={{ version }}&amp;architecture={{ architecture }}" class="contribute__skip" tabindex="11">Not now, take me to the download&nbsp;&rsaquo;</a> {% endif %}
         </div>
       </form>
@@ -253,10 +253,10 @@
 
     if (skip) {
       if (total == 0) {
-        skip.classList.add('p-button--brand');
+        skip.classList.add('p-button--positive');
         submit.classList.add('u-hidden');
       } else {
-        skip.classList.remove('p-button--brand');
+        skip.classList.remove('p-button--positive');
         submit.classList.remove('u-hidden');
       }
     } else {

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -28,7 +28,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            <a class="p-button--brand is-wide js-lts-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a>
+            <a class="p-button--positive is-wide js-lts-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a>
             <script>
               // Contributions only work with JavaScript
               // So if we have JavaScript, send them to /contribute
@@ -55,7 +55,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            <a class="p-button--brand is-wide js-latest-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
+            <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
             <script>
               // Contributions only work with JavaScript
               // So if we have JavaScript, send them to /contribute

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -18,13 +18,13 @@
     <div class="col-6 p-card--highlighted is-divided">
       <h3 class="p-card__title">Ubuntu Server</h3>
       <p class="p-card__content">This is the iso image of the Ubuntu Server installer.</p>
-      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="p-button--brand is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
+      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
       <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-card--highlighted is-divided">
       <h3 class="p-card__title">Ubuntu netboot</h3>
       <p class="p-card__content">This installer lets you install Ubuntu over the network.</p>
-      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}" class="p-button--brand is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
+      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
       <p><a href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images&nbsp;&rsaquo;</a></p>
     </div>
   </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -18,7 +18,7 @@
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
         </div>
         <div class="col-4">
-          <p class="p-card__content"><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="p-button--brand is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a></p>
+          <p class="p-card__content"><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a></p>
           <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
         </div>
       </div>
@@ -34,7 +34,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            <a class="p-button--brand is-wide" href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
+            <a class="p-button--positive is-wide" href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
           <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
         </div>
       </div>

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -23,7 +23,7 @@
           <p class="p-card__content">For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us <tel href="+442076302406">+44&nbsp;(0)&nbsp;207&nbsp;630&nbsp;2406</tel> or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
         </div>
         <div class="col-4 p-divider__block">
-          <p><a href="/download/server/thank-you-linuxone" class="p-button--brand is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download and accept terms</a></p>
+          <p><a href="/download/server/thank-you-linuxone" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download and accept terms</a></p>
           <p class="p-card__content">Your use of Ubuntu on z&nbsp;Systems and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p>
         </div>
       </div>

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -87,7 +87,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
             </li>
             <li>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
             <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--brand is-wide">Submit</button><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
+              <button type="submit" class="mktoButton p-button--positive is-wide">Submit</button><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
                 name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
               <input
                 type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">

--- a/templates/download/shared/_get_ebook.html
+++ b/templates/download/shared/_get_ebook.html
@@ -50,7 +50,7 @@
             </li>
 
             <li class="mktField p-list__item">
-              <button type="submit" class="p-button--brand mktoButton" onsubmit="backgroundSubmitHandler();">Download the eBook</button><input type="hidden" name="formid" class="mktoField " value="1460"><input type="hidden" name="formVid" class="mktoField "
+              <button type="submit" class="p-button--positive mktoButton" onsubmit="backgroundSubmitHandler();">Download the eBook</button><input type="hidden" name="formid" class="mktoField " value="1460"><input type="hidden" name="formVid" class="mktoField "
                 value="1460"><input type="hidden" name="lpId" class="mktoField " value="2707"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden"
                 name="lpurl" class="mktoField " value="https://pages.ubuntu.com/Form---autopilot-cloud-ebook_autopilot-cloud-ebook-landing-page.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden"
                 name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -69,7 +69,7 @@
             </li>
 
             <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--brand" onsubmit="backgroundSubmitHandler();">Download the eBook</button>
+              <button type="submit" class="mktoButton p-button--positive" onsubmit="backgroundSubmitHandler();">Download the eBook</button>
               <input type="hidden" name="formid" class="mktoField " value="1862">
               <input type="hidden" name="formVid" class="mktoField " value="1862">
               <input type="hidden" name="lpId" class="mktoField" value="3635">

--- a/templates/index_kylin.html
+++ b/templates/index_kylin.html
@@ -8,7 +8,7 @@
     <div class="u-equal-height u-vertically-center">
       <div class="col-7 suffix-1">
         <h1>亲， 您知道我们Ubuntu已经有正式的<a href="http://cn.ubuntu.com" >中文官方网站</a>了么?</h1>
-        <p><a href="http://cn.ubuntu.com" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'GeoIP China hoempage', 'eventLabel' : '现在就去看看吧 link', 'eventValue' : undefined });">现在就去看看吧</a></p>
+        <p><a href="http://cn.ubuntu.com" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'GeoIP China hoempage', 'eventLabel' : '现在就去看看吧 link', 'eventValue' : undefined });">现在就去看看吧</a></p>
         <p>Or continue browsing <a href="https://www.ubuntu.com/global">ubuntu.com</a></p>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hidden--small">

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -167,7 +167,7 @@
       </div>
       <div class="col-9">
         <h2>Will your next robot run on Ubuntu?</h2>
-        <p><a href="/internet-of-things/contact-us?product=robotics" class="p-button--brand">Contact us</a></p>
+        <p><a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive">Contact us</a></p>
       </div>
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -10,7 +10,7 @@
     <div class="col-8">
       <h1>Kubernetes for the enterprise</h1>
       <p>This is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.</p>
-      <p class="u-no-margin--top"><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?_ga=2.25375934.2035833349.1504518498-2070601899.1473694436" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Hero CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/containers/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Hero CTA' : undefined });">Contact sales</a></p>
+      <p class="u-no-margin--top"><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?_ga=2.25375934.2035833349.1504518498-2070601899.1473694436" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Hero CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/containers/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Hero CTA' : undefined });">Contact sales</a></p>
     </div>
     <div class="col-4 u-align--center u-hidden--small">
       <img src="{{ ASSET_SERVER_URL }}7c230fc3-kubernetes_certified_service_provider_logo.png?w=300" alt="Kubernetes Certified Service Provider" />
@@ -256,7 +256,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Test drive the Canonical Distribution of Kubernetes today!</h2>
-      <p class="u-no-margin--top"><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?_ga=2.25375934.2035833349.1504518498-2070601899.1473694436" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Bottom CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/containers/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Bottom CTA' : undefined });">Contact sales</a></p>
+      <p class="u-no-margin--top"><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?_ga=2.25375934.2035833349.1504518498-2070601899.1473694436" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Bottom CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/containers/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Bottom CTA' : undefined });">Contact sales</a></p>
     </div>
   </div>
 </section>

--- a/templates/legal/contributors/submit.html
+++ b/templates/legal/contributors/submit.html
@@ -586,7 +586,7 @@
                       </div>
                     </li>
                     <li class="actions">
-                      <input type="submit" class="p-button--brand" id="submit-" name="tfa_submitAction" value="I agree">
+                      <input type="submit" class="p-button--positive" id="submit-" name="tfa_submitAction" value="I agree">
                       <input type="hidden" value="237277" name="tfa_dbFormId" id="tfa_dbFormId">
                       <input type="hidden" value="" name="tfa_dbResponseId" id="tfa_dbResponseId">
                       <input type="hidden" value="d00afcc394fd0912b8a3895b593d43ef" name="tfa_dbControl" id="tfa_dbControl">

--- a/templates/legal/terms-and-policies/confidentiality-agreement.html
+++ b/templates/legal/terms-and-policies/confidentiality-agreement.html
@@ -502,7 +502,7 @@
                     </li>
                     <li class="p-list__item">
                       <div class="actions" id="tfa_0-A">
-                        <input type="submit" class="p-button--brand" value="I agree">
+                        <input type="submit" class="p-button--positive" value="I agree">
                       </div>
                       <div style="clear:both"></div>
                       <input type="hidden" value="353675" name="tfa_dbFormId" id="tfa_dbFormId">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -21,7 +21,7 @@
         <li class="p-list__item is-ticked">BootStack is a fully managed OpenStack cloud, on your hardware, in your data center, by Canonical</li>
         <li class="p-list__item is-ticked">Foundation Cloud Build includes set-up, design, architecture and training in one package by Canonical</li>
       </ul>
-      <p><a href="/download/cloud" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Openstack', 'eventLabel' : 'Install OpenStack ', 'eventValue' : undefined });">Install OpenStack</a></p>
+      <p><a href="/download/cloud" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Openstack', 'eventLabel' : 'Install OpenStack ', 'eventValue' : undefined });">Install OpenStack</a></p>
 
     </div>
     <div class="col-4">
@@ -103,7 +103,7 @@
         <li class="p-list__item is-ticked">Repeatable automated deployment</li>
         <li class="p-list__item is-ticked">Hardware guidance</li>
       </ul>
-      <p><a href="/cloud/contact-us?product=openstack" class="p-button--brand">Contact us for custom OpenStack engineering</a></p>
+      <p><a href="/cloud/contact-us?product=openstack" class="p-button--positive">Contact us for custom OpenStack engineering</a></p>
       <p><a href="/cloud/foundation-cloud">Learn more about Foundation Cloud Build&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 prefix-1">

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -9,7 +9,7 @@
     <div class="col-8">
       <h1>Ubuntu leads in hyperscale</h1>
       <p>Ubuntu is the hyperscale OS, natively powering scale-out workloads on a new wave of low-cost, ultra-dense hardware based on x86 and ARM processors.</p>
-      <p><a class="p-button--brand" href="/download/server">Download Ubuntu Server</a></p>
+      <p><a class="p-button--positive" href="/download/server">Download Ubuntu Server</a></p>
       <p><a href="/download/arm">Download Ubuntu for ARM &nbsp;&rsaquo;</a></p>
     </div>
   </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -15,7 +15,7 @@
     <div class="u-equal-height">
       <div class="col-6">
         <p>Ubuntu Server brings economic and technical scalability to your datacentre, public or private. Whether you want to deploy an OpenStack cloud, a Hadoop cluster or a 50,000-node render farm, Ubuntu Server delivers the best value scale-out performance available.</p>
-        <p><a class="p-button--brand" href="/download/server">Download Ubuntu Server</a></p>
+        <p><a class="p-button--positive" href="/download/server">Download Ubuntu Server</a></p>
       </div>
       <div class="col-6 u-vertically-center u-align--center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}4b47cae5-image-server.svg" width="400" height="121" alt="" />
@@ -207,7 +207,7 @@
       <div class="p-card">
         <h3 class="p-card__title">Get in touch</h3>
         <p class="p-card__content">Speak to our technical support team about your server requirements.</p>
-        <p class="p-card__content"><a class="p-button--brand" href="/server/contact-us?product=server-overview">Contact us</a></p>
+        <p class="p-card__content"><a class="p-button--positive" href="/server/contact-us?product=server-overview">Contact us</a></p>
       </div>
     </div>
   </div>

--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -14,7 +14,7 @@
     <div class="col-7">
       <h2>Apply critical kernel patches without rebooting.</h2>
       <p>Want to apply critical kernel security fixes without rebooting your system? The Canonical Livepatch Service for Ubuntu 16.04 LTS and Ubuntu 14.04 LTS reduces planned or unplanned downtime while maintaining compliance and security.</p>
-      <p><a class="p-button--brand" href="/livepatch">Sign up</a></p>
+      <p><a class="p-button--positive" href="/livepatch">Sign up</a></p>
     </div>
   </div>
 </div>

--- a/templates/server/maas/index.html
+++ b/templates/server/maas/index.html
@@ -10,7 +10,7 @@
       <img src="{{ ASSET_SERVER_URL }}4fac1d52-MAAS-Logo.svg" alt="MAAS"  width="250" />
       <h1>Transform your physical infrastructure into a cloud</h1>
       <p>MAAS is a server provisioning tool which offers complete automation of your physical servers for amazing data centre operational efficiency. On premises, open source and supported.</p>
-      <p><a href="/download/server/provisioning" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Try MAAS', 'eventLabel' : 'Try MAAS - Top CTA' : undefined });" class="p-button--brand">Try MAAS</a>&#8195;<a href="/server/maas/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Top CTA' : undefined });" class="p-button--neutral">Contact sales</a></p>
+      <p><a href="/download/server/provisioning" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Try MAAS', 'eventLabel' : 'Try MAAS - Top CTA' : undefined });" class="p-button--positive">Try MAAS</a>&#8195;<a href="/server/maas/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Top CTA' : undefined });" class="p-button--neutral">Contact sales</a></p>
     </div>
   </div>
 </section>
@@ -170,7 +170,7 @@
   <div class="row">
     <div class="col-8">
       <h2>MAAS is an open source bare-metal server provisioning tool, try it now.</h2>
-      <p class="u-no-margin--top"><a href="/download/server/provisioning" class="p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Try MAAS', 'eventLabel' : 'Try MAAS - Bottom CTA' : undefined });">Install MAAS</a>&#8195;<a href="/server/maas/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Bottom CTA' : undefined });">Contact sales</a></p>
+      <p class="u-no-margin--top"><a href="/download/server/provisioning" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Try MAAS', 'eventLabel' : 'Try MAAS - Bottom CTA' : undefined });">Install MAAS</a>&#8195;<a href="/server/maas/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Bottom CTA' : undefined });">Contact sales</a></p>
     </div>
   </div>
 </section>

--- a/templates/server/plans-and-pricing.html
+++ b/templates/server/plans-and-pricing.html
@@ -10,7 +10,7 @@
       <div class="col-6">
         <h1>Server plans and pricing</h1>
         <p>Get peace of mind with cost-effective systems management and professional support from Canonical, the Ubuntu experts.</p>
-        <p><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="p-button--brand"><span class="p-link--external">Buy Ubuntu Advantage online</span></a></p>
+        <p><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="p-button--positive"><span class="p-link--external">Buy Ubuntu Advantage online</span></a></p>
         <p><a href="https://landscape.canonical.com" class="p-link--external">Learn more about Landscape</a></p>
       </div>
       <div class="col-6 u-align--center u-vertically-center">

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -61,7 +61,7 @@
             </li>
             <li class="p-list__item">All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
             <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
           <input type="hidden" name="formid" class="mktoField" value="{{formid}}" />

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -71,7 +71,7 @@
               All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>.
             </li>
             <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--brand" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
           <!-- hidden fields -->

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -101,4 +101,4 @@
   </tbody>
 </table>
 
-<p><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="p-button--brand"><span class="p-link--external">Buy Ubuntu Advantage for servers</span></a></p>
+<p><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="p-button--positive"><span class="p-link--external">Buy Ubuntu Advantage for servers</span></a></p>

--- a/templates/support/esm.html
+++ b/templates/support/esm.html
@@ -10,7 +10,7 @@
     <div class="col-8">
       <h1>Ubuntu 12.04 ESM</h1>
       <p>In April 2017, Ubuntu 12.04 LTS reached its end-of-life. For Ubuntu Advantage customers who can not upgrade to a newer version of Ubuntu Server, Canonical is offering Ubuntu 12.04 ESM (Extended Security Maintenance). ESM provides ongoing security fixes for the kernel and essential packages through April 2019.</p>
-      <p><a href="https://buy.ubuntu.com/" class="p-button--brand">Buy Ubuntu Advantage</a></p>
+      <p><a href="https://buy.ubuntu.com/" class="p-button--positive">Buy Ubuntu Advantage</a></p>
       <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hidden--small">

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -13,7 +13,7 @@
     <div class="col-7">
       <h1>Ubuntu Advantage commercial support</h1>
       <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Ubuntu Advantage typically include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu {{lts_release_full}} systems.</p>
-      <p><a href="https://buy.ubuntu.com" class="p-button--brand"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
+      <p><a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hidden--small">
       <img alt="" src="{{ ASSET_SERVER_URL }}11da76f5-image-management.svg" class="u-full-width" />
@@ -99,7 +99,7 @@
       </li>
     </ul>
     <p>
-      <a href="/support/plans-and-pricing" class="p-button--brand">Learn more about Ubuntu Advantage</a>
+      <a href="/support/plans-and-pricing" class="p-button--positive">Learn more about Ubuntu Advantage</a>
     </p>
   </div>
 </section>
@@ -129,7 +129,7 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <p><a href="/support/contact-us?product=support-overview" class="p-button--brand">Any questions, contact us</a></p>
+      <p><a href="/support/contact-us?product=support-overview" class="p-button--positive">Any questions, contact us</a></p>
     </div>
   </div>
 </div>

--- a/templates/takeovers/_iot-business.html
+++ b/templates/takeovers/_iot-business.html
@@ -13,7 +13,7 @@
         'eventAction' : 'IoT business model takeover - 07/2017',
         'eventLabel' : 'Download the whitepaper',
         'eventValue' : undefined
-      });" class="p-button--brand">Download the whitepaper</a></p>
+      });" class="p-button--positive">Download the whitepaper</a></p>
     </div>
     <div class="u-hidden--small col-6">
       <img src="{{ ASSET_SERVER_URL }}ac9b8212-iot-business-model-takeover.svg" alt="" />

--- a/templates/takeovers/_maas_may_2017.html
+++ b/templates/takeovers/_maas_may_2017.html
@@ -5,7 +5,7 @@
       <h1>Maximise hardware efficiency</h1>
       <p class="p-heading--five">Build your data centre with <abbr title="Metal as a Service">MAAS</abbr>.</p>
       <div class="u-visible--small u-hidden--medium u-hidden--large"><img src="{{ ASSET_SERVER_URL }}3fb3f433-MAAS-takeover-illustration.svg" alt="MAAS service blocks illustration" /></div>
-      <p><a href="https://pages.ubuntu.com/eBook-MAAS.html?source=ubuntu.com&amp;medium=takeover&amp;campaign=MAAS_eBook " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Maas takeover - 26-05-2017', 'eventLabel' : 'Download the eBook', 'eventValue' : undefined });" class="p-button--brand">Download the eBook</a></p>
+      <p><a href="https://pages.ubuntu.com/eBook-MAAS.html?source=ubuntu.com&amp;medium=takeover&amp;campaign=MAAS_eBook " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Maas takeover - 26-05-2017', 'eventLabel' : 'Download the eBook', 'eventValue' : undefined });" class="p-button--positive">Download the eBook</a></p>
       <p><a href="/server/maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MAAS takeover', 'eventLabel' : 'Learn more about MAAS', 'eventValue' : undefined });">Learn more about MAAS &rsaquo;</a></p>
     </div>
     <div class="u-hidden--small col-6 u-vertically-center">

--- a/templates/takeovers/_tell-us-your-story.html
+++ b/templates/takeovers/_tell-us-your-story.html
@@ -13,7 +13,7 @@
         'eventAction' : 'Tell us your story - 08/2017',
         'eventLabel' : 'Submit a story',
         'eventValue' : undefined
-      });" class="p-button--brand">Submit a story</a></p>
+      });" class="p-button--positive">Submit a story</a></p>
     </div>
     <div class="u-hidden--small col-6 prefix-1">
       <img src="{{ ASSET_SERVER_URL }}98943ac1-Ubuntu-story-illustration.svg" alt="" />


### PR DESCRIPTION
## Done
Update the brand button to replicate to the positive button. Remove the link colour override.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Click about and see that brand/positive buttons are green and links are "Vanilla" blue

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2332
