### PR TITLE
Changed to grey background for pricing tables in server section

### DIFF
--- a/templates/server/maas/index.html
+++ b/templates/server/maas/index.html
@@ -151,7 +151,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>Enterprise support for MAAS</h2>
@@ -166,7 +166,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>MAAS is an open source bare-metal server provisioning tool, try it now.</h2>

--- a/templates/server/plans-and-pricing.html
+++ b/templates/server/plans-and-pricing.html
@@ -20,7 +20,7 @@
   </div>
 </div>
 
-<div class="p-strip--light is-bordered">
+<div class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>Three ways to support and manage Ubuntu</h2>
@@ -57,7 +57,7 @@
   </div>
 </div>
 
-<section class="p-strip--x-light is-deep u-no-padding--bottom" id="ua-support">
+<section class="p-strip--light is-deep u-no-padding--bottom" id="ua-support">
   <div class="row">
     <div class="col-8">
       {% include "shared/pricing/_ua-overview.html" %}
@@ -67,7 +67,7 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-shallow">
+<section class="p-strip--light is-shallow">
   <div class="row" style="overflow-x: auto;">
     <div class="col-10">
       <h3>Ubuntu Advantage for servers</h3>
@@ -77,7 +77,7 @@
 </section>
 
 
-<section class="p-strip--x-light is-deep u-no-padding--top is-bordered">
+<section class="p-strip--light is-deep u-no-padding--top is-bordered">
   {% include "shared/pricing/_ua-server-support-add-ons.html" %}
 </section>
 
@@ -129,7 +129,7 @@
   </div>
 </div>
 
-<section class="p-strip is-deep is-bordered" id="maas">
+<section class="p-strip--light is-deep is-bordered" id="maas">
   <div class="row">
     <div class="col-8">
       <h2>Enterprise support for MAAS</h2>


### PR DESCRIPTION
## Done

* Changed to grey background for pricing tables in server section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [maas page](http://0.0.0.0:8001/server/maas) and [plans-and-pricing page](http://0.0.0.0:8001/server/plans-and-pricing)
- Compare to /support/plans-and-pricing

## Issue / Card

Fixes #2343
