### PR TITLE
Update site with 16.04.4 point release

### DIFF
--- a/templates/download/core/intel-nuc.html
+++ b/templates/download/core/intel-nuc.html
@@ -31,7 +31,7 @@
             <li class="p-list__item is-ticked">A monitor with VGA or HDMI interface</li>
             <li class="p-list__item is-ticked">A VGA or HDMI cable</li>
             <li class="p-list__item is-ticked">A network connection with Internet access</li>
-            <li class="p-list__item is-ticked">An Ubuntu Desktop 16.04.3 LTS image</li>
+            <li class="p-list__item is-ticked">An Ubuntu Desktop {{ lts_release_full_with_point }} image</li>
             <li class="p-list__item is-ticked">An Ubuntu Core image</li>
           </ul>
         </div>
@@ -66,7 +66,7 @@
           </h3>
           <div class="p-list-step__content">
             <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="http://www.ubuntu.com/download/desktop">Ubuntu Desktop 16.04.3 LTS</a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+              <li>Download and copy the <a href="http://www.ubuntu.com/download/desktop">Ubuntu Desktop {{ lts_release_full_with_point }}</a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
               <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
             </ol>
           </div>
@@ -147,7 +147,7 @@
             <li class="p-list__item is-ticked">A monitor with VGA or HDMI interface</li>
             <li class="p-list__item is-ticked">A VGA or HDMI cable</li>
             <li class="p-list__item is-ticked">A network connection with Internet access</li>
-            <li class="p-list__item is-ticked">An Ubuntu Desktop 16.04.3 LTS image</li>
+            <li class="p-list__item is-ticked">An Ubuntu Desktop {{ lts_release_full_with_point }} image</li>
           </ul>
         </div>
       </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ArtfulAardvark" latest_release='17.10' latest_release_with_point="17.10.1" latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 LTS' lts_release_with_point="16.04.3" lts_release_full_with_point='16.04.3 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
+{% with latest_release_name="ArtfulAardvark" latest_release='17.10' latest_release_with_point="17.10.1" latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 LTS' lts_release_with_point="16.04.4" lts_release_full_with_point='16.04.4 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

- Update site with 16.04.4 point release
- Updated core intel nuc with release variable

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [download desktop](http://0.0.0.0:8001/download/desktop), [download server](http://0.0.0.0:8001/download/server) and below, [download alt downloads](http://0.0.0.0:8001/download/alternative-downloads) and [download intel nuc](http://0.0.0.0:8001/download/core/intel-nuc)
- see that it uses 16.04.4 or 16.04.4 LTS where appropriate (note one nuc download is on .1)

## Issue / Card

Fixes #2762
