### PR TITLE
Update legal overview page copy

### DIFF
--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -9,7 +9,7 @@
   <div class="row">
     <div class="col-8">
       <h1>Ubuntu legal terms and&nbsp;policies</h1>
-      <p>We take our legal responsibilities very seriously at Canonical &mdash; especially where they concern the protection of your personal data and the contributions you make to the projects we manage &mdash; so we have a number of legal agreements that govern the way we work. They include privacy policies, agreements allowing us to share our intellectual property (which includes trademarks and content as well as code) and descriptions of exactly what our support services cover.</p>
+      <p>We have a number of legal agreements to protect your personal data and the contributions you make to the projects we manage. We also have agreements that enable us to share intellectual property (which includes our trademarks and content as well as code), plus legal descriptions of exactly what our support services cover.</p>
     </div>
     <div class="col-4">
       <div class="u-align--center">
@@ -62,7 +62,7 @@
               </a>
             </h3>
           </div>
-          <p>A legal description of the services included in the Ubuntu Advantage support package.</p>
+          <p>Details of the agreement you need to send to us before you begin contributing to projects at Canonical.</p>
         </div>
       </div>
       <div class="col-6 p-card">
@@ -75,7 +75,7 @@
               </a>
             </h3>
           </div>
-          <p>A legal description of the services included in BootStack. </p>
+          <p>A legal description of the services included in Bootstack.</p>
         </div>
       </div>
     </div>
@@ -91,7 +91,7 @@
             </a>
           </h3>
         </div>
-        <p>A legal description of the services included in BootStack. </p>
+        <p>This agreement sets out Canonical&rsquo;s standard service terms for both Ubuntu Advantage and Bootstack customers.</p>
       </div>
     </div>
   </div>

--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -8,7 +8,7 @@
 <div class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <h1>Ubuntu legal terms and&nbsp;policies</h1>
+      <h1>Ubuntu legal</h1>
       <p>We have a number of legal agreements to protect your personal data and the contributions you make to the projects we manage. We also have agreements that enable us to share intellectual property (which includes our trademarks and content as well as code), plus legal descriptions of exactly what our support services cover.</p>
     </div>
     <div class="col-4">


### PR DESCRIPTION
## Done
Update legal overview page copy to match the [copy doc](https://docs.google.com/document/d/19yTLYWu7rEErPrO0xDsqMeN8tcWKBjHuarw0tjxRlhY/edit).

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal](http://0.0.0.0:8001/legal)
- Check that the copy matches the copy in the [copy doc](https://docs.google.com/document/d/19yTLYWu7rEErPrO0xDsqMeN8tcWKBjHuarw0tjxRlhY/edit)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/2520