### PR TITLE
Remove instances of Autopilot

### DIFF
--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -190,5 +190,5 @@
     </div>
   </section>
 
-  {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_newsletter" third_item="_cloud_further_reading" %}
+  {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_newsletter" third_item="_cloud_further_reading" %}
 {% endblock content %}

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -418,7 +418,7 @@
   </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
 {% endblock content %}
 
 {% block footer_extra %}

--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -72,6 +72,6 @@
   </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
 
 {% endblock content %}

--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -92,6 +92,6 @@
   </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_newsletter" third_item="_cloud_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="" second_item="_cloud_newsletter" third_item="_cloud_further_reading" %}
 
 {% endblock content %}

--- a/templates/download/shared/_get_ebook.html
+++ b/templates/download/shared/_get_ebook.html
@@ -8,7 +8,7 @@
     <div class="col-7 suffix-1">
       <p class="u-hidden--small u-align--center"><img class="u-align--center" src="{{ ASSET_SERVER_URL }}8697cae9-openstack-made-easy-illustration.svg" height="335" alt="illusration"></p>
       <p>The phase change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge of deployment, integration and operations from a different perspective.</p>
-      <p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical&rsquo;s conjure-up and OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
+      <p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical&rsquo;s conjure-up and OpenStack can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
     </div>
     <div class="col-5">
       <!-- MARKETO FORM -->

--- a/templates/shared/contextual_footers/_cloud_autopilot.html
+++ b/templates/shared/contextual_footers/_cloud_autopilot.html
@@ -1,5 +1,0 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Build a cloud with Autopilot</h3>
-  <p>Deploy and manage your cloud quickly and easily.</p>
-  <p><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'OpenStack Autopilot', 'eventLabel' : 'Build a cloud with Autopilot', 'eventValue' : undefined });">Get started with OpenStack Autopilot&nbsp;&rsaquo;</a></p>
-</div>


### PR DESCRIPTION
## Done

Remove instances of Autopilot

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Compare the following pages with their live counterparts and make sure all instances of Autopilot have been remove from the copy
  - http://0.0.0.0:8001/cloud/partners
  - http://0.0.0.0:8001/cloud/foundation-cloud
  - http://0.0.0.0:8001/cloud/managed-cloud
  - http://0.0.0.0:8001/cloud/public-cloud
  - http://0.0.0.0:8001/download/cloud/try-openstack

## Issue / Card

Fixes #2302
