### PR TITLE
Updated header and style of OpenStack pricing table

### DIFF
--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -4,12 +4,12 @@
       <thead>
         <tr>
           <td style="width: 40%;">&nbsp;</td>
-          <td>MAAS</td>
-          <td colspan="2"></td>
+          <th class=" u-align--center" style="width: 20%;">OpenStack</th>
+          <th class=" u-align--center" colspan="2">Ubuntu Advantage for OpenStack</th>
         </tr>
         <tr>
           <td>&nbsp;</td>
-          <th class="u-align--center" width="15%">Free</th>
+          <th class="u-align--center" width="15%">Without support</th>
           <th class="p-table__cell--highlight u-align--center">Advanced</th>
           <th class="p-table__cell--highlight u-align--center">Managed</th>
         </tr>
@@ -24,7 +24,7 @@
         <tr>
           <td>Or, price per region per year **</td>
           <td class="u-align--center">-</td>
-          <td class="p-table__cell--highlight"><small>Small: $95,000<br />Medium: $225,000<br />Large: $420,000</small></td>
+          <td class="p-table__cell--highlight u-align--center"><small>Small: $95,000<br />Medium: $225,000<br />Large: $420,000</small></td>
           <td class="p-table__cell--highlight u-align--center">-</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Done

* Updated header (which said 'MAAS' not 'Openstack' and was missing a row!) and style of OpenStack pricing table on /support/plans-and-pricing (centring)
* Corrected the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [support/plans-and-pricing page](http://0.0.0.0:8001/support/plans-and-pricing#openstack)


## Issue / Card

Fixes #2354

## Screenshots

old
![image](https://user-images.githubusercontent.com/441217/32298160-66326efc-bf49-11e7-9733-e5f9cae1c259.png)

new
![image](https://user-images.githubusercontent.com/441217/32298147-56e52c78-bf49-11e7-97e0-ff30da3e51ff.png)

