### PR TITLE
Added reg mark to k8s name

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -64,7 +64,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img src="{{ ASSET_SERVER_URL }}24e41fc3-kubernetes_logo.svg" alt="Kubernetes logo" class="p-heading-icon__img" />
-          <h2 class="p-heading-icon__title">The Canonical Distribution of Kubernetes</h2>
+          <h2 class="p-heading-icon__title">The Canonical Distribution of Kubernetes<sup>&reg;<a href="#fn1" id="r1">*</a></sup></h2>
         </div>
       </div>
     </div>
@@ -155,6 +155,12 @@
     </div>
   </div>
 </div>
+
+<section class="p-strip">
+  <div class="row">
+    <p id="fn1" class="note"><a href="#r1">*</a> Kubernetes&reg; is a registered trademark of The Linux Foundation in the United States and other countries, and is used pursuant to a license from The Linux Foundation</p>
+  </div>
+</section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
 


### PR DESCRIPTION
## Done

- Added reg mark to k8s name

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [containers overview](http://0.0.0.0:8001/containers)
- See that the use of k8s has a reg mark, with a footnote at the bottom of the page like the [copy doc](https://docs.google.com/document/d/1OtyfNeA--EJgpgvDzqcbJ8jqa6d9H5H9xyxHNxcKXvc/edit#heading=h.h9fjzuodthq6)

## Issue / Card

Fixes #2610

