### PR TITLE
Fixed typo on developer/desktop page

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -1,7 +1,7 @@
   {% extends "desktop/base_desktop.html" %}
 
   {% block title %}Desktop for developers{% endblock %}
-  
+
 
   {% block content %}
   <section class="p-strip u-image-position is-deep is-bordered">
@@ -115,7 +115,7 @@
           <p>Ubuntu {{ lts_release_full }} introduces snaps: a new application packaging format.</p>
           <p>Snaps are Ubuntu applications that are packaged alongside all their dependencies, making them much more robust. And they couldn’t be easier to write. You can use the language of your choice, be it Python, Go, C, C++, Node JS or even .NET, then package your snap from source using Snapcraft, a new open source tool. Which means practically no learning curve. </p>
           <p>Snaps let you deliver updates unmodified, at your own pace. So whether you’re building for mobile, the desktop or the Internet of Things, there’s no faster, easier or more dependable way of getting your code to market.</p>
-          <p><a class="p-link--external" href="http://snapcraft.io">To find out more about snaps</a></p>
+          <p><a class="p-link--external" href="https://snapcraft.io/">Find out more about snaps</a></p>
         </div>
         <div class="col-5 u-vertically-center">
           <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}bb7f0c54-snaps-hero%403x.png?w=400" alt="Snap icons">


### PR DESCRIPTION
## Done

* Fixed typo on developer/desktops page - changed ‘To find out more about snaps’ to ‘Find out more about snaps’
* the [copy doc](https://docs.google.com/document/d/1VJ3xT2ViC-CvL0UmsAUzpYFmvpuqUP4AbpnlPm8tqOA/edit) was already correct

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [developer/desktops page](http://0.0.0.0:8001/desktop/developers)
- See that the typo has been fixed

## Issue / Card

Fixes #2569

## Screenshots

![image](https://user-images.githubusercontent.com/441217/34779476-3a59cb1c-f618-11e7-93f8-35e947a27863.png)
