### PR TITLE
Release new /download/core pages

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -212,6 +212,30 @@ download:
         - title: Build OpenStack
           path: /download/cloud/build-openstack
 
+    - title: Core
+      path: /download/core
+
+      children:
+        - title: Raspberry Pi 2 or 3
+          path: /download/core/raspberry-pi-2-3
+        - title: Raspberry Pi Compute Module 3
+          path: /download/core/raspberry-pi-compute-module-3
+        - title: Orange Pi Zero
+          path: /download/core/orange-pi-zero
+        - title: Qualcomm Dragonboard 410c
+          path: /download/core/qualcomm-dragonboard-410c
+        - title: Intel NUC
+          path: /download/core/intel-nuc
+        - title: Intel Joule
+          path: /download/core/intel-joule
+        - title: Samsung Artik 5 or 10
+          path: /download/core/samsung-artik-5-10
+        - title: KVM
+          path: /download/core/kvm
+        - title: UP Squared IoT Grove
+          path: /download/core/up-squared-iot-grove
+
+
     - title: Server
       path: /download/server
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -319,3 +319,18 @@ select {
 p + pre {
   margin-top: $sp-medium;
 }
+
+// XXX Caleb 06/02/2018 Modifier to Matrix pattern so images can be large
+.p-matrix {
+  &__img {
+    &-container {
+      min-height: 5rem;
+      padding: .5rem 0 1rem 0;
+    }
+
+    &--large {
+      @extend .p-matrix__img; // sass-lint:disable-line placeholder-in-extend
+      max-width: 100%;
+    }
+  }
+}

--- a/templates/download/core/index.html
+++ b/templates/download/core/index.html
@@ -1,0 +1,105 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Download Ubuntu Core | Download{% endblock %}
+
+{% block content %}
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h1>Get Ubuntu Core</h1>
+    <p>Ubuntu Core is supported on a variety of chipsets, boards, SOCs and virtual machines, including Raspberry Pi 2 and 3, Compute Module 3, Qualcomm DragonBoard 410c, Intel NUC, Intel Joule, Samsung Artik and KVM.</p>
+    <p>We will guide you through the steps of installing Ubuntu Core or Ubuntu Server on these platforms.</p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/raspberry-pi-2-3"><img class="p-matrix__img--large" alt="Raspberry Pi logo" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=200"></a>
+          </div>
+          <p class="p-matrix__desc">Ubuntu Core allows you to install apps on your board in just a few clicks.</p>
+          <p><a class="p-matrix__link" href="/download/core/raspberry-pi-2-3">Install on a Raspberry Pi 2 or&nbsp;3&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/raspberry-pi-compute-module-3"><img class="p-matrix__img--large" alt="Raspberry Pi logo" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=200" /></a>
+          </div>
+          <p class="p-matrix__desc">Ubuntu Core works on minimal setups, embed and go!</p>
+          <p><a class="p-matrix__link" href="/download/core/raspberry-pi-compute-module-3">Install on a Raspberry Pi Compute Module&nbsp;3&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/orange-pi-zero"><img class="p-matrix__img--large" alt="Orange Pi logo" src="{{ ASSET_SERVER_URL }}02251698-orange-pi-logo.png" /></a>
+          </div>
+          <p class="p-matrix__desc">Ubuntu Core also runs on the AllWinner H2 SoC used on Orange Pi boards.</p>
+          <p><a class="p-matrix__link" href="/download/core/orange-pi-zero">Install on an Orange Pi Zero&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/qualcomm-dragonboard-410c"><img class="p-matrix__img--large" alt="Dragonboard logo" src="{{ ASSET_SERVER_URL }}d9ccf84b-qualcoom.png?w=230" /></a>
+          </div>
+          <p class="p-matrix__desc">Ubuntu Core helps you harness the power of boards tailored for the IoT ecosystem.</p>
+          <p><a class="p-matrix__link" href="/download/core/qualcomm-dragonboard-410c">Install on a Qualcomm DragonBoard 410c&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/intel-nuc"><img class="p-matrix__img--large" alt="Intel NUC logo" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg" width="150"/></a>
+          </div>
+          <p class="p-matrix__desc">Ubuntu Core can be easily installed on other architectures like Intel&reg; 64 bits.</p>
+          <p><a class="p-matrix__link" href="/download/core/intel-nuc">Install on an Intel NUC&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/intel-joule"><img class="p-matrix__img--large" alt="Intel Joule Pi logo" src="{{ ASSET_SERVER_URL }}1f53b707-INTEL_JOULE-LOGO.png?w=200" /></a>
+          </div>
+          <p class="p-matrix__desc">Ubuntu Core lets you interact and control complex hardware and modules.</p>
+          <p><a class="p-matrix__link" href="/download/core/intel-joule">Install on an Intel Joule&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/samsung-artik-5-10"><img class="p-matrix__img--large" alt="Samsung Artik logo" src="{{ ASSET_SERVER_URL }}c5dfb2cb-samsung-artik.png?w=150" /></a>
+          </div>
+          <p class="p-matrix__desc">Ubuntu Core runs smoothly on both small and large footprint boards.</p>
+          <p><a class="p-matrix__link" href="/download/core/samsung-artik-5-10">Install on a Samsung Artik 5 or&nbsp;10&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/kvm"><img class="p-matrix__img--large" alt="KVM logo" src="{{ ASSET_SERVER_URL }}aa0e2566-kvm-logo.png?w=120" /></a>
+          </div>
+          <p class="p-matrix__desc">Develop on target or on your Linux desktop, run Ubuntu Core in a virtual environment.</p>
+          <p><a class="p-matrix__link" href="/download/core/kvm">Install on a KVM&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <div class="p-matrix__img-container u-vertically-center">
+            <a href="/download/core/up-squared-iot-grove"><img class="p-matrix__img--large" alt="Up Squared logo" src="{{ ASSET_SERVER_URL }}8cb47950-g46.png?w=70" /></a>
+          </div>
+          <p class="p-matrix__desc">Build snaps using the UP<sup>2</sup> IoT Grove development kit running Ubuntu Server.</p>
+          <p><a class="p-matrix__link" href="/download/core/up-squared-iot-grove">Install on an UP<sup>2</sup> IoT Grove&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+{% endblock content %}

--- a/templates/download/core/intel-joule.html
+++ b/templates/download/core/intel-joule.html
@@ -196,9 +196,9 @@
   </div>
 </section>
 
-{% include "./_boot-tips-strip.html" %}
+{% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
 
-{% include "./_install-snaps-strip.html" with strip="p-strip--light" %}
+{% include "./_install-snaps-strip.html" %}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/core/intel-nuc.html
+++ b/templates/download/core/intel-nuc.html
@@ -206,9 +206,9 @@
   </div>
 </section>
 
-{% include "./_boot-tips-strip.html" %}
+{% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
 
-{% include "./_install-snaps-strip.html" with strip="p-strip--light" %}
+{% include "./_install-snaps-strip.html" %}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -66,11 +66,11 @@
         </div>
         <div class="col-6 p-card u-equal-height">
           <div class="col-4">
-            <h2 class="p-card__title"><a href="https://developer.ubuntu.com/en/snappy/start/" class="p-link--external">Ubuntu Core</a></h2>
+            <h2 class="p-card__title"><a href="/download/core">Ubuntu Core&nbsp;&rsaquo;</a></h2>
             <p class="p-card__content">Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
           </div>
           <div class="col-2 u-align--center u-vertically-center">
-            <a href="https://developer.ubuntu.com/en/snappy/start/"><img src="{{ ASSET_SERVER_URL }}cde21f03-snappy.png" alt="Ubuntu core" height="112" width="112" /></a>
+            <a href="/download/core"><img src="{{ ASSET_SERVER_URL }}442ccba1-snappy-ubuntu-core-logo-01.svg" alt="Ubuntu core" height="112" width="112" /></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updated /download page to reflect new /download/core section [copydoc](https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit#)
- Created /download/core page according to https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit#
- Updated `navigation.yaml` with new /download/core pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download
- Ensure the download page matches the [copydoc](https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit#)
- Navigate to http://0.0.0.0:8001/download/core
- Ensure the download/core page matches the [copydoc]()
- Check that the primary nav has Core listed under the Download dropdown
- Check that the download/core page has all the required breadcrumbs

## Issue / Card

Fixes #2677, fixes #2686 
