### PR TITLE
Updated description of kubuntu on about flavours page

### DIFF
--- a/templates/about/about-ubuntu/flavours.html
+++ b/templates/about/about-ubuntu/flavours.html
@@ -16,7 +16,7 @@
       <h3>Recognised Ubuntu flavours</h3>
       <p>These are flavours that use Ubuntu as their foundation and contribute significantly towards the project.</p>
       <ul class="p-list">
-        <li><a href="https://kubuntu.org/">Kubuntu</a> &mdash; Ubuntu with the K Desktop environment</li>
+        <li><a href="https://kubuntu.org/">Kubuntu</a> &mdash; Ubuntu with the KDE Plasma desktop environment</li>
         <li><a href="http://lubuntu.me/">Lubuntu</a> &mdash; Ubuntu that uses LXDE</li>
         <li><a href="http://www.mythbuntu.org/">Mythbuntu</a> &mdash; Designed for creating a home theatre PC with MythTV</li>
         <li><a href="https://ubuntubudgie.org/">Ubuntu Budgie</a> &mdash; Simplicity and elegance &ndash; Budgie desktop powered by Ubuntu</li>


### PR DESCRIPTION
## Done

- Updated description of kubuntu on about flavours page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [about-ubuntu/flavours](http://0.0.0.0:8001/about/about-ubuntu/flavours)
- See that it says ‘Ubuntu with the KDE Plasma desktop environment’ like in the [copy doc](https://docs.google.com/document/d/1XhfzW57-eaRgObtD6svYOjyh-B9-C2PDyO9MhsEmHSE/edit)

## Issue / Card

Fixes #2601
