### PR TITLE
2755: Build /openstack/install page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -5,6 +5,8 @@ cloud:
   children:
     - title: Overview
       path: /cloud
+    - title: Managed cloud
+      path: /cloud/managed-cloud
     - title: Public cloud
       path: /public-cloud
     - title: Juju
@@ -39,30 +41,14 @@ openstack:
   children:
     - title: Overview
       path: /openstack
-    - title: Managed cloud
-      path: /cloud/managed-cloud
-    - title: Juju
-      path: /cloud/juju
-    - title: Storage
-      path: /cloud/storage
-    - title: Partners
-      path: /cloud/partners
-    - title: Foundation Cloud Build
-      path: /cloud/foundation-cloud
-    - title: Training
-      path: /cloud/training
-
-    - title: Thank you
-      path: /cloud/newsletter-thank-you
-      hidden: True
-    - title: Contact us
-      path: /cloud/contact-us
-      hidden: True
+    - title: Install
+      path: /openstack/install
 
       children:
-        - title: Thank you
-          path: /cloud/thank-you
-          hidden: True
+        - title: Build OpenStack
+          path: /openstack/install/try-openstack
+        - title: Try OpenStack
+          path: /openstack/install/build-openstack
 
 server:
   title: Server

--- a/templates/download/server/_other-ways.html
+++ b/templates/download/server/_other-ways.html
@@ -1,5 +1,5 @@
 <div class="p-strip">
-  {% if level_2 != 'cloud' %}
+  {% if level_1 != 'openstack' %}
   <div class="row">
     <div class="col-12">
       <h2 >Get the version you need</h2>
@@ -8,7 +8,7 @@
   {% endif %}
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
-      {% if level_2 == 'cloud' %}
+      {% if level_1 == 'openstack' %}
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" />
@@ -20,14 +20,14 @@
           {% endif %}
       </div>
     </div>
-    <div class="col-6 p-divider__block last-col">
+    <div class="col-6 p-divider__block">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" />
           <h3 class="p-heading-icon__title"  style="font-size: 1.5rem;">Run Ubuntu in the public cloud</h3>
         </div>
           <p>Optimised Ubuntu images are already available on most major clouds. They are also available for download.</p>
-          <p><a href="https://cloud-images.ubuntu.com">Download standard Ubuntu Server cloud images&nbsp;&rsaquo;</a></p>
+          <p><a href="/download/cloud">Download standard Ubuntu Server cloud images&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>

--- a/templates/openstack/install/index.html
+++ b/templates/openstack/install/index.html
@@ -1,0 +1,71 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Install OpenStack| OpenStack | Ubuntu{% endblock %}
+{% block meta_description %}Want to deploy OpenStack on a single machine or build your own production private cloud? Use conjure-up. It’s easy and free.{% endblock %}
+
+
+{% block content %}
+<section class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <div>
+        <h1>Install OpenStack</h1>
+        <p>Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
+      </div>
+    </div>
+    <div class="col-6">
+      <img src="{{ ASSET_SERVER_URL }}95212c08-OpenStack_Logo_2016.svg" alt="" class="u-align--center u-vertically-center u-hide--small" width="275" />
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <div class="p-card__header">
+        <h2 class="p-heading--five">Single machine</h2>
+      </div>
+      <h3 class="p-card__title">Try OpenStack on a single&nbsp;machine</h3>
+      <div class="p-card__content">
+        <p>Conjure-up is an ideal tool for people who want to build an OpenStack cloud on a single machine in minutes. Using LXD containers, this OpenStack deployment perfectly models a production cluster on real machines.</p>
+        <p><a href="/openstack/install/try-openstack">Install OpenStack on a localhost&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <div class="p-card__header">
+        <h2 class="p-heading--five">Cluster</h2>
+      </div>
+      <h3 class="p-card__title">Build your own production&nbsp;cloud</h3>
+      <div class="p-card__content">
+        <p>The same conjure-up utility also deploys your production OpenStack cloud across a rack of physical servers using <a href="/server/maas">MAAS</a> and the underlying model enables you to operate OpenStack efficiently at scale.</p>
+        <p><a href="/openstack/install/build-openstack">Deploy OpenStack on a cluster of physical machines&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="p-strip--light is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="200" alt="" />
+    </div>
+    <div class="col-7 prefix-1 u-vertically-center">
+      <div class="row">
+        <div class="col-12">
+          <h2>Need more help?</h2>
+          <p>Let our cloud experts help you take the next step.</p>
+          <p>
+            <a class="p-button--positive" href="https://www.ubuntu.com/openstack/contact-us?product=cloud-openstack">Contact us</a>
+          </p>
+          <p>Already a Landscape Dedicated Server customer? Upgrading is simple, see the instructions in the <a class="p-link--external" href="https://help.landscape.canonical.com/LDS/ReleaseNotes">release notes</a>.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% include "download/server/_other-ways.html" %}
+
+{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_download_documentation" %}
+
+{% endblock content %}

--- a/templates/shared/contextual_footers/_cloud_ubuntu_advantage.html
+++ b/templates/shared/contextual_footers/_cloud_ubuntu_advantage.html
@@ -1,0 +1,6 @@
+<div class="col-4 p-divider__block">
+  <h3 class="p-heading--four">Growing your cloud?</h3>
+  <p>Ubuntu Advantage enterprise support agreements cover OpenStack and include the management and operational tooling needed for larger cloud deployments.</p>
+  <p><a class="p-button--neutral" href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud Ubuntu Advantage', 'eventLabel' : 'Buy now', 'eventValue' : undefined });">Buy now</a></p>
+  <p>Or <a href="/support/contact-us">contact us&nbsp;&rsaquo;</a></p>
+</div>


### PR DESCRIPTION
## Done

- Moved /download/cloud/index.html to /openstack/install/index.html
- Updated copy according to [copydoc](https://docs.google.com/document/d/10vJnhP8zjXOdtgLUnTrfKOWAHJflxdvRgAgjM5DbAZ8/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/install
- Check that it matches the [copydoc](https://docs.google.com/document/d/10vJnhP8zjXOdtgLUnTrfKOWAHJflxdvRgAgjM5DbAZ8/edit#)

## Issue / Card

Fixes #2755 