### PR TITLE
2634 support white border

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -84,9 +84,9 @@
             border-left: 0;
           }
 
-          &:last-of-type,
-          &:nth-last-child(2) {
+          &:last-of-type {
             border-bottom: 1px solid $color-mid-light;
+            border-top: 0;
           }
 
           > a {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -82,6 +82,10 @@
 
           &:nth-child(2n) {
             border-left: 0;
+
+            &:nth-last-child(2), &:nth-last-child(3) {
+              border-bottom: 1px solid $color-mid-light;
+            }
           }
 
           &:last-of-type {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -88,6 +88,12 @@
             }
           }
 
+          &:nth-child(2n+1) {
+            &:nth-last-child(2), &:nth-last-child(3), &:nth-last-child(4) {
+              border-bottom: 1px solid $color-mid-light;
+            }
+          }
+
           &:last-of-type {
             border-bottom: 1px solid $color-mid-light;
             border-top: 0;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -92,6 +92,10 @@
             &:nth-last-child(2), &:nth-last-child(3), &:nth-last-child(4) {
               border-bottom: 1px solid $color-mid-light;
             }
+
+            &:nth-last-child(2) {
+              border-top: 0;
+            }
           }
 
           &:last-of-type {


### PR DESCRIPTION
## Done

The Support link in the mobile navigation menu should no longer have a white bottom border. The border started appearing after #2633 was merged.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- View the site with a mobile device screen size. Click the navigation menu. The Support link should no longer have a white bottom border.
- It shouldn't matter if additional links are added to the navigation menu.


## Issue / Card

Fixes #2634 