### PR TITLE
Fixed search icon encoding and secondary nav wrapping

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -127,7 +127,6 @@
 
     @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
       border-top: 1px solid $color-mid-light;
-      white-space: nowrap;
     }
 
     &__row {
@@ -197,7 +196,7 @@
     }
 
     &__menu {
-      display: inline-block;
+      display: inline;
       margin-top: 0;
       position: relative;
 
@@ -221,7 +220,6 @@
       background: $color-light;
       border-bottom: 1px solid $color-mid-light;
       padding: $sp-x-small 0 $sp-small;
-      white-space: nowrap;
 
       .p-breadcrumbs__item {
         margin-bottom: 0;
@@ -231,9 +229,8 @@
         color: $color-mid-dark;
         content: '\203A';
         font-weight: 400;
-        left: -$sp-small;
+        left: -$sp-medium;
         position: absolute;
-        top: 0;
       }
 
       .p-breadcrumbs__link {

--- a/static/sass/_pattern_site_search.scss
+++ b/static/sass/_pattern_site_search.scss
@@ -1,13 +1,12 @@
 @mixin ubuntu-p-site-search {
   .search-toggle {
-    background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 90 90'><g color='" + $color-x-light + "'><path fill='none' stroke-width='4' d='M0 0h90v90H0z'/><path d='M69 36.5a33 33.5 0 1 1-66 0 33 33.5 0 1 1 66 0z' transform='matrix(.636 0 0 .627 16.114 16.12)' fill='none' stroke='" + $color-x-light + "' stroke-width='9.5'/><path d='M55.77 52.92L52.94 55.75l14 14 2.83-2.83-14-14z' fill='" + $color-x-light + "' stroke-width='6' class='s0'/></g></svg>");
+    background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 90 90'><g color='%23fff'><path fill='none' stroke-width='4' d='M0 0h90v90H0z'/><path d='M69 36.5a33 33.5 0 1 1-66 0 33 33.5 0 1 1 66 0z' transform='matrix(.636 0 0 .627 16.114 16.12)' fill='none' stroke='%23fff' stroke-width='9.5'/><path d='M55.77 52.92L52.94 55.75l14 14 2.83-2.83-14-14z' fill='%23fff' stroke-width='6' class='s0'/></g></svg>");
     cursor: pointer;
     height: $sp-large;
     width: $sp-large;
 
     @media (min-width: $breakpoint-medium) {
       position: relative;
-      right: $sp-large;
     }
   }
 
@@ -22,6 +21,10 @@
     margin: .875rem 0;
     position: absolute;
     right: $sp-large * 3;
+
+    @media (min-width: $breakpoint-medium + 1) {
+      right: $sp-small;
+    }
 
     &__form {
       clear: both;
@@ -71,7 +74,7 @@
       @media (max-width: $breakpoint-medium - 1) {
         border-bottom: 1px solid #cdcdcd;
       }
-      
+
     }
 
     &__button {


### PR DESCRIPTION
## Done
- Fixed secondary nav overflowing between 768 and 1024px
- Fixed search icon overlapping nav at 769 - 836px
- Fixed search button being invisible on Firefox


## QA

- Check that the secondary nav on /cloud doesn't overflow beyond the div size (1030px)
- Check that the search icon doesn't overlap the nav between 769 - 836px
- Check that the search icon shows on small screens on Firefox


## Issue / Card

Fixes #2326, #2328, #2341 
