### PR TITLE
Swap uappexplorer link for snap store.

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -31,7 +31,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Popular snaps</h2>
-      <p>To find snaps you can check out <a class="p-link--external" href="https://uappexplorer.com/snaps">uappexplorer.com</a> or just use the command line to install any of these great snaps:</p>
+      <p>To find snaps you can check out the <a class="p-link--external" href="https://snapcraft.io/store">Snap Store</a> or just use the command line to install any of these great snaps:</p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

- replaced UAppExplorer link on the Snappy page to the Snap Store now that it exists

## QA

- ran locally, link works and appears as expected