### PR TITLE
Fix end date of LTS release

### DIFF
--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -79,7 +79,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Ready to get started?</h2>
-      <p>Ubuntu Server {{lts_release_full}} {{lts_release_eol}} is a free download that includes five years worth of  security and maintenance updates, guaranteed. Using an Ubuntu partner cloud ensures access to the latest certified Ubuntu cloud images. To run Ubuntu as guest on participating public clouds, the simplest way is to use the image maintained on their server.</p>
+      <p>Ubuntu Server {{lts_release_full}} is a free download that includes five years worth of  security and maintenance updates, guaranteed. Using an Ubuntu partner cloud ensures access to the latest certified Ubuntu cloud images. To run Ubuntu as guest on participating public clouds, the simplest way is to use the image maintained on their server.</p>
     </div>
   </div>
 

--- a/templates/cloud/storage.html
+++ b/templates/cloud/storage.html
@@ -50,7 +50,7 @@
     <div class="col-8">
       <h2>Storage options</h2>
       <p>With Ubuntu Advantage Storage you chose between four leading open source Software&dash;defined storage technologies.</p>
-      <p>Both technologies are available within our fully&dash;supported reference architectures, deployed on Ubuntu {{ lts_release_full }} {{lts_release_eol}} alongside our award&dash;winning cloud tools.</p>
+      <p>Both technologies are available within our fully&dash;supported reference architectures, deployed on Ubuntu {{ lts_release_full }} alongside our award&dash;winning cloud tools.</p>
     </div>
   </div>
   <div class="row">
@@ -119,7 +119,7 @@
                   <li class="p-list__item is-ticked">Pay only for the data you store &mdash; no cost penalty for increased replication or high&dash;durability erasure coding or early build out of capacity.</li>
                   <li class="p-list__item is-ticked">Landscape customers can use Autopilot to design, deploy and manage their storage clusters in a fully automated&nbsp;manner.</li>
                   <li class="p-list__item is-ticked">World&dash;class support from Canonical, experts in large&dash;scale, multi&dash;site&dash;replicated deployments.</li>
-                  <li class="p-list__item is-ticked">Built with Ubuntu {{ lts_release_full }} {{lts_release_eol}} with five years of support for every component in the stack.</li>
+                  <li class="p-list__item is-ticked">Built with Ubuntu {{ lts_release_full }} with five years of support for every component in the stack.</li>
                 </ul>
                 <p><a class="p-button--neutral" href="/cloud/contact-us?product=cloud-storage">Request a demo</a></p>
               </div>

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -50,7 +50,7 @@
       </ul>
     </div>
     <div class="col-4">
-      <h3 class="p-link--external"><span>Ubuntu {{lts_release_full_with_point}} {{lts_release_eol}}</span></h3>
+      <h3 class="p-link--external"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (64-bit)</a></li>
         <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (32-bit)</a></li>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -12,11 +12,11 @@
   </div>
   <div class="row">
     <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu {{lts_release_full_with_point}} {{lts_release_eol}}</h2>
+      <h2>Ubuntu {{lts_release_full_with_point}}</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
-          <p class="p-card__content">Download the latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until April 2021, of free security and maintenance updates, guaranteed.</p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{lts_release_full}} {{lts_release_eol}} release notes</a></p>
+          <p class="p-card__content">Download the latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{lts_release_eol}}, of free security and maintenance updates, guaranteed.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{lts_release_full}} release notes</a></p>
           <p>Recommended system requirements:</p>
           <ul class="p-list">
             <li class="p-list__item is-ticked">2 GHz dual core processor or better</li>
@@ -48,10 +48,10 @@
       <h2>Ubuntu {{latest_release}}</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
-          <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months, until July 2018, of security and maintenance updates.</p>
+          <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{latest_release}} release notes</a></p>
           <p class="p-card__content"><a href="/desktop/1710">Find out more about {{latest_release}}&nbsp;&rsaquo;</a></p>
-          <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}} {{lts_release_eol}}.</p>
+          <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
         </div>
         <div class="col-4">
           <p class="p-card__content">

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -9,7 +9,7 @@
     <div class="col-8">
       <div>
         <h1>Ubuntu Server for ARM</h1>
-        <p>Ubuntu {{lts_release_full_with_point}} {{lts_release_eol}} includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
+        <p>Ubuntu {{lts_release_full_with_point}} includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
         <p>Develop and test using over 50,000 software packages and runtimes &mdash; including Go, Java, Javascript, PHP, Python and Ruby &mdash; and deploy at scale using our complete scale-out management suite including MAAS and Juju. Ubuntu delivers server-grade performance on ARM, while fully retaining the reliable and familiar Ubuntu experience.</p>
       </div>
     </div>
@@ -18,13 +18,13 @@
     <div class="col-6 p-card--highlighted is-divided">
       <h3 class="p-card__title">Ubuntu Server</h3>
       <p class="p-card__content">This is the iso image of the Ubuntu Server installer.</p>
