### PR TITLE
Added minimums apply footnote to pricing

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -261,11 +261,9 @@
       <p>For more information about Kubernetes support, <a href="/containers/contact-us?product=containers-kubernetes-support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - support packages top CTA' : undefined });">contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
-  <div class="row">
-    <div class="col-10" style="overflow-x: auto;">
-      {% include "shared/pricing/_kubernetes-enterprise-support.html" %}
-    </div>
-  </div>
+
+  {% include "shared/pricing/_kubernetes-enterprise-support.html" %}
+
   <div class="row">
     <div class="col-8">
       <p>For more information about Kubernetes support, <a href="/containers/contact-us?product=containers-kubernetes-support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - support packages bottom CTA' : undefined });">contact us&nbsp;&rsaquo;</a></p>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -1,99 +1,109 @@
-<table style="width: 100%;">
-  <tr>
-    <td width="35%">&nbsp;</td>
-    <th width="15%" class="u-align--center">Ubuntu</th>
-    <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for Kubernetes</th>
-    <th class="p-table__cell--highlight u-align--center">BootStack</th>
-  </tr>
-  <tr>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <th class="p-table__cell--highlight u-align--center">Standard</th>
-    <th class="p-table__cell--highlight u-align--center">Advanced</th>
-    <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
-  </tr>
-  <tr>
-    <th>Price per node (physical)</th>
-    <td class="u-align--center">$0</td>
-    <td class="p-table__cell--highlight u-align--center">$600/year</td>
-    <td class="p-table__cell--highlight u-align--center">$1,200/year</td>
-    <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
-  </tr>
-  <tr>
-    <th>Price per node (virtual)</th>
-    <td class="u-align--center">$0</td>
-    <td class="p-table__cell--highlight u-align--center">$200/year</td>
-    <td class="p-table__cell--highlight u-align--center">$400/year</td>
-    <td class="p-table__cell--highlight u-align--center">$1,460/year</td>
-  </tr>
-  <tr>
-    <th>Phone and web ticket support</th>
-    <td class="u-align--center">None</td>
-    <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
-    <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
-    <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
-  </tr>
-  <tr>
-    <th>Industry-leading cloud operations tooling <br />(Ubuntu, MAAS, Juju, LXD)</th>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>Deploy, run, scale, upgrade K8s</th>
-    <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>Monitoring and logging</th>
-    <td>&nbsp;</td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>Landscape Management</th>
-    <td>&nbsp;</td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>Livepatch</th>
-    <td>&nbsp;</td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>Knowledge Base</th>
-    <td>&nbsp;</td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>High availability support</th>
-    <td>&nbsp;</td>
-    <td class="p-table__cell--highlight">&nbsp;</td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>24x7 remote operations, smart alerts and proactive monitoring by Canonical’s cloud experts</th>
-    <td>&nbsp;</td>
-    <td class="p-table__cell--highlight">&nbsp;</td>
-    <td class="p-table__cell--highlight">&nbsp;</td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-  <tr>
-    <th>Disaster recovery</th>
-    <td>&nbsp;</td>
-    <td class="p-table__cell--highlight">&nbsp;</td>
-    <td class="p-table__cell--highlight">&nbsp;</td>
-    <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-  </tr>
-</table>
+<div class="row">
+  <div class="col-12" style="overflow-x: auto;">
+    <table style="width: 100%;">
+      <tr>
+        <td width="35%">&nbsp;</td>
+        <th width="15%" class="u-align--center">Ubuntu</th>
+        <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for Kubernetes</th>
+        <th class="p-table__cell--highlight u-align--center">BootStack</th>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+        <td>&nbsp;</td>
+        <th class="p-table__cell--highlight u-align--center">Standard</th>
+        <th class="p-table__cell--highlight u-align--center">Advanced</th>
+        <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
+      </tr>
+      <tr>
+        <th>Price per node (physical) <span style="font-size: 1rem;">*</span></th>
+        <td class="u-align--center">$0</td>
+        <td class="p-table__cell--highlight u-align--center">$600/year</td>
+        <td class="p-table__cell--highlight u-align--center">$1,200/year</td>
+        <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
+      </tr>
+      <tr>
+        <th>Price per node (virtual) <span style="font-size: 1rem;">*</span></th>
+        <td class="u-align--center">$0</td>
+        <td class="p-table__cell--highlight u-align--center">$200/year</td>
+        <td class="p-table__cell--highlight u-align--center">$400/year</td>
+        <td class="p-table__cell--highlight u-align--center">$1,460/year</td>
+      </tr>
+      <tr>
+        <th>Phone and web ticket support</th>
+        <td class="u-align--center">None</td>
+        <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
+        <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+        <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+      </tr>
+      <tr>
+        <th>Industry-leading cloud operations tooling <br />(Ubuntu, MAAS, Juju, LXD)</th>
+        <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>Deploy, run, scale, upgrade K8s</th>
+        <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>Monitoring and logging</th>
+        <td>&nbsp;</td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>Landscape management</th>
+        <td>&nbsp;</td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>Livepatch</th>
+        <td>&nbsp;</td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>Knowledge Base</th>
+        <td>&nbsp;</td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>High availability support</th>
+        <td>&nbsp;</td>
+        <td class="p-table__cell--highlight">&nbsp;</td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>24x7 remote operations, smart alerts and proactive monitoring by Canonical’s cloud experts</th>
+        <td>&nbsp;</td>
+        <td class="p-table__cell--highlight">&nbsp;</td>
+        <td class="p-table__cell--highlight">&nbsp;</td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+      <tr>
+        <th>Disaster recovery</th>
+        <td>&nbsp;</td>
+        <td class="p-table__cell--highlight">&nbsp;</td>
+        <td class="p-table__cell--highlight">&nbsp;</td>
+        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-12">
+    <p><small>* Minimums apply</small></p>
+  </div>
+</div>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -15,14 +15,14 @@
         <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
       </tr>
       <tr>
