### PR TITLE
Replace Painless Kubernetes upgrade resource

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -119,7 +119,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Datasheet</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h2>
+          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h2>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
@@ -128,7 +128,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the Enterprise', 'eventLabel' : 'Resources - Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h2>
+          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the Enterprise', 'eventLabel' : 'Resources - Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h2>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
@@ -137,7 +137,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The no-nonsense way to accelerate your business with containers', 'eventLabel' : 'Resources - The no-nonsense way to accelerate your business with containers ', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h2>
+          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The no-nonsense way to accelerate your business with containers', 'eventLabel' : 'Resources - The no-nonsense way to accelerate your business with containers ', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h2>
         </div>
       </div>
     </div>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -128,7 +128,7 @@
               <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
             </div>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/03.UpgradingK8sclusters_LPOn-demandwebinar.html?utm_source=ubuntu.com&utm_medium=website&utm_campaign=On-demand%20webinar%20--%20Painless%20Kubernetes%20upgrades" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Painless Kubernetes upgrades', 'eventLabel' : 'Resources - Painless Kubernetes upgrades', 'eventValue' : undefined });">Painless Kubernetes upgrades</a></h2>
+          <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the Enterprise', 'eventLabel' : 'Resources - Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h2>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">


### PR DESCRIPTION
## Done

Replace 'Painless Kubernetes upgrade' resource
Removal of resource heading top margin

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/managed](http://0.0.0.0:8001/kubernetes/managed)
- Make sure the middle resource has been updated as per card and copy doc


## Issue / Card

Card: https://app.zenhub.com/workspace/o/canonical-websites/www.ubuntu.com/issues/2420
Doc: https://docs.google.com/document/d/1viNQgt99D2_b873Yd98iNT5vEzIbPQFgNI5XBFnszHk/edit
