### PR TITLE
Re-enabled 17.10.1 desktop and server downloads

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -55,7 +55,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            The download of Ubuntu 17.10 is currently discouraged due to <a href="https://wiki.ubuntu.com/ArtfulAardvark/ReleaseNotes#Known_issues" class="p-link--external">a BIOS issue on certain laptops</a>. Once fixed this download will be enabled again.
+            <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
             <script>
               // Contributions only work with JavaScript
               // So if we have JavaScript, send them to /contribute

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ArtfulAardvark" latest_release="17.10" latest_release_full='17.10' latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
+{% with latest_release_name="ArtfulAardvark" latest_release="17.10.1" latest_release_full='17.10' latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

- Re-enabled 17.10.1 desktop and server downloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
     - [server download](http://0.0.0.0:8001/download/server)
    - [desktop download](http://0.0.0.0:8001/download/desktop)
- see that the correct (or any) ISO downloads

## Issue / Card

Fixes #2551

## Screenshots

![image](https://user-images.githubusercontent.com/441217/34886177-25b21928-f7ba-11e7-9e7c-efeec7bbb7db.png)
