### PR TITLE
Updated maas install instructions

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -61,11 +61,11 @@
           </h3>
           <div class="p-list-step__content">
             <p class="p-code-snippet">
-              <input class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
+              <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
             <p class="p-code-snippet">
-              <input class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
+              <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
           </div>
@@ -78,7 +78,7 @@
           <div class="p-list-step__content">
             <p>Create your admin credentials by typing.</p>
             <p class="p-code-snippet">
-              <input class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
+              <input aria-label="code snippet" class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
               <button class="p-code-snippet__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
             </p>
             <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -38,76 +38,104 @@
 <section class="p-strip--light is-deep is-bordered" id="instructions">
   <div class="row">
     <div class="col-12">
-      <h2>Install MAAS in 6 easy steps</h2>
+      <h2>Install MAAS in 7 easy steps</h2>
       <ol class="p-stepped-list--detailed">
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">1</span>Install Ubuntu Server</h3>
-          <div class="p-list-step__content">
-            <p><a href="/download/server">Download Ubuntu Server 16.04 LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
-          </div>
+        <li class="p-list-step__item ">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Setup your hardware
+          </h3>
+          <p class="p-list-step__content">You need one small server for MAAS and at least one server which can be managed with a <abbr title="Baseboard Management Controller">BMC</abbr>. It is recommended to have the MAAS server provide <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> and <abbr title="Domain Name Service">DNS</abbr> on a network the managed machines are connected to.</p>
         </li>
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Install MAAS</h3>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Install Ubuntu Server
+          </h3>
+          <p class="p-list-step__content"><a aria-label="External link to download Ubuntu Server 16.04 LTS" href="/download/server">Download Ubuntu Server 16.04 LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
+        </li>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">3</span>
+            Install MAAS
+          </h3>
           <div class="p-list-step__content">
-            <p>From the command line type the commands below and follow the step-by-step instructions:</p>
             <p class="p-code-snippet">
-              <input class="p-code-snippet__input" value="sudo apt-get update" readonly="readonly">
+              <input class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
             <p class="p-code-snippet">
-              <input class="p-code-snippet__input" value="sudo apt-get install maas" readonly="readonly">
+              <input class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
             </p>
           </div>
         </li>
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Create admin user</h3>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Create admin user
+          </h3>
           <div class="p-list-step__content">
-            <p>Create your admin credentials by typing:</p>
+            <p>Create your admin credentials by typing.</p>
             <p class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+              <button class="p-code-snippet__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
             </p>
-            <p>Login to the MAAS UI at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
+            <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
           </div>
         </li>
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Turn on DHCP</h3>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">5</span>
+            Complete the first user configuration journey
+          </h3>
           <div class="p-list-step__content">
-            <p>Go to the “Networks” tab, and select the VLAN for which you want to enable DHCP. On the “Take action” button select “Provide DHCP”.</p>
-            <ul class="p-list">
-              <li class="p-list__item">Set the Rack controller that will manage DHCP.</li>
-              <li class="p-list__item">Select the subnet where to create the DHCP dynamic range on.</li>
-              <li class="p-list__item">Fill in details for the dynamic range.</li>
+            <p>Follow the instructions on screen to complete the first installation of MAAS. We recommend using the default values unless your installation has different requirements.</p>
+            <p>By the end of the journey you should have the following configured;</p>
+            <ul>
+              <li>Region name (MAAS name)</li>
+              <li>Ubuntu archive, Ubuntu extra architectures</li>
+              <li>Ubuntu images</li>
+              <li><abbr title="Secure shell">SSH</abbr> keys (for currently logged in user)</li>
             </ul>
-            <img src="{{ ASSET_SERVER_URL }}ab018774-vlan-details.png" alt="Screenshot of Networks tab" />
+            <p><a href="{{ ASSET_SERVER_URL }}267759eb-complete-the-first-user-configuration-journey.png" class="venobox venobox--expand" data-gall="installGallery" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}267759eb-complete-the-first-user-configuration-journey.png?w=552"  alt="First user journey screenshot"></a></p>
           </div>
         </li>
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Import images</h3>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">6</span>
+            Turn on DHCP
+          </h3>
           <div class="p-list-step__content">
-            <p>Go to the “Images” tab and choose the OS releases and architectures you want to install dynamically.</p>
-            <img src="{{ ASSET_SERVER_URL }}e4a4fc29-boot-images.png" alt="Screenshot of Images tab">
+            <p>Go to the &ldquo;Subnets&rdquo; tab, and select the <abbr title="Virtual Local Area Network">VLAN</abbr> for which you want to enable DHCP. From the &ldquo;Take action&rdquo; button select &ldquo;Provide DHCP&rdquo;.</p>
+            <ol>
+              <li>Set the Rack controller that will manage DHCP.</li>
+              <li>Select the subnet where to create the DHCP Dynamic range on.</li>
+              <li>Fill in the details for the dynamic range.</li>
+            </ol>
+            <p><a href="{{ ASSET_SERVER_URL }}c3010cc2-turn-on-DHCP.png" class="venobox venobox--expand" data-gall="installGallery" title="VLAN details page in an active MAAS">
+              <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}c3010cc2-turn-on-DHCP.png?w=552" class="image--shadow" alt="VLAN details">
+            </a></p>
           </div>
         </li>
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Enlist and commission servers</h3>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">7</span>
+            Enlist and commission servers
+          </h3>
           <div class="p-list-step__content">
-            <p>Now you are ready to enlist and commission machines.</p>
-            <ul class="p-list">
-              <li class="p-list__item">Set all the servers to PXE boot.</li>
-              <li class="p-list__item">Boot each machine once. You should see these machines appear in MAAS.</li>
-              <li class="p-list__item">If your machines do not have a IPMI based BMC, proceed to edit them and enter their BMC details.</li>
-              <li class="p-list__item">Select all the machines and “Commission” them using the “Take action” button.</li>
-              <li class="p-list__item">When machines have a “Ready” status you can start deploying.</li>
-            </ul>
-            <img src="{{ ASSET_SERVER_URL }}cdc79a2b-node-listing.png" alt="Screenshot of Machines node list" />
+            <p>Now MAAS is ready to enlist and commission machines.</p>
+            <ol>
+              <li>Set all the servers to <abbr title="Preboot Execution Environment">PXE</abbr> boot</li>
+              <li>Boot each machine once. You should see these machines appear in MAAS</li>
+              <li>If your machines do not have a <abbr title="Intelligent Platform Management Interface">IPMI</abbr> based BMC, proceed to edit them and enter their BMC details</li>
+              <li>Select all the machines and &ldquo;Commission&rdquo; them using the &ldquo;Take action&rdquo; button</li>
+              <li>When machines have a &ldquo;Ready&rdquo; status you can start deploying</li>
+            </ol>
+            <p><a href="{{ ASSET_SERVER_URL }}66a25be9-enlist-and-commission-servers.png" class="venobox venobox--expand" data-gall="installGallery" title="The node listing page in MAAS">
+              <img src="{{ ASSET_SERVER_URL }}66a25be9-enlist-and-commission-servers.png?w=552" class="p-image--bordered" alt="MAAS node listing">
+            </a></p>
+            <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
           </div>
         </li>
       </ol>


### PR DESCRIPTION
## Done

- Updated maas install instructions at /download/server/provisioning
- Updated the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/server/provisioning](http://0.0.0.0:8001/download/server/provisioning)
- compare to [maas.io/install]() and the [copy doc]([copy doc](https://docs.google.com/document/d/12GXYcP9WrOgoso6Sf3bQql6nALRUzpdlcRW3Gbu-npM/edit#))

## Issue / Card

Fixes #2335


