### PR TITLE
iot/up² name fix, revert link to initial location

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -168,7 +168,7 @@
           <img src="{{ ASSET_SERVER_URL }}8cb47950-g46.png" style="height: 65px;" alt="Intel Up-squared" />
         </header>
         <h3 class="p-card__title">UP Squared IoT Grove Development Kit</h3>
-        <p class="p-card__content">The UP Squared IoT Grove Development Kit provides a high performance board that provides a clear path to production, simple set up and configuration with pre-installed Ubuntu 16.04 LTS and IoT libraries.</p>
+        <p class="p-card__content">The UP Squared IoT Grove Development Kit is a high performance board and sensors pack that provides a clear path to production, simple set up and configuration with pre-installed Ubuntu 16.04 LTS and IoT libraries.</p>
         <p class="p-card__content"><a href="https://software.intel.com/en-us/iot/hardware/up-squared-grove-dev-kit" class="p-link--external">Learn more on intel.com</a></p>
       </div>
       <div class="col-6 p-card">

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -167,9 +167,9 @@
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">
           <img src="{{ ASSET_SERVER_URL }}8cb47950-g46.png" style="height: 65px;" alt="Intel Up-squared" />
         </header>
-        <h3 class="p-card__title">Intel UP&sup2; Grove IoT kit</h3>
-        <p class="p-card__content">The Intel UP&sup2; Grove IoT Development Kit is a high performance board that provides a clear path to production, simple set up and configuration with pre-installed Ubuntu 16.04 LTS and IoT libraries.</p>
-        <p class="p-card__content"><a href="http://www.up-board.org/upkits/up-squared-grove-iot-development-kit/" class="p-link--external">Learn more on up-board.org.com</a></p>
+        <h3 class="p-card__title">UP Squared IoT Grove Development Kit</h3>
+        <p class="p-card__content">The UP Squared IoT Grove Development Kit provides a high performance board that provides a clear path to production, simple set up and configuration with pre-installed Ubuntu 16.04 LTS and IoT libraries.</p>
+        <p class="p-card__content"><a href="https://software.intel.com/en-us/iot/hardware/up-squared-grove-dev-kit" class="p-link--external">Learn more on intel.com</a></p>
       </div>
       <div class="col-6 p-card">
         <header class="p-card__header no-border u-align--center u-vertically-center u-hidden--small" style="min-height: 8rem;">


### PR DESCRIPTION
## Done

* iot/up² name fix
* revert link to initial location

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things](http://0.0.0.0:8001/internet-of-things)
- Scroll down to Up² box, ensure title is correct and link works 