### PR TITLE
Simpler prometheus buckets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-prometheus==1.0.11
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-deleted-paths==0.1.0
-canonicalwebteam.get-feeds==0.2.2
+canonicalwebteam.get-feeds==0.2.4
 whitenoise==3.3.0
 django-yaml-redirects==0.5.3
 django-asset-server-url==0.1


### PR DESCRIPTION
Buckets should now be 0.25, 0.5, 0.75, 1, 1.2, inf

And we should only store metrics for each domain, not each URL.

QA
--

``` bash
./run build  # Ensure we have the latest dependencies
./run exec --expose-port 8001 --expose-port 9990 --env DJANGO_DEBUG=false ./manage.py runserver --noreload 0.0.0.0:8001
```

Now go to http://127.0.0.1:8001 and http://0.0.0.0:8001/resources?content=videos&topic=cloud-and-server and http://0.0.0.0:8001/desktop/partners.

Now go to http://0.0.0.0:9990/ and see simpler prometheus metrics like:

``` bash
feed_request_latency_seconds_bucket{code="200",domain="partners.ubuntu.com",le="0.25"} 0.0
feed_request_latency_seconds_bucket{code="200",domain="partners.ubuntu.com",le="0.5"} 1.0
feed_request_latency_seconds_bucket{code="200",domain="partners.ubuntu.com",le="0.75"} 1.0
feed_request_latency_seconds_bucket{code="200",domain="partners.ubuntu.com",le="1.0"} 1.0
feed_request_latency_seconds_bucket{code="200",domain="partners.ubuntu.com",le="1.2"} 1.0
feed_request_latency_seconds_bucket{code="200",domain="partners.ubuntu.com",le="+Inf"} 1.0
feed_request_latency_seconds_count{code="200",domain="partners.ubuntu.com"} 1.0
feed_request_latency_seconds_sum{code="200",domain="partners.ubuntu.com"} 0.396624
feed_request_latency_seconds_bucket{code="200",domain="insights.ubuntu.com",le="0.25"} 3.0
feed_request_latency_seconds_bucket{code="200",domain="insights.ubuntu.com",le="0.5"} 3.0
feed_request_latency_seconds_bucket{code="200",domain="insights.ubuntu.com",le="0.75"} 3.0
feed_request_latency_seconds_bucket{code="200",domain="insights.ubuntu.com",le="1.0"} 3.0
feed_request_latency_seconds_bucket{code="200",domain="insights.ubuntu.com",le="1.2"} 5.0
feed_request_latency_seconds_bucket{code="200",domain="insights.ubuntu.com",le="+Inf"} 5.0
feed_request_latency_seconds_count{code="200",domain="insights.ubuntu.com"} 5.0
feed_request_latency_seconds_sum{code="200",domain="insights.ubuntu.com"} 2.485465
```