### PR TITLE
Removed extra_body_class block from site

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,6 +1,6 @@
 {% extends "templates/one-column.html" %}
 {% block title %}404: Page not found{% endblock %}
-{% block extra_body_class %}error-page error404{% endblock %}
+
 
 {% block content %}
 <div class="p-strip is-deep">

--- a/templates/410.html
+++ b/templates/410.html
@@ -1,6 +1,6 @@
 {% extends "templates/one-column.html" %}
 {% block title %}410: Page deleted{% endblock %}
-{% block extra_body_class %}error-page error404{% endblock %}
+
 
 {% block content %}
 <div class="p-strip is-deep">

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,6 @@
 {% extends "templates/one-column.html" %}
 {% block title %}500: Server error{% endblock %}
-{% block extra_body_class %}error-page error500{% endblock %}
+
 
 {% block content %}
 <div class="p-strip is-deep">

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Whether you’re building your own OpenStack cloud, want a hosted private cloud or want to use Ubuntu in the public cloud, we offer all the training, software, tools, services and support you need.{% endblock meta_description %}
 
-{% block extra_body_class %}cloud-home{% endblock %}
+
 
 {% block second_level_nav_items %}
   {% include "templates/_nav_breadcrumb.html" with section_title="Cloud" page_title="Overview" %}

--- a/templates/cloud/newsletter-thank-you.html
+++ b/templates/cloud/newsletter-thank-you.html
@@ -1,5 +1,5 @@
 {% extends "cloud/base_cloud.html" %}
-{% block extra_body_class %}cloud-thank-you{% endblock %}
+
 {% block title %}Thank you{% endblock %}
 
 {% block content %}

--- a/templates/containers/docker-ubuntu.html
+++ b/templates/containers/docker-ubuntu.html
@@ -3,7 +3,7 @@
 {% block title %}Docker Engine on Ubuntu | Containers{% endblock %}
 {% block meta_description %}Canonical works in partnership with Docker Inc. to provide customers with a single path for the commercial support of Docker Engine running in production Ubuntu environments.{% endblock meta_description %}
 
-{% block extra_body_class %}containers-home{% endblock %}
+
 
 
 {% block content %}

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -1,7 +1,7 @@
 {% extends "containers/base_containers.html" %}
 {% block title %}Containers{% endblock %}
 {% block meta_description %}Whether you’re building your own OpenStack cloud, want a hosted private cloud or want to use Ubuntu in the public cloud, we offer all the training, software, tools, services and support you need.{% endblock meta_description %}
