### PR TITLE
Fix the resources group feed

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -125,7 +125,7 @@ class ResourcesView(TemplateView):
                 )
         else:
             for group_name, group in self.GROUPS.items():
-                api_url = '{api_url}/posts?category={group_id}'.format(
+                api_url = '{api_url}/posts?group={group_id}'.format(
                     api_url=self.API_URL,
                     group_id=group['id'],
                 )


### PR DESCRIPTION
## Done
Fixed the feed for filtering groups

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources](http://0.0.0.0:8001/resources)
- Check that each section has the correct and own set of resources (keep in mind some resources are tagged two groups)
