### PR TITLE
Replace kubernetes datasheet

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -71,7 +71,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-8">
       <h2>In partnership with Google GKE</h2>
-      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s alignment.</p>
+      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes&reg;. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s alignment.</p>
       <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
     </div>
     <div class="col-4">

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -49,8 +49,8 @@
       <h4><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?backURL=%2F#0"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Installation tutorial', 'eventLabel' : 'Installation tutorial - get started' : undefined });" class="p-link--external">Installation tutorial</a></h4>
     </div>
     <div class="col-4 p-card u-align--center">
-      <p><a href="{{ ASSET_SERVER_URL }}b35eca50-Enterprise-Kubernetes-datasheet.pdf?_ga=2.172154595.115392878.1508099656-249522427.1505216678" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet icon - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" style="max-height: 47px;" /></a></p>
-      <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}b35eca50-Enterprise-Kubernetes-datasheet.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet - get started' : undefined });">Download datasheet</a></h4>
+      <p><a href="{{ ASSET_SERVER_URL }}894857eb-DS_Enterprise-Kubernetes_screen-AW_11.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet icon - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" style="max-height: 47px;" /></a></p>
+      <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}894857eb-DS_Enterprise-Kubernetes_screen-AW_11.17.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet - get started' : undefined });">Download datasheet</a></h4>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -251,7 +251,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h2>Test drive the Canonical Distribution of Kubernetes today!</h2>
+      <h2>Test drive the Canonical Distribution of Kubernetes<sup>&reg;</sup> today!</h2>
       <p class="u-no-margin--top"><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?_ga=2.25375934.2035833349.1504518498-2070601899.1473694436" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Bottom CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/containers/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Bottom CTA' : undefined });">Contact sales</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Replace /kubernetes datasheet
Add registered sign in Google GKE section as per copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Make sure the PDF has change to the version stated in the copy doc
- Make sure the registered signs have been added in Google GKE section as per copy doc

## Issue / Card

Fixes: #2466 
Doc: https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit