### PR TITLE
Updated desktop end of life table for mobile

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -110,22 +110,22 @@
       </table>
     </div>
   </div>
-  <div class=" row ">
-    <div class="col-6 ">
+  <div class="row">
+    <div class="col-6">
       <p><a href="/download ">Download the latest version of Ubuntu&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
 
 <section class="p-strip is-bordered ">
-  <div class="row ">
-    <div class="col-8 ">
+  <div class="row">
+    <div class="col-8">
       <h2>Kernel release end of life</h2>
       <p>The Ubuntu LTS enablement stacks provide newer kernel and X support for existing Ubuntu LTS releases. These can be installed manually, or are automatically shipped if installing from 12.04.2/14.04.2 and newer release media. These newer enablement stacks are meant for desktop and server, and even recommended for cloud or virtual images. The Ubuntu kernel support lifecycle is as follows:</p>
     </div>
   </div>
-  <div class="row ">
-    <div class="col-12 ">
+  <div class="row">
+    <div class="col-12">
       <p><img src="{{ ASSET_SERVER_URL }}34e06f19-kernel-release-end-of-life.png " alt=" " class="u-hidden--small " /></p>
       <table class="u-hidden--medium u-hidden--large ">
         <thead>
@@ -280,22 +280,22 @@
       </table>
     </div>
   </div>
-  <div class="row ">
-    <div class="col-8 ">
+  <div class="row">
+    <div class="col-8">
       <p>For more information on previous and upcoming kernel releases please see the <a href="https://wiki.ubuntu.com/Kernel/LTSEnablementStack " class="p-link--external ">Ubuntu LTS Enablement Stack wiki page</a>.</p>
     </div>
   </div>
 </section>
 
 <section class="p-strip ">
-  <div class="row ">
-    <div class="col-8 ">
+  <div class="row">
+    <div class="col-8">
       <h2>Ubuntu OpenStack release end of life</h2>
       <p>Canonical&rsquo;s Ubuntu Cloud archive allows users the ability to install newer releases of <a href="/openstack " class="p-link--external ">Ubuntu OpenStack</a> on an Ubuntu Server as they become available up through the next Ubuntu LTS release. The Ubuntu OpenStack support lifecycle is as follows:</p>
     </div>
   </div>
-  <div class="row ">
-    <div class="col-12 ">
+  <div class="row">
+    <div class="col-12">
       <p><img src="{{ ASSET_SERVER_URL }}dd209641-openstack-release-eol-20161213.png " alt=" " class="u-hidden--small " /></p>
       <table class="u-hidden--medium u-hidden--large ">
         <thead>
@@ -431,8 +431,8 @@
       </table>
     </div>
   </div>
-  <div class="row ">
-    <div class="col-8 ">
+  <div class="row">
+    <div class="col-8">
       <p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive " class="p-link--external ">Ubuntu Cloud Archive wiki page</a>.</p>
     </div>
   </div>

--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -30,53 +30,79 @@
   <div class="row">
     <div class="col-7">
       <h2>Ubuntu Server and desktop release end of life</h2>
-      <p>Standard Ubuntu releases are supported for 9 months and Ubuntu LTS (long-term support) releases are supported for five years on both the desktop and the server. During that time, there will be security fixes and other critical updates. The Ubuntu support lifecycle is as follows:</p>
+      <p>Standard Ubuntu releases are supported for 9 months and Ubuntu LTS (long-term support) releases are supported for five years on both the desktop and the server. During that time, there will be security fixes and other critical updates. The Ubuntu
+        support lifecycle is as follows:</p>
     </div>
   </div>
   <div class="row">
     <div class="col-12">
       <img src="{{ ASSET_SERVER_URL }}aed27baa-release-ubuntu-end-of-life.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long-term support" class="u-hidden--small" />
-      <table class="u-visible--small u-hidden--medium u-hidden--large">
+      <table class="u-hidden--medium u-hidden--large">
         <thead>
           <tr>
-            <th>Release</th>
-            <th>Released</th>
-            <th>End of life</th>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Ubuntu 16.04 LTS</td>
+            <td><strong>Ubuntu 20.04 LTS</strong></td>
+            <td>Apr-2020</td>
+            <td>Apr-2025</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.10</td>
+            <td>Oct-2019</td>
+            <td>Jul-2020</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.04</td>
+            <td>Apr-2019</td>
+            <td>Jan-2020</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.10</td>
+            <td>Oct-2018</td>
+            <td>Jul-2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04 LTS</strong></td>
+            <td>Apr-2018</td>
+            <td>Apr-2023</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 17.10</td>
+            <td>Oct-2017</td>
+            <td>Jul-2018</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 17.04</td>
+            <td>Apr-2017</td>
+            <td>Jan-2018</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 16.10</td>
+            <td>Oct-2016</td>
+            <td>Jun-2017</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04 LTS</strong></td>
             <td>Apr-2016</td>
             <td>Apr-2021</td>
           </tr>
           <tr>
