### PR TITLE
Add ids for network installer and bittorrents on /download/alternate-downloads

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -19,7 +19,7 @@
 </div>
 
 <div class="p-strip is-bordered">
-  <div class="row">
+  <div class="row" id="network-installer">
     <div class="col-8">
       <h2>Network installer</h2>
       <p>The network installer lets you install Ubuntu over a network. It includes the minimal set of packages needed to start and the rest of the packages are downloaded over the network. Since only current packages are downloaded, there is no need to upgrade packages immediately after installation.</p>
@@ -34,7 +34,7 @@
 </div>
 
 <div class="p-strip is-bordered">
-  <div class="row">
+  <div class="row" id="bittorrents">
     <div class="col-8">
       <h2>BitTorrent</h2>
       <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>


### PR DESCRIPTION
## Done

- Add ids for network installer and bittorrents on /download/alternate-downloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [network-installer](http://0.0.0.0:8001/download/alternative-downloads#network-installer) and [bittorrents](http://0.0.0.0:8001/download/alternative-downloads#bittorrents)
- see that it goes to the correct part of that page

## Issue / Card

Fixes #2766

