### PR TITLE
Fix appstore thank you page

### DIFF
--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -6,7 +6,7 @@
 {% if product == 'newsletter' %}
   {% include "shared/_thank_you.html" with thanks_context="subscribing!" thanks_message="You will now begin receiving our devices newsletter. You may unsubscribe any time by clicking the link in the email." %}
 
-{% elif %}
+{% elif product == 'appstore' %}
   {% include "shared/_thank_you.html" with thanks_context="your interest in IoT app stores!" thanks_message="A member of our team will follow up with you shortly." %}
 
 {% else %}


### PR DESCRIPTION
## Done

- Fix appstore thank you page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [thank-you](http://0.0.0.0:8001/internet-of-things/thank-you?product=appstore)
- see that it looks correct

