### PR TITLE
Remove nbsp from takeover

### DIFF
--- a/templates/takeovers/_ubuntu-product-month.html
+++ b/templates/takeovers/_ubuntu-product-month.html
@@ -1,12 +1,12 @@
 <section class="p-strip--image is-dark is-deep p-takeover" style="background: #111111; background-size: cover; background-image: url('{{ ASSET_SERVER_URL }}3e3de22c-UPM-background.png'); background-position: 77% 0%;">
   <div class="row">
     <div class="u-equal-height u-vertically-center">
-      <div class="col-6" itemscope="" itemtype="https://schema.org/Event">
-        <h1><span class="event-title" itemprop="name">Ubuntu&nbsp;product&nbsp;month</span></h1>
+      <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
+        <h1><span class="event-title" itemprop="name">Ubuntu product month</span></h1>
         <p class="p-heading--five" style="line-height: 1.264;">Learn about OpenStack, LXD, Juju, and Snaps from&nbsp;the developers and teams behind them</p>
         <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeover', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-button--positive">Find out more</a></p>
       </div>
-      <div class="col-6 u-align--center">
+      <div class="col-5 u-align--center">
         <img src="{{ ASSET_SERVER_URL }}b0bd120e-UPM-Illustration.svg" alt="" />
       </div>
       <p class="u-hide--medium u-hide--large u-show--small u-align--center"><a itemprop="url" href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeover', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-button--positive">Find out more</a></p>


### PR DESCRIPTION
## Done
Remove `&nbsp;` from the title on the homepage. This is not responsive. Increased the size of the content column so that desktop view the title did not wrap.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check the title does not wrap
- Shrink your screen and see that the title wraps when required

## Screenshots
Before:
![screenshot-2018-1-22 the leading operating system for pcs iot devices servers and the cloud ubuntu 1](https://user-images.githubusercontent.com/1413534/35247758-875af83c-ffc3-11e7-8755-dc32477f7583.png)

After:
![screenshot-2018-1-22 the leading operating system for pcs iot devices servers and the cloud ubuntu](https://user-images.githubusercontent.com/1413534/35247766-930c2520-ffc3-11e7-9c60-702f85b7bdeb.png)

