### PR TITLE
Upgrade to get-feeds v0.2.2 - more accurate timing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-prometheus==1.0.11
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
-canonicalwebteam.get-feeds==0.2.1
+canonicalwebteam.get-feeds==0.2.2
 whitenoise==3.3.0
 django-yaml-redirects==0.5.3
 django-asset-server-url==0.1


### PR DESCRIPTION
The latest version of get-feeds uses native requests library features to
measure the request times it reports to prometheus. This is better.

QA
--

``` bash
./run exec --expose-port 8001 --expose-port 9990 --env DJANGO_DEBUG=false ./manage.py runserver --noreload 0.0.0.0:8001
```

Browse around the site a bit at http://0.0.0.0:8001

Now go to http://0.0.0.0:9990 and check the `feed_request_latency_seconds_bucket` and `feed_request_latency_seconds_bucket` measurements look reasonable. Hopefully most requests are taking considerably less than a second.