-        <th>Price per node (physical) <span style="font-size: 1rem;">*</span></th>
+        <th>Price per node (physical) *</th>
         <td class="u-align--center">$0</td>
         <td class="p-table__cell--highlight u-align--center">$600/year</td>
         <td class="p-table__cell--highlight u-align--center">$1,200/year</td>
         <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
       </tr>
       <tr>
-        <th>Price per node (virtual) <span style="font-size: 1rem;">*</span></th>
+        <th>Price per node (virtual) *</th>
         <td class="u-align--center">$0</td>
         <td class="p-table__cell--highlight u-align--center">$200/year</td>
         <td class="p-table__cell--highlight u-align--center">$400/year</td>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -31,7 +31,7 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
-      <th>Landscape Management</th>
+      <th>Landscape management</th>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -43,7 +43,7 @@
     </tr>
 
     <tr>
-      <td>Landscape Management<br />
+      <td>Landscape management<br />
       (for the MAAS servers)</td>
       <td>&nbsp;</td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -40,7 +40,7 @@
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
-          <td>Landscape Management</td>
+          <td>Landscape management</td>
           <td></td>
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>

--- a/templates/shared/pricing/_storage-support.html
+++ b/templates/shared/pricing/_storage-support.html
@@ -38,6 +38,10 @@
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
+      <td>Landscape management</td>
+      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    </tr>
+    <tr>
       <td>Livepatch</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -16,7 +16,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>Price per node (physical) <span style="font-size: 1rem;">*</span></td>
+          <td>Price per node (physical) *</td>
           <td class="u-align--center">$0</td>
           <td class="p-table__cell--highlight u-align--center">$150/year</td>
           <td class="p-table__cell--highlight u-align--center">$300/year</td>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -16,7 +16,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>Price per node (physical)</td>
+          <td>Price per node (physical) <span style="font-size: 1rem;">*</span></td>
           <td class="u-align--center">$0</td>
           <td class="p-table__cell--highlight u-align--center">$150/year</td>
           <td class="p-table__cell--highlight u-align--center">$300/year</td>
@@ -34,7 +34,7 @@
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
-          <td>Landscape Management</td>
+          <td>Landscape management</td>
           <td>&nbsp;</td>
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
@@ -59,5 +59,10 @@
         </tr>
       </tbody>
     </table>
+  </div>
+</div>
+<div class="row">
+  <div class="col-12">
+    <p><small>* Minimums apply</small></p>
   </div>
 </div>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -43,7 +43,7 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
-      <td>Landscape Management</td>
+      <td>Landscape management</td>
       <td>&nbsp;</td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -187,11 +187,9 @@
       <p>For more information about Kubernetes support, <a href="/containers/contact-us">contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12" style="overflow-x: auto;">
-      {% include "shared/pricing/_kubernetes-enterprise-support.html" %}
-    </div>
-  </div>
+
+  {% include "shared/pricing/_kubernetes-enterprise-support.html" %}
+
 </section>
 
 <section class="p-strip--light is-deep is-bordered">


### PR DESCRIPTION
## Done

- Added ‘minimums apply’ footnote to pricing for k8s and desktop
- Sentence cased’ Landscape management’
- Added Landscape management row to Storage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [plans and pricing](http://0.0.0.0:8001/support/plans-and-pricing) and [k8s](http://0.0.0.0:8001/kubernetes)
- compare to the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)

## Issue / Card

Fixes #2613

