### PR TITLE
Export prometheus metrics for feed requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-prometheus==1.0.11
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
-canonicalwebteam.get-feeds==0.1.7
+canonicalwebteam.get-feeds==0.2.1
 whitenoise==3.3.0
 django-yaml-redirects==0.5.3
 django-asset-server-url==0.1

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -75,7 +75,7 @@ if not DEBUG:
         'django_prometheus.middleware.PrometheusAfterMiddleware'
     )
     # Run the prometheus exporters on a range of ports
-    PROMETHEUS_METRICS_EXPORT_PORT_RANGE = range(9090, 9099)
+    PROMETHEUS_METRICS_EXPORT_PORT_RANGE = range(9990, 9999)
 
 
 STATICFILES_FINDERS = [


### PR DESCRIPTION
Feeds should now output prometheus metrics. [Example](https://pastebin.ubuntu.com/=64Gjt8gThT/)

QA
--

``` bash
./run build  # Just make sure all dependencies are up to date
./run exec --expose-port 8001 --expose-port 9990 --env DJANGO_DEBUG=false ./manage.py runserver --noreload 0.0.0.0:8001
```

Now browse around the site a while at http://127.0.0.1:8001.

Then go to http://127.0.0.1:9990 and inspect the prometheus metrics. Particular look for:

- `feed_request_latency_seconds_bucket`
- `feed_requested_from_cache`
- `feed_failed_requests` - you may not see this if there haven't been any errors