### PR TITLE
Remove resource row heading margin top

### DIFF
--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -67,27 +67,27 @@
         <div class="p-heading-icon">
           <div class="p-heading-icon__header u-no-margin--bottom">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
-            <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Why private open cloud makes financial&nbsp;sense</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Why private open cloud makes financial&nbsp;sense</a></h3>
         </div>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header u-no-margin--bottom">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
-            <h3 class="p-heading-icon__title p-heading-icon__title--muted  p-muted-heading">Webinar</h3>
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Cloudbase-webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Run Windows workloads on BootStack', 'eventValue' : undefined });">Run Windows workloads on BootStack</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Cloudbase-webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Run Windows workloads on BootStack', 'eventValue' : undefined });">Run Windows workloads on BootStack</a></h3>
         </div>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header u-no-margin--bottom">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
-            <h3 class="p-heading-icon__title p-heading-icon__title--muted  p-muted-heading">Webinar</h3>
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
           </div>
-          <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Supermicro_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Build a hyperconverged cloud with BootStack and Supermicro', 'eventValue' : undefined });">Hyperconverged cloud with BootStack and&nbsp;Supermicro</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Supermicro_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Build a hyperconverged cloud with BootStack and Supermicro', 'eventValue' : undefined });">Hyperconverged cloud with BootStack and&nbsp;Supermicro</a></h3>
         </div>
       </div>
     </div>

--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -144,7 +144,7 @@
           <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Help</h3>
         </div>
       </div>
-      <h2 class="p-heading--four"><a class="p-link--external" href="https://launchpad.net/ubuntu/artful/+bugs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : '1710 report bug', 'eventLabel' : 'Help make 18.04 better by raising bugs', 'eventValue' : undefined });">Help make 18.04 better by raising bugs</a></h2>
+      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://launchpad.net/ubuntu/artful/+bugs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : '1710 report bug', 'eventLabel' : 'Help make 18.04 better by raising bugs', 'eventValue' : undefined });">Help make 18.04 better by raising bugs</a></h2>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon u-no-margin--bottom">
@@ -153,7 +153,7 @@
           <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Article</h3>
         </div>
       </div>
-      <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/12/ubuntu-desktop-gnome-extensions-poll-results/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventLabel' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventValue' : undefined });">The making of 17.10 &mdash; Choosing your preferred GNOME Extensions</a></h2>
+      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/12/ubuntu-desktop-gnome-extensions-poll-results/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventLabel' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventValue' : undefined });">The making of 17.10 &mdash; Choosing your preferred GNOME Extensions</a></h2>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon u-no-margin--bottom">
@@ -162,7 +162,7 @@
           <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">News</h3>
         </div>
       </div>
-      <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Stay in touch with the latest Ubuntu desktop news', 'eventLabel' : 'Stay in touch with the latest Ubuntu desktop news', 'eventValue' : undefined });">Stay in touch with the latest Ubuntu desktop news</a></h2>
+      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Stay in touch with the latest Ubuntu desktop news', 'eventLabel' : 'Stay in touch with the latest Ubuntu desktop news', 'eventValue' : undefined });">Stay in touch with the latest Ubuntu desktop news</a></h2>
     </div>
   </div>
 </section>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -41,10 +41,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Webinar</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Webinar</h4>
         </div>
       </div>
-      <h2 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h3>
       <!-- rtp section end -->
     </div>
 
@@ -53,10 +53,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Webinar</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Webinar</h4>
         </div>
       </div>
-      <h2 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Data-triggered content and 4G base stations</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Data-triggered content and 4G base stations</a></h3>
       <!-- rtp section end -->
     </div>
 
@@ -65,10 +65,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Case study</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Case study</h4>
         </div>
       </div>
-      <h2 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspag' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });'><span hidden>Read the case study </span>Open Source Digital Signage with Ubuntu</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspag' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });'><span hidden>Read the case study </span>Open Source Digital Signage with Ubuntu</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -35,10 +35,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Case study</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Case study</h4>
         </div>
       </div>
