### PR TITLE
Promoted Managed k8s in the navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -77,11 +77,8 @@ containers:
       path: /containers/lxd
     - title: Kubernetes
       path: /kubernetes
-
-      children:
-        - title: Managed Kubernetes
-          path: /kubernetes/managed
-
+    - title: Managed Kubernetes
+      path: /kubernetes/managed
     - title: Docker Engine
       path: /containers/docker-ubuntu
 


### PR DESCRIPTION
## Done
* Promoted Managed k8s in the navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that it is in the containers dropdown... and on the secondary nav

## Issue / Card

Fixes #2464

## Screenshots

[dropdown]

![image](https://user-images.githubusercontent.com/441217/33613439-86ffc09c-d9cc-11e7-9052-2b261f56c33c.png)

[secondary]

![image](https://user-images.githubusercontent.com/441217/33613413-781a7dd8-d9cc-11e7-9f37-c2c6a16e90e0.png)
