### PR TITLE
Add topic filtering to the resources list

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -6,111 +6,63 @@
 
 {% block content %}
 
-
-
 <section class="p-strip--accent is-shallow">
   <div class="row">
     <h1>Resources</h1>
   </div>
 </section>
 
-{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=1172" limit=10 as case_studies %}
 <section class="p-strip is-shallow">
   <div class="row">
-    <h2>Case studies</h2>
-    {% if case_studies is False %}
-    <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
-    </div>
-    {% else %}
-    {% if case_studies|length is 0 %}
-    <div class="p-notification--information">
-      <p class="p-notification__response">
-        <span class="p-notification__status">Information:</span> There were no results found for this category
-      </p>
-    </div>
-    {% endif %}
-    <ul class="p-list">
-      {% for item in case_studies %}
-        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
-      {% endfor %}
-    </ul>
-    {% endif %}
+    <nav class="p-tabs">
+      <ul class="p-tabs__list" role="tablist">
+        <li class="p-tabs__item" role="presentation">
+          <span class="p-tabs__link">Topic:</span>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="?" class="p-tabs__link" role="tab" aria-controls="section1"{% if slug == 'all' or slug == None %} aria-selected="true"{% endif %}>All</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="?topic=cloud-and-server" class="p-tabs__link" role="tab" aria-controls="section1"{% if slug == 'cloud-and-server' %} aria-selected="true"{% endif %}>Cloud and server</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="?topic=desktop" class="p-tabs__link" role="tab" aria-controls="section2"{% if slug == 'desktop' %} aria-selected="true"{% endif %}>Desktop</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="?topic=internet-of-things" class="p-tabs__link" role="tab" aria-controls="section3"{% if slug == 'internet-of-things' %} aria-selected="true"{% endif %}>IoT</a>
+        </li>
+      </ul>
+    </nav>
   </div>
-</section>
 
-{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=1187" limit=10 as webinars %}
-<section class="p-strip is-shallow">
+  {% if items is False %}
   <div class="row">
-    <h2>Webinars</h2>
-    {% if webinars is False %}
     <div class="p-notification--negative">
       <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
     </div>
-    {% else %}
-    {% if webinars|length is 0 %}
-    <div class="p-notification--information">
-      <p class="p-notification__response">
-        <span class="p-notification__status">Information:</span> There were no results found for this category
-      </p>
-    </div>
-    {% endif %}
-    <ul class="p-list">
-      {% for item in webinars %}
-        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
-      {% endfor %}
-    </ul>
-    {% endif %}
   </div>
-</section>
-
-{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=1485" limit=10 as white_papers %}
-<section class="p-strip is-shallow">
+  {% elif items|length is 0 %}
   <div class="row">
-    <h2>White papers</h2>
-    {% if white_papers is False %}
-    <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
-    </div>
-    {% else %}
-    {% if white_papers|length is 0 %}
     <div class="p-notification--information">
       <p class="p-notification__response">
         <span class="p-notification__status">Information:</span> There were no results found for this category
       </p>
     </div>
-    {% endif %}
-    <ul class="p-list">
-      {% for item in white_papers %}
-        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
-      {% endfor %}
-    </ul>
-    {% endif %}
   </div>
-</section>
+  {% endif %}
 
-{% get_json_feed "https://insights.ubuntu.com/wp-json/wp/v2/posts?categories=2497" limit=10 as tutorials %}
-<section class="p-strip is-shallow">
-  <div class="row">
-    <h2>Tutorials</h2>
-    {% if tutorials is False %}
-    <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
-    </div>
-    {% else %}
-    {% if tutorials|length is 0 %}
-    <div class="p-notification--information">
-      <p class="p-notification__response">
-        <span class="p-notification__status">Information:</span> There were no results found for this category
-      </p>
+  {% for item in items %}
+    {% if forloop.counter0|divisibleby:3 %}
+    {% if not forloop.counter0 is 0 %}
     </div>
     {% endif %}
-    <ul class="p-list">
-      {% for item in tutorials %}
-        <li class="p-list__item"><a href="{{item.link}}" class="p-link--external">{{item.title.rendered | safe}}</a></li>
-      {% endfor %}
-    </ul>
+    <div class="row u-equal-height">
     {% endif %}
+      <div class="p-card col-4">
+        <h3 class="p-header--four"><a href="{{item.link}}">{{item.title.rendered | safe}}</a></h3>
+        {{item.excerpt.rendered | safe}}
+      </div>
+  {% endfor %}
   </div>
 </section>
 

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -29,7 +29,7 @@
           <a href="?topic=desktop" class="p-tabs__link" role="tab" aria-controls="section2"{% if slug == 'desktop' %} aria-selected="true"{% endif %}>Desktop</a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="?topic=internet-of-things" class="p-tabs__link" role="tab" aria-controls="section3"{% if slug == 'internet-of-things' %} aria-selected="true"{% endif %}>IoT</a>
+          <a href="?topic=internet-of-things" class="p-tabs__link" role="tab" aria-controls="section3"{% if slug == 'internet-of-things' %} aria-selected="true"{% endif %}>Internet of things</a>
         </li>
       </ul>
     </nav>
@@ -51,17 +51,29 @@
   </div>
   {% endif %}
 
-  {% for item in items %}
-    {% if forloop.counter0|divisibleby:3 %}
-    {% if not forloop.counter0 is 0 %}
+  {% for group_slug, resources in items.items %}
+    <div class="row">
+      <h2>{{ resources.group_name }}</h2>
     </div>
-    {% endif %}
+
     <div class="row u-equal-height">
-    {% endif %}
+    {% for resource in resources.items %}
       <div class="p-card col-4">
-        <h3 class="p-header--four"><a href="{{item.link}}">{{item.title.rendered | safe}}</a></h3>
-        {{item.excerpt.rendered | safe}}
+        {% if resource.featuredmedia %}
+          <a href="{{resource.link}}">
+            <img src="{{resource.featuredmedia.source_url}}" alt="{{resource.featuredmedia.alt_text}}" />
+          </a>
+        {% endif %}
+        <h3 class="p-header--four"><a href="{{resource.link}}">{{resource.title.rendered | safe}}</a></h3>
+        {{resource.excerpt.rendered | safe}}
       </div>
+
+      {% if forloop.counter|divisibleby:3 %}
+        </div>
+        <div class="row u-equal-height">
+      {% endif %}
+    {% endfor %}
+    </div>
   {% endfor %}
   </div>
 </section>

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -5,7 +5,7 @@ from canonicalwebteam import yaml_deleted_paths
 from ubuntudesign.gsa.views import SearchView
 
 # Local code
-from .views import UbuntuTemplateFinder, DownloadView
+from .views import UbuntuTemplateFinder, DownloadView, ResourcesView
 
 
 urlpatterns = load_redirects()
@@ -19,6 +19,7 @@ urlpatterns += [
         r'^(?P<template>download/desktop/contribute)$',
         DownloadView.as_view()
     ),
+    url(r'^resources', ResourcesView.as_view()),
     url(r'^search$', SearchView.as_view(template_name='search.html')),
     url(r'^(?P<template>.*)[^\/]$', UbuntuTemplateFinder.as_view()),
     url(r'$^', UbuntuTemplateFinder.as_view()),

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -3,7 +3,11 @@ import os
 import re
 
 from feedparser import parse
+from django.views.generic.base import TemplateView
 from django_template_finder_view import TemplateFinder
+from canonicalwebteam.get_feeds import (
+    get_json_feed_content
+)
 
 
 class UbuntuTemplateFinder(TemplateFinder):
@@ -23,6 +27,59 @@ class UbuntuTemplateFinder(TemplateFinder):
         for index, path, in enumerate(clean_path.split('/')):
             context["level_" + str(index + 1)] = path
 
+        return context
+
+
+class ResourcesView(TemplateView):
+    template_name = 'resources/index.html'
+
+    INSIGHTS_URL = 'https://insights.ubuntu.com'
+    API_URL = INSIGHTS_URL + '/wp-json/wp/v2'
+    RESOURCE_FILTER = 'categories=1172,1509,1187'
+
+    def _get_categories_by_slug(self, slugs=[]):
+        if slugs:
+            if isinstance(slugs, list):
+                slugs = ','.join(slugs)
+        api_url = '{api_url}/group?slug={slug}'.format(
+            api_url=self.API_URL,
+            slug=slugs,
+        )
+        response = get_json_feed_content(api_url)
+        return response
+
+    def get_resources(self):
+
+        topic = self.request.GET.get('topic')
+        api_url = '{api_url}/posts?{resource_filter}'.format(
+            api_url=self.API_URL,
+            resource_filter=self.RESOURCE_FILTER,
+        )
+
+        if topic:
+            categories = self._get_categories_by_slug(topic)
+            category_id = categories[0]['id']
+
+            api_url = '{api_url}/posts?group={category_id}&{resource_filter}'
+            api_url = api_url.format(
+                api_url=self.API_URL,
+                category_id=str(category_id),
+                resource_filter=self.RESOURCE_FILTER,
+            )
+
+        resources = get_json_feed_content(api_url)
+        return resources
+
+    def get_context_data(self, **kwargs):
+        """
+        Get the context from insights for the resources page
+        """
+
+        # Get any existing context
+        context = super(ResourcesView, self).get_context_data(**kwargs)
+
+        context['items'] = self.get_resources()
+        context['slug'] = self.request.GET.get('topic')
         return context
 
 


### PR DESCRIPTION
## Done
Add topic filtering to the resources list. Edit the display to be cards.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources](http://0.0.0.0:8001/resources)
- Check the feed shows a list of resources
- Filter by the topic and check it works

## Issue / Card
Fixes https://github.com/ubuntudesign/web-squad/issues/263
