### PR TITLE
Add ITstrategen case study to /server/livepatch

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -119,7 +119,9 @@
   </div>
 </div>
 
-<div class="p-strip">
+{% include "shared/_case-study-itstrategen.html" %}
+
+<div class="p-strip--light">
   <div class="row">
     <div class="u-height-equal">
       <div class="col-7">

--- a/templates/shared/_case-study-itstrategen.html
+++ b/templates/shared/_case-study-itstrategen.html
@@ -6,7 +6,7 @@
       <a class="p-button--positive" href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html" class="p-link--external">Read the case study</a>
     </div>
     <div class="col-6">
-      <img class="u-image-position--top u-hidden--small" src="{{ ASSET_SERVER_URL }}8717cb84-padlock-chain-icon-angular.png?h=480" alt="" />
+      <img class="u-image-position--top u-hidden--small" src="{{ ASSET_SERVER_URL }}37a8dd52-padlock-chain-icon-angular.svg" width="400" alt="" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add ITstrategen case study

## QA

### **Requires https://github.com/canonical-websites/www.ubuntu.com/pull/2402 to land first**

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/server/livepatch](http://0.0.0.0:8001/server/livepatch)
- Make sure the page contains the ITstrategen case study as per copy doc


## Issue / Card

Doc: https://docs.google.com/a/canonical.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit?disco=AAAABa0kIas

Fixes #2396 
