### PR TITLE
Add GTM event to the server provisioning ebook download

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -12,7 +12,7 @@ if (!core) { var core = {}; }
 
 core.supportsSvg = function() {
     return document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image", "1.1");
-}};
+};
 
 core.mobileNav = function () {
     var header = document.querySelector('header.banner');

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -1,3 +1,6 @@
+
+if (!core) { var core = {}; }
+
 // The cookie policy injection and interaction
 core.cookiePolicy = function() {
   if (getCookie('_cookies_accepted') !== 'true'){

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -1,7 +1,7 @@
 <section class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-12">
-      <h2>Before you start, you’ll want this&nbsp;eBook</h2>
+      <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>
     </div>
   </div>
   <div class="row">
@@ -69,7 +69,7 @@
             </li>
 
             <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--positive" onsubmit="backgroundSubmitHandler();">Download the eBook</button>
+              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download link', 'eventAction' : 'Download provisioning', 'eventLabel' : 'MAAS ebook', 'eventValue' : undefined });" onsubmit="backgroundSubmitHandler();">Download the eBook</button>
               <input type="hidden" name="formid" class="mktoField " value="1862">
               <input type="hidden" name="formVid" class="mktoField " value="1862">
               <input type="hidden" name="lpId" class="mktoField" value="3635">


### PR DESCRIPTION
## Done
Add GTM event to the server provisioning ebook download. Drive by fixes to the JS.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/server/provisioning](http://0.0.0.0:8001/download/server/provisioning)
- Check there are no js errors
- Check the download button has a onclick event

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2519