### PR TITLE
Ubuntu no longer includes Unity

### DIFF
--- a/templates/about/about-ubuntu/ubuntu-and-debian.html
+++ b/templates/about/about-ubuntu/ubuntu-and-debian.html
@@ -17,7 +17,7 @@
       <h3>About Debian</h3>
       <p><a href="http://www.debian.org/">Debian</a> can be considered the rock upon which Ubuntu is built. It is a volunteer project that has developed and maintained a GNU/Linux operating system of the same name for well over a decade. Since its launch, the Debian project has grown to comprise more than 1,000 members with official developer status, alongside many more volunteers and contributors. Today, Debian encompasses over 20,000 packages of free, open source applications and documentation.</p>
       <h3>About Ubuntu</h3>
-      <p>Ubuntu is an open source project that develops and maintains a cross-platform, open-source operating system based on Debian. It includes Unity, a consistent user interface for the smartphone, the tablet and the PC. Upgrades are released every six months and support is guaranteed by Canonical for up to five years. Canonical also provides commercial support for Ubuntu deployments across the desktop, the server and the cloud.</p>
+      <p>Ubuntu is an open source project that develops and maintains a cross-platform, open-source operating system based on Debian. Upgrades are released every six months and support is guaranteed by Canonical for up to five years. Canonical also provides commercial support for Ubuntu deployments across the desktop, the server and the cloud.</p>
       <p><a href="https://wiki.ubuntu.com/Debian">Learn more about how Debian and Ubuntu fit together</a>.</p>
     </div>
   </div>


### PR DESCRIPTION
Fixes #2493

However, it does not consider Ubuntu 16.04 LTS, which does include Unity.