### PR TITLE
2671: Create /download/core/up-squared-iot-grove page

### DIFF
--- a/templates/download/core/up-squared-iot-grove.html
+++ b/templates/download/core/up-squared-iot-grove.html
@@ -21,13 +21,9 @@
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">An Ubuntu SSO account with an SSH key</li>
-            <li class="p-list__item is-ticked">A Raspberry Pi 2 or 3</li>
-            <li class="p-list__item is-ticked">A microSD card</li>
-            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
-            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-            <li class="p-list__item is-ticked">An HDMI cable</li>
-            <li class="p-list__item is-ticked">A USB keyboard</li>
+            <li class="p-list__item is-ticked">An UP2 IoT Grove Development Kit</li>
+            <li class="p-list__item is-ticked">A USB flash drive</li>
+            <li class="p-list__item is-ticked">An Ubuntu Server image</li>
           </ul>
         </div>
       </div>

--- a/templates/download/core/up-squared-iot-grove.html
+++ b/templates/download/core/up-squared-iot-grove.html
@@ -1,0 +1,92 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Install Ubuntu Server on an UP Squared IoT Grove Development Kit{% endblock %}}
+
+{% block content %}
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-10">
+      <div>
+        <h1>Install Ubuntu Server on an UP<sup>2</sup> IoT Grove Development Kit</h1>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 p-card">
+      <div class="u-equal-height p-divider">
+        <div class="col-6 p-divider__block">
+          <h2>Install Ubuntu Server</h2>
+          <p>We will walk you through the steps of installing Ubuntu Server on the UP<sup>2</sup> IoT Grove Development Kit. At the end of this process, you will have a fully fledged development or production environment.</p>
+        </div>
+        <div class="col-6 p-divider__block">
+          <h3>Minimum requirements</h3>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">An Ubuntu SSO account with an SSH key</li>
+            <li class="p-list__item is-ticked">A Raspberry Pi 2 or 3</li>
+            <li class="p-list__item is-ticked">A microSD card</li>
+            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
+            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
+            <li class="p-list__item is-ticked">An HDMI cable</li>
+            <li class="p-list__item is-ticked">A USB keyboard</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "download/shared/_get-ebook-security.html"%}
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Installation instructions</h2>
+      <ol class="p-stepped-list--detailed">
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Download Ubuntu Server
+          </h3>
+          <div class="p-list-step__content">
+            <p>Get the correct Ubuntu Server image for your board:</p>
+            <ul class="u-no-margin--left">
+              <li>Intel provides a modified Ubuntu Server 16.04.3 LTS image shipped with a custom 4.10 kernel and the Intel IoT Developer Kit.</li>
+              <li>Download and copy the <a class="p-link--external" href="https://downloads.up-community.org/download/up-squared-iot-grove-development-kit-ubuntu-16-04-server-image/">Ubuntu Server 16.04 LTS</a> image on a USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+            </ul>
+          </div>
+        </li>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Install Ubuntu Server
+          </h3>
+          <div class="p-list-step__content">
+            <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
+            <ol class="u-no-margin--left">
+              <li>Insert the USB flash drive in the Up<sup>2</sup> board.</li>
+              <li>Power on the board.</li>
+              <li>The installer will start automatically. Follow the prompts to install Ubuntu Server on the on-board eMMC disk. You can refer to <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server#4">this tutorial</a> for complete Ubuntu Server installation guidance.</li>
+            </ol>
+          </div>
+        </li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}0c16085c-network-equipment_2px.svg" alt="" width="150">
+    </div>
+    <div class="col-8">
+      <h3>Install and develop snaps</h3>
+      <p>Your {{ board|default:"board" }} is now ready to have snaps installed — <a class="p-link--external" href="http://snapcraft.io/docs/core/usage">get started with the <code>snap</code> command</a></p>
+      <p>Your board is ready to develop and run snaps, secured application packages tailored for IoT, this tutorial will show you <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap">how to create your first snap</a>.</p>
+    </div>
+  </div>
+</section>
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+{% endblock content %}


### PR DESCRIPTION
# NOTE
**Don't merge until it's decided where this page should live.** Check [copydoc](https://docs.google.com/document/d/1-q8NzhmqYvPCAT2AwSv7N9sr_TgJdCc8_gLT7RmaoNE/edit#) for more info

## Done

- Created /download/core/up-squared-iot-grove page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/core/up-squared-iot-grove
- Check that content matches the [copydoc](https://docs.google.com/document/d/1-q8NzhmqYvPCAT2AwSv7N9sr_TgJdCc8_gLT7RmaoNE/edit#)

## Issue / Card

Fixes #2671 