### PR TITLE
Update UES takeover CTA

### DIFF
--- a/templates/takeovers/_ues_takeover.html
+++ b/templates/takeovers/_ues_takeover.html
@@ -5,12 +5,12 @@
         <h1 class="p-heading--two"><span class="event-title" itemprop="name">Ubuntu Enterprise Summit</span></h1>
         <h2 class="p-heading--three"><span class="event-date" itemprop="startDate" content="2017-12-05T16:00">5</span> – <span class="event-date" itemprop="endDate" content="2017-12-06T21:00">6 December 2017</span></h2>
         <p class="p-heading--five">Find out how the world&rsquo;s top companies use Ubuntu to succeed</p>
-        <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Sign up now', 'eventValue' : undefined });" class="p-button--positive">Sign up now</a></p>
+        <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Join in', 'eventValue' : undefined });" class="p-button--positive">Join in</a></p>
       </div>
       <div class="col-6 u-align--right">
         <img src="{{ ASSET_SERVER_URL }}9c1315fb-IOT_Ubuntu_devices_inforgrapic+v3.svg" alt="" />
       </div>
-      <p class="u-hide--medium u-hide--large u-show--small"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Sign up now', 'eventValue' : undefined });" class="p-button--positive">Sign up now</a></p>
+      <p class="u-hide--medium u-hide--large u-show--small"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Join in', 'eventValue' : undefined });" class="p-button--positive">Join in</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Updated the text on the takeover to "Join in" and updated the GA event label.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that the homepage takeover has CTA text of "Join in"

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2485