### PR TITLE
Removed jquery from pages that do not require it

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -22,7 +22,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deept is-bordered">
+<section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>All things OpenStack</h2>
@@ -392,8 +392,6 @@
 {% endblock content %}
 
 {% block head_extra %}
-
-<script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
 
 <style type="text/css">
   @keyframes fadeIn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,6 @@
 {% block takeover_body_class %}homepage-enterprise-kubernetes{% endblock takeover_body_class %}
 
 {% block head_extra %}
-  <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
 {% endblock %}
 
 {% block takeover_content %}

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -3,7 +3,6 @@
 {% block takeover_body_class %}homepage-cloud-default--2{% endblock takeover_body_class %}
 
 {% block head_extra %}
-  <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
 {% endblock %}
 
 {% block takeover_content %}


### PR DESCRIPTION
## Done

* To speed up pages, removed jquery from the homepages and cloud overview
* Drive-by: fixed typo in class name - s/is-deept/is-deep/

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: - [homepage](http://0.0.0.0:8001/), [homepage2](http://0.0.0.0:8001/) and [cloud overview](http://0.0.0.0:8001/cloud)
- see that the page is the same with no console errors
