### PR TITLE
Add Rancher section on /Kubernetes

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -40,9 +40,9 @@
     <div class="col-6 p-divider__block">
       <h2>In partnership with Google&nbsp;GKE</h2>
       <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
-      <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
+      <p><a href="https://cloud.google.com/kubernetes-engine/docs/node-images#ubuntu" class="p-link--external">Try GKE with Ubuntu now</a></p>
       <div class="u-align--center u-hidden--small">
-        <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine" />
+        <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine logo" />
       </div>
     </div>
     <div class="col-6 p-divider__block">
@@ -50,7 +50,7 @@
       <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximize developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
       <p><a href="#" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar [Need link]</a></p>
       <div class="u-align--center u-hidden--small">
-        <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="240" alt="" />
+        <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="240" alt="Rancher Labs logo" />
       </div>
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -35,28 +35,28 @@
   </div>
 </section>
 
-<section id="partnerships-rancher" class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-6">
-      <h2>Cloud native platform</h3>
+<section id="partnerships-rancher" class="p-strip--accent">
+  <div class="row  u-vertically-center">
+    <div class="col-7">
+      <h2>Cloud Native Platform</h3>
       <p>Canonical, in partnership with Rancher Labs, delivers the Cloud Native Platform. The Cloud Native Platform is a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
-      <p><a href="https://www.brighttalk.com/webcast/6793/292819" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
+      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
     </div>
-    <div class="col-6 u-align--center u-hidden--small">
+    <div class="col-4 prefix-1 u-align--center u-hidden--small">
       <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="270" alt="Rancher Labs logo" />
     </div>
   </div>
 </section>
 
 <section id="partnerships-google-gke" class="p-strip is-bordered">
-  <div class="row">
-    <div  class="col-8">
-      <h3>Google&nbsp;GKE</h3>
+  <div class="row u-vertically-center">
+    <div class="col-4  u-hidden--small u-align--center">
+      <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine logo" />
+    </div>
+    <div class="col-8">
+      <h2>Google&nbsp;GKE</h2>
       <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
       <p><a href="https://cloud.google.com/kubernetes-engine/docs/node-images#ubuntu" class="p-link--external">Try GKE with Ubuntu now</a></p>
-      <div class="u-hidden--small">
-        <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine logo" />
-      </div>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -43,7 +43,7 @@
       <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
     </div>
     <div class="col-4 prefix-1 u-align--center u-hidden--small">
-      <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="270" alt="Rancher Labs logo" />
+      <img src="{{ ASSET_SERVER_URL }}85700cb3-rancher_cloud_partnerships_visual.svg" width="270" alt="Rancher Labs logo" />
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -40,7 +40,7 @@
     <h2>Partnerships</h2>
   </div>
   <div class="row">
-    <div class="col-6">
+    <div id="partnerships-google-gke" class="col-6">
       <h3>Google&nbsp;GKE</h3>
       <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
       <p><a href="https://cloud.google.com/kubernetes-engine/docs/node-images#ubuntu" class="p-link--external">Try GKE with Ubuntu now</a></p>
@@ -48,10 +48,10 @@
         <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine logo" />
       </div>
     </div>
-    <div class="col-6">
+    <div id="partnerships-rancher" class="col-6">
       <h3>Rancher&nbsp;Labs</h3>
       <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
-      <p><a href="#" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar [Need link]</a></p>
+      <p><a href="https://www.brighttalk.com/webcast/6793/292819" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
       <div class="u-align--center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="270" alt="Rancher Labs logo" />
       </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -40,7 +40,7 @@
     <div class="col-6">
       <h2>Cloud Native Platform</h3>
       <p>Canonical, in partnership with Rancher Labs, delivers the Cloud Native Platform. The Cloud Native Platform is a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
-      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
+      <p><a class="p-link--external p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
     </div>
     <div class="col-6 prefix-1 u-align--center u-hidden--small">
       <img src="{{ ASSET_SERVER_URL }}85700cb3-rancher_cloud_partnerships_visual.svg" alt="Rancher Labs logo" />

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -35,25 +35,27 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section id="partnerships-rancher" class="p-strip is-bordered">
   <div class="row">
-    <h2>Partnerships</h2>
+    <div class="col-6">
+      <h2>Cloud native platform</h3>
+      <p>Canonical, in partnership with Rancher Labs, delivers the Cloud Native Platform. The Cloud Native Platform is a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
+      <p><a href="https://www.brighttalk.com/webcast/6793/292819" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
+    </div>
+    <div class="col-6 u-align--center u-hidden--small">
+      <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="270" alt="Rancher Labs logo" />
+    </div>
   </div>
