### PR TITLE
Create the finance vertical page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -21,6 +21,8 @@ cloud:
       path: /cloud/foundation-cloud
     - title: Training
       path: /cloud/training
+    - title: Financial services
+      path: /financial-services
 
     - title: Thank you
       path: /cloud/newsletter-thank-you

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -1,0 +1,239 @@
+{% extends "templates/one-column.html" %}
+
+{% block meta_description %}With evolving regulations, growing security threats and increasing costs – plus the emergence of game-changing new technologies like AI and Blockchain – the finance world needs practical solutions, now more than ever.{% endblock %}
+
+{% block title %}Financial services{% endblock %}
+
+{% block content %}
+
+<section class="p-strip--accent is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Canonical empowers the financial services industry</h1>
+      <p>With evolving regulations, growing security threats and increasing costs – plus the emergence of game-changing new technologies like AI and Blockchain – the finance world needs practical solutions, now more than ever. That’s why Canonical enables sellside and buyside financial services institutions, retail banking operations and insurance and fintech firms to build secure, agile infrastructure with the flexibility to scale.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12">
+      <h2>Services for the finance industry</h2>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" alt="" />
+          <h3 class="p-heading-icon__title p-heading--four">Consultation services</h3>
+        </div>
+        <p>
+          <a href="/cloud/foundation-cloud">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}034573f2-icon-intro-cloud.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Managed cloud services</h3>
+        </div>
+        <p>
+          <a href="/cloud/managed-cloud">The BootStack service for a managed cloud operated for you to the highest standards&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Managed Kubernetes services</h3>
+        </div>
+        <p>
+          <a href="/kubernetes/managed">With the managed Kubernetes service, Canonical will set-up and operate your Kubernetes cluster for you&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}27141e8b-picto-support-warmgrey.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Support</h3>
+        </div>
+        <p>
+          <a href="/support">24-hour support services with FIPS certification for compliance requirements&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+        <h2 class="p-muted-heading u-align--center">Ubuntu is used by</h2>
+        <ul class="p-inline-images">
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" alt="Bloomberg" />
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png" alt="City Network" />
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}0c18b0ae-paypal_logo.svg" alt="PayPal" />
+          </li>
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}62ca4529-16-11-02_R3_Master-Logo.png" alt="R3" />
+          </li>
+        </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12">
+      <h2>Products for the finance industry</h2>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}623e36f9-OpenStack_Logo_Mark+%281%29.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">OpenStack</h3>
+        </div>
+        <p>
+          <a href="/openstack">As the number one platform for OpenStack, Canonical supports local clouds and public clouds, at large volume with dynamic scale&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
+            <h3 class="p-heading-icon__title  p-heading--four">Kubernetes</h3>
+        </div>
+        <p>
+          <a href="/kubernetes">Canonical provides enterprise-calibre support for Kubernetes&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}daeaa851-server.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Server provisioning</h3>
+        </div>
+        <p>
+          <a href="/server">MAAS for automated and optimised provisioning for your production hardware&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Live automatic security fixes</h3>
+        </div>
+        <p>
+          <a href="/server/livepatch">Livepatch for automatic kernel security hotfixes without rebooting&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h2>Resources</h2>
+    </div>
+    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+      <div class="col-8">
+        <div class="p-heading-icon u-no-margin--bottom">
+          <div class="p-heading-icon__header u-no-margin--bottom">
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+          </div>
+        </div>
+        <h3 class="u-no-margin--top">Hybrid cloud and financial services: How to compete on the cloud</h3>
+        <p>Learn how to keep up with the pace of change as you adopt new development methodologies, new technologies and new infrastructure.</p>
+        <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/290063" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Sign up now', 'eventLabel' : 'Hybrid cloud and financial services: How to compete on the cloud', 'eventValue' : undefined });">Sign up now</a></p>
+      </div>
+      <div class="col-4 prefix-1 u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}58442bcb-business-promo-webinar.png" alt="" />
+      </div>
+    </div>
+    <hr />
+    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+      <div class="col-8">
+        <div class="p-heading-icon u-no-margin--bottom">
+          <div class="p-heading-icon__header u-no-margin--bottom">
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Article</h4>
+          </div>
+        </div>
+        <h3 class="u-no-margin--top">Bloomberg&rsquo;s OpenStack deployment</h3>
+        <p>Find out why Bloomberg chooses Ubuntu-based OpenStack to handle customisation and integration with their internal systems.</p>
+        <p><a class="p-link--external" href="http://superuser.openstack.org/articles/openstack-at-bloomberg/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read article', 'eventLabel' : 'Bloomberg’s OpenStack deployment', 'eventValue' : undefined });">Read article</a></p>
+      </div>
+      <div class="col-4 prefix-1 u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" alt="" />
+      </div>
+    </div>
+    <hr />
+    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+      <div class="col-8">
+        <div class="p-heading-icon u-no-margin--bottom">
+          <div class="p-heading-icon__header u-no-margin--bottom">
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" />
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h4>
+          </div>
+        </div>
+        <h3 class="u-no-margin--top">Accelerate your business with containers</h3>
+        <p>Discover how Linux container technologies offer control and flexible provisioning while driving greater density, efficiency and manageability, without additional hardware or infrastructure investment.</p>
+        <p><a class="p-link--external" href="https://insights.ubuntu.com/2017/02/27/the-no-nonsense-way-to-accelerate-your-business-with-containers/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download whitepaper', 'eventLabel' : 'Accelerate your business with containers', 'eventValue' : undefined });">Download whitepaper</a></p>
+      </div>
+      <div class="col-4 prefix-1 u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}a9aff224-Containers-illustration.svg" alt="" />
+      </div>
+    </div>
+    <hr />
+    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+      <div class="col-8">
+        <div class="p-heading-icon u-no-margin--bottom">
+          <div class="p-heading-icon__header u-no-margin--bottom">
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" alt="" />
+            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h4>
+          </div>
+        </div>
+        <h3 class="u-no-margin--top">OpenStack in the financial services sector</h3>
+        <p>Read about how Canonical ensured that City Network stood out from the crowd thanks to superb service quality and a unique focus on industry-specific regulatory compliance.</p>
+        <p><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the case study', 'eventLabel' : 'OpenStack in the financial services sector', 'eventValue' : undefined });">Read the case study</a></p>
+      </div>
+      <div class="col-4 prefix-1 u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png" alt="" />
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--accent">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <p class="p-heading--three">Talk to us about how Canonical can help you build a secure, agile infrastructure designed for scale.</p>
+      <p><a href="/contact-us" class="p-button">Contact us</a></p>
+    </div>
+    <div class="col-4 prefix-1 suffix-1 u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" class="u-hide--small" alt="" />
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -28,7 +28,7 @@
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" alt="" />
           <h3 class="p-heading-icon__title p-heading--four">Consultation services</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/cloud/foundation-cloud">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -36,10 +36,10 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}034573f2-icon-intro-cloud.svg" alt="" />
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}b5fde8bb-easy-way-in.svg" alt="" />
           <h3 class="p-heading-icon__title  p-heading--four">Managed cloud services</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/cloud/managed-cloud">The BootStack service for a managed cloud operated for you to the highest standards&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -52,7 +52,7 @@
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
           <h3 class="p-heading-icon__title  p-heading--four">Managed Kubernetes services</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/kubernetes/managed">With the managed Kubernetes service, Canonical will set-up and operate your Kubernetes cluster for you&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -60,10 +60,10 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}27141e8b-picto-support-warmgrey.svg" alt="" />
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}e60711e6-pictogram-support-orange.svg" alt="" />
           <h3 class="p-heading-icon__title  p-heading--four">Support</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/support">24-hour support services with FIPS certification for compliance requirements&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -106,7 +106,7 @@
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}623e36f9-OpenStack_Logo_Mark+%281%29.svg" alt="" />
           <h3 class="p-heading-icon__title  p-heading--four">OpenStack</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/openstack">As the number one platform for OpenStack, Canonical supports local clouds and public clouds, at large volume with dynamic scale&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -117,7 +117,7 @@
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
             <h3 class="p-heading-icon__title  p-heading--four">Kubernetes</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/kubernetes">Canonical provides enterprise-calibre support for Kubernetes&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -127,10 +127,10 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}daeaa851-server.svg" alt="" />
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}0de4fcd5-logo-maas-icon.svg" alt="" />
           <h3 class="p-heading-icon__title  p-heading--four">Server provisioning</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/server">MAAS for automated and optimised provisioning for your production hardware&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -141,7 +141,7 @@
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg" alt="" />
           <h3 class="p-heading-icon__title  p-heading--four">Live automatic security fixes</h3>
         </div>
