### PR TITLE
Updated Intel NUC link on digital-signage page

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -125,7 +125,7 @@
     <div class="u-equal-height">
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-          <a href="https://www.screenly.io/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}5917a214-logo-screenly.png" alt="Screenly logo" /></a>
+          <a href="https://www.screenly.io/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}5917a214-logo-screenly.png" alt="Screenly logo" /></a>
         </header>
         <h3 class="p-card__title">Screenly</h3>
         <p class="p-card__content">The world's most popular digital signage player for the Raspberry Pi.</p>
@@ -133,7 +133,7 @@
       </div>
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-          <a href="https://www.4yousee.com.br/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}391ea778-logo-4yousee.png" alt="4YouSee logo" /></a>
+          <a href="https://www.4yousee.com.br/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}391ea778-logo-4yousee.png" alt="4YouSee logo" /></a>
         </header>
         <h3 class="p-card__title">4YouSee</h3>
         <p class="p-card__content">A complete digital signage solution to create, manage and play your digital content, and analyse your audience.</p>
@@ -143,14 +143,14 @@
       <div class="u-equal-height">
         <div class="col-6 p-card">
           <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-            <a href="https://developer.ubuntu.com/en/snappy/start/intel-nuc/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" alt="Intel® NUC logo" /></a>
+            <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" alt="Intel® NUC logo" /></a>
           </header>
-          <h3 class="p-card__title">Intel® NUC</h3>
+          <h3 class="p-card__title">Intel<sup>®</sup> NUC</h3>
           <p class="p-card__content">Small size, low consumption, fanless operations and low cost mini-PC for digital display or retail kiosks.</p>
         </div>
         <div class="col-6 p-card">
           <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-            <a href="https://www.risevision.com/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}f2396b21-logo-risevision.png" alt="Rise Vision logo" /></a>
+            <a href="https://www.risevision.com/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}f2396b21-logo-risevision.png" alt="Rise Vision logo" /></a>
           </header>
           <h3 class="p-card__title">Rise Vision</h3>
           <p class="p-card__content">A simple solution for delivering content worth sharing to digital signage everywhere.</p>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -171,7 +171,7 @@
     <div class="u-equal-height">
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-          <a href="http://www.boldmind.co.uk/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}d4e5daf4-logo-boldmind.png" alt="Boldmind logo" /></a>
+          <a href="http://www.boldmind.co.uk/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}d4e5daf4-logo-boldmind.png" alt="Boldmind logo" /></a>
         </header>
         <h3 class="p-card__title">Boldmind</h3>
         <p class="p-card__content">Use data triggers to schedule content.</p>
@@ -179,7 +179,7 @@
       </div>
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-          <a href="http://www.limemicro.com/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}5e68dad7-logo-lime-microsystems.png" alt="Lime Micro logo" /></a>
+          <a href="http://www.limemicro.com/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}5e68dad7-logo-lime-microsystems.png" alt="Lime Micro logo" /></a>
         </header>
         <h3 class="p-card__title">Lime Micro</h3>
         <p class="p-card__content">Turn a digital signage player into a 4G base station.</p>
@@ -190,7 +190,7 @@
       <div class="u-equal-height">
         <div class="col-6 p-card">
           <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-            <a href="http://www.hoxtonanalytics.com/"><img style="height: 65px;" src="{{ ASSET_SERVER_URL }}d4ae60aa-logo-hoxton-analytics.svg" alt="Hoxton Analytics logo" /></a>
+            <a href="http://www.hoxtonanalytics.com/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}d4ae60aa-logo-hoxton-analytics.svg" alt="Hoxton Analytics logo" /></a>
           </header>
           <h3 class="p-card__title">Hoxton Analytics</h3>
           <p class="p-card__content">Turn your digital sign into a people counter.</p>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -139,22 +139,22 @@
         <p class="p-card__content">A complete digital signage solution to create, manage and play your digital content, and analyse your audience.</p>
       </div>
     </div>
-    <div class="row">
-      <div class="u-equal-height">
-        <div class="col-6 p-card">
-          <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-            <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" alt="Intel® NUC logo" /></a>
-          </header>
-          <h3 class="p-card__title">Intel<sup>®</sup> NUC</h3>
-          <p class="p-card__content">Small size, low consumption, fanless operations and low cost mini-PC for digital display or retail kiosks.</p>
-        </div>
-        <div class="col-6 p-card">
-          <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-            <a href="https://www.risevision.com/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}f2396b21-logo-risevision.png" alt="Rise Vision logo" /></a>
-          </header>
-          <h3 class="p-card__title">Rise Vision</h3>
-          <p class="p-card__content">A simple solution for delivering content worth sharing to digital signage everywhere.</p>
-        </div>
+  </div>
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 p-card">
+        <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+          <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" alt="Intel® NUC logo" /></a>
+        </header>
+        <h3 class="p-card__title">Intel<sup>®</sup> NUC</h3>
+        <p class="p-card__content">Small size, low consumption, fanless operations and low cost mini-PC for digital display or retail kiosks.</p>
+      </div>
+      <div class="col-6 p-card">
+        <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+          <a href="https://www.risevision.com/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}f2396b21-logo-risevision.png" alt="Rise Vision logo" /></a>
+        </header>
+        <h3 class="p-card__title">Rise Vision</h3>
+        <p class="p-card__content">A simple solution for delivering content worth sharing to digital signage everywhere.</p>
       </div>
     </div>
   </div>
@@ -186,15 +186,15 @@
         <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&utm_medium=dspagelimemicrobox&utm_campaign=DSwebinar" title="View Lime Micro webinar">View webinar</a>
       </div>
     </div>
-    <div class="row">
-      <div class="u-equal-height">
-        <div class="col-6 p-card">
-          <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
-            <a href="http://www.hoxtonanalytics.com/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}d4ae60aa-logo-hoxton-analytics.svg" alt="Hoxton Analytics logo" /></a>
-          </header>
-          <h3 class="p-card__title">Hoxton Analytics</h3>
-          <p class="p-card__content">Turn your digital sign into a people counter.</p>
-        </div>
+  </div>
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 p-card">
+        <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
+          <a href="http://www.hoxtonanalytics.com/"><img style="max-height: 65px; height: 65px;" src="{{ ASSET_SERVER_URL }}d4ae60aa-logo-hoxton-analytics.svg" alt="Hoxton Analytics logo" /></a>
+        </header>
+        <h3 class="p-card__title">Hoxton Analytics</h3>
+        <p class="p-card__content">Turn your digital sign into a people counter.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done
## Done

* Updated Intel NUC link on digital-signage page to point to Intel, not developer
* set max-height on logos as the Vanilla pattern changed and made the logos too small
* updated the [copy doc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [digital signage page](http://0.0.0.0:8001/internet-of-things/digital-signage)

## Issue / Card

Fixes #2356

## Screenshots

![image](https://user-images.githubusercontent.com/441217/32297329-c340c970-bf46-11e7-90f4-bced7d6bbcaa.png)
