### PR TITLE
Remove 'has-background' from /support page and add to just hero row

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -4,11 +4,11 @@
 
 {% block title %}Support and management{% endblock %}
 
-{% block extra_body_class %}support-home has-background{% endblock %}
+{% block extra_body_class %}support-home{% endblock %}
 
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip has-background is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Ubuntu Advantage commercial support</h1>
@@ -186,7 +186,7 @@
 </div>
 </section>
 
-<section id="community-support" class="p-strip--light is-deep">
+<section id="community-support" class="p-strip--light has-background is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Community support</h2>


### PR DESCRIPTION
## Done

* removed `has-background` from whole page added it to just the hero row otherwise the background goes under the logo cloud

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [support page](http://0.0.0.0:8001/support)
- Review the visual changes

## Issue / Card

Fixes #2374