### PR TITLE
Trivial grammar fix: inflected verb form, not contraction

### DIFF
--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -9,7 +9,7 @@
   <div class="row">
     <div class="col-8">
       <h1>Ubuntu for telcos</h1>
-      <p>As an established leader in cloud computing, Canonical let&rsquo;s you apply the webscale savings and best practice  that are necessary to succeed in the telco world. By using established open source software to automate the deployment and operation of NFVI and IoT solutions, we can help you become even more agile while reducing your costs and time to market.</p>
+      <p>As an established leader in cloud computing, Canonical lets you apply the webscale savings and best practice  that are necessary to succeed in the telco world. By using established open source software to automate the deployment and operation of NFVI and IoT solutions, we can help you become even more agile while reducing your costs and time to market.</p>
       <ul class="p-inline-list">
           <li class="p-inline-list__item">
             <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290067" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch Cloud to Edge webinar', 'eventLabel' : 'Watch Cloud to Edge webinar', 'eventValue' : undefined });" ><span class="p-link--external">Watch Cloud to Edge webinar</span></a>


### PR DESCRIPTION
This is the third-person singular simple present indicative form of “let”,
not a contraction of “let us”.
