### PR TITLE
2668: Create /download/core/raspberry-pi-2-3 page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -313,3 +313,9 @@ select {
   background-size: $sp-medium;
   padding-right: $sp-xxx-large;
 }
+
+// XXX Caleb: Temporary code block spacing fix until issue is resolved in Vanilla
+// https://github.com/vanilla-framework/vanilla-framework/issues/1385
+p + pre {
+  margin-top: $sp-medium;
+}

--- a/templates/download/core/_boot-tips-strip.html
+++ b/templates/download/core/_boot-tips-strip.html
@@ -8,7 +8,7 @@
       </ul>
     </div>
     <div class="col-4 u-hide--small u-align--center u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}e2047558-pictogram-knowledge-orange-white-background.svg" alt="" width="250">
+      <img src="{{ ASSET_SERVER_URL }}e2047558-pictogram-knowledge-orange-white-background.svg" alt="" width="180">
     </div>
   </div>
 </section>

--- a/templates/download/core/_boot-tips-strip.html
+++ b/templates/download/core/_boot-tips-strip.html
@@ -1,0 +1,14 @@
+<section class="{{strip|default:'p-strip'}} is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h3>First boot tips</h3>
+      <ul>
+        <li>During setup, <code>console-conf</code> will download the SSH key registered with your Store account and configure it so you can log into the device via <code>ssh &lt;Ubuntu SSO account name&gt;@&lt;device IP address&gt;</code> without a password.</li>
+        <li>There is no default <code>ubuntu</code> user on these images, but you can run <code>sudo passwd &lt;account name&gt;</code> to set a password if you need a local console login.</li>
+      </ul>
+    </div>
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}e2047558-pictogram-knowledge-orange-white-background.svg" alt="" width="250">
+    </div>
+  </div>
+</section>

--- a/templates/download/core/_first-boot-setup.html
+++ b/templates/download/core/_first-boot-setup.html
@@ -9,7 +9,7 @@
       <li>The device will display the prompt “Press enter to configure”.</li>
       <li>Press enter then select “Start” to begin configuring your network and an administrator account. Follow the instructions on the screen, you will be asked to configure your network and enter your Ubuntu SSO credentials.</li>
       <li>
-        At the end of the process, you will see your credentials to access your Ubuntu Core machine:
+        <p>At the end of the process, you will see your credentials to access your Ubuntu Core machine:</p>
         <pre><code>This device is registered to &lt;Ubuntu SSO email address&gt;.
 Remote access was enabled via authentication with the SSO user &lt;Ubuntu SSO user name&gt;
 Public SSH keys were added to the device for remote access.</code></pre>

--- a/templates/download/core/_first-boot-setup.html
+++ b/templates/download/core/_first-boot-setup.html
@@ -1,0 +1,19 @@
+<li class="p-list-step__item">
+  <h3 class="p-list-step__title">
+    <span class="p-list-step__bullet">{{ number|default:1 }}</span>
+    First boot setup
+  </h3>
+  <div class="p-list-step__content">
+    <ol class="u-no-margin--left">
+      <li>The system will boot then become ready to configure.</li>
+      <li>The device will display the prompt “Press enter to configure”.</li>
+      <li>Press enter then select “Start” to begin configuring your network and an administrator account. Follow the instructions on the screen, you will be asked to configure your network and enter your Ubuntu SSO credentials.</li>
+      <li>
+        At the end of the process, you will see your credentials to access your Ubuntu Core machine:
+        <pre><code>This device is registered to &lt;Ubuntu SSO email address&gt;.
+Remote access was enabled via authentication with the SSO user &lt;Ubuntu SSO user name&gt;
+Public SSH keys were added to the device for remote access.</code></pre>
+      </li>
+    </ol>
+  </div>
+</li>

