### PR TITLE
17.10.1 update for torrents and server release notes

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -56,7 +56,7 @@
     <div class="row">
       <div class="col-8">
         <h2>What&rsquo;s new in Ubuntu {{lts_release_full}}?</h2>
-        <p>Ubuntu {{lts_release_no_point}} is the latest LTS release. Alongside support for the very latest hardware, this release includes new versions of many core apps and developer technologies.</p>
+        <p>Ubuntu {{ lts_release }} is the latest LTS release. Alongside support for the very latest hardware, this release includes new versions of many core apps and developer technologies.</p>
       </div>
     </div>
     <div class="row">
@@ -76,8 +76,8 @@
   <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-8">
-        <h2>What&rsquo;s new in Ubuntu {{latest_release_full}}?</h2>
-        <p class="eight-col">Ubuntu {{latest_release_full}} brings a new desktop environment to Ubuntu with a redesigned interface. It has been designed to get you up and running quickly and to help keep you focused on the task at hand.</p>
+        <h2>What&rsquo;s new in Ubuntu {{ latest_release }}?</h2>
+        <p class="eight-col">Ubuntu {{ latest_release }} brings a new desktop environment to Ubuntu with a redesigned interface. It has been designed to get you up and running quickly and to help keep you focused on the task at hand.</p>
       </div>
     </div>
     <div class="row">

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -44,9 +44,9 @@
     <div class="col-4">
       <h3 class="p-link--external"><span>Ubuntu {{latest_release}}</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release_full}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release_full}}/ubuntu-{{latest_release}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release_full}}/ubuntu-{{latest_release}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)</a></li>
       </ul>
     </div>
     <div class="col-4">

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -24,7 +24,7 @@
       <h2>Network installer</h2>
       <p>The network installer lets you install Ubuntu over the network. This is useful, for example, if you have an old machine with a non-bootable CD-ROM or a computer that can&rsquo;t run the graphical interface-based installer, either because they don&rsquo;t meet the minimum requirements for the live CD/DVD or because they require extra configuration before  the graphical desktop can be used, or if you want to install Ubuntu on a large number of computers at once.</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{latest_release}}/">Download the network installer for {{latest_release_full}}</a></li>
+        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/">Download the network installer for {{ latest_release }}</a></li>
         <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/16.04/">Download the network installer for 16.04 LTS</a></li>
         <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
       </ul>
@@ -42,20 +42,20 @@
 
   <div class="row">
     <div class="col-4">
-      <h3 class="p-link--external"><span>Ubuntu {{latest_release}}</span></h3>
+      <h3 class="p-link--external"><span>Ubuntu {{ latest_release_with_point }}</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release_full}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release_full}}/ubuntu-{{latest_release}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release_full}}/ubuntu-{{latest_release}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ latest_release }}/ubuntu-{{ latest_release_with_point }}-desktop-amd64.iso.torrent">Ubuntu {{ latest_release_with_point }} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ latest_release }}/ubuntu-{{ latest_release_with_point }}-server-amd64.iso.torrent">Ubuntu {{ latest_release_with_point }} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ latest_release }}/ubuntu-{{ latest_release_with_point }}-server-i386.iso.torrent">Ubuntu {{ latest_release_with_point }} Server (32-bit)</a></li>
       </ul>
     </div>
     <div class="col-4">
       <h3 class="p-link--external"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (32-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Server (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Server (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-desktop-amd64.iso.torrent">Ubuntu {{ lts_release_with_point }} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-desktop-i386.iso.torrent">Ubuntu {{ lts_release_with_point }} Desktop (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-server-amd64.iso.torrent">Ubuntu {{ lts_release_with_point }} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-server-i386.iso.torrent">Ubuntu {{ lts_release_with_point }} Server (32-bit)</a></li>
       </ul>
     </div>
     <div class="col-4">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -28,7 +28,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            <a class="p-button--positive is-wide js-lts-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a>
+            <a class="p-button--positive is-wide js-lts-download" href="/download/desktop/thank-you?version={{lts_release_with_point}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download</a>
             <script>
               // Contributions only work with JavaScript
               // So if we have JavaScript, send them to /contribute
@@ -45,17 +45,17 @@
 
   <div class="row">
     <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu {{latest_release}}</h2>
+      <h2>Ubuntu {{ latest_release_with_point }}</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
-          <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{latest_release_full}} release notes</a></p>
-          <p class="p-card__content"><a href="/desktop/1710">Find out more about {{latest_release_full}}&nbsp;&rsaquo;</a></p>
+          <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ latest_release_with_point }} comes with nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{ latest_release }} release notes</a></p>
+          <p class="p-card__content"><a href="/desktop/1710">Find out more about {{ latest_release }}&nbsp;&rsaquo;</a></p>
           <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
+            <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a>
             <script>
               // Contributions only work with JavaScript
               // So if we have JavaScript, send them to /contribute

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -2,10 +2,6 @@
 
 {% block title %}Get Ubuntu | Download{% endblock %}
 
-
-{% block meta_keywords %}Ubuntu, Ubuntu operating system, OS, platform, Linux, distribution, OpenStack, Ubuntu OpenStack, Ubuntu Cloud, server, tablet, smartphone, phone, Windows alternative, Mac alternative, free software, open source, thin client, download Ubuntu, long-term support, LTS, {{ latest_release_with_point }}, Trusty Tahr, Icehouse, Juno, Kilo, Vivid Vervet, 15.04{% endblock meta_keywords %}
-
-
 {% block content %}<div class="p-strip is-deep">
   <div class="row">
     <div class="col-12">

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -3,7 +3,7 @@
 {% block title %}Get Ubuntu | Download{% endblock %}
 
 
