### PR TITLE
Update requirements on build cloud page

### DIFF
--- a/templates/download/cloud/build-openstack.html
+++ b/templates/download/cloud/build-openstack.html
@@ -1,14 +1,14 @@
 {% extends "download/_base_download.html" %}
 {% block title %}Build OpenStack with conjure-up | Download{% endblock %}
-{% block meta_description %}Want to build your own production cloud? Use conjure-up. It’s easy and free.{% endblock %}
+{% block meta_description %}Want to build your own production private cloud? Use conjure-up. It’s easy and free.{% endblock %}
 {% block extra_body_class %}download-build-openstack{% endblock %}
 
 
 {% block content %}
 <div class="p-strip--light is-deep">
   <div class="row">
-    <div class="col-10">
-      <h1>Build your own production cloud</h1>
+    <div class="col-11">
+      <h1>Build your own production private cloud</h1>
     </div>
   </div>
   <div class="row">
@@ -19,12 +19,13 @@
           <p>Thanks to MAAS, the bare metal provisioning and management tool, conjure-up can talk to a cluster of servers.</p>
         </div>
         <div class="col-6 p-divider__block">
-          <h3>Requirements</h3>
+          <h3>Minimum requirements<sup>*</sup></h3>
           <p>4 x Intel x64 servers each with:</p>
           <ul class="p-list">
             <li class="p-list__item is-ticked">8GB RAM</li>
             <li class="p-list__item is-ticked">Management card/BMC with IPMI onboard</li>
           </ul>
+          <p><sup>*</sup> <small>Note: for production clouds 12 nodes are required,  including 3 nodes for High Availability MAAS-based infrastructure.</small></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

* Updated the requirements on build-cloud page per James Donner and Stefan Fabel
* Update the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
[build-cloud page](http://0.0.0.0:8001/download/cloud/build-openstack)
check against the [copy doc](https://docs.google.com/document/d/1b-KJ3Ext5geHtRU26UrXusLNoulSJ3jqvLl5NlwbyQo/edit#)

## Issue / Card

Fixes #2554

