### PR TITLE
Updated k8s logo and GKE strip

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -12,7 +12,7 @@
       <p class="u-no-margin--top"><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?_ga=2.25375934.2035833349.1504518498-2070601899.1473694436" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Hero CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/containers/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact sales', 'eventLabel' : 'Contact sales - Hero CTA' : undefined });">Contact sales</a></p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}7c230fc3-kubernetes_certified_service_provider_logo.png?w=300" alt="Kubernetes Certified Service Provider" />
+      <img src="{{ ASSET_SERVER_URL }}96d35aa4-certified-kubernetes-logo.svg?w=300" alt="Kubernetes Certified Service Provider" />
     </div>
   </div>
 </section>
@@ -47,15 +47,15 @@
   </div>
 </section>
 
-<section id="partnerships-google-gke" class="p-strip is-bordered">
-  <div class="row u-vertically-center">
-    <div class="col-4  u-hide--small u-align--center">
-      <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?h=160" alt="Google Container Engine logo" />
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-5 suffix-1 u-align--center u-hide--small u-align--center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png?w=380" alt="Google Container Engine" />
     </div>
-    <div class="col-8">
-      <h2>Google&nbsp;GKE</h2>
-      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes &reg;. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s&nbsp;alignment.</p>
-      <p><a href="https://cloud.google.com/kubernetes-engine/docs/node-images#ubuntu" class="p-link--external">Try GKE with Ubuntu now</a></p>
+    <div class="col-7">
+      <h2>In partnership with Google GKE</h2>
+      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes&reg;<a href="#fn1" id="r1">*</a>. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s alignment.</p>
+      <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
     </div>
   </div>
 </section>
@@ -88,19 +88,6 @@
       <div class="u-embedded-media">
         <iframe class="u-embedded-media__element" src="https://player.vimeo.com/video/190300823?color=ffffff&title=0&byline=0&portrait=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-8">
-      <h2>In partnership with Google GKE</h2>
-      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes&reg;<a href="#fn1" id="r1">*</a>. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s alignment.</p>
-      <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
-    </div>
-    <div class="col-4">
-      <img src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png" alt="Google Container Engine" />
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -55,7 +55,7 @@
     <div class="col-7">
       <h2>In partnership with Google GKE</h2>
       <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical&rsquo;s Distribution of Kubernetes&reg;<a href="#fn1" id="r1">*</a>. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s alignment.</p>
-      <p><a href="https://cloud.google.com/container-engine/docs/node-images#ubuntu_beta" class="p-link--external">Try GKE with Ubuntu now</a></p>
+      <p><a href="https://cloud.google.com/kubernetes-engine/docs/node-images#ubuntu" class="p-link--external">Try GKE with Ubuntu now</a></p>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -39,7 +39,7 @@
     <div class="col-6">
       <h2>Cloud Native Platform</h3>
       <p>Canonical, in partnership with Rancher Labs, delivers the Cloud Native Platform. The Cloud Native Platform is a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher.  Maximise developer velocity integrated CI/CD, and ease the path from development into production with enterprise-caliber container management.</p>
-      <p><a class="p-link--external p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });">Watch webinar</a></p>
+      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });"><span class="p-link--external">Watch webinar</span></a></p>
     </div>
     <div class="col-6 prefix-1 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}85700cb3-rancher_cloud_partnerships_visual.svg" alt="Rancher Labs logo" />


### PR DESCRIPTION
## Done

- Updated k8s logo and GKE strip

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [k8s page](http://0.0.0.0:8001/kubernetes)
- Compare to the [copy doc](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#)

## Issue / Card

Fixes #2607

## Screenshots

[logo]
![image](https://user-images.githubusercontent.com/441217/35509830-aa01a76c-04ed-11e8-994d-713759cb005e.png)

[gke strip]
![image](https://user-images.githubusercontent.com/441217/35509846-b7c5c9be-04ed-11e8-80e6-e338e19f57aa.png)

