### PR TITLE
Removed duplicate intro

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -224,11 +224,6 @@
   <div class="row">
     <h2>Consulting packages</h2>
   </div>
-  <div class="row">
-    <div class="col-8">
-      <p >Canonical has two Kubernetes offerings: Kubernetes Explorer and Kubernetes Discoverer, but every Kubernetes we build is future-proof with automated upgrades to newer versions on demand.</p>
-    </div>
-  </div>
   {% include "shared/pricing/_kubernetes-consulting.html" %}
 </section>
 

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-8">
-    <p >Canonical has two Kubernetes offerings: Kubernetes Explorer and Kubernetes Discoverer, but every Kubernetes we build is future-proof with automated upgrades to newer versions on demand.</p>
+    <p>Canonical has two Kubernetes offerings: Kubernetes Explorer and Kubernetes Discoverer, but every Kubernetes we build is future-proof with automated upgrades to newer versions on demand.</p>
   </div>
 </div>
 <div class="row u-equal-height">


### PR DESCRIPTION
## Done

* Removed duplicate intro to the ‘Consulting packages’ section as it was moved into the include

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [[k8s page](http://0.0.0.0:8001/kubernetes) and the other location of the include - [plans and pricing page](http://0.0.0.0:8001/support/plans-and-pricing#kubernetes)

## Issue / Card

Fixes #2423