### PR TITLE
Swap out screenshot on 1710 page with the one from the takeover

### DIFF
--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -15,7 +15,7 @@
       <p><a href="/download/desktop" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get Ubuntu 17.10', 'eventLabel' : 'Get Ubuntu 17.10 - hero' : undefined });">Get Ubuntu 17.10</a></p>
     </div>
     <div class="col-6 u-hidden--small ">
-      <img src="{{ ASSET_SERVER_URL }}0ace706d-LAPTOP%402x.png?w=654" alt="Laptop running Ubuntu 17.10, showing insights.ubuntu.com" />
+      <img src="{{ ASSET_SERVER_URL }}b0b06642-Laptop.png?w=654" alt="Laptop running Ubuntu 17.10, showing insights.ubuntu.com" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Swapped the image on the 17.10 page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/17.10](http://0.0.0.0:8001/desktop/17.10)

## Issue / Card

Fixes #2347