### PR TITLE
2688: Update /about page to reflect new /community pages

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -23,12 +23,12 @@
       <p>Ubuntu comes with full support and all kinds of services available worldwide.</p>
     </div>
     <div class="col-4 p-divider__block">
-      <h2 class="p-heading--three"><a href="/about/about-ubuntu/our-philosophy">Open-source software&nbsp;&rsaquo;</a></h2>
+      <h2 class="p-heading--three"><a href="/community/mission">Open-source software&nbsp;&rsaquo;</a></h2>
       <p>Ubuntu is created by open-source developers because we believe that everybody should have access to the best possible technologies.</p>
       <p>This passionate global community works together to continually evolve the best systems in the world and then make them available to everybody, absolutely free.</p>
     </div>
     <div class="col-4 p-divider__block">
-      <h2 class="p-heading--three"><a href="/about/canonical-and-ubuntu">Ubuntu and Canonical&nbsp;&rsaquo;</a></h2>
+      <h2 class="p-heading--three"><a href="/community/canonical">Ubuntu and Canonical&nbsp;&rsaquo;</a></h2>
       <p>Ubuntu is backed by Canonical &mdash; the number-one Ubuntu services provider.</p>
       <p>Companies can choose to receive expert training, support or consultancy for a fee that goes towards the continued development of Ubuntu.</p>
     </div>


### PR DESCRIPTION
## Done

- Updated links in /about page according to [copydoc](https://docs.google.com/document/d/1NvYOhOJzdY5ypifTPs73vH5Nb7rFABRWMzjXyDUQt_U/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/about
- Check that the links for "Open-source software" and "Ubuntu and Canoncical" go to the right community pages

## Issue / Card

Fixes #2688 