-      <h2 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/AzetiCS.html?campaign=Device_FY17_IOT&amp;medium=edgegatewaycontentblock&amp;source=ubuntuwebsite&amp;content=azeticasestudy' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - left', 'eventLabel' : 'Case study - Azeti uses Ubuntu Core to improve deployment operations and security', 'eventValue' : '1' });'><span hidden>Read the case study </span>Azeti uses Ubuntu Core to improve deployment operations and security</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/AzetiCS.html?campaign=Device_FY17_IOT&amp;medium=edgegatewaycontentblock&amp;source=ubuntuwebsite&amp;content=azeticasestudy' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - left', 'eventLabel' : 'Case study - Azeti uses Ubuntu Core to improve deployment operations and security', 'eventValue' : '1' });'><span hidden>Read the case study </span>Azeti uses Ubuntu Core to improve deployment operations and security</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_center">
@@ -46,10 +46,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Webinar</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Webinar</h4>
         </div>
       </div>
-      <h2 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - center', 'eventLabel' : 'Webinar - Watch CloudPlugs define Industry 4.0', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Watch CloudPlugs define Industry 4.0</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - center', 'eventLabel' : 'Webinar - Watch CloudPlugs define Industry 4.0', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Watch CloudPlugs define Industry 4.0</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_right">
@@ -57,10 +57,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>White paper</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>White paper</h4>
         </div>
       </div>
-      <h2 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'White paper - The Eclipse IoT Working Group outlines the three required software stacks', 'eventValue' : '1' });'><span hidden>Read the white paper </span>The Eclipse IoT Working Group outlines the three required software stacks</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'White paper - The Eclipse IoT Working Group outlines the three required software stacks', 'eventValue' : '1' });'><span hidden>Read the white paper </span>The Eclipse IoT Working Group outlines the three required software stacks</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -45,10 +45,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Case study</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Case study</h4>
         </div>
       </div>
-      <h2 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AerolionCS.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - left', 'eventLabel' : 'Case study - Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places', 'eventValue' : '1' });'><span hidden>Read the case study </span>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/AerolionCS.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - left', 'eventLabel' : 'Case study - Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places', 'eventValue' : '1' });'><span hidden>Read the case study </span>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_center">
@@ -56,10 +56,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Article</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Article</h4>
         </div>
       </div>
-      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_right">
@@ -67,10 +67,10 @@
       <div class='p-heading-icon u-no-margin--bottom'>
         <div class='p-heading-icon__header u-no-margin--bottom'>
           <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Article</h3>
+          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Article</h4>
         </div>
       </div>
-      <h2 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'Article - ROScon &mdash; the robotics conference for developers and entrepreneurs', 'eventValue' : '1' });'><span hidden>Read the article </span>ROScon &mdash; the robotics conference for developers and entrepreneurs</a></h2>
+      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'Article - ROScon &mdash; the robotics conference for developers and entrepreneurs', 'eventValue' : '1' });'><span hidden>Read the article </span>ROScon &mdash; the robotics conference for developers and entrepreneurs</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -153,28 +153,28 @@
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+          <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
         </div>
       </div>
-      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/09/webinar-how-to-get-started-with-your-kubernetes-strategy/?_ga=2.160429757.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'How to get started with your Kubernetes strategy', 'eventValue' : undefined });">How to get started with your Kubernetes strategy</a></h2>
+      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/09/webinar-how-to-get-started-with-your-kubernetes-strategy/?_ga=2.160429757.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'How to get started with your Kubernetes strategy', 'eventValue' : undefined });">How to get started with your Kubernetes strategy</a></h3>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+          <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
         </div>
       </div>
-      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h2>
+      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h3>
+          <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h4>
         </div>
       </div>
-      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/02/27/the-no-nonsense-way-to-accelerate-your-business-with-containers/?_ga=2.164082367.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h2>
+      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/02/27/the-no-nonsense-way-to-accelerate-your-business-with-containers/?_ga=2.164082367.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -116,28 +116,28 @@
           <div class="p-heading-icon u-no-margin--bottom">
             <div class="p-heading-icon__header u-no-margin--bottom">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Datasheet</h3>
+              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Datasheet</h4>
             </div>
           </div>
-          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
             <div class="p-heading-icon__header u-no-margin--bottom">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
             </div>
           </div>
-          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the Enterprise', 'eventLabel' : 'Resources - Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the Enterprise', 'eventLabel' : 'Resources - Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
             <div class="p-heading-icon__header u-no-margin--bottom">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h3>
+              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h4>
             </div>
           </div>