-{% block meta_keywords %}Ubuntu, Ubuntu operating system, OS, platform, Linux, distribution, OpenStack, Ubuntu OpenStack, Ubuntu Cloud, server, tablet, smartphone, phone, Windows alternative, Mac alternative, free software, open source, thin client, download Ubuntu, long-term support, LTS, {{ latest_release }}, Trusty Tahr, Icehouse, Juno, Kilo, Vivid Vervet, 15.04{% endblock meta_keywords %}
+{% block meta_keywords %}Ubuntu, Ubuntu operating system, OS, platform, Linux, distribution, OpenStack, Ubuntu OpenStack, Ubuntu Cloud, server, tablet, smartphone, phone, Windows alternative, Mac alternative, free software, open source, thin client, download Ubuntu, long-term support, LTS, {{ latest_release_with_point }}, Trusty Tahr, Icehouse, Juno, Kilo, Vivid Vervet, 15.04{% endblock meta_keywords %}
 
 
 {% block content %}<div class="p-strip is-deep">

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -15,10 +15,10 @@
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ lts_release }} release notes</a></p>
         </div>
         <div class="col-4">
-          <p class="p-card__content"><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{lts_release_full}}', 'eventValue' : undefined });">Download</a></p>
+          <p class="p-card__content"><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
           <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
         </div>
       </div>
@@ -26,15 +26,15 @@
   </div>
   <div class="row">
     <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu Server {{latest_release}}</h2>
+      <h2>Ubuntu Server {{ latest_release_with_point }}</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{latest_release_full}} release notes</a></p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ latest_release }} release notes</a></p>
         </div>
         <div class="col-4">
           <p class="p-card__content">
-            <a class="p-button--positive is-wide" href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
+            <a class="p-button--positive is-wide" href="/download/server/thank-you?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a></p>
           <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
         </div>
       </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -30,7 +30,7 @@
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The latest version of Ubuntu Server, including the {{latest_openstack_version}} release of OpenStack and nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{latest_release}} release notes</a></p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{latest_release_full}} release notes</a></p>
         </div>
         <div class="col-4">
           <p class="p-card__content">

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -20,7 +20,7 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{latest_release_full}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">{{latest_release_full}}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release }}&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
       <div class="col-6">
@@ -28,7 +28,7 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{latest_release_full}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">{{latest_release_full}}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release }}&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
     </div>
@@ -43,12 +43,12 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3>Ubuntu {{lts_release_full}} for IBM POWER8</h3>
-      <p>Ubuntu {{lts_release_no_point}} continues to enable rapid innovation for POWER8 including support for new POWER8 models, memory and PCI Hotplug, Docker 1.9.1, many performance and availability enhancements. Includes the only commercially available Linux to provide initial support for support the OpenPOWER Foundation’s industry leading NVLink technology.</p>
+      <p>Ubuntu {{ lts_release_full }} continues to enable rapid innovation for POWER8 including support for new POWER8 models, memory and PCI Hotplug, Docker 1.9.1, many performance and availability enhancements. Includes the only commercially available Linux to provide initial support for support the OpenPOWER Foundation’s industry leading NVLink technology.</p>
     </div>
     <div class="col-4 p-divider__block">
-      <h3>Ubuntu {{latest_release_full}} for IBM POWER8</h3>
+      <h3>Ubuntu {{ latest_release }} for IBM POWER8</h3>
       <p>
-        The Ubuntu {{latest_release_full}} standard release builds on top of Ubuntu {{lts_release_full}}, further enabling rapid innovation for POWER8.
+        The Ubuntu {{ latest_release }} standard release builds on top of Ubuntu {{lts_release_full}}, further enabling rapid innovation for POWER8.
       </p>
     </div>
   </div>

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -20,7 +20,7 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
       <div class="col-6">

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -28,7 +28,7 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
     </div>

--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -2,9 +2,7 @@
 
 {% block title %}Ubuntu flavours{% endblock %}
 
-{% block meta_description %}Ubuntu flavours offer a unique way to experience Ubuntu, each with
-their own choice of default applications and settings, backed by the
-full Ubuntu archive for packages and updates.{% endblock %}
+{% block meta_description %}Ubuntu flavours offer a unique way to experience Ubuntu, each with their own choice of default applications and settings, backed by the full Ubuntu archive for packages and updates.{% endblock %}
 
 
 {% block content %}

--- a/templates/shared/contextual_footers/_download_documentation.html
+++ b/templates/shared/contextual_footers/_download_documentation.html
@@ -2,7 +2,7 @@
   <h3 class="p-heading--four">Detailed documentation</h3>
   <p><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation/UbuntuServerGuide" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c server guide', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server Guide</a></p>
 
-  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c latest', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{latest_release_full}} documentation</a></p>
+  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c latest', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{ latest_release }} documentation</a></p>
 
   <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ArtfulAardvark" latest_release="17.10.1" latest_release_full='17.10' latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.3" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
+{% with latest_release_name="ArtfulAardvark" latest_release='17.10' latest_release_with_point="17.10.1" latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

- 17.10.1 update for torrents and server release notes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - see that [server download](http://0.0.0.0:8001/download/server) says ‘Ubuntu Server 17.10 release notes’
    - see that [alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads) 17.10 torrents point to the 17.10.1 versions
