### PR TITLE
Set the external-link color on positive buttons

### DIFF
--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -6,7 +6,8 @@
   // XXX Ant: 16.10.17 - Can be removed when the following issue is resolved:
   // https://github.com/vanilla-framework/vanilla-framework/issues/1378
   [class^='p-strip'] .p-button--brand .p-link--external,
-  .p-strip--accent .p-link--external {
+  .p-strip--accent .p-link--external,
+  .p-button--positive .p-link--external {
     color: $color-x-light;
   }
 


### PR DESCRIPTION
## Done
Added a hotfix for an issue in Vanilla

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Check that the "Try now" button in the top section has white text now

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2349
