### PR TITLE
Fixed typos in /security page

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -99,7 +99,7 @@
         <li class="p-matrix__item">
           <div>
             <h3 class="p-matrix__title p-heading--four">FIPS</h3>
-            <p class="p-matrix__desc">Ubuntu is certified to US government standards by FIPS (Federal Information Processing Standard) to ensure compliance and tougher security that mandates.</p>
+            <p class="p-matrix__desc">Ubuntu is certified to US government standards by FIPS (Federal Information Processing Standard) to ensure compliance and tougher security.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -111,7 +111,7 @@
         <li class="p-matrix__item">
           <div>
             <h3 class="p-matrix__title p-heading--four">Protected VMs</h3>
-            <p class="p-matrix__desc">LXD containers, libvirt VMs and OpenStack VMs are protected by AppArmor by default. A rich set of profiles is provided so users can opt-in to protection for other applications.</p>
+            <p class="p-matrix__desc">LXD containers, libvirt VMs and OpenStack VMs are protected by AppArmor by default. A rich set of profiles are provided so users can opt-in to protection for other applications.</p>
           </div>
         </li>
         <li class="p-matrix__item">


### PR DESCRIPTION
## Done

* Fixed typos in /security page
* Updated the [copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [security page](http://0.0.0.0:8001/security) and compare to the copy doc

## Issue / Card

Fixes #2530