-{% block extra_body_class %}containers-home{% endblock %}
+
 
 
 {% block content %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -3,7 +3,7 @@
 {% block title %}Ubuntu Core{% endblock %}
 {% block meta_description %}Introducing Ubuntu Core, the smallest Ubuntu ever, the perfect host operating system for IoT devices and large-scale cloud container deployments{% endblock meta_description %}
 
-{% block extra_body_class %}core-overview{% endblock %}
+
 
 
 {% block content %}

--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -3,7 +3,7 @@
 {% block title %}Ubuntu 17.10{% endblock %}
 {% block meta_description %}Fast, secure and stylishly simple, the Ubuntu operating system is used by 50 million people worldwide every day.{% endblock %}
 
-{% block extra_body_class %}1710{% endblock %}
+
 
 {% block content %}
 

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -1,7 +1,7 @@
   {% extends "desktop/base_desktop.html" %}
 
   {% block title %}Desktop for developers{% endblock %}
-  {% block extra_body_class %}desktop-for-developers{% endblock %}
+  
 
   {% block content %}
   <section class="p-strip u-image-position is-deep is-bordered">

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -1,7 +1,7 @@
 {% extends "desktop/base_desktop.html" %}
 
 {% block title %}For education{% endblock %}
-{% block extra_body_class %}desktop-education{% endblock %}
+
 
 
 {% block content %}

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -1,7 +1,7 @@
 {% extends "desktop/base_desktop.html" %}
 
 {% block title %}For enterprise{% endblock %}
-{% block extra_body_class %}desktop-enterprise{% endblock %}
+
 
 {% block content %}
 

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -1,5 +1,5 @@
 {% extends "desktop/base_desktop.html" %}
-{% block extra_body_class %}desktop-features{% endblock %}
+
 {% block head_extra %}
 <style type="text/css">
 @-webkit-keyframes flash-sign {

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -3,7 +3,7 @@
 {% block title %}Ubuntu PC operating system{% endblock %}
 {% block meta_description %}Fast, secure and stylishly simple, the Ubuntu operating system is used by 50 million people worldwide every day.{% endblock %}
 
-{% block extra_body_class %}desktop-home{% endblock %}
+
 
 {% block content %}
 

--- a/templates/download/cloud/build-openstack.html
+++ b/templates/download/cloud/build-openstack.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 {% block title %}Build OpenStack with conjure-up | Download{% endblock %}
 {% block meta_description %}Want to build your own production private cloud? Use conjure-up. It’s easy and free.{% endblock %}
-{% block extra_body_class %}download-build-openstack{% endblock %}
+
 
 
 {% block content %}

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Build OpenStack with conjure-up | Download{% endblock %}
-{% block extra_body_class %}download-cloud-home{% endblock %}
+
 
 
 {% block content %}

--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -2,7 +2,7 @@
 {% load versioned_static  %}
 
 {% block title %}Contribute to Ubuntu | Ubuntu{% endblock %}
-{% block extra_body_class %}contribute-to-ubuntu{% endblock %}
+
 
 
 {% block outer_content %}

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Download Ubuntu Desktop | Download{% endblock %}
-{% block extra_body_class %}download-desktop-home{% endblock %}
+
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -8,7 +8,7 @@ Thanks for downloading Ubuntu Desktop
 Thank you for your contribution
 {% endif %}
 {% endblock %}
-{% block extra_body_class %}download-thankyou{% endblock %}
+
 
 
 {% block content %}

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Get Ubuntu | Download{% endblock %}
-{% block extra_body_class %}download-home{% endblock %}
+
 
 {% block meta_keywords %}Ubuntu, Ubuntu operating system, OS, platform, Linux, distribution, OpenStack, Ubuntu OpenStack, Ubuntu Cloud, server, tablet, smartphone, phone, Windows alternative, Mac alternative, free software, open source, thin client, download Ubuntu, long-term support, LTS, {{ latest_release }}, Trusty Tahr, Icehouse, Juno, Kilo, Vivid Vervet, 15.04{% endblock meta_keywords %}
 

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -3,7 +3,7 @@
 {% block title %}
 Thanks for downloading Ubuntu for LinuxONE and z Systems
 {% endblock %}
-{% block extra_body_class %}download-thankyou{% endblock %}
+
 
 
 {% block head_extra %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -4,7 +4,7 @@
 {% block title %}
 Thanks for downloading Ubuntu Server
 {% endblock %}
-{% block extra_body_class %}download-thankyou{% endblock %}
+
 
 
 {% block content %}

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -1,7 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 {% block title %}Kubernetes{% endblock %}
 {% block meta_description %}The Canonical Distribution of Kubernetes delivers a ‘pure K8s’ experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.{% endblock meta_description %}
-{% block extra_body_class %}kubernetes{% endblock %}
+
 
 {% block content %}
 <section class="p-strip is-bordered">

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -1,7 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 {% block title %}Managed Kubernetes | Kubernetes{% endblock %}
 {% block meta_description %}With managed kubernetes, Canonical will build, support and manage your cluster for only $4 per node per day.{% endblock meta_description %}
-{% block extra_body_class %}kubernetes{% endblock %}
+
 
 
 {% block content %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,7 +1,7 @@
 {% extends "templates/one-column.html" %}
 
 {% block title %}Search results{% if query %} for "{{query}}"{% endif %} | Ubuntu{% endblock %}
-{% block extra_body_class %}ubuntu-search{% endblock %}
+
 
 {% block content %}
 <div class="p-strip is-shallow">

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -1,7 +1,7 @@
 {% extends "server/base_server.html" %}
 {% block title %}Ubuntu Server - for scale out workloads{% endblock %}
 {% block meta_description %}Secure, fast and economically scalable, Ubuntu helps you make the most of your infrastructure. Whether you want to deploy a cloud or a web farm, Ubuntu Server supports the most popular hardware and software.{% endblock %}
-{% block extra_body_class %}server-home{% endblock %}
+
 
 
 {% block content %}

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -2,7 +2,7 @@
 
 {% block title %}Community support{% endblock %}
 
-{% block extra_body_class %}support-community-support has-background{% endblock %}
+
 
 
 {% block content %}

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -4,7 +4,7 @@
 
 {% block title %}Support and management{% endblock %}
 
-{% block extra_body_class %}support-home{% endblock %}
+
 
 
 {% block content %}

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -1,7 +1,7 @@
 {% extends "support/base_support.html" %}
 
 {% block title %}Plans and pricing | Support{% endblock %}
-{% block extra_body_class %}support-plans-and-pricing has-background{% endblock %}
+
 
 {% block meta_description %}A summary of all our support offerings. Ubuntu offers the best economics of any commercially supported Linux solution and the best community support.{% endblock %}
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -61,7 +61,7 @@
     <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
   </head>
 
-  <body class="{% block extra_body_class %}{% endblock %}">
+  <body>
     <!-- google tag manager -->
     <noscript>
       <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe>

--- a/templates/templates/error.html
+++ b/templates/templates/error.html
@@ -2,7 +2,7 @@
 
 {% block title %}404 Page not found{% endblock %}
 
-{% block extra_body_class %}error-page error404{% endblock %}
+
 
 {% block head_extra %}{% endblock %}
 


### PR DESCRIPTION
## Done

* Removed all `s/{% block extra_body_class %}(.*)?{% endblock %}//` blocks as they are no longer used by any css
* removed block from base.html <body> tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- click around the site, see that it looks the same as live

## Issue / Card

Fixes #1948


  