### PR TITLE
Lower async-hide timeout

### DIFF
--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -3,7 +3,7 @@
         <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
         h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
         (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-        })(window,document.documentElement,'async-hide','dataLayer',4000,
+        })(window,document.documentElement,'async-hide','dataLayer',1000,
         {'GTM-TNDW25H':true});</script>
         <!-- End Google Optimize page-hiding -->
 


### PR DESCRIPTION
## Done

This lowers the timeout of hiding the page to one second. Pages on ubuntu.com currently show a white page for 4 seconds.

This snippet is recommented by Google Optimize
https://developers.google.com/optimize/

I think it should remove this async-timeout when Optimize is ready but is failing to do so. This is a quick fix to avoid the long timeout.


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Page shows in a reasonable time

