### PR TITLE
Add resources strip to /cloud/foundation-cloud

### DIFF
--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -68,7 +68,9 @@
     </div>
   </section>
 
-{% include "shared/_resources_openstack.html"%}
+  <section class="p-strip--light is-deep is-bordered">
+    {% include "shared/_resources_openstack.html"%}
+  </section>
 
   <section class="p-strip is-bordered">
     <div class="row">

--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -68,40 +68,7 @@
     </div>
   </section>
 
-  <section class="p-strip--light is-deep is-bordered">
-    <div class="row">
-      <h2>Learn more about Openstack</h2>
-      <div class="row p-divider">
-        <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
-              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
-            </div>
-          </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'Learn how to upgrade your OpenStack cloud easily without downtime.', 'eventValue' : undefined });">Learn how to upgrade your OpenStack cloud easily without downtime</a></h2>
-        </div>
-        <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
-              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h3>
-            </div>
-          </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction', 'eventValue' : undefined });">Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction</a></h2>
-        </div>
-        <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
-              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h3>
-            </div>
-          </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to escaping StuckStack and profit from your OpenStack investment', 'eventValue' : undefined });">Our guide to escaping StuckStack and profit from your OpenStack investment</a></h2>
-        </div>
-      </div>
-    </div>
-  </section>
+{% include "shared/_resources_openstack.html"%}
 
   <section class="p-strip is-bordered">
     <div class="row">

--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -68,6 +68,41 @@
     </div>
   </section>
 
+  <section class="p-strip--light is-deep is-bordered">
+    <div class="row">
+      <h2>Learn more about Openstack</h2>
+      <div class="row p-divider">
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon u-no-margin--bottom">
+            <div class="p-heading-icon__header u-no-margin--bottom">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
+              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+            </div>
+          </div>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'Learn how to upgrade your OpenStack cloud easily without downtime.', 'eventValue' : undefined });">Learn how to upgrade your OpenStack cloud easily without downtime</a></h2>
+        </div>
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon u-no-margin--bottom">
+            <div class="p-heading-icon__header u-no-margin--bottom">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" alt="" />
+              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h3>
+            </div>
+          </div>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction', 'eventValue' : undefined });">Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction</a></h2>
+        </div>
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon u-no-margin--bottom">
+            <div class="p-heading-icon__header u-no-margin--bottom">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
+              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h3>
+            </div>
+          </div>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to escaping StuckStack and profit from your OpenStack investment', 'eventValue' : undefined });">Our guide to escaping StuckStack and profit from your OpenStack investment</a></h2>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-12">

--- a/templates/server/maas/index.html
+++ b/templates/server/maas/index.html
@@ -99,7 +99,7 @@
             <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Video</h3>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?source=maas_page&medium=Banner&campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h2>
+        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?source=maas_page&medium=Banner&campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the video - Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h2>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon u-no-margin--bottom">
@@ -108,7 +108,7 @@
             <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?source=maas_page&medium=Banner&campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h2>
+        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?source=maas_page&medium=Banner&campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the webinar - Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h2>
       </div>
     </div>
   </div>

--- a/templates/shared/_resources_openstack.html
+++ b/templates/shared/_resources_openstack.html
@@ -1,4 +1,3 @@
-  <section class="p-strip--light is-deep is-bordered">
     <div class="row">
       <h2>Learn more about Openstack</h2>
       <div class="row p-divider">
@@ -31,4 +30,3 @@
         </div>
       </div>
     </div>
-  </section>

--- a/templates/shared/_resources_openstack.html
+++ b/templates/shared/_resources_openstack.html
@@ -8,7 +8,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'Learn how to upgrade your OpenStack cloud easily without downtime.', 'eventValue' : undefined });">Learn how to upgrade your OpenStack cloud easily without downtime</a></h2>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'How to upgrade your OpenStack cloud easily without downtime', 'eventValue' : undefined });">How to upgrade your OpenStack cloud easily without downtime</a></h2>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
@@ -17,7 +17,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction', 'eventValue' : undefined });">Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction</a></h2>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping satisfy City Network customers', 'eventValue' : undefined });">Hear how Ubuntu is helping satisfy City Network customers</a></h2>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
@@ -26,7 +26,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to escaping StuckStack and profit from your OpenStack investment', 'eventValue' : undefined });">Our guide to escaping StuckStack and profit from your OpenStack investment</a></h2>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to profiting from your OpenStack investment', 'eventValue' : undefined });">Our guide to profiting from your OpenStack investment</a></h2>
         </div>
       </div>
     </div>

--- a/templates/shared/_resources_openstack.html
+++ b/templates/shared/_resources_openstack.html
@@ -8,7 +8,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'How to upgrade your OpenStack cloud easily without downtime', 'eventValue' : undefined });">How to upgrade your OpenStack cloud easily without downtime</a></h2>
+          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'How to upgrade your OpenStack cloud easily without downtime', 'eventValue' : undefined });">How to upgrade your OpenStack cloud easily without downtime</a></h2>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
@@ -17,7 +17,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping satisfy City Network customers', 'eventValue' : undefined });">Hear how Ubuntu is helping satisfy City Network customers</a></h2>
+          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping satisfy City Network customers', 'eventValue' : undefined });">Hear how Ubuntu is helping satisfy City Network customers</a></h2>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
@@ -26,7 +26,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to profiting from your OpenStack investment', 'eventValue' : undefined });">Our guide to profiting from your OpenStack investment</a></h2>
+          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to profiting from your OpenStack investment', 'eventValue' : undefined });">Our guide to profiting from your OpenStack investment</a></h2>
         </div>
       </div>
     </div>

--- a/templates/shared/_resources_openstack.html
+++ b/templates/shared/_resources_openstack.html
@@ -1,0 +1,34 @@
+  <section class="p-strip--light is-deep is-bordered">
+    <div class="row">
+      <h2>Learn more about Openstack</h2>
+      <div class="row p-divider">
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon u-no-margin--bottom">
+            <div class="p-heading-icon__header u-no-margin--bottom">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
+              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+            </div>
+          </div>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'Learn how to upgrade your OpenStack cloud easily without downtime.', 'eventValue' : undefined });">Learn how to upgrade your OpenStack cloud easily without downtime</a></h2>
+        </div>
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon u-no-margin--bottom">
+            <div class="p-heading-icon__header u-no-margin--bottom">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" alt="" />
+              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h3>
+            </div>
+          </div>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction', 'eventValue' : undefined });">Hear how Ubuntu is helping City Network reach new heights of quality and customer satisfaction</a></h2>
+        </div>
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon u-no-margin--bottom">
+            <div class="p-heading-icon__header u-no-margin--bottom">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
+              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h3>
+            </div>
+          </div>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to escaping StuckStack and profit from your OpenStack investment', 'eventValue' : undefined });">Our guide to escaping StuckStack and profit from your OpenStack investment</a></h2>
+        </div>
+      </div>
+    </div>
+  </section>


### PR DESCRIPTION
## Done

Add resources strip to /cloud/foundation-cloud

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud/foundation-cloud](http://0.0.0.0:8001/cloud/foundation-cloud)
- Check that the new 'resources' section has been added and is as per copy doc


## Issue / Card

Fixes #2408 

Doc: https://docs.google.com/a/canonical.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit?disco=AAAABa2uerY
