### PR TITLE
Fix secondary navigation wrapping issue

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -125,9 +125,8 @@
       display: inline-block;
     }
 
-    @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
       border-top: 1px solid $color-mid-light;
-      white-space: nowrap;
     }
 
     &__row {
@@ -139,7 +138,6 @@
 
   .nav-secondary,
   .nav-tertiary {
-
     .p-inline-list__link,
     .p-breadcrumbs__link {
       font-size: .875rem;
@@ -197,7 +195,7 @@
     }
 
     &__menu {
-      display: inline-block;
+      display: inline;
       margin-top: 0;
       position: relative;
 
@@ -221,7 +219,6 @@
       background: $color-light;
       border-bottom: 1px solid $color-mid-light;
       padding: $sp-x-small 0 $sp-small;
-      white-space: nowrap;
 
       .p-breadcrumbs__item {
         margin-bottom: 0;
@@ -345,7 +342,6 @@
   }
 
   .nav-tertiary__menu {
-    white-space: normal;
     width: 85%;
 
     .p-inline-list {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -125,8 +125,9 @@
       display: inline-block;
     }
 
-    @media (max-width: $breakpoint-large) {
+    @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
       border-top: 1px solid $color-mid-light;
+      white-space: nowrap;
     }
 
     &__row {
@@ -195,7 +196,7 @@
     }
 
     &__menu {
-      display: inline;
+      display: inline-block;
       margin-top: 0;
       position: relative;
 
@@ -219,6 +220,7 @@
       background: $color-light;
       border-bottom: 1px solid $color-mid-light;
       padding: $sp-x-small 0 $sp-small;
+      white-space: nowrap;
 
       .p-breadcrumbs__item {
         margin-bottom: 0;
@@ -376,5 +378,9 @@
         margin-right: 1.5rem;
       }
     }
+  }
+
+  .nav-secondary .p-inline-list__item {
+    white-space: normal;
   }
 }


### PR DESCRIPTION
## Done

Fix secondary navigation wrapping issue

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud](http://0.0.0.0:8001/cloud)
- Make sure the secondary navigation wraps when one is making ones viewport smaller, before it snaps to small styles

### Bad

![screen shot 2017-11-27 at 16 10 24](https://user-images.githubusercontent.com/2152/33276458-89619e86-d38d-11e7-9b60-b863dabb0fcc.png)

### Good

![screen shot 2017-11-27 at 16 11 12](https://user-images.githubusercontent.com/2152/33276487-9ecb3ade-d38d-11e7-8fa7-ecf923352ce0.png)

## Issue / Card

Fixes #2405 