--- a/templates/download/core/_flash-image.html
+++ b/templates/download/core/_flash-image.html
@@ -1,0 +1,9 @@
+<li class="p-list-step__item">
+  <h3 class="p-list-step__title">
+    <span class="p-list-step__bullet">{{ number|default:1 }}</span>
+    Flash the {{ card|default:"card" }}
+  </h3>
+  <div class="p-list-step__content">
+    <p>Copy the Ubuntu Core image on the {{ card|default:"card" }} by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
+  </div>
+</li>

--- a/templates/download/core/_install-snaps-strip.html
+++ b/templates/download/core/_install-snaps-strip.html
@@ -1,0 +1,12 @@
+<section class={{strip|default:"p-strip"}}>
+  <div class="row u-equal-height">
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}0c16085c-network-equipment_2px.svg" alt="" width="150">
+    </div>
+    <div class="col-8">
+      <h3>Install and develop snaps</h3>
+      <p>Your {{ board|default:"board" }} is now ready to have snaps installed — <a class="p-link--external" href="http://snapcraft.io/docs/core/usage">get started with the <code>snap</code> command</a></p>
+      <p>You can install a classic Ubuntu environment on top of Ubuntu Core to have a fully-fledged development environment and <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/developer-setup">develop snaps on target</a></p>
+    </div>
+  </div>
+</section>

--- a/templates/download/core/_login.html
+++ b/templates/download/core/_login.html
@@ -1,0 +1,11 @@
+<li class="p-list-step__item">
+  <h3 class="p-list-step__title">
+    <span class="p-list-step__bullet">{{ number|default:1 }}</span>
+    Login
+  </h3>
+  <div class="p-list-step__content">
+    <p>Once setup is done, you can login with SSH into Ubuntu Core, from a machine on the same network, using the following command:</p>
+    <pre><code>ssh &lt;Ubuntu SSO user name&gt;@&lt;device IP address&gt;</code></pre>
+    <p>Your user name is your Ubuntu SSO user name, it has been reminded to you at the end of the account configuration step.</p>
+  </div>
+</li>

--- a/templates/download/core/_setup-ubuntu-sso.html
+++ b/templates/download/core/_setup-ubuntu-sso.html
@@ -1,0 +1,13 @@
+<li class="p-list-step__item ">
+  <h3 class="p-list-step__title">
+    <span class="p-list-step__bullet">{{number|default:1}}</span>
+    Setup an Ubuntu SSO account
+  </h3>
+  <div class="p-list-step__content">
+    <p>An Ubuntu SSO account is required to create the first user on an Ubuntu Core installation.</p>
+    <ol class="u-no-margin--left">
+      <li>Start by creating an <a class="p-link--external" href="https://login.ubuntu.com/">Ubuntu SSO account</a>.</li>
+      <li>Import an SSH Key into your <a class="p-link--external" href="https://login.ubuntu.com/ssh-keys">Ubuntu SSO account</a>. (<a class="p-link--external" href="https://help.ubuntu.com/community/SSH/OpenSSH/Keys">instructions</a>)</li>
+    </ol>
+  </div>
+</li>

--- a/templates/download/core/raspberry-pi-2-3.html
+++ b/templates/download/core/raspberry-pi-2-3.html
@@ -21,7 +21,7 @@
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">An Ubuntu <abbr title="Single Sign-On">SSO</abbr> account with an <abbr title="Secure Shell">SSH</abbr> key</li>
+            <li class="p-list__item is-ticked">An <a class="p-link--external" href="https://login.ubuntu.com/">Ubuntu <abbr title="Single Sign-On">SSO</abbr> account</a> with an <abbr title="Secure Shell">SSH</abbr> key</li>
             <li class="p-list__item is-ticked">A Raspberry Pi 2 or 3</li>
             <li class="p-list__item is-ticked">A microSD card</li>
             <li class="p-list__item is-ticked">An Ubuntu Core image</li>
@@ -34,6 +34,8 @@
     </div>
   </div>
 </section>
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 <section class="p-strip is-deep is-bordered">
   <div class="row">

