### PR TITLE
Update up² link

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -169,7 +169,7 @@
         </header>
         <h3 class="p-card__title">Intel UP&sup2; Grove IoT kit</h3>
         <p class="p-card__content">The Intel UP&sup2; Grove IoT Development Kit is a high performance board that provides a clear path to production, simple set up and configuration with pre-installed Ubuntu 16.04 LTS and IoT libraries.</p>
-        <p class="p-card__content"><a href="https://software.intel.com/en-us/iot/hardware/up-squared-grove-dev-kit" class="p-link--external">Learn more on intel.com</a></p>
+        <p class="p-card__content"><a href="http://www.up-board.org/upkits/up-squared-grove-iot-development-kit/" class="p-link--external">Learn more on up-board.org.com</a></p>
       </div>
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">


### PR DESCRIPTION
## Done

* Update Up² link on /iot to point to the new page released by Intel http://www.up-board.org/upkits/up-squared-grove-iot-development-kit/

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/internet-of-things)
- Ensure the link works
