### PR TITLE
Add ITstrategen case study to /support

### DIFF
--- a/templates/desktop/government.html
+++ b/templates/desktop/government.html
@@ -41,7 +41,7 @@
     </div>
     <div class="col-6">
       <div style="overflow: hidden;">
-        <img class="u-image-position--top u-hidden--small" src="{{ ASSET_SERVER_URL }}99d49a7d-padlock-chain.png" alt="" style="top: -9%; z-index: -1;" />
+        <img class="u-image-position--top u-hidden--small" src="{{ ASSET_SERVER_URL }}8717cb84-padlock-chain-icon-angular.png?h=360" alt="" style="top: -9%; z-index: -1;" />
       </div>
     </div>
   </div>

--- a/templates/shared/_case-study-itstrategen.html
+++ b/templates/shared/_case-study-itstrategen.html
@@ -1,0 +1,12 @@
+<section class="p-strip is-deep u-image-position">
+  <div class="row">
+    <div class="col-6">
+      <h2>Learn how ITstrategen keeps their applications secure with Ubuntu</h2>
+      <p>The security of customer data is of the utmost importance to ITstrategen, which is why Ubuntu is their server operating system of choice.</p>
+      <a href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html" class="p-link--external">Read the case study</a>
+    </div>
+    <div class="col-6">
+      <img class="u-image-position--bottom u-hidden--small" src="{{ ASSET_SERVER_URL }}99d49a7d-padlock-chain.png" alt="" />
+    </div>
+  </div>
+</section>

--- a/templates/shared/_case-study-itstrategen.html
+++ b/templates/shared/_case-study-itstrategen.html
@@ -1,9 +1,9 @@
-<section class="p-strip is-deep u-image-position">
+<section class="p-strip is-deep u-image-position is-bordered">
   <div class="row">
     <div class="col-6">
       <h2>Learn how ITstrategen keeps their applications secure with Ubuntu</h2>
       <p>The security of customer data is of the utmost importance to ITstrategen, which is why Ubuntu is their server operating system of choice.</p>
-      <a href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html" class="p-link--external">Read the case study</a>
+      <a class="p-button--positive" href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html" class="p-link--external">Read the case study</a>
     </div>
     <div class="col-6">
       <img class="u-image-position--bottom u-hidden--small" src="{{ ASSET_SERVER_URL }}99d49a7d-padlock-chain.png" alt="" />

--- a/templates/shared/_case-study-itstrategen.html
+++ b/templates/shared/_case-study-itstrategen.html
@@ -6,7 +6,7 @@
       <a class="p-button--positive" href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html" class="p-link--external">Read the case study</a>
     </div>
     <div class="col-6">
-      <img class="u-image-position--bottom u-hidden--small" src="{{ ASSET_SERVER_URL }}99d49a7d-padlock-chain.png" alt="" />
+      <img class="u-image-position--top u-hidden--small" src="{{ ASSET_SERVER_URL }}8717cb84-padlock-chain-icon-angular.png?h=480" alt="" />
     </div>
   </div>
 </section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -186,6 +186,19 @@
 </div>
 </section>
 
+<section class="p-strip is-deep u-image-position">
+  <div class="row">
+    <div class="col-6">
+      <h2>Learn how ITstrategen keeps their applications secure with Ubuntu</h2>
+      <p>The security of customer data is of the utmost importance to ITstrategen, which is why Ubuntu is their server operating system of choice.</p>
+      <a href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html" class="p-link--external">Read the case study</a>
+    </div>
+    <div class="col-6">
+      <img class="u-image-position--bottom u-hidden--small" src="{{ ASSET_SERVER_URL }}99d49a7d-padlock-chain.png" alt="" />
+    </div>
+  </div>
+</section>
+
 <section id="community-support" class="p-strip--light has-background is-deep">
   <div class="row u-equal-height">
     <div class="col-8">

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -186,18 +186,7 @@
 </div>
 </section>
 
-<section class="p-strip is-deep u-image-position">
-  <div class="row">
-    <div class="col-6">
-      <h2>Learn how ITstrategen keeps their applications secure with Ubuntu</h2>
-      <p>The security of customer data is of the utmost importance to ITstrategen, which is why Ubuntu is their server operating system of choice.</p>
-      <a href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html" class="p-link--external">Read the case study</a>
-    </div>
-    <div class="col-6">
-      <img class="u-image-position--bottom u-hidden--small" src="{{ ASSET_SERVER_URL }}99d49a7d-padlock-chain.png" alt="" />
-    </div>
-  </div>
-</section>
+{% include "shared/_case-study-itstrategen.html" %}
 
 <section id="community-support" class="p-strip--light has-background is-deep">
   <div class="row u-equal-height">


### PR DESCRIPTION
## Done

Add new ITstrategen case study to /support overview page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support](http://0.0.0.0:8001/support)
- Make sure the case study has been added [as per the copy doc](https://docs.google.com/a/canonical.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit?disco=AAAABa0-_v4)

## Issue / Card

Doc: https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit#
Issue: https://app.zenhub.com/workspace/o/canonical-websites/www.ubuntu.com/issues/2398

Fixes #2398 
