### PR TITLE
The webinar on financial services should say Watch now on demand

### DIFF
--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -52,7 +52,7 @@
         </div>
         <h3 class="u-no-margin--top">Hybrid cloud and financial services: How to compete on the cloud</h3>
         <p>Learn how to keep up with the pace of change as you adopt new development methodologies, new technologies and new infrastructure.</p>
-        <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/290063" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Sign up now', 'eventLabel' : 'Hybrid cloud and financial services: How to compete on the cloud', 'eventValue' : undefined });">Sign up now</a></p>
+        <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/290063" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch now on demand', 'eventLabel' : 'Hybrid cloud and financial services: How to compete on the cloud', 'eventValue' : undefined });">Watch now on demand</a></p>
       </div>
       <div class="col-4 prefix-1 u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}7d6041a7-image-cloud.svg" alt="" />


### PR DESCRIPTION
## Done
Updated the text in the button in the webinar section. Updated the [copy doc](https://docs.google.com/document/d/1o9s_MFaiZZIS26tusRi0ALNrcqUihhTSZgxS55oHZj4/edit#heading=h.d2zdo2krbafk).

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/financial-services](http://0.0.0.0:8001/financial-services)
- Check that the button in the webinar section says "Watch now on demand"

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2525