### PR TITLE
2578: Add new Ubuntu Product Month takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_ues_takeover.html" %}
+{% include "takeovers/_ubuntu-product-month.html" %}
 
 {% include "shared/_insights_news_strip.html"  with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
 

--- a/templates/takeovers/_ubuntu-product-month.html
+++ b/templates/takeovers/_ubuntu-product-month.html
@@ -1,0 +1,15 @@
+<section class="p-strip--image is-dark is-deep p-takeover" style="background: #111111; background-size: cover; background-image: url('{{ ASSET_SERVER_URL }}3e3de22c-UPM-background.png'); background-position: 77% 0%;">
+  <div class="row">
+    <div class="u-equal-height u-vertically-center">
+      <div class="col-6" itemscope="" itemtype="https://schema.org/Event">
+        <h1><span class="event-title" itemprop="name">Ubuntu&nbsp;product&nbsp;month</span></h1>
+        <p class="p-heading--five" style="line-height: 1.264;">Learn about OpenStack, LXD, Juju, and Snaps from&nbsp;the developers and teams behind them</p>
+        <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeover', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-button--positive">Find out more</a></p>
+      </div>
+      <div class="col-6 u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}b0bd120e-UPM-Illustration.svg" alt="" />
+      </div>
+      <p class="u-hide--medium u-hide--large u-show--small u-align--center"><a itemprop="url" href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeover', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-button--positive">Find out more</a></p>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Added new Ubuntu Product Month takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that the takeover matches the [copydoc](https://docs.google.com/document/d/1GQAsZVnrFqXI7SlxAuNXIoQXgeSWd4MSbrSYO2djbPU/edit) and [design](https://github.com/canonical-websites/www.ubuntu.com/issues/2577#issuecomment-358942312)

## Issue / Card

Fixes #2578  