+</section>
+
+<section id="partnerships-google-gke" class="p-strip is-bordered">
   <div class="row">
-    <div id="partnerships-google-gke" class="col-6">
+    <div  class="col-8">
       <h3>Google&nbsp;GKE</h3>
       <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
       <p><a href="https://cloud.google.com/kubernetes-engine/docs/node-images#ubuntu" class="p-link--external">Try GKE with Ubuntu now</a></p>
-      <div class="u-align--center u-hidden--small">
+      <div class="u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine logo" />
-      </div>
-    </div>
-    <div id="partnerships-rancher" class="col-6">
-      <h3>Rancher&nbsp;Labs</h3>
-      <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
-      <p><a href="https://www.brighttalk.com/webcast/6793/292819" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
-      <div class="u-align--center u-hidden--small">
-        <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="270" alt="Rancher Labs logo" />
       </div>
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -35,6 +35,20 @@
   </div>
 </section>
 
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h1>The Cloud Native Platform</h1>
+      <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximize developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
+      <p><a href="/containers/contact-us" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Hero CTA' : undefined });">Contact sales</a></p>
+
+    </div>
+    <div class="col-4 u-align--center u-hidden--small">
+      <img src="https://picsum.photos/300/300" alt="" />
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light is-bordered">
   <div class="row">
     <h2 >Get started</h2>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -36,21 +36,24 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row p-divider">
-    <div class="col-6 p-divider__block">
-      <h2>In partnership with Google&nbsp;GKE</h2>
+  <div class="row">
+    <h2>Partnerships</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Google&nbsp;GKE</h3>
       <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
       <p><a href="https://cloud.google.com/kubernetes-engine/docs/node-images#ubuntu" class="p-link--external">Try GKE with Ubuntu now</a></p>
       <div class="u-align--center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine logo" />
       </div>
     </div>
-    <div class="col-6 p-divider__block">
-      <h2>In partnership with Rancher&nbsp;Labs</h2>
+    <div class="col-6">
+      <h3>Rancher&nbsp;Labs</h3>
       <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
       <p><a href="#" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar [Need link]</a></p>
       <div class="u-align--center u-hidden--small">
-        <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="240" alt="Rancher Labs logo" />
+        <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="270" alt="Rancher Labs logo" />
       </div>
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -37,13 +37,13 @@
 
 <section id="partnerships-rancher" class="p-strip--accent">
   <div class="row  u-vertically-center">
-    <div class="col-7">
+    <div class="col-6">
       <h2>Cloud Native Platform</h3>
       <p>Canonical, in partnership with Rancher Labs, delivers the Cloud Native Platform. The Cloud Native Platform is a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
       <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
     </div>
-    <div class="col-4 prefix-1 u-align--center u-hidden--small">
-      <img src="{{ ASSET_SERVER_URL }}85700cb3-rancher_cloud_partnerships_visual.svg" width="270" alt="Rancher Labs logo" />
+    <div class="col-6 prefix-1 u-align--center u-hidden--small">
+      <img src="{{ ASSET_SERVER_URL }}85700cb3-rancher_cloud_partnerships_visual.svg" alt="Rancher Labs logo" />
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -139,7 +139,7 @@
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title p-heading--five">GPU and CUDA ready</h3>
-            <p class="p-matrix__desc">Automatically detect and configure GPGPU resources for accelerated machine learning, AI, transcoding and HPC workloads on K8s.</p>
+            <p class="p-matrix__desc">Automatically detect and configure GPGPU resources for accelerated machine learning, AI and transcoding workloads on K8s.</p>
           </div>
         </li>
         <li class="p-matrix__item">

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -48,7 +48,7 @@
     <div class="col-6 p-divider__block">
       <h2>In partnership with Rancher&nbsp;Labs</h2>
       <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximize developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
-      <p><a href="/containers/contact-us" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
+      <p><a href="#" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar [Need link]</a></p>
       <div class="u-align--center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="240" alt="" />
       </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -36,15 +36,22 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-8">
-      <h1>The Cloud Native Platform</h1>
-      <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximize developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
-      <p><a href="/containers/contact-us" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Hero CTA' : undefined });">Contact sales</a></p>
-
+  <div class="row p-divider">
+    <div class="col-6 p-divider__block">
+      <h2>In partnership with Google&nbsp;GKE</h2>
+      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
+      <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
+      <div class="u-align--center u-hidden--small">
+        <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=200" alt="Google Container Engine" />
+      </div>
     </div>
