### PR TITLE
Fix resources search functionality

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -128,14 +128,15 @@ class ResourcesView(TemplateView):
                 resource_filter=self.RESOURCE_FILTER,
             )
             group_name = 'search'
-            feed_items[group_name] = {}
-            feed_items[group_name]['items'] = get_json_feed_content(
+            feed_items['posts'] = {}
+            feed_items['posts'][group_name] = {}
+            feed_items['posts'][group_name]['posts'] = get_json_feed_content(
                 api_url,
             )
             group_title = 'Search results for "{search}"'.format(
                 search=search,
             )
-            feed_items[group_name]['group_name'] = group_title
+            feed_items['posts'][group_name]['group_name'] = group_title
             return feed_items
         if topic or content:
             if not content:


### PR DESCRIPTION
## Done
Fix resources search functionality

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources](http://0.0.0.0:8001/resources)
- Search something and behold the results