### PR TITLE
Remove mentions of autopilot

### DIFF
--- a/templates/cloud/storage.html
+++ b/templates/cloud/storage.html
@@ -117,7 +117,6 @@
                   <li class="p-list__item is-ticked">Plan, build and grow your production-grade <abbr title="Software&dash;defined storage">SDS</abbr> infrastructure on commodity hardware using proven open source solutions.</li>
                   <li class="p-list__item is-ticked">Deploy and scale an Ubuntu Advantage Storage cluster in hours, not weeks, using Juju and MAAS.</li>
                   <li class="p-list__item is-ticked">Pay only for the data you store &mdash; no cost penalty for increased replication or high&dash;durability erasure coding or early build out of capacity.</li>
-                  <li class="p-list__item is-ticked">Landscape customers can use Autopilot to design, deploy and manage their storage clusters in a fully automated&nbsp;manner.</li>
                   <li class="p-list__item is-ticked">World&dash;class support from Canonical, experts in large&dash;scale, multi&dash;site&dash;replicated deployments.</li>
                   <li class="p-list__item is-ticked">Built with Ubuntu {{ lts_release_full }} with five years of support for every component in the stack.</li>
                 </ul>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -44,7 +44,7 @@
       <div class="col-6 p-card u-equal-height">
         <div class="col-4">
           <h2 class="p-card__title"><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
-          <p class="p-card__content">Ubuntu is the reference OS for OpenStack. Canonical&rsquo;s OpenStack Autopilot is a fully automated deployment of an OpenStack cloud on Ubuntu &mdash; just add servers.</p>
+          <p class="p-card__content">Ubuntu is the reference OS for OpenStack. Try Canonical&rsquo;s OpenStack on a single machine or start building a production cloud on a cluster &mdash; just add servers.</p>
         </div>
         <div class="col-2 u-align--center u-vertically-center">
           <a href="/download/cloud"><img src="{{ ASSET_SERVER_URL }}dfd42685-picto-cloud-darkaubergine.svg" alt="" width="113" height="113" /></a>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -60,9 +60,6 @@
           Landscape is the leading management tool to deploy, monitor and manage your Ubuntu servers
         </li>
         <li class="p-list__item">
-          It features Autopilot, the fastest way to build an OpenStack cloud
-        </li>
-        <li class="p-list__item">
           Landscape is also available as part of Ubuntu Advantage, Canonical&rsquo;s world-class support service
         </li>
       </ul>

--- a/templates/shared/contextual_footers/_download_all_installation.html
+++ b/templates/shared/contextual_footers/_download_all_installation.html
@@ -4,6 +4,6 @@
   <ul class="p-list">
       <li><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install desktop guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Desktop</a></li>
       <li><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install server guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Server</a></li>
-      <li><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install autopilot', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing OpenStack Autopilot&nbsp;&rsaquo;</a></li>
+      <li><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install openstack', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Install OpenStack&nbsp;&rsaquo;</a></li>
   </ul>
 </div>

--- a/templates/shared/contextual_footers/_download_cloud_askubuntu_autopilot.html
+++ b/templates/shared/contextual_footers/_download_cloud_askubuntu_autopilot.html
@@ -1,5 +1,0 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Ask Ubuntu</h3>
-  <p>Do you have any questions or feedback about setting up OpenStack Autopilot?</p>
-  <p><a href="https://askubuntu.com/questions/ask?tags=landscape+openstack-autopilot" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu for autopilot help', 'eventLabel' : 'Ask Ubuntu', 'eventValue' : undefined });">Talk to us on Ask Ubuntu</a></p>
-</div>

--- a/templates/shared/contextual_footers/_download_openstack_autopilot.html
+++ b/templates/shared/contextual_footers/_download_openstack_autopilot.html
@@ -1,5 +1,0 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Download OpenStack Autopilot</h3>
-  <p>Canonical&rsquo;s OpenStack Autopilot fully automates the deployment of an OpenStack Cloud &mdash; just add VMs or servers.</p>
-  <a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'download cloud', 'eventLabel' : 'Download OpenStack Autopilot', 'eventValue' : undefined });">Download now ›</a>
-</div>

--- a/templates/shared/contextual_footers/_download_server_installation.html
+++ b/templates/shared/contextual_footers/_download_server_installation.html
@@ -3,6 +3,6 @@
   <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
   <ul class="p-list">
       <li><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu Server</a></li><li>
-      </li><li><a href="/download/cloud/install-openstack-with-autopilot" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'autopilot instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu OpenStack&nbsp;&rsaquo;</a></li>
+      </li><li><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu OpenStack&nbsp;&rsaquo;</a></li>
   </ul>
 </div>

--- a/templates/shared/contextual_footers/_maas-autopilot.html
+++ b/templates/shared/contextual_footers/_maas-autopilot.html
@@ -1,5 +1,0 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Build your cloud using MAAS and&nbsp;Autopilot</h3>
-  <p>MAAS is perfect for deploying OpenStack with Autopilot  – the fastest and easiest way to build a cloud from the bare metal up.</p>
-  <p><a href="/cloud/openstack/autopilot" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS page', 'eventLabel' : 'Install Autopilot and MAAS', 'eventValue' : undefined });">Install Autopilot and MAAS&nbsp;&rsaquo;</a></p>
-</div>


### PR DESCRIPTION
## Done

Removed all remaining mentions of Autopilot from the site.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- from footer on [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads) and updated the [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit)
- update cloud text on [/download](http://0.0.0.0:8001/download) and the [copy doc](https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit#)
- removed autopilot bullet on [/cloud/storage](http://0.0.0.0:8001/cloud/storage) and updated the [copy doc](https://docs.google.com/document/d/1iw2SWNmoj4GZ2pUh0yB8gbtVXK0oXfyEaXT44bQbPlI/edit)
- removed autopilot bullet from [/download/server](http://0.0.0.0:8001/download/server) and updated the [copy doc](https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit#heading=h.9yxl6zlngg)
- deleted
    - _download_cloud_askubuntu_autopilot.html
    - _download_openstack_autopilot.html
    - _maas-autopilot.html
- updated _download_server_installation.html contextual footer to just point to /download/cloud

## Issue / Card

Fixes #2636
