### PR TITLE
Fix logos from being cropped on small screens (ref: #2618)

### DIFF
--- a/static/sass/_pattern_inline-images.scss
+++ b/static/sass/_pattern_inline-images.scss
@@ -20,7 +20,7 @@
   .p-inline-images__logo {
     max-height: $sp-xxx-large;
     max-width: 7rem;
-    width: auto;
+    width: 100%;
 
     @media only screen and (min-width: $breakpoint-medium) {
       max-height: 5.5rem;


### PR DESCRIPTION
## Done

Set the `width` property of `.p-inline-images__logo` to `100%` so that logos are not cropped on smaller screens, e.g., mobile phone screens. `width` set to `auto` results in the browser calculating an incorrect width for logos.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)

Specifically, view the following pages on a smaller screen, e.g., a mobile phone screen:

/cloud/foundation-cloud/index.html
/containers/lxd.html
/core/index.html
/financial-services/index.html
/internet-of-things/appstore.html
/internet-of-things/gateways.html
/kubernetes/index.html
/security/index.html
/server/index.html
/server/maas/index.html
/support/index.html
/telecommunications/index.html

## Issue / Card

Fixes #2618 