### PR TITLE
Update text in UA service-description

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -228,7 +228,7 @@
             <li class="p-list__item">For any deployments done under contract with Canonical, which results in customization of any Charms, customization will be valid for 90 days after the official release of the Charm which includes the customizations.</li>
             <li class="p-list__item">Support is included for all packages required to run OpenStack as deployed via the Foundation OpenStack Build engagement.</li>
             <li class="p-list__item">Upgrades of OpenStack components as part of the regular Ubuntu LTS maintenance cycle are supported.</li>
-            <li class="p-list__item">Upgrades between versions of OpenStack (for instance, from OpenStack Newton to Mitaka) or versions of Ubuntu (for instance, from Ubuntu 14.04 LTS to Ubuntu 16.04 LTS), Juju and MAAS are supported as long as the upgrade is performed following a documented process as specified by Canonical as part of the Foundation OpenStack Build.</li>
+            <li class="p-list__item">Upgrades between versions of OpenStack (for instance, from OpenStack Mitaka to Newton) or versions of Ubuntu (for instance, from Ubuntu 14.04 LTS to Ubuntu 16.04 LTS), Juju and MAAS are supported as long as the upgrade is performed following a documented process as specified by Canonical as part of the Foundation OpenStack Build.</li>
             <li class="p-list__item">Addition of new cloud nodes and replacement of existing nodes with new nodes of equivalent capacity are both supported.</li>
             <li class="p-list__item">Full Stack Support excludes customizations which are not considered Valid Customizations.</li>
             <li class="p-list__item">Ubuntu Advantage Virtual Guest Advanced services for Cloud Guests.</li>


### PR DESCRIPTION
## Done

* Updated text in service description from *OpenStack Newton to Mitaka* to *from OpenStack Mitaka to Newton*

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description)
- compare to the [copy doc](https://docs.google.com/document/d/1mrNrsC1WDf6QTg3nrVCEZS8vJzGz1fokvoFDVC4s_mI/edit)

## Issue / Card

Fixes #2422
