### PR TITLE
Change takeover CTA copy

### DIFF
--- a/templates/takeovers/_ues_takeover.html
+++ b/templates/takeovers/_ues_takeover.html
@@ -5,7 +5,7 @@
         <h1 class="p-heading--two"><span class="event-title" itemprop="name">Ubuntu Enterprise Summit</span></h1>
         <h2 class="p-heading--three"><span class="event-date" itemprop="startDate" content="2017-12-05T16:00">5</span> – <span class="event-date" itemprop="endDate" content="2017-12-06T21:00">6 December 2017</span></h2>
         <p class="p-heading--five">Find out how the world&rsquo;s top companies use Ubuntu to succeed</p>
-        <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Join in', 'eventValue' : undefined });" class="p-button--positive">Join in</a></p>
+        <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'View on demand', 'eventValue' : undefined });" class="p-button--positive">View on demand</a></p>
       </div>
       <div class="col-6 u-align--right">
         <img src="{{ ASSET_SERVER_URL }}9c1315fb-IOT_Ubuntu_devices_inforgrapic+v3.svg" alt="" />

--- a/templates/takeovers/_ues_takeover.html
+++ b/templates/takeovers/_ues_takeover.html
@@ -10,7 +10,7 @@
       <div class="col-6 u-align--right">
         <img src="{{ ASSET_SERVER_URL }}9c1315fb-IOT_Ubuntu_devices_inforgrapic+v3.svg" alt="" />
       </div>
-      <p class="u-hide--medium u-hide--large u-show--small"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'Join in', 'eventValue' : undefined });" class="p-button--positive">Join in</a></p>
+      <p class="u-hide--medium u-hide--large u-show--small"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'View on demand', 'eventValue' : undefined });" class="p-button--positive">View on demand</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

### To go live on Thursday 7th December

Change takeover CTA copy 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Make sure the homepage takeover CTA copy has changed as per [issue](https://app.zenhub.com/workspace/o/canonical-websites/www.ubuntu.com/issues/2490) 

## Issue / Card

Fixes #2490 