-          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The no-nonsense way to accelerate your business with containers', 'eventLabel' : 'Resources - The no-nonsense way to accelerate your business with containers ', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The no-nonsense way to accelerate your business with containers', 'eventLabel' : 'Resources - The no-nonsense way to accelerate your business with containers ', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
         </div>
       </div>
     </div>

--- a/templates/server/maas/index.html
+++ b/templates/server/maas/index.html
@@ -87,28 +87,28 @@
         <div class="p-heading-icon u-no-margin--bottom">
           <div class="p-heading-icon__header u-no-margin--bottom">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-            <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h3>
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h4>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Download the eBook - What you need to know about server provisioning', 'eventValue' : undefined });">What you need to know about server provisioning</a></h2>
+        <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Download the eBook - What you need to know about server provisioning', 'eventValue' : undefined });">What you need to know about server provisioning</a></h3>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon u-no-margin--bottom">
           <div class="p-heading-icon__header u-no-margin--bottom">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-            <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Video</h3>
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Video</h4>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?source=maas_page&medium=Banner&campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the video - Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h2>
+        <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?source=maas_page&medium=Banner&campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the video - Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h3>
       </div>
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon u-no-margin--bottom">
           <div class="p-heading-icon__header u-no-margin--bottom">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-            <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
           </div>
         </div>
-        <h2 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?source=maas_page&medium=Banner&campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the webinar - Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h2>
+        <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?source=maas_page&medium=Banner&campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the webinar - Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h3>
       </div>
     </div>
   </div>

--- a/templates/shared/_resources_openstack.html
+++ b/templates/shared/_resources_openstack.html
@@ -5,28 +5,28 @@
           <div class="p-heading-icon u-no-margin--bottom">
             <div class="p-heading-icon__header u-no-margin--bottom">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h3>
+              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
             </div>
           </div>
-          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'How to upgrade your OpenStack cloud easily without downtime', 'eventValue' : undefined });">How to upgrade your OpenStack cloud easily without downtime</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'How to upgrade your OpenStack cloud easily without downtime', 'eventValue' : undefined });">How to upgrade your OpenStack cloud easily without downtime</a></h3>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
             <div class="p-heading-icon__header u-no-margin--bottom">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h3>
+              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h4>
             </div>
           </div>
-          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping satisfy City Network customers', 'eventValue' : undefined });">Hear how Ubuntu is helping satisfy City Network customers</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping satisfy City Network customers', 'eventValue' : undefined });">Hear how Ubuntu is helping satisfy City Network customers</a></h3>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">
             <div class="p-heading-icon__header u-no-margin--bottom">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-              <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h3>
+              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h4>
             </div>
           </div>
-          <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to profiting from your OpenStack investment', 'eventValue' : undefined });">Our guide to profiting from your OpenStack investment</a></h2>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to profiting from your OpenStack investment', 'eventValue' : undefined });">Our guide to profiting from your OpenStack investment</a></h3>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Remove resource row heading margin top
- Change some headings to make more semantic

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
  - [http://0.0.0.0:8001/internet-of-things/digital-signage](http://0.0.0.0:8001/internet-of-things/digital-signage)
  - [http://0.0.0.0:8001/internet-of-things/gateways](http://0.0.0.0:8001/internet-of-things/gateways)
  - [http://0.0.0.0:8001/internet-of-things/robotics](http://0.0.0.0:8001/internet-of-things/robotics)
  - [http://0.0.0.0:8001/desktop/1710](http://0.0.0.0:8001/desktop/1710)
  - [http://0.0.0.0:8001/server/maas](http://0.0.0.0:8001/server/maas)
  - [http://0.0.0.0:8001/openstack](http://0.0.0.0:8001/openstack)
  - [http://0.0.0.0:8001/cloud/managed-cloud](http://0.0.0.0:8001/cloud/managed-cloud)
  - [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
  - [http://0.0.0.0:8001/kubernetes/managed](http://0.0.0.0:8001/kubernetes/managed)

- Make sure the resource type rows have reduced margin above heading links

### Old (bad)

![screen shot 2017-11-20 at 10 25 49](https://user-images.githubusercontent.com/2152/33013842-45590da6-cddd-11e7-9b6b-ae2098837ebf.png)

### New (good)

![screen shot 2017-11-20 at 10 26 08](https://user-images.githubusercontent.com/2152/33013854-4d1e7648-cddd-11e7-91af-edd9a7392a0e.png)

## Issue / Card

Fixes #2358 
