### PR TITLE
Moved ebook on /download/core/board pages

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -218,23 +218,31 @@ download:
       children:
         - title: Raspberry Pi 2 or 3
           path: /download/core/raspberry-pi-2-3
+          hidden: True
         - title: Raspberry Pi Compute Module 3
           path: /download/core/raspberry-pi-compute-module-3
+          hidden: True
         - title: Orange Pi Zero
           path: /download/core/orange-pi-zero
+          hidden: True
         - title: Qualcomm Dragonboard 410c
           path: /download/core/qualcomm-dragonboard-410c
+          hidden: True
         - title: Intel NUC
           path: /download/core/intel-nuc
+          hidden: True
         - title: Intel Joule
           path: /download/core/intel-joule
+          hidden: True
         - title: Samsung Artik 5 or 10
           path: /download/core/samsung-artik-5-10
+          hidden: True
         - title: KVM
           path: /download/core/kvm
+          hidden: True
         - title: UP Squared IoT Grove
           path: /download/core/up-squared-iot-grove
-
+          hidden: True
 
     - title: Server
       path: /download/server

--- a/templates/download/core/intel-joule.html
+++ b/templates/download/core/intel-joule.html
@@ -39,8 +39,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -97,6 +95,8 @@
     </div>
   </div>
 </section>
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 <section id="desktop" class="p-strip--light is-bordered">
   <div class="row">

--- a/templates/download/core/intel-nuc.html
+++ b/templates/download/core/intel-nuc.html
@@ -40,8 +40,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -126,6 +124,8 @@
     </div>
   </div>
 </section>
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 <section class="p-strip--light is-bordered" id="desktop">
   <div class="row">

--- a/templates/download/core/kvm.html
+++ b/templates/download/core/kvm.html
@@ -30,8 +30,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -122,6 +120,8 @@ KVM acceleration can be used</code></pre>
 {% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
 
 {% include "./_install-snaps-strip.html" with board="virtual machine"%}
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/core/orange-pi-zero.html
+++ b/templates/download/core/orange-pi-zero.html
@@ -35,8 +35,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -87,6 +85,8 @@
 {% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
 
 {% include "./_install-snaps-strip.html" %}
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/core/qualcomm-dragonboard-410c.html
+++ b/templates/download/core/qualcomm-dragonboard-410c.html
@@ -36,8 +36,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -82,6 +80,8 @@
 {% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
 
 {% include "./_install-snaps-strip.html" %}
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/core/raspberry-pi-2-3.html
+++ b/templates/download/core/raspberry-pi-2-3.html
@@ -34,8 +34,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -88,6 +86,8 @@
 {% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
 
 {% include "./_install-snaps-strip.html" %}
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/core/raspberry-pi-compute-module-3.html
+++ b/templates/download/core/raspberry-pi-compute-module-3.html
@@ -38,8 +38,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -139,6 +137,8 @@ sudo ./rpiboot</code></pre>
 {% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
 
 {% include "./_install-snaps-strip.html" %}
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/core/samsung-artik-5-10.html
+++ b/templates/download/core/samsung-artik-5-10.html
@@ -33,8 +33,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html" %}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -75,6 +73,8 @@
     </div>
   </div>
 </section>
+
+{% include "download/shared/_get-ebook-security.html" %}
 
 <section class="p-strip--light is-bordered" id="server">
   <div class="row">

--- a/templates/download/core/up-squared-iot-grove.html
+++ b/templates/download/core/up-squared-iot-grove.html
@@ -31,8 +31,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get-ebook-security.html"%}
-
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -82,6 +80,8 @@
     </div>
   </div>
 </section>
+
+{% include "download/shared/_get-ebook-security.html"%}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -6,7 +6,7 @@
   </div>
   <div class="row">
     <div class="col-7 suffix-1">
-      <p>A recent Canonical survey of 2,000 consumers suggests that a shockingly high percentage of connected devices may be vulnerable to botnets, hackers and cyber atacks:</p>
+      <p>A recent Canonical survey of 2,000 consumers suggests that a shockingly high percentage of connected devices may be vulnerable to botnets, hackers and cyber attacks:</p>
       <ul>
         <li>Only 31% of consumers update the firmware on their connected devices as soon as updates become available.</li>
         <li>40% of consumers have never performed firmware updates on their connected devices</li>


### PR DESCRIPTION
## Done

- Moved ebook on /download/core/board pages
- Put the text in a [copy doc](https://docs.google.com/document/d/1uniGWQZokDNQIzdUEeq6WGs_x2jxa-vwA03TZ39kCWc/edit#heading=h.2jo6p3omp6hs)
- hid the pages from the secondary nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [look at all pages under /download/core](http://0.0.0.0:8001/download/core)
- see that the ebook strip is either at the bottom of the page, or in the middle of two sets of instructions
- see that the secondary nav only shows the current breadcrumb trail

## Issue / Card

Fixes #2744
