### PR TITLE
Make mobile menu background white

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -22,7 +22,7 @@
         }
 
         .p-navigation__row {
-          background-color: #fff;
+          background-color: $color-x-light;
         }
       }
     }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -15,6 +15,18 @@
     font-weight: 400;
     margin-bottom: 0;
 
+    &:target {
+      @media (max-width: $breakpoint-medium) {
+        .p-navigation__nav {
+          background-color: $color-navigation-background;
+        }
+
+        .p-navigation__row {
+          background-color: #fff;
+        }
+      }
+    }
+
     @media (max-width: $breakpoint-medium) {
       border-bottom: 1px solid $color-light;
       font-weight: 300;


### PR DESCRIPTION
## Done

The mobile menu background is now white instead of orange. The header remains orange.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- While simulating a mobile device, click the navigation menu. The background of the menu should be white. The header should remain orange. No changes should be visible on larger screen sizes.

## Issue / Card

Fixes #2617 