### PR TITLE
2331: Added StuckStack ebook takeunder to homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -97,7 +97,7 @@
   <div class="row">
     <div class="u-equal-height">
       {% include "takeovers/takeunders/_iot-business-report-08-2017.html" %}
-      {% include "takeovers/takeunders/_stuck-stack.html" %}
+      {% include "takeovers/takeunders/_openstack-ebook.html" %}
     </div>
   </div>
 </section>

--- a/templates/takeovers/takeunders/_iot-business-report-08-2017.html
+++ b/templates/takeovers/takeunders/_iot-business-report-08-2017.html
@@ -1,7 +1,7 @@
-<div class="col-6 p-takeunder" style="background-color: #444444;">
-  <div class="row">
+<div class="col-6 p-takeunder u-vertically-center" style="background-color: #444444;">
+  <div class="row u-vertically-center">
     <div class="u-equal-height">
-      <div class="col-4 u-align--center u-hidden--small">
+      <div class="col-4 u-align--center u-vertically-center u-hidden--small">
         <img  src="{{ ASSET_SERVER_URL }}cebe4366-iot-orange-icon.svg" width="175" alt="" />
       </div>
       <div class="col-8">

--- a/templates/takeovers/takeunders/_openstack-ebook.html
+++ b/templates/takeovers/takeunders/_openstack-ebook.html
@@ -1,0 +1,22 @@
+<div class="col-6 p-takeunder u-vertically-center" style="background-color: #da2643;">
+  <div class="row u-vertically-center">
+    <div class="u-equal-height">
+      <div class="col-8">
+        <h3>
+          <a href="https://pages.ubuntu.com/stuckstack_download.html?utm_source=website&utm_medium=takeunder& "
+          onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'Homepage Link',
+            'eventAction' : 'OpenStack costs takeunder',
+            'eventLabel' : 'OpenStack costs increasing?',
+            'eventValue' : undefined
+          });">OpenStack costs increasing?&nbsp;&rsaquo;</a>
+        </h3>
+        <p>Keep control of costs with our four-step approach to OpenStack upgrades.</p>
+      </div>
+      <div class="col-4 u-align--center u-vertically-center u-hidden--small">
+        <img class="p-takeunder__image p-takeunder--right__image" src="{{ ASSET_SERVER_URL }}c8efedd7-OpenStack_Logo_white.svg" width="175" alt="" />
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Changed OpenStack takeunder on the index page as per [copydoc](https://docs.google.com/document/d/16L-rEd_H5Ryj683Wl8vjOxFNSgs4UJlcUdwfPmmFHgY/edit)
- NOTE: It has been decided to keep the same OpenStack logo


## QA

- Check that the new takeunder adheres to copydoc


## Issue / Card

Fixes #2331 