-            <td>Ubuntu 15.10</td>
-            <td>Oct-2015</td>
-            <td>Dec-2015</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 15.04</td>
-            <td>Apr-2015</td>
-            <td>Jun-2015</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 14.10</td>
-            <td>Oct-2014</td>
-            <td>Dec-2014</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 14.04 LTS</td>
+            <td><strong>Ubuntu 14.04 LTS</strong></td>
             <td>Apr-2014</td>
             <td>Apr-2019</td>
           </tr>
           <tr>
-            <td>Ubuntu 12.04 LTS</td>
+            <td><strong>Ubuntu 12.04 LTS</strong></td>
             <td>Apr-2012</td>
             <td>Apr-2017</td>
           </tr>
           <tr>
-            <td>Ubuntu 10.04 LTS</td>
+            <td><strong>Ubuntu 10.04 LTS</strong></td>
             <td>Apr-2010</td>
             <td>Apr-2015</td>
           </tr>
@@ -84,24 +110,24 @@
       </table>
     </div>
   </div>
-  <div class="row">
-    <div class="col-6">
-      <p><a href="/download">Download the latest version of Ubuntu&nbsp;&rsaquo;</a></p>
+  <div class=" row ">
+    <div class="col-6 ">
+      <p><a href="/download ">Download the latest version of Ubuntu&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
+<section class="p-strip is-bordered ">
+  <div class="row ">
+    <div class="col-8 ">
       <h2>Kernel release end of life</h2>
       <p>The Ubuntu LTS enablement stacks provide newer kernel and X support for existing Ubuntu LTS releases. These can be installed manually, or are automatically shipped if installing from 12.04.2/14.04.2 and newer release media. These newer enablement stacks are meant for desktop and server, and even recommended for cloud or virtual images. The Ubuntu kernel support lifecycle is as follows:</p>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <p><img src="{{ ASSET_SERVER_URL }}34e06f19-kernel-release-end-of-life.png" alt="" class="u-hidden--small" /></p>
-      <table class="u-visible--small u-hidden--medium u-hidden--large">
+  <div class="row ">
+    <div class="col-12 ">
+      <p><img src="{{ ASSET_SERVER_URL }}34e06f19-kernel-release-end-of-life.png " alt=" " class="u-hidden--small " /></p>
+      <table class="u-hidden--medium u-hidden--large ">
         <thead>
           <tr>
             <th>Release</th>
@@ -254,24 +280,24 @@
       </table>
     </div>
   </div>
-  <div class="row">
-    <div class="col-8">
-      <p>For more information on previous and upcoming kernel releases please see the <a href="https://wiki.ubuntu.com/Kernel/LTSEnablementStack" class="p-link--external">Ubuntu LTS Enablement Stack wiki page</a>.</p>
+  <div class="row ">
+    <div class="col-8 ">
+      <p>For more information on previous and upcoming kernel releases please see the <a href="https://wiki.ubuntu.com/Kernel/LTSEnablementStack " class="p-link--external ">Ubuntu LTS Enablement Stack wiki page</a>.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
+<section class="p-strip ">
+  <div class="row ">
+    <div class="col-8 ">
       <h2>Ubuntu OpenStack release end of life</h2>
-      <p>Canonical&rsquo;s Ubuntu Cloud archive allows users the ability to install newer releases of <a href="/openstack" class="p-link--external">Ubuntu OpenStack</a> on an Ubuntu Server as they become available up through the next Ubuntu LTS release. The Ubuntu OpenStack support lifecycle is as follows:</p>
+      <p>Canonical&rsquo;s Ubuntu Cloud archive allows users the ability to install newer releases of <a href="/openstack " class="p-link--external ">Ubuntu OpenStack</a> on an Ubuntu Server as they become available up through the next Ubuntu LTS release. The Ubuntu OpenStack support lifecycle is as follows:</p>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <p><img src="{{ ASSET_SERVER_URL }}dd209641-openstack-release-eol-20161213.png" alt="" class="u-hidden--small" /></p>
-      <table class="u-visible--small u-hidden--medium u-hidden--large">
+  <div class="row ">
+    <div class="col-12 ">
+      <p><img src="{{ ASSET_SERVER_URL }}dd209641-openstack-release-eol-20161213.png " alt=" " class="u-hidden--small " /></p>
+      <table class="u-hidden--medium u-hidden--large ">
         <thead>
           <tr>
             <th>Release</th>
@@ -405,9 +431,9 @@
       </table>
     </div>
   </div>
-  <div class="row">
-    <div class="col-8">
-      <p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive" class="p-link--external">Ubuntu Cloud Archive wiki page</a>.</p>
+  <div class="row ">
+    <div class="col-8 ">
+      <p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive " class="p-link--external ">Ubuntu Cloud Archive wiki page</a>.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

* updated desktop end of life table for mobile
* removed `u-visible--small` from tables as they were displayed as blocks

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/info/release-end-of-life](http://0.0.0.0:8001/info/release-end-of-life) and compare to the [spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1712489059)

## Issue / Card

Fixes #2434

## Screenshots

![image](https://user-images.githubusercontent.com/441217/33611845-a97388c0-d9c7-11e7-8eee-5e3227458fee.png)