--- a/templates/download/core/raspberry-pi-2-3.html
+++ b/templates/download/core/raspberry-pi-2-3.html
@@ -1,0 +1,93 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Install Ubuntu Core on a Raspberry Pi 2 or 3{% endblock %}}
+
+{% block content %}
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-10">
+      <div>
+        <h1>Install Ubuntu on a Raspberry Pi 2 or 3</h1>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 p-card">
+      <div class="u-equal-height p-divider">
+        <div class="col-6 p-divider__block">
+          <h2>Install Ubuntu Core</h2>
+          <p>We will walk you through the steps of flashing Ubuntu Core on a Raspberry Pi 2 or 3. At the end of this process, you will have a board ready for production or testing snaps.</p>
+        </div>
+        <div class="col-6 p-divider__block">
+          <h3>Minimum requirements</h3>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">An Ubuntu <abbr title="Single Sign-On">SSO</abbr> account with an <abbr title="Secure Shell">SSH</abbr> key</li>
+            <li class="p-list__item is-ticked">A Raspberry Pi 2 or 3</li>
+            <li class="p-list__item is-ticked">A microSD card</li>
+            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
+            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
+            <li class="p-list__item is-ticked">An HDMI cable</li>
+            <li class="p-list__item is-ticked">A USB keyboard</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Installation instructions</h2>
+      <ol class="p-stepped-list--detailed">
+        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Download Ubuntu Core
+          </h3>
+          <div class="p-list-step__content">
+            <p>Get the correct Ubuntu Core image for your board:</p>
+            <ul class="u-no-margin--left">
+              <li>Raspberry Pi 2
+                <ul>
+                  <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/ubuntu-core-16-pi2.img.xz">Ubuntu Core 16 image for Raspberry Pi 2 (stable)</a></li>
+                </ul>
+              </li>
+              <li>Raspberry Pi 3
+                <ul>
+                  <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/ubuntu-core-16-pi3.img.xz">Ubuntu Core 16 image for Raspberry Pi 3 (stable)</a> - the older kernel shipped with this image can trigger Wi-Fi issues during first boot, a network cable is recommended.</li>
+                  <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/edge/current/ubuntu-core-16-armhf+raspi3.img.xz">Ubuntu Core 16 image for Raspberry Pi 3 (edge)</a> - this image provides reliable Wi-Fi at first boot, but is a daily build and not deemed stable.</li>
+                </ul>
+              </li>
+              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+            </ul>
+          </div>
+        </li>
+        {% include "./_flash-image.html" with card="microSD card" number=3 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Install Ubuntu Core
+          </h3>
+          <div class="p-list-step__content">
+            <ol class="u-no-margin--left">
+              <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
+              <li>Insert the microSD card and plug the power adaptor into the board.</li>
+            </ol>
+          </div>
+        </li>
+        {% include "./_first-boot-setup.html" with number=5 %}
+        {% include "./_login.html" with number=6 %}
+      </ol>
+    </div>
+  </div>
+</section>
+
+{% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
+
+{% include "./_install-snaps-strip.html" %}
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+{% endblock content %}

--- a/templates/download/core/raspberry-pi-2-3.html
+++ b/templates/download/core/raspberry-pi-2-3.html
@@ -21,7 +21,6 @@
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">An <a class="p-link--external" href="https://login.ubuntu.com/">Ubuntu <abbr title="Single Sign-On">SSO</abbr> account</a> with an <abbr title="Secure Shell">SSH</abbr> key</li>
             <li class="p-list__item is-ticked">A Raspberry Pi 2 or 3</li>
             <li class="p-list__item is-ticked">A microSD card</li>
             <li class="p-list__item is-ticked">An Ubuntu Core image</li>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -1,0 +1,429 @@
+<section class="p-strip--accent is-deep">
+  <div class="row">
+    <div class="col-12">
+      <h2>Before you start, get your IoT security story straight</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-7 suffix-1">
+      <p>A recent Canonical survey of 2,000 consumers suggests that a shockingly high percentage of connected devices may be vulnerable to botnets, hackers and cyber atacks:</p>
+      <ul>
+        <li>Only 31% of consumers update the firmware on their connected devices as soon as updates become available.</li>
+        <li>40% of consumers have never performed firmware updates on their connected devices</li>
+        <li>40% of consumers believe that performing firmware updates on their connected devices is the responsibility of either software developers or the device manufacturer</li>
+      </ul>
+      <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}783e1354-iot-business-model-takeover.svg" alt="" width="440" />
+    </div>
+
+    <div class="col-5">
+      <!-- MARKETO FORM -->
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1917">
+        <fieldset>
+          <ul class="p-list">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel">First name:</label>
+              <input required  id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" >
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="LastName" class="mktoLabel">Last name:</label>
+              <input required  id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired">
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Company" class="mktoLabel">Company Name:</label>
+              <input required  id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired">
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Email" class="mktoLabel ">Work email address:</label>
+              <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Phone" class="mktoLabel">Phone Number:</label>
+              <input required  id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired mktoInvalid">
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Country" class="mktoLabel">Country:</label>
+              <select required id="Country" name="Country" class="mktoField mktoRequired mktoInvalid">
+              <option disabled selected value="">Select...</option>
+              <option value="FR">France</option>
+              <option value="DE">Germany</option>
+              <option value="JP">Japan</option>
+              <option value="GB">United Kingdom</option>
+              <option value="US">United States of America</option>
+              <option value="------" disabled>------</option>
+              <option value="AF">Afghanistan</option>
+              <option value="AX">&Aring;land Islands</option>
+              <option value="AL">Albania</option>
+              <option value="DZ">Algeria</option>
+              <option value="AS">American Samoa</option>
+              <option value="AD">Andorra</option>
+              <option value="AO">Angola</option>
+              <option value="AI">Anguilla</option>
+              <option value="AQ">Antarctica</option>
+              <option value="AG">Antigua and Barbuda</option>
+              <option value="AR">Argentina</option>
+              <option value="AM">Armenia</option>
+              <option value="AW">Aruba</option>
+              <option value="AU">Australia</option>
+              <option value="AT">Austria</option>
+              <option value="AZ">Azerbaijan</option>
+              <option value="BS">Bahamas</option>
+              <option value="BH">Bahrain</option>
+              <option value="BD">Bangladesh</option>
+              <option value="BB">Barbados</option>
+              <option value="BY">Belarus</option>
+              <option value="BE">Belgium</option>
+              <option value="BZ">Belize</option>
+              <option value="BJ">Benin</option>
+              <option value="BM">Bermuda</option>
+              <option value="BT">Bhutan</option>
+              <option value="BO">Bolivia (Plurinational State of)</option>
+              <option value="BQ">Bonaire, Sint Eustatius and Saba</option>
+              <option value="BA">Bosnia and Herzegovina</option>
+              <option value="BW">Botswana</option>
+              <option value="BV">Bouvet Island</option>
+              <option value="BR">Brazil</option>
+              <option value="IO">British Indian Ocean Territory</option>
+              <option value="BN">Brunei Darussalam</option>
+              <option value="BG">Bulgaria</option>
+              <option value="BF">Burkina Faso</option>
+              <option value="BI">Burundi</option>
+              <option value="KH">Cambodia</option>
+              <option value="CM">Cameroon</option>
+              <option value="CA">Canada</option>
+              <option value="CV">Cabo Verde</option>
+              <option value="KY">Cayman Islands</option>
+              <option value="CF">Central African Republic</option>
+              <option value="TD">Chad</option>
+              <option value="CL">Chile</option>
+              <option value="CN">China</option>
+              <option value="CX">Christmas Island</option>
+              <option value="CC">Cocos (Keeling) Islands</option>
+              <option value="CO">Colombia</option>
+              <option value="KM">Comoros</option>
+              <option value="CG">Congo</option>
+              <option value="CD">Congo (Democratic Republic of the)</option>
+              <option value="CK">Cook Islands</option>
+              <option value="CR">Costa Rica</option>
+              <option value="CI">C&ocirc;te d'Ivoire</option>
+              <option value="HR">Croatia</option>
+              <option value="CU">Cuba</option>
+              <option value="CW">Cura&ccedil;ao</option>
+              <option value="CY">Cyprus</option>
+              <option value="CZ">Czech Republic</option>
+              <option value="DK">Denmark</option>
+              <option value="DJ">Djibouti</option>
+              <option value="DM">Dominica</option>
+              <option value="DO">Dominican Republic</option>
+              <option value="EC">Ecuador</option>
+              <option value="EG">Egypt</option>
+              <option value="SV">El Salvador</option>
+              <option value="GQ">Equatorial Guinea</option>
+              <option value="ER">Eritrea</option>
+              <option value="EE">Estonia</option>
+              <option value="ET">Ethiopia</option>
+              <option value="FK">Falkland Islands (Malvinas)</option>
+              <option value="FO">Faroe Islands</option>
+              <option value="FJ">Fiji</option>
+              <option value="FI">Finland</option>
+              <option value="FR">France</option>
+              <option value="GF">French Guiana</option>
+              <option value="PF">French Polynesia</option>
+              <option value="TF">French Southern Territories</option>
+              <option value="GA">Gabon</option>
+              <option value="GM">Gambia</option>
+              <option value="GE">Georgia</option>
+              <option value="DE">Germany</option>
+              <option value="GH">Ghana</option>
+              <option value="GI">Gibraltar</option>
+              <option value="GR">Greece</option>
+              <option value="GL">Greenland</option>
+              <option value="GD">Grenada</option>
+              <option value="GP">Guadeloupe</option>
+              <option value="GU">Guam</option>
+              <option value="GT">Guatemala</option>
+              <option value="GG">Guernsey</option>
+              <option value="GN">Guinea</option>
+              <option value="GW">Guinea-Bissau</option>
+              <option value="GY">Guyana</option>
+              <option value="HT">Haiti</option>
+              <option value="HM">Heard Island and McDonald Islands</option>
+              <option value="VA">Holy See</option>
+              <option value="HN">Honduras</option>
+              <option value="HK">Hong Kong</option>
+              <option value="HU">Hungary</option>
+              <option value="IS">Iceland</option>
+              <option value="IN">India</option>
+              <option value="ID">Indonesia</option>
+              <option value="IR">Iran (Islamic Republic of)</option>
+              <option value="IQ">Iraq</option>
+              <option value="IE">Ireland</option>
+              <option value="IM">Isle of Man</option>
+              <option value="IL">Israel</option>
+              <option value="IT">Italy</option>
+              <option value="JM">Jamaica</option>
+              <option value="JP">Japan</option>
+              <option value="JE">Jersey</option>
+              <option value="JO">Jordan</option>
+              <option value="KZ">Kazakhstan</option>
+              <option value="KE">Kenya</option>
+              <option value="KI">Kiribati</option>
+              <option value="KP">Korea (Democratic People's Republic of)</option>
+              <option value="KR">Korea (Republic of)</option>
+              <option value="KW">Kuwait</option>
+              <option value="KG">Kyrgyzstan</option>
+              <option value="LA">Lao People's Democratic Republic</option>
+              <option value="LV">Latvia</option>
+              <option value="LB">Lebanon</option>
+              <option value="LS">Lesotho</option>
+              <option value="LR">Liberia</option>
+              <option value="LY">Libya</option>
+              <option value="LI">Liechtenstein</option>
+              <option value="LT">Lithuania</option>
+              <option value="LU">Luxembourg</option>
+              <option value="MO">Macao</option>
+              <option value="MK">Macedonia (the former Yugoslav Republic of)</option>
+              <option value="MG">Madagascar</option>
+              <option value="MW">Malawi</option>
+              <option value="MY">Malaysia</option>
+              <option value="MV">Maldives</option>
+              <option value="ML">Mali</option>
+              <option value="MT">Malta</option>
+              <option value="MH">Marshall Islands</option>
+              <option value="MQ">Martinique</option>
+              <option value="MR">Mauritania</option>
+              <option value="MU">Mauritius</option>
+              <option value="YT">Mayotte</option>
+              <option value="MX">Mexico</option>
+              <option value="FM">Micronesia (Federated States of)</option>
+              <option value="MD">Moldova (Republic of)</option>
+              <option value="MC">Monaco</option>
+              <option value="MN">Mongolia</option>
+              <option value="ME">Montenegro</option>
+              <option value="MS">Montserrat</option>
+              <option value="MA">Morocco</option>
+              <option value="MZ">Mozambique</option>
+              <option value="MM">Myanmar</option>
+              <option value="NA">Namibia</option>
+              <option value="NR">Nauru</option>
+              <option value="NP">Nepal</option>
+              <option value="NL">Netherlands</option>
+              <option value="NC">New Caledonia</option>
+              <option value="NZ">New Zealand</option>
+              <option value="NI">Nicaragua</option>
+              <option value="NE">Niger</option>
+              <option value="NG">Nigeria</option>
+              <option value="NU">Niue</option>
+              <option value="NF">Norfolk Island</option>
+              <option value="MP">Northern Mariana Islands</option>
+              <option value="NO">Norway</option>
+              <option value="OM">Oman</option>
+              <option value="PK">Pakistan</option>
+              <option value="PW">Palau</option>
+              <option value="PS">Palestine, State of</option>
+              <option value="PA">Panama</option>
+              <option value="PG">Papua New Guinea</option>
+              <option value="PY">Paraguay</option>
+              <option value="PE">Peru</option>
+              <option value="PH">Philippines</option>
+              <option value="PN">Pitcairn</option>
+              <option value="PL">Poland</option>
+              <option value="PT">Portugal</option>
+              <option value="PR">Puerto Rico</option>
+              <option value="QA">Qatar</option>
+              <option value="RE">RÃ©union</option>
+              <option value="RO">Romania</option>
+              <option value="RU">Russian Federation</option>
+              <option value="RW">Rwanda</option>
+              <option value="BL">Saint BarthÃ©lemy</option>
+              <option value="SH">Saint Helena, Ascension and Tristan da Cunha</option>
+              <option value="KN">Saint Kitts and Nevis</option>
+              <option value="LC">Saint Lucia</option>
+              <option value="MF">Saint Martin (French part)</option>
+              <option value="PM">Saint Pierre and Miquelon</option>
+              <option value="VC">Saint Vincent and the Grenadines</option>
+              <option value="WS">Samoa</option>
+              <option value="SM">San Marino</option>
+              <option value="ST">Sao Tome and Principe</option>
+              <option value="SA">Saudi Arabia</option>
+              <option value="SN">Senegal</option>
+              <option value="RS">Serbia</option>
+              <option value="SC">Seychelles</option>
+              <option value="SL">Sierra Leone</option>
+              <option value="SG">Singapore</option>
+              <option value="SX">Sint Maarten (Dutch part)</option>
+              <option value="SK">Slovakia</option>
+              <option value="SI">Slovenia</option>
+              <option value="SB">Solomon Islands</option>
+              <option value="SO">Somalia</option>
+              <option value="ZA">South Africa</option>
+              <option value="GS">South Georgia and the South Sandwich Islands</option>
+              <option value="SS">South Sudan</option>
+              <option value="ES">Spain</option>
+              <option value="LK">Sri Lanka</option>
+              <option value="SD">Sudan</option>
+              <option value="SR">Suriname</option>
+              <option value="SJ">Svalbard and Jan Mayen</option>
+              <option value="SZ">Swaziland</option>
+              <option value="SE">Sweden</option>
+              <option value="CH">Switzerland</option>
+              <option value="SY">Syrian Arab Republic</option>
+              <option value="TW">Taiwan</option>
+              <option value="TJ">Tajikistan</option>
+              <option value="TZ">Tanzania, United Republic of</option>
+              <option value="TH">Thailand</option>
+              <option value="TL">Timor-Leste</option>
+              <option value="TG">Togo</option>
+              <option value="TK">Tokelau</option>
+              <option value="TO">Tonga</option>
+              <option value="TT">Trinidad and Tobago</option>
+              <option value="TN">Tunisia</option>
+              <option value="TR">Turkey</option>
+              <option value="TM">Turkmenistan</option>
+              <option value="TC">Turks and Caicos Islands</option>
+              <option value="TV">Tuvalu</option>
+              <option value="UG">Uganda</option>
+              <option value="UA">Ukraine</option>
+              <option value="AE">United Arab Emirates</option>
+              <option value="GB">United Kingdom</option>
+              <option value="US">United States of America</option>
+              <option value="UM">United States Minor Outlying Islands</option>
+              <option value="UY">Uruguay</option>
+              <option value="UZ">Uzbekistan</option>
+              <option value="VU">Vanuatu</option>
+              <option value="VE">Venezuela (Bolivarian Republic of)</option>
+              <option value="VN">Viet Nam</option>
+              <option value="VG">Virgin Islands (British)</option>
+              <option value="VI">Virgin Islands (U.S.)</option>
+              <option value="WF">Wallis and Futuna</option>
+              <option value="EH">Western Sahara</option>
+              <option value="YE">Yemen</option>
+              <option value="ZM">Zambia</option>
+              <option value="ZW">Zimbabwe</option></select>
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="MktoPersonNotes" class="mktoLabel">Are you working on a commercial IoT deployment?</label>
+              <select required id="MktoPersonNotes" name="MktoPersonNotes" class="mktoField mktoRequired mktoInvalid"><option value="">Select...</option>
+              <option value="Working on a commercial IoT deployment">Yes</option>
+              <option value="Not working on a commercial IoT deployment">No</option></select>
+            </li>
+            <li class="mktField p-list__item">
+              <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
+              <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In"><small>I would like to receive occasional news from Canonical by email.</small></label>
+            </li>
+            <li class="mktField p-list__item">
+              <button type="submit" class="mktoButton p-button--positive" onsubmit="backgroundSubmitHandler();">Download the white paper</button>
+              <input type="hidden" name="formid" class="mktoField" value="1917">
+              <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
+            </li>
+            <li class="mktField p-list__item">
+              <input type="hidden" name="utm_source" class="mktoField mktoFormCol" value="" >
+            </li>
+            <li class="mktField p-list__item">
+              <input type="hidden" name="utm_campaign" class="mktoField mktoFormCol" value="" >
+            </li>
+            <li class="mktField p-list__item">
+              <input type="hidden" name="utm_medium" class="mktoField mktoFormCol" value="" >
+            </li>
+            <li class="mktField p-list__item">
+              <input type="hidden" name="utm_term" class="mktoField mktoFormCol" value="" >
+            </li>
+            <li>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</li>
+          </ul>
+      </fieldset>
+      <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/core" />
+      <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/core" />
+      </form>
+
+      <!-- marketo form dependencies -->
+      <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}ec520d10-XMLHttpRequest.min.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}4176b39e-serialize.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}6b7597df-event-listener-polyfill.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
+      <!-- script -->
+      <script>
+      $("#mktoForm_1917").validate({
+        errorElement: "span",
+        errorClass: "mktFormMsg mktError",
+        onkeyup: false,
+        onclick: false,
+        onblur: false
+      });
+
+      /**
+      * Given a form element, extract its data and its "action" target URL
+      * and submit the form using Ajax
+      */
+      backgroundSubmit = function(formElement, submitCallback) {
+        var request = new XMLHttpRequest();
+        var submitUrl = formElement.getAttribute('action');
+        var formData = serialize(formElement)
+
+        request.open("POST", submitUrl, true);
+
+        //Send the proper header information along with the request
+        request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+
+        // When request has finished, call the callback function
+        if (submitCallback) {
+          request.addEventListener(
+            'readystatechange',
+            function() {
+              if (this.readyState == 4) {
+                // Pass context and arguments on to submitCallback
+                submitCallback.apply(this, arguments);
+              }
+            }
+          );
+        }
+
+        // Send off the POST request
+        request.send(formData);
+      }
+
+      /**
+      * After submit has happened
+      * start download and send the user to the instructions page
+      */
+      afterSubmit = function() {
+        // Now start the download
+        downloadFrame = document.createElement("iframe");
+        downloadFrame.setAttribute("src", "https://pages.ubuntu.com/rs/066-EOV-335/images/IoTSecurityWhitepaper-FinalReport.pdf");
+        downloadFrame.style.width = 0 + "px";
+        downloadFrame.style.height = 0 + "px";
+        document.body.insertBefore(downloadFrame, document.body.childNodes[0]);
+      }
+
+      /**
+      * Handler for a form submit event
+      * to disable the normal submit, and instead use backgroundSubmit
+      */
+
+      backgroundSubmitHandlerClosure = function($) {
+        return function(submitEvent) {
+          // Prevent normal submit
+          submitEvent.preventDefault ? submitEvent.preventDefault() : submitEvent.returnValue = false;
+          // Check form is valid
+          if ($(marketoForm).valid()) {
+            // Change the submit location
+            marketoForm.action = "https://app-sjg.marketo.com/index.php/leadCapture/save2"
+            // Submit the form in the background
+            backgroundSubmit(marketoForm, afterSubmit);
+          }
+        }
+      }
+
+      // Get the form
+      marketoForm = document.getElementById('mktoForm_1917');
+
+      // Attach the submit handler to the form
+      marketoForm.addEventListener(
+        'submit',
+        backgroundSubmitHandlerClosure(jQuery)
+      )
+      </script>
+      <!-- /MARKETO FORM -->
+    </div>
+  </div>
+</section>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -387,12 +387,7 @@
       * start download and send the user to the instructions page
       */
       afterSubmit = function() {
-        // Now start the download
-        downloadFrame = document.createElement("iframe");
-        downloadFrame.setAttribute("src", "https://pages.ubuntu.com/rs/066-EOV-335/images/IoTSecurityWhitepaper-FinalReport.pdf");
-        downloadFrame.style.width = 0 + "px";
-        downloadFrame.style.height = 0 + "px";
-        document.body.insertBefore(downloadFrame, document.body.childNodes[0]);
+        window.location.href = "https://pages.ubuntu.com/rs/066-EOV-335/images/IoTSecurityWhitepaper-FinalReport.pdf";
       }
 
       /**


### PR DESCRIPTION
## Done

- Created /download/core/raspberry-pi-2-3 page
- Created generic includes for:
  - Setup Ubuntu SSO step
  - First boot setup step
  - Flash image step
  - Login step
  - Install snaps strip
  - First boot tips strip
  - IoT Security ebook
- Hotfixed a [Vanilla issue](https://github.com/vanilla-framework/vanilla-framework/issues/1385) where `<pre>` blocks don't have a top margin following a `<p>` block

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/core/raspberry-pi-2-3 page
- Check that content matches the [copydoc](https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit#heading=h.jg3nijeu6k0w)

## Issue / Card

Fixes #2668 
