### PR TITLE
Build the initial resources page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -375,3 +375,11 @@ legal:
         - title: Thank you
           path: /legal/terms-and-policies/thank-you
           hidden: True
+
+resources:
+  title: Resources
+  path: /resources
+
+  children:
+    - title: Overview
+      path: /resources

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -1,0 +1,15 @@
+{% extends "templates/one-column.html" %}
+
+{% block meta_description %}Resources from across Ubuntu and Canonical combined into a single portal{% endblock %}
+
+{% block title %}Resources{% endblock %}
+
+{% block content %}
+
+<section class="p-strip">
+  <div class="row">
+    <h1>Resources</h1>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -100,6 +100,7 @@
             {% include 'templates/_menu_section.html' with section=nav_sections.iot %}
             {% include 'templates/_menu_section.html' with section=nav_sections.support %}
             {% include 'templates/_menu_section.html' with section=nav_sections.download %}
+            {% include 'templates/_menu_section.html' with section=nav_sections.resources %}
           </ul>
         </nav>
 


### PR DESCRIPTION
## Done
Add resources to the navigation. Created a stub page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the navigation has `resources`
- Click and check it goes to a stub page

## Issue / Card
Fixes https://github.com/ubuntudesign/web-squad/issues/261
