### PR TITLE
Updated /info/release-end-of-life charts and tables

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -36,7 +36,9 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <img src="{{ ASSET_SERVER_URL }}aed27baa-release-ubuntu-end-of-life.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long-term support" class="u-hide--small" />
+      <div>
+        <img src="{{ ASSET_SERVER_URL }}f02f0a4b-r-eol-ubuntu-full-2018-02-28.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long-term support" class="u-hide--small" />
+      </div>
       <table class="u-hide--medium u-hide--large">
         <thead>
           <tr>
@@ -47,64 +49,84 @@
         </thead>
         <tbody>
           <tr>
+            <td><strong>Ubuntu 22.04 LTS</strong></td>
+            <td>April 2022</td>
+            <td>April 2027</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 21.10</td>
+            <td>October 2021</td>
+            <td>July 2022</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 21.04</td>
+            <td>April 2021</td>
+            <td>January 2022</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 20.10</td>
+            <td>October 2020</td>
+            <td>July 2021</td>
+          </tr>
+          <tr>
             <td><strong>Ubuntu 20.04 LTS</strong></td>
-            <td>Apr-2020</td>
-            <td>Apr-2025</td>
+            <td>April 2020</td>
+            <td>April 2025</td>
           </tr>
           <tr>
             <td>Ubuntu 19.10</td>
-            <td>Oct-2019</td>
-            <td>Jul-2020</td>
+            <td>October 2019</td>
+            <td>July 2020</td>
           </tr>
           <tr>
             <td>Ubuntu 19.04</td>
-            <td>Apr-2019</td>
-            <td>Jan-2020</td>
+            <td>April 2019</td>
+            <td>January 2020</td>
           </tr>
           <tr>
             <td>Ubuntu 18.10</td>
-            <td>Oct-2018</td>
-            <td>Jul-2019</td>
+            <td>October 2018</td>
+            <td>July 2019</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04 LTS</strong></td>
-            <td>Apr-2018</td>
-            <td>Apr-2023</td>
+            <td>April 2018</td>
+            <td>April 2023</td>
           </tr>
           <tr>
             <td>Ubuntu 17.10</td>
-            <td>Oct-2017</td>
-            <td>Jul-2018</td>
+            <td>October 2017</td>
+            <td>July 2018</td>
           </tr>
           <tr>
             <td>Ubuntu 17.04</td>
-            <td>Apr-2017</td>
-            <td>Jan-2018</td>
+            <td>April 2017</td>
+            <td>January 2018</td>
           </tr>
           <tr>
             <td>Ubuntu 16.10</td>
-            <td>Oct-2016</td>
-            <td>Jun-2017</td>
+            <td>October 2016</td>
+            <td>June 2017</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04 LTS</strong></td>
-            <td>Apr-2016</td>
-            <td>Apr-2021</td>
+            <td>April 2016</td>
+            <td>April 2021</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04 LTS</strong></td>
-            <td>Apr-2014</td>
-            <td>Apr-2019</td>
+            <td>April 2014</td>
+            <td>April 2019</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04 LTS</strong></td>
-            <td>Apr-2012</td>
-            <td>Apr-2017</td>
+            <td>April 2012</td>
+            <td>April 2017</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 10.04 LTS</strong></td>
-            <td>Apr-2010</td>
-            <td>Apr-2015</td>
+            <td>April 2010</td>
+            <td>April 2015</td>
           </tr>
         </tbody>
       </table>
@@ -126,7 +148,9 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><img src="{{ ASSET_SERVER_URL }}34e06f19-kernel-release-end-of-life.png " alt=" " class="u-hide--small " /></p>
+      <div>
+        <img src="{{ ASSET_SERVER_URL }}100060c2-r-eol-ubuntu-kernel-2018-02-28.png" alt="" class="u-hide--small " />
+      </div>
       <table class="u-hide--medium u-hide--large ">
         <thead>
           <tr>
@@ -137,144 +161,189 @@
         </thead>
         <tbody>
           <tr>
-            <td>Ubuntu 16.04.5</td>
-            <td>Aug-2018</td>
-            <td>Apr-2021</td>
+            <td>Ubuntu 18.04.5</td>
+            <td>August 2020</td>
+            <td>April 2023</td>
           </tr>
           <tr>
