### PR TITLE
Update openstack zip pdf download asset

### DIFF
--- a/templates/download/shared/_get_ebook.html
+++ b/templates/download/shared/_get_ebook.html
@@ -119,7 +119,7 @@
   afterSubmit = function() {
     // Now start the download
     downloadFrame = document.createElement("iframe");
-    downloadFrame.setAttribute("src", "{{ ASSET_SERVER_URL }}f1bfc377-ebook_OpenStack_Made_Easy_20160726.pdf.zip");
+    downloadFrame.setAttribute("src", "{{ ASSET_SERVER_URL }}e922aac4-OpenStack-made-easy_eBook_11.17.zip");
     downloadFrame.style.width = 0 + "px";
     downloadFrame.style.height = 0 + "px";
     document.body.insertBefore(downloadFrame, document.body.childNodes[0]);


### PR DESCRIPTION
## Done

Update openstack zip pdf download asset

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/cloud/build-openstack](http://0.0.0.0:8001/download/cloud/build-openstack) and [http://0.0.0.0:8001/download/cloud/try-openstack](http://0.0.0.0:8001/download/cloud/try-openstack)
- Make sure the zip download has been updated to the latest version mentioned in the issue https://app.zenhub.com/workspace/o/canonical-websites/www.ubuntu.com/issues/2388


## Issue / Card

Fixes #2388 

Brief: https://docs.google.com/document/d/1GQLzMVe8f78EPm9OorJjuyFawxlu3nV-VLRjMcB2AAk/edit#heading=h.meo0azuz09li 
