### PR TITLE
Minor updates to /download/cloud

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -9,11 +9,11 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <div>
-        <h1>Optimised Ubuntu on public clouds</h1>
-        <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, Oracle, Rackspace and IBM Softlayer. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
+        <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
+        <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, Oracle, Rackspace and IBM Cloud. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
       </div>
     </div>
-    <div class="col-4 u-align--center u-vertically-center">
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}1c786630-image-cloud.svg" alt="Ubuntu cloud">
     </div>
   </div>
@@ -35,7 +35,7 @@
         <a class="p-card__image-container" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
           <img src="{{ ASSET_SERVER_URL }}410984a3-Google-cloud-platform-stacked.svg" alt="" style="max-height: 10rem;">
         </a>
-        <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>  
+        <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>
       </div>
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu" class="p-link--external">Guide to using GCP</a></li>
@@ -118,7 +118,7 @@
 
 <section class="p-strip--light is-deep is-bordered">
   <div class="row u-equal-height">
-    <div class="col-6 u-vertically-center">
+    <div class="col-6 u-vertically-center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}2e62cdb4-desktop-developer-hero.png?w=600" alt="Ubuntu cloud">
     </div>
     <div class="col-6">


### PR DESCRIPTION
## Done

- Minor updates to /download/cloud
  - better text line break on h1
  - the correct name for IBM Cloud
  - hide banner and developer images on small screens
  - updated the [copy doc](https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/cloud](http://0.0.0.0:8001/download/cloud)
- see that the above-mentioned changes are there

## Issues

Fixes #2764
