### PR TITLE
Update to point release for ARM and linuxone lts

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -18,7 +18,7 @@
     <div class="col-6 p-card--highlighted is-divided">
       <h3 class="p-card__title">Ubuntu Server</h3>
       <p class="p-card__content">This is the iso image of the Ubuntu Server installer.</p>
-      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
+      <p class="p-card__content"><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release_with_point}}-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
       <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-card--highlighted is-divided">

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -7,7 +7,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
 
 
 {% block head_extra %}
-  <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-s390x.iso">
+  <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release_with_point}}-server-s390x.iso">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- Update to point release for ARM and linuxone lts downloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [arm](http://0.0.0.0:8001/download/server/arm) and [linuxone](http://0.0.0.0:8001/download/server/linuxone)
- see that the LTS download

## Issue / Card

Fixes #2624