-      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}} {{lts_release_eol}}</a></p>
+      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
       <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-card--highlighted is-divided">
       <h3 class="p-card__title">Ubuntu netboot</h3>
       <p class="p-card__content">This installer lets you install Ubuntu over the network.</p>
-      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}} {{lts_release_eol}}</a></p>
+      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
       <p><a href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images&nbsp;&rsaquo;</a></p>
     </div>
   </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -11,10 +11,10 @@
   </div>
   <div class="row">
     <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu Server {{lts_release_full_with_point}} {{lts_release_eol}}</h2>
+      <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
-          <p class="p-card__content">The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
+          <p class="p-card__content">The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
         </div>
         <div class="col-4">
@@ -29,7 +29,7 @@
       <h2>Ubuntu Server {{latest_release}}</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
-          <p class="p-card__content">The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months of security and maintenance updates.</p>
+          <p class="p-card__content">The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{latest_release}} release notes</a></p>
         </div>
         <div class="col-4">
@@ -89,7 +89,7 @@
 <section class="p-strip is-bordered is-shallow">
   <div class="row">
     <div class="col-12">
-      <h2>Ubuntu Server {{ lts_release_full_with_point }} {{lts_release_eol}} for OpenStack</h2>
+      <h2>Ubuntu Server {{ lts_release_full_with_point }} for OpenStack</h2>
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Supported for five years by Canonical</li>
         <li class="p-list__item is-ticked">ZFS support for LXD OpenStack hosts</li>

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -15,11 +15,11 @@
 
   <div class="row">
     <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu Server {{lts_release_full}} {{lts_release_eol}}</h2>
+      <h2>Ubuntu Server {{lts_release_full}}</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
-          <p class="p-card__content">IBM LinuxONE and z&nbsp;Systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, security and resiliency. Ubuntu {{lts_release_full}} {{lts_release_eol}} was released for general availability (GA) in April and can now be downloaded by all IBM LinuxOne and z Systems customers.</p>
-          <p class="p-card__content">Ubuntu {{lts_release_full}} {{lts_release_eol}} for IBM LinuxONE and z&nbsp;Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
+          <p class="p-card__content">IBM LinuxONE and z&nbsp;Systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, security and resiliency. Ubuntu {{lts_release_full}} was released for general availability (GA) in April and can now be downloaded by all IBM LinuxOne and z Systems customers.</p>
+          <p class="p-card__content">Ubuntu {{lts_release_full}} for IBM LinuxONE and z&nbsp;Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
           <p class="p-card__content">For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us <tel href="+442036565291">+44&nbsp;(0)&nbsp;203&nbsp;656&nbsp;5291</tel> or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
         </div>
         <div class="col-4 p-divider__block">

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -19,16 +19,16 @@
         <h2>Ubuntu Server</h2>
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}} {{lts_release_eol}}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{latest_release_full}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">{{latest_release_full}} {{lts_release_eol}}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{latest_release_full}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">{{latest_release_full}}&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
       <div class="col-6">
         <h2>Netboot image</h2>
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}} {{lts_release_eol}}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{latest_release_full}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">{{latest_release_full}} {{lts_release_eol}}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{latest_release_full}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">{{latest_release_full}}&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
     </div>
@@ -42,13 +42,13 @@
       <p>Ubuntu 14.04 brings with it, for the first time, support for IBM POWER8 including our MAAS provisioning, Juju cloud orchestration, Landscape systems management and Ubuntu OpenStack. Ubuntu 14.04.4 adds CAPI and PowerNV support.</p>
     </div>
     <div class="col-4 p-divider__block">
-      <h3>Ubuntu {{lts_release_full}} {{lts_release_eol}} for IBM POWER8</h3>
+      <h3>Ubuntu {{lts_release_full}} for IBM POWER8</h3>
       <p>Ubuntu {{lts_release_no_point}} continues to enable rapid innovation for POWER8 including support for new POWER8 models, memory and PCI Hotplug, Docker 1.9.1, many performance and availability enhancements. Includes the only commercially available Linux to provide initial support for support the OpenPOWER Foundation’s industry leading NVLink technology.</p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Ubuntu {{latest_release_full}} for IBM POWER8</h3>
       <p>
-        The Ubuntu {{latest_release_full}} standard release builds on top of Ubuntu {{lts_release_full}} {{lts_release_eol}}, further enabling rapid innovation for POWER8.
+        The Ubuntu {{latest_release_full}} standard release builds on top of Ubuntu {{lts_release_full}}, further enabling rapid innovation for POWER8.
       </p>
     </div>
   </div>

--- a/templates/download/shared/_buy_a_usb.html
+++ b/templates/download/shared/_buy_a_usb.html
@@ -1,8 +1,8 @@
   <div class="p-heading-icon">
     <div class="p-heading-icon__header">
       <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}a9ed9a5c-picto-cddvd-warmgrey.svg" alt="dvd icon" />
