### PR TITLE
Add content type filtering to the resources list

### DIFF
--- a/static/js/polyfills.js
+++ b/static/js/polyfills.js
@@ -46,3 +46,21 @@ if("document"in self){if(!("classList"in document.createElement("_"))||document.
 /* String.prototype.startsWith polyfill, by Mathius Bynens, https://mathiasbynens.be/
  * https://github.com/mathiasbynens/String.prototype.startsWith */
 String.prototype.startsWith||!function(){"use strict";var t=function(){try{var t={},r=Object.defineProperty,e=r(t,t,t)&&r}catch(n){}return e}(),r={}.toString,e=function(t){if(null==this)throw TypeError();var e=String(this);if(t&&"[object RegExp]"==r.call(t))throw TypeError();var n=e.length,i=String(t),a=i.length,o=arguments.length>1?arguments[1]:void 0,h=o?Number(o):0;h!=h&&(h=0);var u=Math.min(Math.max(h,0),n);if(a+u>n)return!1;for(var g=-1;++g<a;)if(e.charCodeAt(u+g)!=i.charCodeAt(g))return!1;return!0};t?t(String.prototype,"startsWith",{value:e,configurable:!0,writable:!0}):String.prototype.startsWith=e}();
+
+
+/**
+ * Add support for Element.closest()
+ */
+if (window.Element && !Element.prototype.closest) {
+    Element.prototype.closest =
+    function(s) {
+        var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+            i,
+            el = this;
+        do {
+            i = matches.length;
+            while (--i >= 0 && matches.item(i) !== el) {};
+        } while ((i < 0) && (el = el.parentElement));
+        return el;
+    };
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -220,3 +220,25 @@ abbr[title] {
 .p-link--external::after {
   -webkit-mask-size: cover;
 }
+
+// XXX Ant: 27.10.17
+select {
+  background-position-y: center;
+  min-height: 0;
+  padding-right: 2rem;
+}
+
+
+// XXX Ant: 27.10.17 - Can be removed when this issue has been resolved.
+// https://github.com/vanilla-framework/vanilla-framework/issues/1458
+.p-tabs {
+  &__item:last-of-type {
+    @media (max-width: $breakpoint-small) {
+      padding-right: 4rem;
+    }
+  }
+
+  &::before {
+    width: 70px;
+  }
+}

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -14,25 +14,48 @@
 
 <section class="p-strip is-shallow">
   <div class="row">
-    <nav class="p-tabs">
+    <nav class="p-tabs col-8">
       <ul class="p-tabs__list" role="tablist">
         <li class="p-tabs__item" role="presentation">
           <span class="p-tabs__link">Topic:</span>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="?" class="p-tabs__link" role="tab" aria-controls="section1"{% if slug == 'all' or slug == None %} aria-selected="true"{% endif %}>All</a>
+          <a href="?{% if content_slug %}content={{ content_slug }}{% endif %}" class="p-tabs__link" role="tab" aria-controls="section1"{% if topic_slug == 'all' or topic_slug == None %} aria-selected="true"{% endif %}>All</a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="?topic=cloud-and-server" class="p-tabs__link" role="tab" aria-controls="section1"{% if slug == 'cloud-and-server' %} aria-selected="true"{% endif %}>Cloud and server</a>
+          <a href="?topic=cloud-and-server{% if content_slug %}&content={{ content_slug }}{% endif %}" class="p-tabs__link" role="tab" aria-controls="section1"{% if topic_slug == 'cloud-and-server' %} aria-selected="true"{% endif %}>Cloud and server</a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="?topic=desktop" class="p-tabs__link" role="tab" aria-controls="section2"{% if slug == 'desktop' %} aria-selected="true"{% endif %}>Desktop</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="?topic=internet-of-things" class="p-tabs__link" role="tab" aria-controls="section3"{% if slug == 'internet-of-things' %} aria-selected="true"{% endif %}>Internet of things</a>
+          <a href="?topic=desktop{% if content_slug %}&content={{ content_slug }}{% endif %}" class="p-tabs__link" role="tab" aria-controls="section2"{% if topic_slug == 'desktop' %} aria-selected="true"{% endif %}>Desktop</a>
         </li>
       </ul>
     </nav>
+    <div class="col-4">
+      <form action="?foo=bar" method="get" class="p-form p-form--inline">
+        <div class="p-form__group">
+          <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter:</label>
+          <select class="js-submit-on-change p-form__control" name="content">
+              <option value="">All content types</option>
+              <option value="case-studies" {% if content_slug == 'case-studies' %}selected{% endif %}>Case studies</option>
+              <option value="videos" {% if content_slug == 'videos' %}selected{% endif %}>Videos</option>
+              <option value="webinars" {% if content_slug == 'webinars' %}selected{% endif %}>Webinars</option>
+            </select>
+          <input type="submit" value="Send Request" class="u-hide">
+          {% if topic_slug %}
+            <input type="hidden" name="topic" value="{{ topic_slug }}">
+          {% endif %}
+        </div>
+      </form>
+      <script>
+        var select = document.querySelector('.js-submit-on-change');
+        select.addEventListener('change', function(e) {
+          var form = this.closest('form');
+          if (form) {
+            form.submit();
+          }
+        });
+      </script>
+    </div>
   </div>
 
   {% if items is False %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -99,8 +99,8 @@
             {% include 'templates/_menu_section.html' with section=nav_sections.core %}
             {% include 'templates/_menu_section.html' with section=nav_sections.iot %}
             {% include 'templates/_menu_section.html' with section=nav_sections.support %}
-            {% include 'templates/_menu_section.html' with section=nav_sections.download %}
             {% include 'templates/_menu_section.html' with section=nav_sections.resources %}
+            {% include 'templates/_menu_section.html' with section=nav_sections.download %}
           </ul>
         </nav>
 


### PR DESCRIPTION
## Done
Added a select element to filter the content type. Added the functionality to filter by type, topic and both. Moved the navigation item to the left of downloads.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources](http://0.0.0.0:8001/resources)
- Filter some and check it works

## Issue / Card
Fixes https://github.com/ubuntudesign/web-squad/issues/264