-            <td>Ubuntu 18.04.0</td>
-            <td>Apr-2018</td>
-            <td>Apr-2023</td>
+            <td>Ubuntu 20.04</td>
+            <td>April 2020</td>
+            <td>January 2021</td>
           </tr>
           <tr>
-            <td>Ubuntu 16.04.4</td>
-            <td>Feb-2018</td>
-            <td>Aug-2018</td>
+            <td>Ubuntu 18.04.4</td>
+            <td>February 2020</td>
+            <td>July 2020</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.10</td>
+            <td>October 2019</td>
+            <td>July 2020</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.04.3</td>
+            <td>August 2019</td>
+            <td>January 2020</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.04</td>
+            <td>April 2019</td>
+            <td>January 2020</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.04.2</td>
+            <td>February 2019</td>
+            <td>July 2019</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.10</td>
+            <td>October 2018</td>
+            <td>July 2019</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.04.1 (v.4.15)</td>
+            <td>July 2018</td>
+            <td>April 2023</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 16.04.5 (v.4.15)</td>
+            <td>August 2018</td>
+            <td>April 2021</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.04.0 (v.4.15)</td>
+            <td>April 2018</td>
+            <td>April 2023</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 16.04.4 (v.4.13)</td>
+            <td>February 2018</td>
+            <td>August 2018</td>
           </tr>
           <tr>
             <td>Ubuntu 17.10</td>
-            <td>Oct-2017</td>
-            <td>Jul-2018</td>
+            <td>October 2017</td>
+            <td>July 2018</td>
           </tr>
           <tr>
-            <td>Ubuntu 16.04.3</td>
-            <td>Aug-2017</td>
-            <td>Feb-2018</td>
+            <td>Ubuntu 16.04.3 (v.4.10)</td>
+            <td>August 2017</td>
+            <td>February 2018</td>
           </tr>
           <tr>
             <td>Ubuntu 17.04</td>
-            <td>Apr-2017</td>
-            <td>Jan-2018</td>
+            <td>April 2017</td>
+            <td>January 2018</td>
           </tr>
           <tr>
             <td>Ubuntu 16.04.2 (v4.8)</td>
-            <td>Feb-2017</td>
-            <td>Aug-2017</td>
+            <td>February 2017</td>
+            <td>August 2017</td>
           </tr>
           <tr>
             <td>Ubuntu 16.10</td>
-            <td>Oct-2016</td>
-            <td>Jul-2017</td>
+            <td>October 2016</td>
+            <td>July 2017</td>
           </tr>
           <tr>
             <td>Ubuntu 16.04.1 (v4.4)</td>
-            <td>Aug-2016</td>
-            <td>Apr-2021</td>
+            <td>August 2016</td>
+            <td>April 2021</td>
           </tr>
           <tr>
-            <td>Ubuntu 14.04.5 (v4.4)</td>
-            <td>Aug-2016</td>
-            <td>May-2019</td>
+            <td>Ubuntu 14.04.5</td>
+            <td>August 2016</td>
+            <td>May 2019</td>
           </tr>
           <tr>
             <td>Ubuntu 16.04.0 (v4.4)</td>
-            <td>Apr-2016</td>
-            <td>Apr-2021</td>
+            <td>April 2016</td>
+            <td>April 2021</td>
           </tr>
           <tr>
             <td>Ubuntu 14.04.4 (v4.2)</td>
-            <td>Feb-2016</td>
-            <td>Aug-2016</td>
+            <td>February 2016</td>
+            <td>August 2016</td>
           </tr>
           <tr>
             <td>Ubuntu 15.10 (v4.2)</td>
-            <td>Oct-2015</td>
-            <td>Oct-2015</td>
+            <td>October 2015</td>
+            <td>October 2015</td>
           </tr>
           <tr>
             <td>Ubuntu 14.04.3 (v3.19)</td>
-            <td>Aug-2015</td>
-            <td>Aug-2016</td>
+            <td>August 2015</td>
+            <td>August 2016</td>
           </tr>
           <tr>
             <td>Ubuntu 15.04 (v3.19)</td>
