### PR TITLE
Replaced "live-migrate" to "copy" on /containers/lxd

### DIFF
--- a/templates/containers/lxd.html
+++ b/templates/containers/lxd.html
@@ -78,7 +78,7 @@
     <div class="u-equal-height">
       <div class="col-6 p-card">
         <h3 class="p-card__title">Your first step to containers is easy</h3>
-        <p class="p-card__content">LXD containers are just like traditional physical and virtual machines.  You can log in remotely, manage the guest OS the standard way, install applications, secure them, and operate them with the same tools, but gain the raw performance and density of containers.  LXD guests launch in seconds and you can run hundreds on a single server. Connect them separately and securely to networks, live-migrate between hosts and drive all of this through a clean REST API.</p>
+        <p class="p-card__content">LXD containers are just like traditional physical and virtual machines.  You can log in remotely, manage the guest OS the standard way, install applications, secure them, and operate them with the same tools, but gain the raw performance and density of containers.  LXD guests launch in seconds and you can run hundreds on a single server. Connect them separately and securely to networks, copy between hosts and drive all of this through a clean REST API.</p>
       </div>
       <div class="col-6 p-card">
         <h3 class="p-card__title">Like a virtual machine, only faster</h3>


### PR DESCRIPTION
## Done

- replace "live-migrate" to "copy" in "Your first step to containers is easy" section

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [lxd page](http://0.0.0.0:8001/containers/lxd)
- See that the text has been updated [copy doc](https://docs.google.com/document/d/1wBAeklBtadvh4jKuoPFSJxoX2k0zyWt07ZI4nytwYSA/edit)

## Issues

Fixes #2640

