### PR TITLE
Pull the insights feeds and display the basic list on resources

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -20,12 +20,19 @@
     <h2>Case studies</h2>
     {% if case_studies is False %}
     <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
     </div>
     {% else %}
+    {% if case_studies|length is 0 %}
+    <div class="p-notification--information">
+      <p class="p-notification__response">
+        <span class="p-notification__status">Information:</span> There were no results found for this category
+      </p>
+    </div>
+    {% endif %}
     <ul class='p-list'>
       {% for item in case_studies %}
-        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}
     </ul>
     {% endif %}
@@ -38,12 +45,19 @@
     <h2>Webinars</h2>
     {% if webinars is False %}
     <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
     </div>
     {% else %}
+    {% if webinars|length is 0 %}
+    <div class="p-notification--information">
+      <p class="p-notification__response">
+        <span class="p-notification__status">Information:</span> There were no results found for this category
+      </p>
+    </div>
+    {% endif %}
     <ul class='p-list'>
       {% for item in webinars %}
-        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}
     </ul>
     {% endif %}
@@ -56,12 +70,19 @@
     <h2>White papers</h2>
     {% if white_papers is False %}
     <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
     </div>
     {% else %}
+    {% if white_papers|length is 0 %}
+    <div class="p-notification--information">
+      <p class="p-notification__response">
+        <span class="p-notification__status">Information:</span> There were no results found for this category
+      </p>
+    </div>
+    {% endif %}
     <ul class='p-list'>
       {% for item in white_papers %}
-        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}
     </ul>
     {% endif %}
@@ -74,12 +95,19 @@
     <h2>Tutorials</h2>
     {% if tutorials is False %}
     <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
     </div>
     {% else %}
+    {% if tutorials|length is 0 %}
+    <div class="p-notification--information">
+      <p class="p-notification__response">
+        <span class="p-notification__status">Information:</span> There were no results found for this category
+      </p>
+    </div>
+    {% endif %}
     <ul class='p-list'>
       {% for item in tutorials %}
-        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}
     </ul>
     {% endif %}

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -30,7 +30,7 @@
       </p>
     </div>
     {% endif %}
-    <ul class='p-list'>
+    <ul class="p-list">
       {% for item in case_studies %}
         <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}
@@ -55,7 +55,7 @@
       </p>
     </div>
     {% endif %}
-    <ul class='p-list'>
+    <ul class="p-list">
       {% for item in webinars %}
         <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}
@@ -80,7 +80,7 @@
       </p>
     </div>
     {% endif %}
-    <ul class='p-list'>
+    <ul class="p-list">
       {% for item in white_papers %}
         <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}
@@ -105,7 +105,7 @@
       </p>
     </div>
     {% endif %}
-    <ul class='p-list'>
+    <ul class="p-list">
       {% for item in tutorials %}
         <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
       {% endfor %}

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -6,9 +6,83 @@
 
 {% block content %}
 
-<section class="p-strip">
+
+
+<section class="p-strip--accent is-shallow">
   <div class="row">
     <h1>Resources</h1>
+  </div>
+</section>
+
+{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=1172" limit=10 as case_studies %}
+<section class="p-strip is-shallow">
+  <div class="row">
+    <h2>Case studies</h2>
+    {% if case_studies is False %}
+    <div class="p-notification--negative">
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+    </div>
+    {% else %}
+    <ul class='p-list'>
+      {% for item in case_studies %}
+        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+</section>
+
+{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=1187" limit=10 as webinars %}
+<section class="p-strip is-shallow">
+  <div class="row">
+    <h2>Webinars</h2>
+    {% if webinars is False %}
+    <div class="p-notification--negative">
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+    </div>
+    {% else %}
+    <ul class='p-list'>
+      {% for item in webinars %}
+        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+</section>
+
+{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=1485" limit=10 as white_papers %}
+<section class="p-strip is-shallow">
+  <div class="row">
+    <h2>White papers</h2>
+    {% if white_papers is False %}
+    <div class="p-notification--negative">
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+    </div>
+    {% else %}
+    <ul class='p-list'>
+      {% for item in white_papers %}
+        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+</section>
+
+{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=2497" limit=10 as tutorials %}
+<section class="p-strip is-shallow">
+  <div class="row">
+    <h2>Tutorials</h2>
+    {% if tutorials is False %}
+    <div class="p-notification--negative">
+      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+    </div>
+    {% else %}
+    <ul class='p-list'>
+      {% for item in tutorials %}
+        <li class="p-list__item"><a href="{{item.link}}">{{item.title.rendered | safe}}&nbsp;&rsaquo;</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
   </div>
 </section>
 


### PR DESCRIPTION
## Done
Pull the insights feeds and display the basic list on resources

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources](http://0.0.0.0:8001/resources)
- Check the list of items appears on the page

## Issue / Card
Fixes https://github.com/ubuntudesign/web-squad/issues/262