-            <td>Apr-2015</td>
-            <td>Jan-2016</td>
+            <td>April 2015</td>
+            <td>January 2016</td>
           </tr>
           <tr>
             <td>Ubuntu 14.04.2 (v3.16)</td>
-            <td>Feb-2015</td>
-            <td>Feb-2016</td>
+            <td>February 2015</td>
+            <td>February 2016</td>
           </tr>
           <tr>
             <td>Ubuntu 14.10 (v3.16)</td>
-            <td>Oct-2010</td>
-            <td>Jul-2011</td>
+            <td>October 2010</td>
+            <td>July 2011</td>
           </tr>
           <tr>
             <td>Ubuntu 14.04.1 (v3.13)</td>
-            <td>Aug-2014</td>
-            <td>Feb-2016</td>
+            <td>August 2014</td>
+            <td>February 2016</td>
           </tr>
           <tr>
             <td>Ubuntu 12.04.5 (v3.13)</td>
-            <td>Aug-2014</td>
-            <td>May-2017</td>
+            <td>August 2014</td>
+            <td>May 2017</td>
           </tr>
           <tr>
             <td>Ubuntu 14.04.0 (v3.13)</td>
-            <td>Apr-2014</td>
-            <td>Mar-2019</td>
+            <td>April 2014</td>
+            <td>March 2019</td>
           </tr>
           <tr>
             <td>Ubuntu 12.04.4 (v3.11)</td>
-            <td>Feb-2014</td>
-            <td>Aug-2014</td>
+            <td>February 2014</td>
+            <td>August 2014</td>
           </tr>
           <tr>
             <td>Ubuntu 13.10 (v3.11)</td>
-            <td>Oct-2010</td>
-            <td>Jul-2011</td>
+            <td>October 2010</td>
+            <td>July 2011</td>
           </tr>
           <tr>
             <td>Ubuntu 12.04.3 (v3.8)</td>
-            <td>Aug-2013</td>
-            <td>Aug-2014</td>
+            <td>August 2013</td>
+            <td>August 2014</td>
           </tr>
           <tr>
             <td>Ubuntu 13.04 (v3.8)</td>
-            <td>Apr-2013</td>
-            <td>Jan-2014</td>
+            <td>April 2013</td>
+            <td>January 2014</td>
           </tr>
           <tr>
             <td>Ubuntu 12.04.2 (v3.5)</td>
-            <td>Feb-2013</td>
-            <td>Aug-2014</td>
+            <td>February 2013</td>
+            <td>August 2014</td>
           </tr>
           <tr>
             <td>Ubuntu 12.10 (v3.5)</td>
-            <td>Oct-2012</td>
-            <td>Apr-2014</td>
+            <td>October 2012</td>
+            <td>April 2014</td>
           </tr>
           <tr>
             <td>Ubuntu 12.04.1 (v3.2)</td>
-            <td>Aug-2012</td>
-            <td>Apr-2017</td>
+            <td>August 2012</td>
+            <td>April 2017</td>
           </tr>
           <tr>
             <td>Ubuntu 12.04.0 (v3.2)</td>
-            <td>Apr-2012</td>
-            <td>Apr-2017</td>
+            <td>April 2012</td>
+            <td>April 2017</td>
           </tr>
         </tbody>
       </table>
@@ -296,7 +365,9 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><img src="{{ ASSET_SERVER_URL }}dd209641-openstack-release-eol-20161213.png " alt=" " class="u-hide--small " /></p>
+      <div>
+        <img src="{{ ASSET_SERVER_URL }}7f30f643-r-eol-openstack-2018-02-28.png" alt=" " class="u-hide--small " />
+      </div>
       <table class="u-hide--medium u-hide--large ">
         <thead>
           <tr>
@@ -308,123 +379,117 @@
         </thead>
         <tbody>
           <tr>
-            <td>OpenStack Queens</td>
-            <td>Apr-2019</td>
-            <td>Apr-2024</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 18.04 LTS</td>
-            <td>Oct-2018</td>
-            <td>Oct-2023</td>
+            <td>OpenStack Rocky</td>
+            <td>August 2018</td>
+            <td>February 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Queens</td>
-            <td>Apr-2018</td>
-            <td>Apr-2021</td>
+            <td>April 2018</td>
+            <td>April 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04 LTS</strong></td>
+            <td>April 2018</td>
+            <td>April 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>OpenStack Queens</td>
+            <td>February 2018</td>
+            <td>April 2021</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Pike</td>
-            <td>Oct-2017</td>
-            <td>Apr-2019</td>
-            <td>&nbsp;</td>
+            <td>August 2017</td>
+            <td>September 2018</td>
           </tr>
           <tr>
             <td>OpenStack Ocata</td>
