### PR TITLE
Fix height of cloud strip image on the homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
 <section class="p-strip is-deep u-image-position is-bordered u-vertically-center">
   <div class="row">
     <div class="col-7">
-      <img src="{{ ASSET_SERVER_URL }}0bfbd13b-cloud_section_bundle.svg?h=404" class="u-image-position--top u-hide--small" style="height: 380px; right: 50%;" />
+      <img src="{{ ASSET_SERVER_URL }}0bfbd13b-cloud_section_bundle.svg?h=460" class="u-image-position--top u-hide--small" style="height: 100%; right: 47%;" />
     </div>
     <div class="col-5">
       <h3><a href="/cloud/managed-cloud">The world’s most popular operating system across public clouds and OpenStack clouds&nbsp;&rsaquo;</a></h3>

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
 <section class="p-strip is-deep u-image-position is-bordered u-vertically-center">
   <div class="row">
     <div class="col-7">
-      <img src="{{ ASSET_SERVER_URL }}0bfbd13b-cloud_section_bundle.svg?h=460" class="u-image-position--top u-hide--small" style="height: 100%; right: 47%;" />
+      <img src="{{ ASSET_SERVER_URL }}0bfbd13b-cloud_section_bundle.svg?h=460" class="u-image-position--top u-hide--small" alt="" style="height: 100%; right: 47%;" />
     </div>
     <div class="col-5">
       <h3><a href="/cloud/managed-cloud">The world’s most popular operating system across public clouds and OpenStack clouds&nbsp;&rsaquo;</a></h3>


### PR DESCRIPTION
## Done

- Fix height of cloud strip image on the homepage
- FYI, this happened when text was added to the cloud section.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [homepage](http://0.0.0.0:8001/)
- See that the juju lines touch top and bottom

## Issue / Card

Fixes #2629

## Screenshots

![image](https://user-images.githubusercontent.com/441217/35826814-c7c73306-0ab1-11e8-9a69-e8cbcacda844.png)