-      <h3 class="p-heading-icon__title">Buy a {{lts_release_full}} {{lts_release_eol}} USB stick</h3>
+      <h3 class="p-heading-icon__title">Buy a {{lts_release_full}} USB stick</h3>
     </div>
   </div>
-  <p>Ubuntu {{lts_release_full}} {{lts_release_eol}} is available for purchase on USB stick, from the online Ubuntu shop.</p>
+  <p>Ubuntu {{lts_release_full}} is available for purchase on USB stick, from the online Ubuntu shop.</p>
   <p><a class="p-link--external" href="https://shop.canonical.com/index.php?cPath=17">Buy now</a></p>

--- a/templates/shared/contextual_footers/_download_desktop_guide.html
+++ b/templates/shared/contextual_footers/_download_desktop_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ubuntu desktop guide</h3>
   <p>Read the official Ubuntu desktop documentation.</p>
-  <p><a class="p-link--external" href="https://help.ubuntu.com/stable/ubuntu-help" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c', 'eventLabel' : 'Ubuntu desktop guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} {{lts_release_eol}} documentation</a></p>
+  <p><a class="p-link--external" href="https://help.ubuntu.com/stable/ubuntu-help" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c', 'eventLabel' : 'Ubuntu desktop guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_documentation.html
+++ b/templates/shared/contextual_footers/_download_documentation.html
@@ -2,9 +2,9 @@
   <h3 class="p-heading--four">Detailed documentation</h3>
   <p><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation/UbuntuServerGuide" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c server guide', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server Guide</a></p>
 
-  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c latest', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{latest_release_full}} {{lts_release_eol}} documentation</a></p>
+  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c latest', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{latest_release_full}} documentation</a></p>
 
-  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} {{lts_release_eol}} documentation</a></p>
+  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
 
   <p><a href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'how to verify', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Verify your download</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_server_guide.html
+++ b/templates/shared/contextual_footers/_download_server_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ubuntu Server guide</h3>
   <p>Read the official Ubuntu Server documentation.</p>
-  <p><a class="p-link--external" href="https://help.ubuntu.com/lts/serverguide/index.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c server guide', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} {{lts_release_eol}} documentation</a></p>
+  <p><a class="p-link--external" href="https://help.ubuntu.com/lts/serverguide/index.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c server guide', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
 </div>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -12,7 +12,7 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Ubuntu Advantage commercial support</h1>
-      <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Ubuntu Advantage typically include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu {{lts_release_full}} {{lts_release_eol}} systems.</p>
+      <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Ubuntu Advantage typically include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu {{lts_release_full}} systems.</p>
       <p><a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hidden--small">

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ArtfulAardvark" latest_release="17.10" latest_release_full='17.10' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='(Apr 2016 &ndash; Jul 2021)' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
+{% with latest_release_name="ArtfulAardvark" latest_release="17.10" latest_release_full='17.10' latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION

## Done

* Updated the variable for LTS to be ‘April 2021’ - `lts_release_eol='April 2021'`
* Created a variable for Latest eof to be ‘July 2018’ `latest_release_eol='July 2018'`
* Removed the incorrect LTS eof variable everywhere
* Added the LTS and Latest eof variable to /download/desktop and download/server
* Updated the [/download/desktop copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit) and the [/download/server copy doc](https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
- [/cloud/public-cloud.html](http://0.0.0.0:8001/cloud/public-cloud.html)
- [/cloud/storage.html](http://0.0.0.0:8001/cloud/storage.html)
- [/download/alternative-downloads.html](http://0.0.0.0:8001/download/alternative-downloads.html)
- [/download/desktop/index.html](http://0.0.0.0:8001/download/desktop/index.html)
- [/download/server/arm.html](http://0.0.0.0:8001/download/server/arm.html)
- [/download/server/index.html](http://0.0.0.0:8001/download/server/index.html)
- [/download/server/linuxone.html](http://0.0.0.0:8001/download/server/linuxone.html)
- [/download/server/power8.html](http://0.0.0.0:8001/download/server/power8.html)
- [/download/shared/_buy_a_usb.html](http://0.0.0.0:8001/download/shared/_buy_a_usb.html)
- [/shared/contextual_footers/_download_desktop_guide.html](http://0.0.0.0:8001/shared/contextual_footers/_download_desktop_guide.html)
- [/shared/contextual_footers/_download_documentation.html](http://0.0.0.0:8001/shared/contextual_footers/_download_documentation.html)
- [/shared/contextual_footers/_download_server_guide.html](http://0.0.0.0:8001/shared/contextual_footers/_download_server_guide.html)
- [/support/index.html](http://0.0.0.0:8001/support/index.html)


## Issue / Card

Fixes #2496

