### PR TITLE
Remove Ubuntu GNOME from flavor matrix

### DIFF
--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -55,13 +55,6 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}61f6a064-gnome.svg" alt="Ubuntu GNOME icon">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link--external" href="https://ubuntugnome.org/">Ubuntu GNOME</a></h3>
-            <p class="p-matrix__desc">Ubuntu GNOME uses GNOME Shell along with a plethora of applications from the GNOME Desktop Environment.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
           <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}a9914e3f-ubuntu-kylin.svg" alt="Ubuntu Kylin icon">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="http://www.ubuntukylin.com/index.php?lang=en">Ubuntu Kylin</a></h3>


### PR DESCRIPTION
## Done

Remove Ubuntu GNOME from flavor matrix

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- http://0.0.0.0:8001/download/ubuntu-flavours

## Issue / Card

Fixes: #2631 

Note: The bottom border of row 2 column 3 will disappear if this PR is merged. See #2639. This is an issue with vanilla-framework. See https://github.com/vanilla-framework/vanilla-framework/issues/1587.