### PR TITLE
Corrected spelling on Contributor on legal overview

### DIFF
--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -58,7 +58,7 @@
             <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b06cbaa6-picto-canonical-warmgrey.svg" alt="" />
             <h3 class="p-heading-icon__title">
               <a href="/legal/contributors">
-                Contributors agreement&nbsp;&rsaquo;
+                Contributor agreement&nbsp;&rsaquo;
               </a>
             </h3>
           </div>


### PR DESCRIPTION
## Done

* Corrected spelling on Contributor on legal overview

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [legal overview](http://0.0.0.0:8001/legal/contributors)
- see that it is singular

## Issue / Card

Fixes #2536
