### PR TITLE
Add overlay card on hero text for robotics page

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -6,8 +6,8 @@
 
 <div class="p-strip--image is-deep is-dark js-livestream__intro" style="background-position: center center; background-image:url('{{ ASSET_SERVER_URL }}ecdbd3cb-robotics.jpg?w=984')">
   <div class="row">
-    <div class="col-6">
-      <h1>Robots and drones,<br />rocking Ubuntu Core</h1>
+    <div class="col-6 p-card--overlay">
+      <h1>Robots and drones,<br />rocking&nbsp;Ubuntu&nbsp;Core</h1>
       <p>Autonomous, secure, and remotely upgradeable, the new wave of robots and drones feature amazing apps for advanced industrial intelligence.</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

* Add overlay card on hero text for robotics page
* Used 2 non-breaking spaces to make it wrap correctly

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [robotics page](http://0.0.0.0:8001/internet-of-things/robotics)

## Issue / Card

Fixes #2489

## Screenshots

![image](https://user-images.githubusercontent.com/441217/33613100-9ca9af44-d9cb-11e7-8e25-17bd5f4f7e13.png)
