### PR TITLE
Update takeover image

### DIFF
--- a/templates/takeovers/_ues_takeover.html
+++ b/templates/takeovers/_ues_takeover.html
@@ -8,7 +8,7 @@
         <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Sign up now', 'eventValue' : undefined });" class="p-button--positive">Sign up now</a></p>
       </div>
       <div class="col-6 u-align--right">
-        <img src="{{ ASSET_SERVER_URL }}1a045963-IOT_edge_cloud_visual.svg" alt="" />
+        <img src="{{ ASSET_SERVER_URL }}9c1315fb-IOT_Ubuntu_devices_inforgrapic+v3.svg" alt="" />
       </div>
       <p class="u-hide--medium u-hide--large u-show--small"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Sign up now', 'eventValue' : undefined });" class="p-button--positive">Sign up now</a></p>
     </div>


### PR DESCRIPTION
## Done

* updated the homepage takeover image per Thibaut’s request

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/32607929-68eaa754-c552-11e7-82fe-48fac5b5a5c5.png)