-        <p>
+        <p style="margin-top: 1rem;">
           <a href="/server/livepatch">Livepatch for automatic kernel security hotfixes without rebooting&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -228,7 +228,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <p class="p-heading--three">Talk to us about how Canonical can help you build a secure, agile infrastructure designed for scale.</p>
-      <p><a href="/contact-us" class="p-button">Contact us</a></p>
+      <p style="margin-top: 2rem;"><a href="/contact-us" class="p-button">Contact us</a></p>
     </div>
     <div class="col-4 prefix-1 suffix-1 u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" class="u-hide--small" alt="" />

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -36,7 +36,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}b5fde8bb-easy-way-in.svg" alt="" />
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" style="max-height:23px;margin-top:9px;" />
           <h3 class="p-heading-icon__title  p-heading--four">Managed cloud services</h3>
         </div>
         <p style="margin-top: 1rem;">
@@ -86,7 +86,7 @@
             <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}0c18b0ae-paypal_logo.svg" alt="PayPal" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}62ca4529-16-11-02_R3_Master-Logo.png" alt="R3" />
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}62ca4529-16-11-02_R3_Master-Logo.png" alt="R3" style="max-height:50px;" />
           </li>
         </ul>
     </div>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -111,7 +111,7 @@
         <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/290063" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Sign up now', 'eventLabel' : 'Hybrid cloud and financial services: How to compete on the cloud', 'eventValue' : undefined });">Sign up now</a></p>
       </div>
       <div class="col-4 prefix-1 u-vertically-center">