-    <div class="col-4 u-align--center u-hidden--small">
-      <img src="https://picsum.photos/300/300" alt="" />
+    <div class="col-6 p-divider__block">
+      <h2>In partnership with Rancher</h2>
+      <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximize developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
+      <p><a href="/containers/contact-us" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
+      <div class="u-align--center u-hidden--small">
+        <img src="https://picsum.photos/150/150" alt="" />
+      </div>
     </div>
   </div>
 </section>
@@ -77,19 +84,6 @@
       <div class="u-embedded-media">
         <iframe class="u-embedded-media__element" src="https://player.vimeo.com/video/190300823?color=ffffff&title=0&byline=0&portrait=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-8">
-      <h2>In partnership with Google GKE</h2>
-      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s alignment.</p>
-      <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
-    </div>
-    <div class="col-4">
-      <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png" alt="Google Container Engine" />
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -42,15 +42,15 @@
       <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
       <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
       <div class="u-align--center u-hidden--small">
-        <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=200" alt="Google Container Engine" />
+        <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine" />
       </div>
     </div>
     <div class="col-6 p-divider__block">
-      <h2>In partnership with Rancher</h2>
+      <h2>In partnership with Rancher&nbsp;Labs</h2>
       <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximize developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
       <p><a href="/containers/contact-us" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
       <div class="u-align--center u-hidden--small">
-        <img src="https://picsum.photos/150/150" alt="" />
+        <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="240" alt="" />
       </div>
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -47,7 +47,7 @@
     </div>
     <div class="col-6 p-divider__block">
       <h2>In partnership with Rancher&nbsp;Labs</h2>
-      <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximize developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
+      <p>Canonical, in partnership with Rancher Labs, delivers The Cloud Native Platform: a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
       <p><a href="#" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar [Need link]</a></p>
       <div class="u-align--center u-hidden--small">
         <img src="{{ ASSET_SERVER_URL }}8f878ba0-rancher-logo-stacked-color.svg" width="240" alt="Rancher Labs logo" />

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -25,7 +25,7 @@
       <h3 class="p-heading--five">Kubernetes Discoverer</h3>
       <p class="p-heading--two">$35,000 <span class="p-heading--six">one off fee</span></p>
     </div>
-    <p>Get a customized architecture to fit your  requirements, including bare-metal environments or custom integrations, with many optional add ons.</p>
+    <p>Get a customised architecture to fit your  requirements, including bare-metal environments or custom integrations, with many optional add ons.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">High availability Kubernetes, deployed on Public Cloud, VMware, OpenStack, or Bare metal</li>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -9,10 +9,10 @@
       <h3 class="p-heading--five">Kubernetes Explorer</h3>
       <p class="p-heading--two">$15,000 <span class="p-heading--six">one off fee</span></p>
     </div>
-    <p>Get up and running quickly with minimal setup, predefined architecture and on-site training.</p>
+    <p>Get up and running quickly with minimal setup, predefined architecture and web-based training.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
-      <li class="p-list__item is-ticked">High availability Kubernetes, deployed on cloud or VMware</li>
+      <li class="p-list__item is-ticked">High availability Kubernetes, deployed on public cloud</li>
       <li class="p-list__item is-ticked">Reference architecture</li>
       <li class="p-list__item is-ticked">NodePort and Flannel networking</li>
       <li class="p-list__item is-ticked">8 hours hands-on, web-based training</li>
@@ -25,12 +25,12 @@
       <h3 class="p-heading--five">Kubernetes Discoverer</h3>
       <p class="p-heading--two">$35,000 <span class="p-heading--six">one off fee</span></p>
     </div>
-    <p>Get a customised architecture to fit your  requirements, including bare-metal environments or custom integrations, with many optional add ons.</p>
+    <p>Get a customised architecture to fit your requirements, including bare-metal environments or custom integrations and on-site training.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">High availability Kubernetes, deployed on Public Cloud, VMware, OpenStack, or Bare metal</li>
       <li class="p-list__item is-ticked">Custom Kubernetes architecture optimised for your workloads</li>
-      <li class="p-list__item is-ticked">Any CNI-compatible network (Calico, Flannel, Weave)</li>
+      <li class="p-list__item is-ticked">Any CNI-compatible network (Calico, Canal, Flannel, Weave)</li>
       <li class="p-list__item is-ticked">4 days on-site  in-person training</li>
       <li class="p-list__item is-ticked">30 days of phone support *</li>
     </ul>


### PR DESCRIPTION
# Please don't merge until 5 December

## Done

Add Rancher section on /Kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Make sure the copy correlates with the doc


## Issue / Card

Fixes #2438 and #2453 
Doc: https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#
