### PR TITLE
Update Arm logo and company name spelling

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -157,7 +157,7 @@
         <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}5afc09fa-partner-logo-eclipse.png" alt="Eclipse logo" /></li>
         <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}208cd3a7-azure-logo-blue-on-white.svg" alt="Azure logo" /></li>
         <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e9108036-amazon.svg" alt="Amazon web services logo" /></li>
-        <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b5352dc1-logo-arm.svg" alt="Arm logo" /></li>
+        <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4efbd291-Arm_logo_blue_cropped.svg" alt="Arm logo" /></li>
         <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e40ec1d6-logo-kvm-116x36.png" alt="KVM logo" /></li>
         <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1b79e4c0-google-cloud.svg" alt="Google Cloud Platform logo" /></li>
         <li class="p-inline-images__item"><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}5ea48272-Qualcomm_Snapdragon_logo.png" alt="Snapdragon logo" /></li>

--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -21,7 +21,7 @@
         <li class="p-list__item">
           <img src="{{ ASSET_SERVER_URL }}47e40767-power8.png" class="inline-logos__image" alt="POWER logo" /></li>
         <li class="p-list__item">
-          <img src="{{ ASSET_SERVER_URL }}15214c8e-logo-arm.png" alt="ARM logo" /></li>
+          <img src="{{ ASSET_SERVER_URL }}4efbd291-Arm_logo_blue_cropped.svg" alt="Arm logo" /></li>
       </ul>
     </div>
   </div>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -51,7 +51,7 @@
 <div class="p-strip is-deep">
   <div class="row u-equal-height">
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}b5352dc1-logo-arm.svg" alt="" width="200" height="200" />
+      <img src="{{ ASSET_SERVER_URL }}4efbd291-Arm_logo_blue_cropped.svg" alt="" width="200" height="200" />
     </div>
     <div class="col-8">
       <h3>Commercially supported and ready to deploy today</h3>

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-8">
       <h1>Ubuntu leads in hyperscale</h1>
-      <p>Ubuntu is the hyperscale OS, natively powering scale-out workloads on a new wave of low-cost, ultra-dense hardware based on x86 and ARM processors.</p>
+      <p>Ubuntu is the hyperscale OS, natively powering scale-out workloads on a new wave of low-cost, ultra-dense hardware based on x86 and Arm processors.</p>
       <p><a class="p-button--positive" href="/download/server">Download Ubuntu Server</a></p>
       <p><a href="/download/arm">Download Ubuntu for ARM &nbsp;&rsaquo;</a></p>
     </div>
@@ -173,14 +173,14 @@
           <img src="{{ ASSET_SERVER_URL }}cd5c35a3-partners-logo-hp.png" width="94" height="94" alt="" />
         </div>
         <p class="p-card__content">Canonical has been involved in the development of Moonshot, HP&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
-        <p class="p-card__content"><a href="http://partners.ubuntu.com/hp" class="external">Learn more</a></p>
+        <p class="p-card__content"><a href="http://partners.ubuntu.com/hp" class="p-link--external">Learn more</a></p>
       </div>
       <div class="col-6 p-card">
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-          <img src="{{ ASSET_SERVER_URL }}388b97f3-partners-logo-arm.png" width="150" height="45" alt="ARM logo" />
+          <img src="{{ ASSET_SERVER_URL }}4efbd291-Arm_logo_blue_cropped.svg" width="150" height="45" alt="Arm logo" />
         </div>
-        <p class="p-card__content">ARM and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
-        <p class="p-card__content"><a href="http://partners.ubuntu.com/arm" class="external">Learn more</a></p>
+        <p class="p-card__content">Arm and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
+        <p class="p-card__content"><a href="http://partners.ubuntu.com/arm" class="p-link--external">Learn more</a></p>
       </div>
     </div>
   </div>
@@ -191,7 +191,7 @@
           <img src="{{ ASSET_SERVER_URL }}d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium logo" />
         </div>
         <p class="p-card__content">Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
-        <p class="p-card__content"><a href="http://www.cavium.com">Learn more&nbsp;&rsaquo;</a></p>
+        <p class="p-card__content"><a class="p-link--external" href="http://www.cavium.com">Learn more</a></p>
       </div>
       <div class="col-6 p-card">
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -130,7 +130,7 @@
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}731aab6c-logo-amd.svg" alt="AMD" />
         </li>
         <li class="last-item p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b5352dc1-logo-arm.svg" alt="Intel" />
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4efbd291-Arm_logo_blue_cropped.svg" alt="Arm" />
         </li>
       </ul>
       <p class="u-align--center u-vertically-spaced"><a href="https://certification.ubuntu.com">View all certified hardware&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done

- Updated logo and name when it refers to the company - NOT architecture
- Updated partners.u.c - https://partners.ubuntu.com/arm
- Updated www.canonical.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - [/core](http://0.0.0.0:8011/core)
    - [/desktop/snappy](http://0.0.0.0:8011/desktop/snappy)
    - [/download/server/arm](http://0.0.0.0:8011/download/server/arm)
    - [/server/hyperscale](http://0.0.0.0:8011/server/hyperscale)
    - [server](http://0.0.0.0:8011/server)

## Issue / Card

Fixes #2571

