### PR TITLE
Move Services for the finance industry section

### DIFF
--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -37,7 +37,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>Resources</h2>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -15,62 +15,6 @@
   </div>
 </section>
 
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-12">
-      <h2>Services for the finance industry</h2>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading--four">Consultation services</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/cloud/foundation-cloud">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" style="max-height:30px;max-width: 50px;margin-top:9px;" />
-          <h3 class="p-heading-icon__title  p-heading--four">Managed cloud services</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/cloud/managed-cloud">The BootStack service for a managed cloud operated for you to the highest standards&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Managed Kubernetes services</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/kubernetes/managed">With the managed Kubernetes service, Canonical will set-up and operate your Kubernetes cluster for you&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}e60711e6-pictogram-support-orange.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Support</h3>
-        </div>
-        <p style="margin-top: 1rem;">
-          <a href="/support">24-hour support services with FIPS certification for compliance requirements&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
-
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
@@ -168,7 +112,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>Products for the finance industry</h2>
@@ -218,6 +162,62 @@
         </div>
         <p style="margin-top: 1rem;">
           <a href="/server/livepatch">Use Livepatch for automatic kernel security hotfixes without rebooting&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12">
+      <h2>Services for the finance industry</h2>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" alt="" />
+          <h3 class="p-heading-icon__title p-heading--four">Consultation services</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/cloud/foundation-cloud">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" style="max-height:30px;max-width: 50px;margin-top:9px;" />
+          <h3 class="p-heading-icon__title  p-heading--four">Managed cloud services</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/cloud/managed-cloud">The BootStack service for a managed cloud operated for you to the highest standards&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Managed Kubernetes services</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/kubernetes/managed">With the managed Kubernetes service, Canonical will set-up and operate your Kubernetes cluster for you&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-heading-icon u-no-margin--bottom">
+        <div class="p-heading-icon__header u-no-margin--bottom">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}e60711e6-pictogram-support-orange.svg" alt="" />
+          <h3 class="p-heading-icon__title  p-heading--four">Support</h3>
+        </div>
+        <p style="margin-top: 1rem;">
+          <a href="/support">24-hour support services with FIPS certification for compliance requirements&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

Move Services for the finance industry section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/financial-services](http://0.0.0.0:8001/financial-services)
- Check that the Services for the finance industry section has moved as per copy doc


## Issue / Card

Doc: https://docs.google.com/document/d/1o9s_MFaiZZIS26tusRi0ALNrcqUihhTSZgxS55oHZj4/edit
