### PR TITLE
Encoded and obfuscated email links

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -793,8 +793,8 @@
       </ul>
       <p>Urgent needs</p>
       <ul>
-        <li class="p-list__item">You may escalate to Canonical&#39;s Support &amp; Technical Services Manager by emailing <a href="mailto:%73%75%70%70%6F%72%74%2D%6D%61%6E%61%67%65%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">support-manager@canonical.com</a>.</li>
-        <li class="p-list__item">If you require further escalation, you may email Canonical&#39;s Support &amp; Technical Services Director at <a href="mailto:%6F%70%65%72%61%74%69%6F%6E%73%2D%64%69%72%65%63%74%6F%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">operations-director@canonical.com</a>.</li>
+        <li class="p-list__item">You may escalate to Canonical&#39;s Support &amp; Technical Services Manager by emailing <a href="mailto:%73%75%70%70%6F%72%74%2D%6D%61%6E%61%67%65%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">support-manager {at} canonical {dot} com</a>.</li>
+        <li class="p-list__item">If you require further escalation, you may email Canonical&#39;s Support &amp; Technical Services Director at <a href="mailto:%6F%70%65%72%61%74%69%6F%6E%73%2D%64%69%72%65%63%74%6F%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">operations-director {at} canonical {dot} com</a>.</li>
       </ul>
     </div>
     <!-- / Appendix 3 -->


### PR DESCRIPTION
## Done

* Encoded and obfuscated email links on /legal/ubuntu-advantage/service-description page
* e.g. `<a href="mailto:%73%75%70%70%6F%72%74%2D%6D%61%6E%61%67%65%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">support-manager {at} canonical {dot} com</a>`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
[/legal/ubuntu-advantage/service-description page](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description#ua-support-regions)
- See that you can still understand the visible text as an email.
- See that the mailto links still wor

## Issue / Card

Fixes #2507

