### PR TITLE
Turn toc and links from divs to navs

### DIFF
--- a/templates/legal/short-terms/2015-06-24.html
+++ b/templates/legal/short-terms/2015-06-24.html
@@ -137,12 +137,12 @@
       </ol>
     </div>
 
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Latest version</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms">Latest version&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </section>
 

--- a/templates/legal/short-terms/2015-09-09.html
+++ b/templates/legal/short-terms/2015-09-09.html
@@ -6,140 +6,204 @@
 
 {% block content %}
 
-<div class="row">
-  <div class="col-8">
-    <h1>Short Form Services Agreement</h1>
-    <p>This short form services agreement (the “Agreement”) takes effect as of the date Customer signs an Order incorporating its terms or otherwise accepts its terms as part of a Registration Process (the “Effective Date”) between, Canonical Group Limited, a company registered in England (company number 6870835) whose registered office is at 5th Floor, Blue Fin Building, 110 Southwark Street, London SE1 0SU, United Kingdom (“Canonical”), and the customer identified in the Order (“Customer”).</p>
-    <ol class="p-list">
-      <li class="p-list__item">
-        <h2>1. Interpretation</h2>
-        <p>When used in this Agreement, the following terms mean:</p>
-        <p><strong>Affiliate</strong>: a corporate entity that directly or indirectly controls, is controlled by, or is under common control with a party, where “control” means ownership of more than 50% of the outstanding shares or securities representing
-          the right to vote for the election of directors or other managing authority of such corporate entity.</p>
-        <p><strong>Confidential Information</strong>: the terms of this Agreement, and any information identified by the disclosing party as confidential or which the receiving party reasonably ought to know is confidential in light of the nature of the
-          information or the circumstances of its disclosure.</p>
-        <p><strong>Fee(s)</strong>: the amounts payable by Customer for the Services, as set out in the Order.</p>
-        <p><strong>Intellectual Property Rights</strong>: all vested and future rights of copyright and related rights, design rights, database rights, patents, rights to inventions, trade marks and get-up (and goodwill attaching to those trade marks and that get up), domain names, applications for and the right to apply for any of the above, moral rights, goodwill (and the right to sue for passing off and unfair competition), rights in know-how, rights in confidential information, rights in computer software and semiconductor topographies, and any other intellectual or industrial property rights or equivalent forms of protection, whether or not registered or capable of registration, and all renewals and extensions of such rights, whether now known or in future subsisting in any part of the world.</p>
-        <p><strong>Open Source Software</strong>: any software which is distributed under any of the many known variations of licence terms which allow the free distribution and modification of the software’s source code or which require all distributors to make such source code freely available upon request, including any contributions or modifications thereto made by such distributor.</p>
-        <p><strong>Order</strong>: If Customer is buying Services directly from Canonical: Customer's order for Services which incorporates this Agreement and identifies Customer's name, contact information, Services, Fees, and Services Term. If Customer is buying Services through Canonical's reseller: Customer's agreement to purchase the Services and pay applicable Fees.</p>
-        <p><strong>Registration Process</strong>: The process under which a Customer registers with Canonical to receive Services purchased through Canonical's reseller.</p>
-        <p><strong>Services</strong>: the services to be performed by Canonical as identified in the Order and described at <a href="/legal/ubuntu-advantage/service-description">www.ubuntu.com/legal/ubuntu-advantage/service-description</a> and/or <a href="/legal/bootstack/service-description">www.ubuntu.com/legal/bootstack/service-description</a>          as of the Effective Date.</p>
-        <p><strong>Services Term</strong>: the period of time beginning when Canonical first makes the Services available to Customer and ending after the period of time specified in the Order.</p>
-        <p><strong>Ubuntu</strong>: a version of the operating system known as “Ubuntu”, which is supported by Canonical pursuant to Canonical's public announcements and support schedule and is either Canonical's standard version with no modifications or a version modified by Canonical.</p>
-      </li>
-      <li class="p-list__item">
-        <h2>2. Services</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">2.1</span> Canonical will make the Services available to Customer within 5 days of any of the following events: (i) Canonical receives a purchase order from Customer for the Fees, (ii) Customer pays the Fees to Canonical, or (iii) Canonical's reseller orders the Services with respect to Customer. Subject to this Agreement, including Customer's payment of the Fees, Canonical will provide the Services during the Services Term using reasonable skill and care and through suitably qualified employees and contractors.</li>
-          <li class="p-list__item"><span class="number">2.2</span> Canonical is not obligated to perform (i) any service or function except as expressly identified in the Order (ii) any Services to the extent its performance is limited by Customer's failure to meet any reasonable dependency.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>3. Intellectual Property Rights</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">3.1</span> Each party will retain ownership of its Intellectual Property Rights and any Intellectual Property Rights it creates or obtains. Nothing Canonical creates or provides under this Agreement will be considered a “work made for hire”, and no Intellectual Property Rights will transfer under this Agreement.</li>
-          <li class="p-list__item"><span class="number">3.2</span> Ubuntu is licensed under applicable Open Source Software licences and not this Agreement. If Canonical creates or provides any software to Customer in the course of providing the Services, Canonical will provide such software under an Open Source Software licence, unless otherwise licensed under this Agreement.</li>
-          <li class="p-list__item"><span class="number">3.3</span> During and after the term of this Agreement, Customer will comply with Canonical's Intellectual Property Rights policy at <a href="https://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy">https://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy</a>.</li>
-          <li class="p-list__item"><span class="number">3.4</span> With respect to Services which include Canonical's “Landscape Dedicated Server” product (the “LDS Product”), Canonical hereby grants to Customer, subject to all Open Source Software licences, a world-wide, non-exclusive, non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of this Agreement, to (i) use the LDS Product in accordance with this Agreement and subject to any quantity or usage limitations set forth in the Order and (ii) to make a reasonable number of copies of the LDS Product for backup and installation purposes. Customer may not: use, copy, modify, disassemble, decompile, reverse engineer, or distribute the LDS Product except as expressly permitted in this Agreement; permit access to the LDS Product to any third party other than those acting on Customer's behalf; or move the LDS Product from one machine to another without the prior written consent of Canonical.</li>
-          <li class="p-list__item"><span class="number">3.5</span> With respect to Services which include Canonical's paravirtualized drivers for Microsoft Windows systems to run as guests on Ubuntu (the “VirtIO Drivers”), Canonical hereby grants to Customer, a world-wide, non-exclusive, non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of the applicable Services, to (i) use the VirtIO Drivers in accordance with this Agreement solely in connection with those computer systems for which Customer has purchased the Services, (ii) to make a reasonable number of copies of the VirtIO Drivers for backup and installation purposes. Customer may not: use, copy, modify, disassemble, decompile, reverse engineer, or distribute the VirtIO Drivers except as expressly permitted in this Agreement or permit access to the VirtIO Drivers to any third party other than those acting on Customer's behalf, and (iii) to distribute the VirtIO Drivers to third party users of Customer's cloud computing services. In connection with the distribution licence granted under (iii) of the preceding sentence, Customer may sublicense the licence granted under (i) and (ii) of the preceding sentence to third party users Customer's cloud computing services. Such sublicence must be on terms that are no less protective of Canonical's rights than those of this Agreement, and must be revoked upon the revocation of the licence under this Clause 3.5.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>4. Customer responsibilities</h2>
-        <ol class="p-list">
-          <p><span class="number">4.1</span> Customer will not (i) use the Services other than in connection with the Customer systems for which Customer has purchased the Services or (ii) resell the Services.</p>
-          <p><span class="number">4.2</span> Customer is responsible for the back-up of its data and software. Canonical will not be liable for any loss, corruption, or damage to data or software.</p>
-          <p><span class="number">4.3</span> If Customer engages Canonical to install or use any third party software or materials as part of the Services, Customer will have and maintain sufficient rights or licences to such software to allow Canonical to perform the Services.</p>
-          <p><span class="number">4.4</span> Where Canonical provides access to online resources as part of the Services, Customer (i) will comply with Canonical&rsquo;s reasonable instructions and (ii) will not cause any adverse impact to the Services.</p>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>5. Confidentiality</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">5.1</span> During and after the term of this Agreement, each party will and will cause its officers, employees, contractors and agents to keep secret and confidential all Confidential Information of the other and will not copy, use or disclose any such information to any third party, other than as may be necessary to comply with its obligations under this Agreement; provided that a party may disclose the other party's Confidential Information to Affiliates.</li>
-          <li class="p-list__item"><span class="number">5.2</span> The obligation of confidence will not apply where the Confidential Information: is required to be disclosed by operation of law; was lawfully in the possession of the recipient prior to disclosure by the other party; is subsequently lawfully acquired from a third party or independently developed by the recipient without breach of any known obligation of confidence; is or becomes generally available to the public through no act or default of the recipient; or is disclosed on a confidential basis for the purposes of obtaining professional advice.</li>
-          <li class="p-list__item"><span class="number">5.3</span> Each party will give the other prompt written notice of any disclosure of the party's Confidential Information as required by operation of law during and after the term of this Agreement.</li>
-          <li class="p-list__item"><span class="number">5.4</span> Each party agrees that damages would not be an adequate remedy for any failure to comply with the confidentiality obligations in this Agreement and that the other party will be entitled to the remedies of injunction, specific performance and/or other equitable relief for any threatened or actual failure to comply with those obligations.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>6. Fees and payment</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">6.1</span> If Customer is purchasing the Ubuntu Advantage Services directly from Canonical, Customer will pay the Fees at the time of Customer's Order. If Customer is purchasing the BootStack Services directly from Canonical, Customer will pay the Fees monthly, in advance, in accordance with the BootStack services description and the Order. If Customer is purchasing Services through Canonical's reseller, Customer shall pay the Fees in accordance with the reseller's
-            process and the terms of this Clause 6 will not otherwise apply.</li>
-          <li class="p-list__item"><span class="number">6.2</span> The Fees are exclusive of all applicable taxes, which Customer will pay in addition to the Fees at the rate prevailing on the date of the invoice. Any sums payable by Customer to Canonical will be paid clear of any deductions or withholdings. In the event that Customer is required by applicable law to withhold or deduct any amounts from the Fees, Customer will pay any additional amounts necessary to ensure that Canonical is in the same position as it would have been in had no deductions or withholdings been required.</li>
-          <li class="p-list__item"><span class="number">6.3</span> During the term of this Agreement, Canonical may request Customer's confirmation of its compliance with this Agreement or, if Canonical reasonably suspects that Customer is not in compliance with this Agreement, audit Customer's use of the Services to confirm compliance. If any audit reveals that Customer was not in compliance with the Agreement, Customer will immediately come into compliance. If Customer's confirmation or an audit reveals that additional
-          Fees are due, Customer will pay such Fees and interest (at the rate applicable to past due amounts), within 30 days of the date of Canonical’s invoice. If the additional Fees exceed the Fees originally invoiced for the period covered by the audit by 5%, Customer will reimburse Canonical for the costs of the audit.</li>
-          <li class="p-list__item"><span class="number">6.4</span> Canonical may charge interest on any past due payment amounts, plus any related collection and legal costs. Such interest will accrue at the annual rate of 2% above the base rate of the Bank of England in force from the due date until the date of payment, or the highest rate allowable by applicable law (if lower). Interest will accrue on a daily basis, whether before or after judgement.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>7. Warranty disclaimer</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">7.1</span> Neither party makes any representations or warranties of any kind, whether oral or written, whether express, implied, or arising by statute, custom, course of dealing or trade usage, with respect to the subject matter hereof or otherwise in connection with this Agreement. Each party specifically disclaims any and all implied warranties or conditions of title, satisfactory quality, merchantability, satisfactoriness, fitness for a particular purpose and non-infringement.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>8. Liability limitations</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">8.1</span> Subject to Clause 8.3, each party’s aggregate liability under this Agreement, in any Contract Year, whether based on contract, tort (including negligence) or otherwise, will not exceed the amount of Fees paid or payable in that particular Contract Year. “Contract Year” means any period of 12 months commencing on the Effective Date or any anniversary of the Effective Date.</li>
-          <li class="p-list__item"><span class="number">8.2</span> Subject to Clause 8.3, neither party will be liable for any indirect, special, incidental, punitive, or consequential loss or damage or for any loss of or damage to data, ex gratia payments, loss of profit, loss of contract or loss of other economic advantage (in each case whether direct or indirect) arising out of or in connection with this Agreement, even if that party has previously been advised of the possibility of the same and whether foreseeable or not. These limitations will apply notwithstanding any failure of essential purpose of any limited remedy.</li>
-          <li class="p-list__item"><span class="number">8.3</span> Nothing in this Agreement excludes or limits the liability of either party for: (i) death or personal injury; (ii) fraud; (iii) breach of the confidentiality provisions of this Agreement, and (iv) anything else that cannot be excluded of limited by applicable law.</li>
-          <li class="p-list__item"><span class="number">8.4</span> The limitations of liability set forth in this Clause 8 are a reasonable allocation of risk between the parties, and the parties would not have entered into this Agreement, absent such allocation.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>9. Term and termination</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">9.1</span> This Agreement will come into force on the Effective Date and will continue until the end of the Services Term unless terminated earlier under this Clause 9.</li>
-          <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rsquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement will automatically terminate.</li>
-          <li class="p-list__item"><span class="number">9.3</span> Either party may terminate this Agreement immediately by written notice if the other party:
-            <ol class="p-list">
-              <li class="p-list__item"><span class="number">9.3.1</span>commits a material breach of this Agreement and, if such breach is capable of remedy, fails to remedy the breach within 14 days of receiving notice of the breach;</li>
-              <li class="p-list__item"><span class="number">9.3.2</span>enters into liquidation whether compulsorily or voluntarily (otherwise than for the purposes of a solvent amalgamation or reconstruction); becomes insolvent; ceases or threatens to cease to carry on business; or any similar event.</li>
-            </ol>
-          </li>
-          <li class="p-list__item"><span class="number">9.4</span>Canonical may terminate this Agreement for convenience upon giving 90 days prior notice to Customer.</li>
-          <li class="p-list__item"><span class="number">9.5</span>On expiration or termination this Agreement for any reason, Canonical&rsquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise agreed. On termination other than by Canonical for convenience in accordance with Clause 9.4, Customer will immediately pay all outstanding Fees applicable to this Agreement including Fees that would otherwise have been payable with respect to the full Agreement term. On termination of this Agreement by Canonical for convenience in accordance with Clause 9.4, Canonical will provide Customer with a pro rata refund of any prepaid Fees for the remaining unexpired portion of the Services Term.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>10. Escalation</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">10.1</span> If there is a disagreement in relation to this Agreement, the parties will use their reasonable endeavours to negotiate and settle the disagreement. If it is not possible to settle the disagreement within 14 days, representatives of both parties will meet to try to resolve the disagreement. If the disagreement is not resolved within a further 14 days, the disagreement may be referred by either party to a meeting between the senior managers of the parties. Subject to Clause 10.2, neither party will refer any dispute to the courts unless and until the dispute resolution procedures of this Clause 10 have been followed.</li>
-          <li class="p-list__item"><span class="number">10.2</span> Nothing in this Clause 10 will prevent either party applying to the courts of any country for injunctive or other interim relief.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>11. General</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">11.1</span> Neither party will be liable for any breach of this Agreement directly or indirectly caused by circumstances beyond the reasonable control of that party, provided that a lack of funds will not be regarded as a circumstance beyond that party’s reasonable control.</li>
-          <li class="p-list__item"><span class="number">11.2</span> Neither party may assign, transfer, charge, create a trust over or otherwise deal in its rights and/or obligations under this Agreement (or purport to do so) without the other party’s prior written consent except to an Affiliate pursuant to a bona fide re-structure, merger, consolidation, sale of all or substantially all of its assets, or a sale of the business to which the Services relate.</li>
-          <li class="p-list__item"><span class="number">11.3</span> There are no intended third party beneficiaries to this Agreement. The parties do not intend that any provision of this Agreement will be enforceable by virtue of the Contracts (Rights of Third Parties) Act 1999 (England), as amended from time to time, by any person who is not a party to this Agreement.</li>
-          <li class="p-list__item"><span class="number">11.4</span> No amendment or modification of this Agreement will be binding upon the parties unless made in writing and signed by the authorized representatives of both parties.</li>
-          <li class="p-list__item"><span class="number">11.5</span> A failure or delay by a party to exercise any right or remedy under this Agreement will not be construed or operate as a waiver of that right or remedy. Nor single or partial exercise of any right or remedy will preclude the further exercise of that right or remedy by that party.</li>
-          <li class="p-list__item"><span class="number">11.6</span> During the term of this Agreement and for 6 months thereafter, Customer will not solicit to be hired or hire, as an employee or independent contractor, any individual (i) who is then the personnel of Canonical or any of its Affiliates or was the personnel of Canonical or any of its Affiliates during the previous 6 months (unless Canonical terminated that individual's employment or contract) and (ii) who during any part of the term of this Agreement was assigned by Canonical to provide services to Canonical's customers.</li>
-          <li class="p-list__item"><span class="number">11.7</span> This Agreement represents the entire terms agreed between the parties in relation to its subject matter and supersedes all previous contracts or arrangements (including any usage or custom and any terms arising through any course of dealing) of any kind between the parties relating to its subject matter. No terms or conditions included in or delivered with any Customer acceptance of Services, proposal, purchase order or similar document will form part of this Agreement.</li>
-          <li class="p-list__item"><span class="number">11.8</span> Each of the provisions of this Agreement will be construed as independent of every other such provision, so that if any provision of this Agreement will be determined by any court of competent authority to be illegal, invalid and/or unenforceable this will not affect any other provision of this Agreement, which will remain in full force and effect.</li>
-          <li class="p-list__item"><span class="number">11.9</span> Nothing in this Agreement and no action taken by the parties pursuant to this Agreement will be construed as creating a partnership or joint venture of any kind between the parties or as constituting either party as the agent of the other party. No party will have the authority to bind the other party or to contract in the name of or create a liability against the other party.</li>
-          <li class="p-list__item"><span class="number">11.10</span> Any notice required to be given or sent under this Agreement will be in writing and delivered to the recipient at the address set out in this Agreement or, if no address is set out, to the recipient's registered office address. A party may update its address by providing notice to the other party. Valid delivery methods are (i) in-person delivery, (ii) first class registered post (or equivalent), or (iii) internationally recognized overnight courier service.</li>
-          <li class="p-list__item"><span class="number">11.11</span> Canonical may provide copies of this Agreement in different languages for information purposes. Only the English language version of this Agreement will be binding. In the event of any dispute, any version in any language other than English will be disregarded.</li>
-          <li class="p-list__item"><span class="number">11.12</span> Customer acknowledges that export laws and regulations of the United States and European territories may apply to materials delivered by Canonical under this Agreement. Customer agrees that such export control laws and regulations govern its use of materials and will comply with all such laws and regulations. Customer will not export, directly or indirectly, such materials in violation of these laws or regulations, or use them for any purpose prohibited by these laws.</li>
-        </ol>
-      </li>
-      <li class="p-list__item">
-        <h2>12. Governing law</h2>
-        <ol class="p-list">
-          <li class="p-list__item"><span class="number">12.1</span> This Agreement and any non-contractual obligations arising from this Agreement will be governed by and construed in accordance with the laws of England. The parties submit to the exclusive jurisdiction of the courts of England, except when a party seeks immediate injunctive relief (for example, in connection with a breach or impending breach of confidentiality obligations) that would not be reasonably effective unless obtained in the jurisdiction of the conduct at issue. The provisions of the United Nations Convention on Contracts for the International Sale of Goods will not apply to this Agreement.</li>
-        </ol>
-      </li>
-    </ol>
-  </div>
-  <div class="col-4 p-card">
-    <h3>Latest version</h3>
-    <ul class="p-list">
-      <li class="p-list__item"><a href="/legal/short-terms">Latest version&nbsp;›</a></li>
-    </ul>
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>Short Form Services Agreement</h1>
+      <p>This short form services agreement (the “Agreement”) takes effect as of the date Customer signs an Order incorporating its terms or otherwise accepts its terms as part of a Registration Process (the “Effective Date”) between, Canonical Group Limited,
+        a company registered in England (company number 6870835) whose registered office is at 5th Floor, Blue Fin Building, 110 Southwark Street, London SE1 0SU, United Kingdom (“Canonical”), and the customer identified in the Order (“Customer”).</p>
+      <ol class="p-list">
+        <li class="p-list__item">
+          <h2>1. Interpretation</h2>
+          <p>When used in this Agreement, the following terms mean:</p>
+          <p><strong>Affiliate</strong>: a corporate entity that directly or indirectly controls, is controlled by, or is under common control with a party, where “control” means ownership of more than 50% of the outstanding shares or securities representing
+            the right to vote for the election of directors or other managing authority of such corporate entity.</p>
+          <p><strong>Confidential Information</strong>: the terms of this Agreement, and any information identified by the disclosing party as confidential or which the receiving party reasonably ought to know is confidential in light of the nature of the
+            information or the circumstances of its disclosure.</p>
+          <p><strong>Fee(s)</strong>: the amounts payable by Customer for the Services, as set out in the Order.</p>
+          <p><strong>Intellectual Property Rights</strong>: all vested and future rights of copyright and related rights, design rights, database rights, patents, rights to inventions, trade marks and get-up (and goodwill attaching to those trade marks and
+            that get up), domain names, applications for and the right to apply for any of the above, moral rights, goodwill (and the right to sue for passing off and unfair competition), rights in know-how, rights in confidential information, rights
+            in computer software and semiconductor topographies, and any other intellectual or industrial property rights or equivalent forms of protection, whether or not registered or capable of registration, and all renewals and extensions of such
+            rights, whether now known or in future subsisting in any part of the world.</p>
+          <p><strong>Open Source Software</strong>: any software which is distributed under any of the many known variations of licence terms which allow the free distribution and modification of the software’s source code or which require all distributors
+            to make such source code freely available upon request, including any contributions or modifications thereto made by such distributor.</p>
+          <p><strong>Order</strong>: If Customer is buying Services directly from Canonical: Customer's order for Services which incorporates this Agreement and identifies Customer's name, contact information, Services, Fees, and Services Term. If Customer
+            is buying Services through Canonical's reseller: Customer's agreement to purchase the Services and pay applicable Fees.</p>
+          <p><strong>Registration Process</strong>: The process under which a Customer registers with Canonical to receive Services purchased through Canonical's reseller.</p>
+          <p><strong>Services</strong>: the services to be performed by Canonical as identified in the Order and described at <a href="/legal/ubuntu-advantage/service-description">www.ubuntu.com/legal/ubuntu-advantage/service-description</a> and/or <a href="/legal/bootstack/service-description">www.ubuntu.com/legal/bootstack/service-description</a>            as of the Effective Date.</p>
+          <p><strong>Services Term</strong>: the period of time beginning when Canonical first makes the Services available to Customer and ending after the period of time specified in the Order.</p>
+          <p><strong>Ubuntu</strong>: a version of the operating system known as “Ubuntu”, which is supported by Canonical pursuant to Canonical's public announcements and support schedule and is either Canonical's standard version with no modifications
+            or a version modified by Canonical.</p>
+        </li>
+        <li class="p-list__item">
+          <h2>2. Services</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">2.1</span> Canonical will make the Services available to Customer within 5 days of any of the following events: (i) Canonical receives a purchase order from Customer for the Fees, (ii) Customer pays the Fees to Canonical,
+              or (iii) Canonical's reseller orders the Services with respect to Customer. Subject to this Agreement, including Customer's payment of the Fees, Canonical will provide the Services during the Services Term using reasonable skill and care
+              and through suitably qualified employees and contractors.</li>
+            <li class="p-list__item"><span class="number">2.2</span> Canonical is not obligated to perform (i) any service or function except as expressly identified in the Order (ii) any Services to the extent its performance is limited by Customer's failure to meet any reasonable
+              dependency.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>3. Intellectual Property Rights</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">3.1</span> Each party will retain ownership of its Intellectual Property Rights and any Intellectual Property Rights it creates or obtains. Nothing Canonical creates or provides under this Agreement will be considered
+              a “work made for hire”, and no Intellectual Property Rights will transfer under this Agreement.</li>
+            <li class="p-list__item"><span class="number">3.2</span> Ubuntu is licensed under applicable Open Source Software licences and not this Agreement. If Canonical creates or provides any software to Customer in the course of providing the Services, Canonical will provide
+              such software under an Open Source Software licence, unless otherwise licensed under this Agreement.</li>
+            <li class="p-list__item"><span class="number">3.3</span> During and after the term of this Agreement, Customer will comply with Canonical's Intellectual Property Rights policy at <a href="https://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy">https://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy</a>.</li>
+            <li class="p-list__item"><span class="number">3.4</span> With respect to Services which include Canonical's “Landscape Dedicated Server” product (the “LDS Product”), Canonical hereby grants to Customer, subject to all Open Source Software licences, a world-wide, non-exclusive,
+              non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of this Agreement, to (i) use the LDS Product in accordance with this Agreement and subject to any quantity or usage limitations
+              set forth in the Order and (ii) to make a reasonable number of copies of the LDS Product for backup and installation purposes. Customer may not: use, copy, modify, disassemble, decompile, reverse engineer, or distribute the LDS Product except
+              as expressly permitted in this Agreement; permit access to the LDS Product to any third party other than those acting on Customer's behalf; or move the LDS Product from one machine to another without the prior written consent of Canonical.</li>
+            <li class="p-list__item"><span class="number">3.5</span> With respect to Services which include Canonical's paravirtualized drivers for Microsoft Windows systems to run as guests on Ubuntu (the “VirtIO Drivers”), Canonical hereby grants to Customer, a world-wide,
+              non-exclusive, non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of the applicable Services, to (i) use the VirtIO Drivers in accordance with this Agreement solely in connection
+              with those computer systems for which Customer has purchased the Services, (ii) to make a reasonable number of copies of the VirtIO Drivers for backup and installation purposes. Customer may not: use, copy, modify, disassemble, decompile,
+              reverse engineer, or distribute the VirtIO Drivers except as expressly permitted in this Agreement or permit access to the VirtIO Drivers to any third party other than those acting on Customer's behalf, and (iii) to distribute the VirtIO
+              Drivers to third party users of Customer's cloud computing services. In connection with the distribution licence granted under (iii) of the preceding sentence, Customer may sublicense the licence granted under (i) and (ii) of the preceding
+              sentence to third party users Customer's cloud computing services. Such sublicence must be on terms that are no less protective of Canonical's rights than those of this Agreement, and must be revoked upon the revocation of the licence under
+              this Clause 3.5.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>4. Customer responsibilities</h2>
+          <ol class="p-list">
+            <p><span class="number">4.1</span> Customer will not (i) use the Services other than in connection with the Customer systems for which Customer has purchased the Services or (ii) resell the Services.</p>
+            <p><span class="number">4.2</span> Customer is responsible for the back-up of its data and software. Canonical will not be liable for any loss, corruption, or damage to data or software.</p>
+            <p><span class="number">4.3</span> If Customer engages Canonical to install or use any third party software or materials as part of the Services, Customer will have and maintain sufficient rights or licences to such software to allow Canonical
+              to perform the Services.</p>
+            <p><span class="number">4.4</span> Where Canonical provides access to online resources as part of the Services, Customer (i) will comply with Canonical&rsquo;s reasonable instructions and (ii) will not cause any adverse impact to the Services.</p>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>5. Confidentiality</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">5.1</span> During and after the term of this Agreement, each party will and will cause its officers, employees, contractors and agents to keep secret and confidential all Confidential Information of the other and will
+              not copy, use or disclose any such information to any third party, other than as may be necessary to comply with its obligations under this Agreement; provided that a party may disclose the other party's Confidential Information to Affiliates.</li>
+            <li class="p-list__item"><span class="number">5.2</span> The obligation of confidence will not apply where the Confidential Information: is required to be disclosed by operation of law; was lawfully in the possession of the recipient prior to disclosure by the other
+              party; is subsequently lawfully acquired from a third party or independently developed by the recipient without breach of any known obligation of confidence; is or becomes generally available to the public through no act or default of the
+              recipient; or is disclosed on a confidential basis for the purposes of obtaining professional advice.</li>
+            <li class="p-list__item"><span class="number">5.3</span> Each party will give the other prompt written notice of any disclosure of the party's Confidential Information as required by operation of law during and after the term of this Agreement.</li>
+            <li class="p-list__item"><span class="number">5.4</span> Each party agrees that damages would not be an adequate remedy for any failure to comply with the confidentiality obligations in this Agreement and that the other party will be entitled to the remedies of injunction,
+              specific performance and/or other equitable relief for any threatened or actual failure to comply with those obligations.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>6. Fees and payment</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">6.1</span> If Customer is purchasing the Ubuntu Advantage Services directly from Canonical, Customer will pay the Fees at the time of Customer's Order. If Customer is purchasing the BootStack Services directly from Canonical,
+              Customer will pay the Fees monthly, in advance, in accordance with the BootStack services description and the Order. If Customer is purchasing Services through Canonical's reseller, Customer shall pay the Fees in accordance with the reseller's
+              process and the terms of this Clause 6 will not otherwise apply.</li>
+            <li class="p-list__item"><span class="number">6.2</span> The Fees are exclusive of all applicable taxes, which Customer will pay in addition to the Fees at the rate prevailing on the date of the invoice. Any sums payable by Customer to Canonical will be paid clear
+              of any deductions or withholdings. In the event that Customer is required by applicable law to withhold or deduct any amounts from the Fees, Customer will pay any additional amounts necessary to ensure that Canonical is in the same position
+              as it would have been in had no deductions or withholdings been required.</li>
+            <li class="p-list__item"><span class="number">6.3</span> During the term of this Agreement, Canonical may request Customer's confirmation of its compliance with this Agreement or, if Canonical reasonably suspects that Customer is not in compliance with this Agreement,
+              audit Customer's use of the Services to confirm compliance. If any audit reveals that Customer was not in compliance with the Agreement, Customer will immediately come into compliance. If Customer's confirmation or an audit reveals that
+              additional Fees are due, Customer will pay such Fees and interest (at the rate applicable to past due amounts), within 30 days of the date of Canonical’s invoice. If the additional Fees exceed the Fees originally invoiced for the period
+              covered by the audit by 5%, Customer will reimburse Canonical for the costs of the audit.</li>
+            <li class="p-list__item"><span class="number">6.4</span> Canonical may charge interest on any past due payment amounts, plus any related collection and legal costs. Such interest will accrue at the annual rate of 2% above the base rate of the Bank of England in force
+              from the due date until the date of payment, or the highest rate allowable by applicable law (if lower). Interest will accrue on a daily basis, whether before or after judgement.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>7. Warranty disclaimer</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">7.1</span> Neither party makes any representations or warranties of any kind, whether oral or written, whether express, implied, or arising by statute, custom, course of dealing or trade usage, with respect to the subject
+              matter hereof or otherwise in connection with this Agreement. Each party specifically disclaims any and all implied warranties or conditions of title, satisfactory quality, merchantability, satisfactoriness, fitness for a particular purpose
+              and non-infringement.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>8. Liability limitations</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">8.1</span> Subject to Clause 8.3, each party’s aggregate liability under this Agreement, in any Contract Year, whether based on contract, tort (including negligence) or otherwise, will not exceed the amount of Fees paid
+              or payable in that particular Contract Year. “Contract Year” means any period of 12 months commencing on the Effective Date or any anniversary of the Effective Date.</li>
+            <li class="p-list__item"><span class="number">8.2</span> Subject to Clause 8.3, neither party will be liable for any indirect, special, incidental, punitive, or consequential loss or damage or for any loss of or damage to data, ex gratia payments, loss of profit,
+              loss of contract or loss of other economic advantage (in each case whether direct or indirect) arising out of or in connection with this Agreement, even if that party has previously been advised of the possibility of the same and whether
+              foreseeable or not. These limitations will apply notwithstanding any failure of essential purpose of any limited remedy.</li>
+            <li class="p-list__item"><span class="number">8.3</span> Nothing in this Agreement excludes or limits the liability of either party for: (i) death or personal injury; (ii) fraud; (iii) breach of the confidentiality provisions of this Agreement, and (iv) anything else
+              that cannot be excluded of limited by applicable law.</li>
+            <li class="p-list__item"><span class="number">8.4</span> The limitations of liability set forth in this Clause 8 are a reasonable allocation of risk between the parties, and the parties would not have entered into this Agreement, absent such allocation.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>9. Term and termination</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">9.1</span> This Agreement will come into force on the Effective Date and will continue until the end of the Services Term unless terminated earlier under this Clause 9.</li>
+            <li class="p-list__item"><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical&rsquo;s reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement
+              will automatically terminate.</li>
+            <li class="p-list__item"><span class="number">9.3</span> Either party may terminate this Agreement immediately by written notice if the other party:
+              <ol class="p-list">
+                <li class="p-list__item"><span class="number">9.3.1</span>commits a material breach of this Agreement and, if such breach is capable of remedy, fails to remedy the breach within 14 days of receiving notice of the breach;</li>
+                <li class="p-list__item"><span class="number">9.3.2</span>enters into liquidation whether compulsorily or voluntarily (otherwise than for the purposes of a solvent amalgamation or reconstruction); becomes insolvent; ceases or threatens to cease to carry on business;
+                  or any similar event.</li>
+              </ol>
+            </li>
+            <li class="p-list__item"><span class="number">9.4</span>Canonical may terminate this Agreement for convenience upon giving 90 days prior notice to Customer.</li>
+            <li class="p-list__item"><span class="number">9.5</span>On expiration or termination this Agreement for any reason, Canonical&rsquo;s obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless
+              otherwise agreed. On termination other than by Canonical for convenience in accordance with Clause 9.4, Customer will immediately pay all outstanding Fees applicable to this Agreement including Fees that would otherwise have been payable
+              with respect to the full Agreement term. On termination of this Agreement by Canonical for convenience in accordance with Clause 9.4, Canonical will provide Customer with a pro rata refund of any prepaid Fees for the remaining unexpired
+              portion of the Services Term.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>10. Escalation</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">10.1</span> If there is a disagreement in relation to this Agreement, the parties will use their reasonable endeavours to negotiate and settle the disagreement. If it is not possible to settle the disagreement within 14
+              days, representatives of both parties will meet to try to resolve the disagreement. If the disagreement is not resolved within a further 14 days, the disagreement may be referred by either party to a meeting between the senior managers of
+              the parties. Subject to Clause 10.2, neither party will refer any dispute to the courts unless and until the dispute resolution procedures of this Clause 10 have been followed.</li>
+            <li class="p-list__item"><span class="number">10.2</span> Nothing in this Clause 10 will prevent either party applying to the courts of any country for injunctive or other interim relief.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>11. General</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">11.1</span> Neither party will be liable for any breach of this Agreement directly or indirectly caused by circumstances beyond the reasonable control of that party, provided that a lack of funds will not be regarded as
+              a circumstance beyond that party’s reasonable control.</li>
+            <li class="p-list__item"><span class="number">11.2</span> Neither party may assign, transfer, charge, create a trust over or otherwise deal in its rights and/or obligations under this Agreement (or purport to do so) without the other party’s prior written consent
+              except to an Affiliate pursuant to a bona fide re-structure, merger, consolidation, sale of all or substantially all of its assets, or a sale of the business to which the Services relate.</li>
+            <li class="p-list__item"><span class="number">11.3</span> There are no intended third party beneficiaries to this Agreement. The parties do not intend that any provision of this Agreement will be enforceable by virtue of the Contracts (Rights of Third Parties) Act
+              1999 (England), as amended from time to time, by any person who is not a party to this Agreement.</li>
+            <li class="p-list__item"><span class="number">11.4</span> No amendment or modification of this Agreement will be binding upon the parties unless made in writing and signed by the authorized representatives of both parties.</li>
+            <li class="p-list__item"><span class="number">11.5</span> A failure or delay by a party to exercise any right or remedy under this Agreement will not be construed or operate as a waiver of that right or remedy. Nor single or partial exercise of any right or remedy
+              will preclude the further exercise of that right or remedy by that party.</li>
+            <li class="p-list__item"><span class="number">11.6</span> During the term of this Agreement and for 6 months thereafter, Customer will not solicit to be hired or hire, as an employee or independent contractor, any individual (i) who is then the personnel of Canonical
+              or any of its Affiliates or was the personnel of Canonical or any of its Affiliates during the previous 6 months (unless Canonical terminated that individual's employment or contract) and (ii) who during any part of the term of this Agreement
+              was assigned by Canonical to provide services to Canonical's customers.</li>
+            <li class="p-list__item"><span class="number">11.7</span> This Agreement represents the entire terms agreed between the parties in relation to its subject matter and supersedes all previous contracts or arrangements (including any usage or custom and any terms arising
+              through any course of dealing) of any kind between the parties relating to its subject matter. No terms or conditions included in or delivered with any Customer acceptance of Services, proposal, purchase order or similar document will form
+              part of this Agreement.</li>
+            <li class="p-list__item"><span class="number">11.8</span> Each of the provisions of this Agreement will be construed as independent of every other such provision, so that if any provision of this Agreement will be determined by any court of competent authority to
+              be illegal, invalid and/or unenforceable this will not affect any other provision of this Agreement, which will remain in full force and effect.</li>
+            <li class="p-list__item"><span class="number">11.9</span> Nothing in this Agreement and no action taken by the parties pursuant to this Agreement will be construed as creating a partnership or joint venture of any kind between the parties or as constituting either
+              party as the agent of the other party. No party will have the authority to bind the other party or to contract in the name of or create a liability against the other party.</li>
+            <li class="p-list__item"><span class="number">11.10</span> Any notice required to be given or sent under this Agreement will be in writing and delivered to the recipient at the address set out in this Agreement or, if no address is set out, to the recipient's registered
+              office address. A party may update its address by providing notice to the other party. Valid delivery methods are (i) in-person delivery, (ii) first class registered post (or equivalent), or (iii) internationally recognized overnight courier
+              service.</li>
+            <li class="p-list__item"><span class="number">11.11</span> Canonical may provide copies of this Agreement in different languages for information purposes. Only the English language version of this Agreement will be binding. In the event of any dispute, any version
+              in any language other than English will be disregarded.</li>
+            <li class="p-list__item"><span class="number">11.12</span> Customer acknowledges that export laws and regulations of the United States and European territories may apply to materials delivered by Canonical under this Agreement. Customer agrees that such export control
+              laws and regulations govern its use of materials and will comply with all such laws and regulations. Customer will not export, directly or indirectly, such materials in violation of these laws or regulations, or use them for any purpose
+              prohibited by these laws.</li>
+          </ol>
+        </li>
+        <li class="p-list__item">
+          <h2>12. Governing law</h2>
+          <ol class="p-list">
+            <li class="p-list__item"><span class="number">12.1</span> This Agreement and any non-contractual obligations arising from this Agreement will be governed by and construed in accordance with the laws of England. The parties submit to the exclusive jurisdiction of the
+              courts of England, except when a party seeks immediate injunctive relief (for example, in connection with a breach or impending breach of confidentiality obligations) that would not be reasonably effective unless obtained in the jurisdiction
+              of the conduct at issue. The provisions of the United Nations Convention on Contracts for the International Sale of Goods will not apply to this Agreement.</li>
+          </ol>
+        </li>
+      </ol>
+    </div>
+    <nav class="col-4 p-card">
+      <h3>Latest version</h3>
+      <ul class="p-list">
+        <li class="p-list__item"><a href="/legal/short-terms">Latest version&nbsp;›</a></li>
+      </ul>
+    </nav>
   </div>
 </div>
 

--- a/templates/legal/short-terms/2016-05-20.html
+++ b/templates/legal/short-terms/2016-05-20.html
@@ -135,19 +135,19 @@
       </ol>
     </div>
 
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Latest version</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms">Latest version&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
 
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Japanese translation</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms/ja">略式サービス契約&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </div>
 

--- a/templates/legal/short-terms/2016-06-24.html
+++ b/templates/legal/short-terms/2016-06-24.html
@@ -136,20 +136,21 @@
       </ol>
     </div>
 
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Latest version</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms">Latest version&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
 
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Japanese translation</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms/ja">略式サービス契約&nbsp;&rsaquo;</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </div>
+
 
 {% endblock content %}

--- a/templates/legal/short-terms/index.html
+++ b/templates/legal/short-terms/index.html
@@ -132,7 +132,7 @@
         </li>
       </ol>
     </div>
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Older versions</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms/2016-06-24">24 June 2016&nbsp;&rsaquo;</a></li>
@@ -140,13 +140,13 @@
         <li class="p-list__item"><a href="/legal/short-terms/2015-09-09">09 September 2015&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/short-terms/2015-06-24">24 June 2015&nbsp;&rsaquo;</a></li>
       </ul>
-    </div>
-    <div class="col-4 p-card">
+    </nav>
+    <nav class="col-4 p-card">
       <h3>Japanese translation</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms/ja">略式サービス契約&nbsp;&rsaquo;</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </div>
 

--- a/templates/legal/short-terms/ja.html
+++ b/templates/legal/short-terms/ja.html
@@ -103,12 +103,12 @@
         <p><span class="number">12.1:</span> 本契約および本契約から生じる一切の契約外の義務は、イングランド法に準拠し、それに従って解釈されます。両当事者は、イングランド裁判所の専属管轄権に服します。ただし、問題の行為を管轄する法域内でしか合理的に有効とならないような、即時差止による救済（例えば、秘密保持義務違反もしくは切迫したその違反に関連する場合）を当事者が求める場合を除きます。国際物品売買契約に関する国際連合条約は、本契約には適用されません。</p>
       </div>
     </div>
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>英訳</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/short-terms">Short Form Services Agreement&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </div>
 

--- a/templates/legal/ubuntu-advantage/service-description-ja/2017-02-09.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja/2017-02-09.html
@@ -104,11 +104,11 @@
         </li>
       </ol>
     </div>
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Latest version</h3>
       <p>This is a previous version of this document, please refer to the <a href="/legal/ubuntu-advantage/service-description-ja/">latest version</a>.</p>
-    </div>
-    <div class="col-4 u-hidden--small">
+    </nav>
+    <nav class="col-4 u-hidden--small p-card">
       <h3>Contents</h3>
       <ol class="p-nested-counter-list">
         <li class="p-nested-counter-list__item"><a href="#service-description-overview">概要&nbsp;&rsaquo;</a></li>
@@ -129,7 +129,7 @@
         <li class="p-nested-counter-list__item"><a href="#assurance">保証&nbsp;&rsaquo;</a></li>
       </ol>
 
-      <h3><a href="#appendix-1">付録1 - サポート範囲&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--four"><a href="#appendix-1">付録1 - サポート範囲&nbsp;&rsaquo;</a></h3>
       <ol class="p-list">
         <li class="p-list__item"><a href="#ua-openstack-cloud-region">OpenStack Cloud Region&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-server">Server&nbsp;&rsaquo;</a></li>
@@ -144,7 +144,7 @@
         <li class="p-list__item"><a href="#dedicated-services-engineer">専任サービスエンジニア (DSE)&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#landscape-on-premises">Landscape On Premises&nbsp;&rsaquo;</a></li>
       </ol>
-      <h3><a href="#appendix-2">付録2 - サポートプロセス&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--four"><a href="#appendix-2">付録2 - サポートプロセス&nbsp;&rsaquo;</a></h3>
       <ol class="p-list">
         <li class="p-list__item"><a href="#ua-support-service-initiation">サービス開始&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-support-submitting-support-requests">サポート要求の提出&nbsp;&rsaquo;</a></li>
@@ -154,14 +154,14 @@
         <li class="p-list__item"><a href="#ua-support-remote-sessions">リモートセッション&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-support-regions">サポート地域&nbsp;&rsaquo;</a></li>
       </ol>
-      <h3><a href="#appendix-3">付録3 - マネジメントエスカレーション&nbsp;&rsaquo;</a></h3>
-    </div>
-    <div class="col-4 p-card">
+      <h3 class="p-heading--four"><a href="#appendix-3">付録3 - マネジメントエスカレーション&nbsp;&rsaquo;</a></h3>
+    </nav>
+    <nav class="col-4 p-card">
       <h3>英訳</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/ubuntu-advantage/service-description">Ubuntu Advantage service description&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
     <div class="col-8">
       <h2 id="response-times">3. 応答時間</h2>
       <ol class="p-list">

--- a/templates/legal/ubuntu-advantage/service-description-ja/index.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja/index.html
@@ -1015,12 +1015,12 @@
         </ul>
       </ul>
     </div>
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Older versions</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/ubuntu-advantage/service-description-ja/2017-02-09">9 February 2017&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </div>
 

--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -74,7 +74,7 @@
       </ol>
     </div>
 
-    <div class="col-4 u-hidden--small p-card">
+    <nav class="col-4 u-hidden--small p-card">
       <h3>Contents</h3>
       <ol class="p-nested-counter-list">
         <li class="p-nested-counter-list__item"><a href="#service-description-overview">Overview&nbsp;&rsaquo;</a></li>
@@ -93,7 +93,7 @@
         <li class="p-nested-counter-list__item"><a href="#assurance">Assurance&nbsp;&rsaquo;</a></li>
       </ol>
 
-      <h3><a href="#appendix-1">Appendix 1 - Support scope&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--four"><a href="#appendix-1">Appendix 1 - Support scope&nbsp;&rsaquo;</a></h3>
       <ol class="p-list">
         <li class="p-list__item"><a href="#ua-openstack">Ubuntu Advantage OpenStack&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-advantage-openstack-cloud-region">Ubuntu Advantage OpenStack Cloud Region&nbsp;&rsaquo;</a></li>
@@ -115,7 +115,7 @@
         <li class="p-list__item"><a href="#landscape-on-premises">Landscape on-premises&nbsp;&rsaquo;</a></li>
       </ol>
 
-      <h3><a href="#appendix-2">Appendix 2 - Support process&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--four"><a href="#appendix-2">Appendix 2 - Support process&nbsp;&rsaquo;</a></h3>
       <ol class="p-list">
         <li class="p-list__item"><a href="#ua-support-service-initiation">Service initiation&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-support-submitting-support-requests">Submitting support requests&nbsp;&rsaquo;</a></li>
@@ -125,14 +125,14 @@
         <li class="p-list__item"><a href="#ua-support-remote-sessions">Remote sessions&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="#ua-support-regions">Support regions&nbsp;&rsaquo;</a></li>
       </ol>
-      <h3><a href="#appendix-3">Appendix 3 - Management escalation&nbsp;&rsaquo;</a></h3>
-    </div>
-    <div class="col-4 p-card">
+      <h3 class="p-heading--four"><a href="#appendix-3">Appendix 3 - Management escalation&nbsp;&rsaquo;</a></h3>
+    </nav>
+    <nav class="col-4 p-card">
       <h3>Japanese translation</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/ubuntu-advantage/service-description-ja">UA 略式サービス契約&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
   <div class="row">
     <div class="col-8">

--- a/templates/legal/ubuntu-advantage/ua-terms.html
+++ b/templates/legal/ubuntu-advantage/ua-terms.html
@@ -194,12 +194,12 @@
         </li>
       </ol>
     </div>
-    <div class="col-4 p-card">
+    <nav class="col-4 p-card">
       <h3>Japanese translation</h3>
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/ubuntu-advantage/ua-terms-ja">UA 略式サービス契約&nbsp;›</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Turn toc and links from divs to navs so they do not appear printed pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally and see that it looks the same as live in your web browser at: 
- [/legal/short-terms/2015-06-24.html](http://0.0.0.0:8001/legal/short-terms/2015-06-24.html]
- [/legal/short-terms/2015-09-09.html](http://0.0.0.0:8001/legal/short-terms/2015-09-09.html]
- [/legal/short-terms/2016-05-20.html](http://0.0.0.0:8001/legal/short-terms/2016-05-20.html]
- [/legal/short-terms/2016-06-24.html](http://0.0.0.0:8001/legal/short-terms/2016-06-24.html]
- [/legal/short-terms/index.html](http://0.0.0.0:8001/legal/short-terms/index.html]
- [/legal/short-terms/ja.html](http://0.0.0.0:8001/legal/short-terms/ja.html]
- [/legal/ubuntu-advantage/service-description-ja/2017-02-09.html](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description-ja/2017-02-09.html]
- [/legal/ubuntu-advantage/service-description-ja/index.html](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description-ja/index.html]
- [/legal/ubuntu-advantage/service-description.html](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description.html]
- [/legal/ubuntu-advantage/ua-terms.html](http://0.0.0.0:8011/legal/ubuntu-advantage/ua-terms.html)

## Issue / Card

Fixes #2516

