### PR TITLE
s/joule/up2 on IoT page

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -167,9 +167,9 @@
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
           <img src="{{ ASSET_SERVER_URL }}8cb47950-g46.png" style="height: 65px;" alt="Intel Up-squared" />
         </header>
-        <h3 class="p-card__title">Intel UP&sup2;</h3>
-        <p class="p-card__content">The Intel UP&sup2; is the world’s fastest x86 maker board based on latest Intel platform, Apollo Lake. As the successor of the UP board, it integrates seemlessly with Intel RealSense and features the same pin layout as the Raspberry Pi.</p>
-        <p class="p-card__content"><a href="http://www.up-board.org/upsquared/" class="p-link--external">Learn more on up-board.org</a></p>
+        <h3 class="p-card__title">Intel UP&sup2; Grove IoT kit</h3>
+        <p class="p-card__content">The Intel UP&sup2; Grove IoT Development Kit is a high performance board that provides a clear path to production, simple set up and configuration with pre-installed Ubuntu 16.04 LTS and IoT libraries.</p>
+        <p class="p-card__content"><a href="https://software.intel.com/en-us/iot/hardware/up-squared-grove-dev-kit" class="p-link--external">Learn more on intel.com</a></p>
       </div>
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -167,7 +167,7 @@
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
           <img src="{{ ASSET_SERVER_URL }}8cb47950-g46.png" style="height: 65px;" alt="Intel Up-squared" />
         </header>
-        <h3 class="p-card__title">Intel Up&sup2;</h3>
+        <h3 class="p-card__title">Intel UP&sup2;</h3>
         <p class="p-card__content">The Intel UP&sup2; is the world’s fastest x86 maker board based on latest Intel platforms Apollo Lake. Successor of the Up board, it integrates seemlessly with Intel RealSense and features the same pin layout as the Raspberry Pi.</p>
         <p class="p-card__content"><a href="http://www.up-board.org/upsquared/" class="p-link--external">Learn more on up-board.org</a></p>
       </div>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -168,7 +168,7 @@
           <img src="{{ ASSET_SERVER_URL }}8cb47950-g46.png" style="height: 65px;" alt="Intel Up-squared" />
         </header>
         <h3 class="p-card__title">Intel UP&sup2;</h3>
-        <p class="p-card__content">The Intel UP&sup2; is the world’s fastest x86 maker board based on latest Intel platforms Apollo Lake. Successor of the UP board, it integrates seemlessly with Intel RealSense and features the same pin layout as the Raspberry Pi.</p>
+        <p class="p-card__content">The Intel UP&sup2; is the world’s fastest x86 maker board based on latest Intel platform, Apollo Lake. As the successor of the UP board, it integrates seemlessly with Intel RealSense and features the same pin layout as the Raspberry Pi.</p>
         <p class="p-card__content"><a href="http://www.up-board.org/upsquared/" class="p-link--external">Learn more on up-board.org</a></p>
       </div>
       <div class="col-6 p-card">

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -168,7 +168,7 @@
           <img src="{{ ASSET_SERVER_URL }}8cb47950-g46.png" style="height: 65px;" alt="Intel Up-squared" />
         </header>
         <h3 class="p-card__title">Intel UP&sup2;</h3>
-        <p class="p-card__content">The Intel UP&sup2; is the world’s fastest x86 maker board based on latest Intel platforms Apollo Lake. Successor of the Up board, it integrates seemlessly with Intel RealSense and features the same pin layout as the Raspberry Pi.</p>
+        <p class="p-card__content">The Intel UP&sup2; is the world’s fastest x86 maker board based on latest Intel platforms Apollo Lake. Successor of the UP board, it integrates seemlessly with Intel RealSense and features the same pin layout as the Raspberry Pi.</p>
         <p class="p-card__content"><a href="http://www.up-board.org/upsquared/" class="p-link--external">Learn more on up-board.org</a></p>
       </div>
       <div class="col-6 p-card">

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -165,11 +165,11 @@
     <div class="u-equal-height">
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-          <img src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png" style="height: 65px;" alt="Intel Joule" />
+          <img src="{{ ASSET_SERVER_URL }}8cb47950-g46.png" style="height: 65px;" alt="Intel Up-squared" />
         </header>
-        <h3 class="p-card__title">Intel Joule</h3>
-        <p class="p-card__content">Intel&rsquo;s dedicated IoT modules bring 64-bit multi-core Atom processing to the connected device market, for rapid developer engagement and industry-standard code.</p>
-        <p class="p-card__content"><a href="https://software.intel.com/en-us/iot/hardware/joule" class="p-link--external">Learn more on intel.com</a></p>
+        <h3 class="p-card__title">Intel Up&sup2;</h3>
+        <p class="p-card__content">The Intel UP&sup2; is the world’s fastest x86 maker board based on latest Intel platforms Apollo Lake. Successor of the Up board, it integrates seemlessly with Intel RealSense and features the same pin layout as the Raspberry Pi.</p>
+        <p class="p-card__content"><a href="http://www.up-board.org/upsquared/" class="p-link--external">Learn more on up-board.org</a></p>
       </div>
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">


### PR DESCRIPTION
:warning: Please do not merge before Nov 2 :warning:

## Done

Acting on Intel feedback: replacing Joule by Up&sup2;

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001//internet-of-things](http://0.0.0.0:8001//internet-of-things)
- Scroll down the page and ensure the Up&sup2; box looks right.
