### PR TITLE
Disable 17.10 download

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -55,7 +55,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
+            The download of Ubuntu 17.10 is currently discouraged due to an issue on certain Lenovo laptops. Once fixed this download will be enabled again.
             <script>
               // Contributions only work with JavaScript
               // So if we have JavaScript, send them to /contribute


### PR DESCRIPTION
## Done
Replaced the 17.10 download button with a notice.

_Landing without review for speed, this should be reverted shortly_