### PR TITLE
Make sales numbers an include for both /about and /cloud sections

### DIFF
--- a/templates/about/contact-us/index.html
+++ b/templates/about/contact-us/index.html
@@ -13,13 +13,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Sales enquiries</h2>
-      <ul class="p-list">
-        <li>Americas <a href="tel:+1 888 9861322">+1 888 9861322</a></li>
-        <li>Germany <a href="tel:+49 800 1838219">+49 800 1838219</a></li>
-        <li>France <a href="tel:+33 800914061">+33 800914061</a></li>
-        <li>Spain <a href="tel:+34 900 833872">+34 900 833872</a></li>
-        <li>UK and rest of world <a href="tel:+44 800 0588704">+44 800 0588704</a></li>
-      </ul>
+      {% include "shared/_call-sales-long.html" %}
       <p>Or <a href="/about/contact-us/form?product=generic-contact-us">contact us</a> at Canonical to discuss support, training or technical consulting and we will get in touch with you within two working days.</p>
     </div>
   </div>

--- a/templates/shared/_call-sales-long.html
+++ b/templates/shared/_call-sales-long.html
@@ -1,0 +1,8 @@
+<ul class="p-list--divided">
+  <li class="p-list__item">Americas <a href="tel:+18889861322" class="u-float--right">+1 888 9861322</a></li>
+  <li class="p-list__item">France <a href="tel:+33800914061" class="u-float--right">+33 800914061</a></li>
+  <li class="p-list__item">Germany <a href="tel:+498001838219" class="u-float--right">+49 800 1838219</a></li>
+  <li class="p-list__item">Japan <a href="tel:+81362053075" class="u-float--right">+81 3 6205 3075</a></li>
+  <li class="p-list__item">Spain <a href="tel:+34900833872" class="u-float--right">+34 900 833872</a></li>
+  <li class="p-list__item">UK and RoW <a href="tel:+448000588704" class="u-float--right">+44 800 0588704</a></li>
+</ul>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -92,14 +92,7 @@
     <div class="col-4">
       <div class="p-card">
         <h3 class="p-card__title">Any questions? Call us</h3>
-        <ul class="p-list--divided">
-          <li class="p-list__item">Americas <a href="tel:+18889861322" class="u-float--right">+1 888 9861322</a></li>
-          <li class="p-list__item">France <a href="tel:+33800914061" class="u-float--right">+33 800914061</a></li>
-          <li class="p-list__item">Germany <a href="tel:+498001838219" class="u-float--right">+49 800 1838219</a></li>
-          <li class="p-list__item">Japan <a href="tel:+81362053075" class="u-float--right">+81 3 6205 3075</a></li>
-          <li class="p-list__item">Spain <a href="tel:+34900833872" class="u-float--right">+34 900 833872</a></li>
-          <li class="p-list__item">UK and RoW <a href="tel:+448000588704" class="u-float--right">+44 800 0588704</a></li>
-        </ul>
+          {% include "shared/_call-sales-long.html" %}
       </div>
       <div class="p-card" />
         <h3 class="p-card__title">Need help with Ubuntu?</h3>


### PR DESCRIPTION
## Done

* Make sales numbers an include for both /about and /cloud sections
* Added Japan to the list
* Minor visual change to the about page
* Updated the [copy doc](https://docs.google.com/document/d/1v8mR0qE_AWVXBw0yQutdDaTmooodtMhc9dMzGqba4vg/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [cloud contact-us](http://0.0.0.0:8001/cloud/contact-us) and [about-us contact-us](http://0.0.0.0:8001/about/contact-us)
- See that it looks ok

## Issue / Card

Fixes #2353