-        <img src="{{ ASSET_SERVER_URL }}58442bcb-business-promo-webinar.png" alt="" />
+        <img src="{{ ASSET_SERVER_URL }}7d6041a7-image-cloud.svg" alt="" />
       </div>
     </div>
     <hr />

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -36,7 +36,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon u-no-margin--bottom">
         <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" style="max-height:23px;margin-top:9px;" />
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" style="max-height:30px;max-width: 50px;margin-top:9px;" />
           <h3 class="p-heading-icon__title  p-heading--four">Managed cloud services</h3>
         </div>
         <p style="margin-top: 1rem;">

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -71,7 +71,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
         <h2 class="p-muted-heading u-align--center">Ubuntu is used by</h2>
@@ -89,62 +89,6 @@
             <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}62ca4529-16-11-02_R3_Master-Logo.png" alt="R3" />
           </li>
         </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-12">
-      <h2>Products for the finance industry</h2>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}623e36f9-OpenStack_Logo_Mark+%281%29.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">OpenStack</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/openstack">As the number one platform for OpenStack, Canonical supports private and public clouds, at volume and at scale&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
-            <h3 class="p-heading-icon__title  p-heading--four">Kubernetes</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/kubernetes">Canonical provides enterprise-calibre support for Kubernetes&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}0de4fcd5-logo-maas-icon.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Server provisioning</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/server">MAAS for automated and optimised provisioning for your production hardware&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Live automatic security fixes</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/server/livepatch">Livepatch for automatic kernel security hotfixes without rebooting&nbsp;&rsaquo;</a>
-        </p>
-      </div>
     </div>
   </div>
 </section>
@@ -219,6 +163,62 @@
       </div>
       <div class="col-4 prefix-1 u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png" alt="" />
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12">
+      <h2>Products for the finance industry</h2>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}623e36f9-OpenStack_Logo_Mark+%281%29.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">OpenStack</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/openstack">As the number one platform for OpenStack, Canonical supports private and public clouds, at volume and at scale&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
+            <h3 class="p-heading-icon__title  p-heading--four">Kubernetes</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/kubernetes">Canonical provides enterprise-calibre support for Kubernetes&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}0de4fcd5-logo-maas-icon.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Server provisioning</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/server">Use MAAS for automated and optimised provisioning for your production hardware&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Live automatic security fixes</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/server/livepatch">Use Livepatch for automatic kernel security hotfixes without rebooting&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
   </div>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -107,7 +107,7 @@
           <h3 class="p-heading-icon__title  p-heading--four">OpenStack</h3>
         </div>
         <p style="margin-top: 1rem;">
-          <a href="/openstack">As the number one platform for OpenStack, Canonical supports local clouds and public clouds, at large volume with dynamic scale&nbsp;&rsaquo;</a>
+          <a href="/openstack">As the number one platform for OpenStack, Canonical supports private and public clouds, at volume and at scale&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done
Create the finance vertical page

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/financial-services](http://0.0.0.0:8001/financial-services)
- Check the page looks ok
- Check the copy is the same as the [copy doc](https://docs.google.com/document/d/1o9s_MFaiZZIS26tusRi0ALNrcqUihhTSZgxS55oHZj4/edit#)
- Check it matches [the design](https://github.com/ubuntudesign/web-squad/issues/266) closely (still to be design +1'ed)
- Check all viewports

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2472

## Screenshots
![screen shot 2017-11-29 at 13 13 28-fullpage](https://user-images.githubusercontent.com/1413534/33376839-2dd7dbcc-d507-11e7-926c-83cb10455854.png)

