### PR TITLE
Update developer terms

### DIFF
--- a/templates/legal/terms-and-policies/developer-terms-and-conditions/index.html
+++ b/templates/legal/terms-and-policies/developer-terms-and-conditions/index.html
@@ -24,8 +24,8 @@
         <li class="p-list__item">App(s): one or more applications or content items owned by you which you submit through the Developer Site and any associated screen shots and marketing materials provided by you, these may be Snappy Ubuntu apps.</li>
         <li class="p-list__item">Client Software: any utilities provided by Canonical which enable end users to discover, install, and remove software including Apps.</li>
         <li class="p-list__item">Developer Account: Your account on the Developer Site.</li>
-        <li class="p-list__item">Developer Site: Canonical&apos;s websites for uploading and managing Apps including myapps.developer.ubuntu.com</li>
-        <li class="p-list__item">Publishing Policy: the Developer Site policy for accepting Apps for publishing at developer.ubuntu.com/en/publish, as updated from time to time.</li>
+        <li class="p-list__item">Developer Site: Canonical&apos;s websites for uploading and managing Apps, including <a href="https://dashboard.snapcraft.io/snaps/">dashboard.snapcraft.io/snaps</a>.</li>
+        <li class="p-list__item">Publishing Policy: Canonical&apos;s policy for accepting Apps for publishing, as notified by Canonical from time to time.</li>
         <li class="p-list__item">Services: Canonical&apos;s services for distributing, publishing, discovery, installation, and removal of your Apps and payment collection.</li>
         <li class="p-list__item">Term: the term of this Agreement, as set out in Clause 10.</li>
         <li class="p-list__item">Ubuntu: any versions of the Linux-based operating system known as Ubuntu.</li>


### PR DESCRIPTION
## Done

- Updated section 1., d. & e. per Canonical legal as original links have changed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [dev t&c page](http://0.0.0.0:8001/legal/terms-and-policies/developer-terms-and-conditions)
- check that the copy for d. and e. in section 1. match the [copy doc](https://docs.google.com/document/d/1I0wumuzwywfKjiKC4YmQ-9h9O3ZvCaBTe2CIIyoEtJQ/edit)

>d. Developer Site: Canonical's websites for uploading and managing Apps, including dashboard.snapcraft.io/snaps.
>e. Publishing Policy: Canonical's policy for accepting Apps for publishing, as notified by Canonical from time to time.

## Issue / Card

Fixes #2544
