### PR TITLE
Added AWS Essential package to /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -119,7 +119,7 @@
     <div class="col-4 p-divider__block">
       <h4>Buy from AWS Marketplace</h4>
       <p>For Amazon AWS users, you can purchase Ubuntu Advantage through the AWS Marketplace.</p>
-      <p>Purchase <a href="https://aws.amazon.com/marketplace/pp/B01MZ1LSBQ?qid=1486382973569&sr=0-1&ref_=srh_res_product_title" class="p-link--external">Standard</a> or <a href="https://aws.amazon.com/marketplace/pp/B01N9JG6EM?qid=1490357851557&sr=0-7&ref_=srh_res_product_title" class="p-link--external">Advanced</a></p>
+      <p>Purchase <a href="https://aws.amazon.com/marketplace/pp/B0733NKN6C?qid=1508399270716&sr=0-2&ref_=srh_res_product_title" class="p-link--external">Essential</a>, <a href="https://aws.amazon.com/marketplace/pp/B01MZ1LSBQ?qid=1486382973569&sr=0-1&ref_=srh_res_product_title" class="p-link--external">Standard</a> or <a href="https://aws.amazon.com/marketplace/pp/B01N9JG6EM?qid=1490357851557&sr=0-7&ref_=srh_res_product_title" class="p-link--external">Advanced</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h4>Talk to a member of our team</h4>


### PR DESCRIPTION
## Done

- Added AWS Essential package to /support
- Updated [copydoc](https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit)

## QA

- Check that the /support page shows 'Purchase Essential, Standard, or Advanced' in the AWS Marketplace section
- Check that it links to the correct page


## Issue / Card

Fixes #2312 