-            <td>Apr-2017</td>
-            <td>Jan-2019</td>
-            <td>Aug-2019</td>
+            <td>February 2017</td>
+            <td>February 2018</td>
           </tr>
           <tr>
             <td>OpenStack Newton</td>
-            <td>Oct-2016</td>
-            <td>Apr-2018</td>
+            <td>October 2016</td>
+            <td>April 2018</td>
+          </tr>
+          <tr>
+            <td>OpenStack Mitaka</td>
+            <td>April 2016</td>
+            <td>April 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04 LTS</strong></td>
+            <td>April 2016</td>
+            <td>April 2021</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Mitaka</td>
-            <td>Apr-2016</td>
-            <td>Apr-2021</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 16.04 LTS</td>
-            <td>Apr-2016</td>
-            <td>Apr-2021</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Mitaka</td>
-            <td>Apr-2016</td>
-            <td>Apr-2019</td>
+            <td>April 2016</td>
+            <td>April 2019</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Liberty</td>
-            <td>Oct-2015</td>
-            <td>Apr-2017</td>
-            <td>&nbsp;</td>
+            <td>October 2015</td>
+            <td>April 2017</td>
           </tr>
           <tr>
             <td>OpenStack Kilo</td>
-            <td>Apr-2015</td>
-            <td>Oct-2016</td>
-            <td>Apr-2017</td>
+            <td>April 2015</td>
+            <td>October 2016</td>
           </tr>
           <tr>
             <td>OpenStack Juno</td>
-            <td>Oct-2014</td>
-            <td>Apr-2016</td>
+            <td>October 2014</td>
+            <td>April 2016</td>
+          </tr>
+          <tr>
+            <td>OpenStack Icehouse</td>
+            <td>April 2014</td>
+            <td>April 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.10 LTS</strong></td>
+            <td>April 2014</td>
+            <td>April 2019</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Icehouse</td>
-            <td>Apr-2014</td>
-            <td>Apr-2019</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 14.04 LTS</td>
-            <td>Apr-2014</td>
-            <td>Apr-2019</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Icehouse</td>
-            <td>Apr-2014</td>
-            <td>Apr-2017</td>
+            <td>April 2014</td>
+            <td>April 2017</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Havana</td>
-            <td>Oct-2013</td>
-            <td>Jul-2014</td>
-            <td>&nbsp;</td>
+            <td>October 2013</td>
+            <td>July 2014</td>
           </tr>
           <tr>
             <td>OpenStack Grizzly</td>
-            <td>May-2013</td>
-            <td>Aug-2014</td>
-            <td>&nbsp;</td>
+            <td>May 2013</td>
+            <td>August 2014</td>
           </tr>
           <tr>
             <td>OpenStack Folsom</td>
-            <td>Sep-2012</td>
-            <td>Jun-2014</td>
-            <td>&nbsp;</td>
+            <td>September 2012</td>
+            <td>June 2014</td>
           </tr>
           <tr>
             <td>OpenStack Essex</td>
-            <td>Apr-2012</td>
-            <td>Apr-2017</td>
-            <td>&nbsp;</td>
+            <td>April 2012</td>
+            <td>April 2017</td>
           </tr>
           <tr>
-            <td>Ubuntu 12.04 LTS</td>
-            <td>Apr-2012</td>
-            <td>Apr-2017</td>
+            <td><strong>Ubuntu 12.04 LTS</strong></td>
+            <td>April 2012</td>
+            <td>April 2017</td>
             <td>&nbsp;</td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Done

- Updated /info/release-end-of-life charts and tables

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [the release-end-of-life page](http://0.0.0.0:8001/info/release-end-of-life)
- See that the dates and charts match the [charts doc](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit?ts=5a95e390#gid=1241705826)

## Issue / Card

Fixes #2681

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
