### PR TITLE
Update OpenStack on /info/release-end-of-life

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -35,7 +35,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
+    <div class="col-10">
       <div>
         <img src="{{ ASSET_SERVER_URL }}f02f0a4b-r-eol-ubuntu-full-2018-02-28.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long-term support" class="u-hide--small" />
       </div>
@@ -147,7 +147,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
+    <div class="col-10">
       <div>
         <img src="{{ ASSET_SERVER_URL }}100060c2-r-eol-ubuntu-kernel-2018-02-28.png" alt="" class="u-hide--small " />
       </div>
@@ -364,9 +364,9 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
+    <div class="col-10">
       <div>
-        <img src="{{ ASSET_SERVER_URL }}dea6f3d7-r-eol-openstack-2018-02-28.png" alt=" " class="u-hide--small " />
+        <img src="{{ ASSET_SERVER_URL }}21318ad0-r-eol-openstack-2018-03-02.png" alt=" " class="u-hide--small " />
       </div>
       <table class="u-hide--medium u-hide--large ">
         <thead>

--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -366,7 +366,7 @@
   <div class="row">
     <div class="col-12">
       <div>
-        <img src="{{ ASSET_SERVER_URL }}7f30f643-r-eol-openstack-2018-02-28.png" alt=" " class="u-hide--small " />
+        <img src="{{ ASSET_SERVER_URL }}dea6f3d7-r-eol-openstack-2018-02-28.png" alt=" " class="u-hide--small " />
       </div>
       <table class="u-hide--medium u-hide--large ">
         <thead>
@@ -405,22 +405,26 @@
           <tr>
             <td>OpenStack Pike</td>
             <td>August 2017</td>
-            <td>September 2018</td>
+            <td>February 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Ocata</td>
             <td>February 2017</td>
-            <td>February 2018</td>
+            <td>August 2018</td>
+            <td>February 2020</td>
           </tr>
           <tr>
             <td>OpenStack Newton</td>
             <td>October 2016</td>
             <td>April 2018</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Mitaka</td>
             <td>April 2016</td>
             <td>April 2021</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04 LTS</strong></td>
@@ -438,21 +442,25 @@
             <td>OpenStack Liberty</td>
             <td>October 2015</td>
             <td>April 2017</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Kilo</td>
             <td>April 2015</td>
             <td>October 2016</td>
+            <td>April 2018</td>
           </tr>
           <tr>
             <td>OpenStack Juno</td>
             <td>October 2014</td>
             <td>April 2016</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Icehouse</td>
             <td>April 2014</td>
             <td>April 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.10 LTS</strong></td>
@@ -470,21 +478,25 @@
             <td>OpenStack Havana</td>
             <td>October 2013</td>
             <td>July 2014</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Grizzly</td>
             <td>May 2013</td>
             <td>August 2014</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Folsom</td>
             <td>September 2012</td>
             <td>June 2014</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Essex</td>
             <td>April 2012</td>
             <td>April 2017</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04 LTS</strong></td>


### PR DESCRIPTION
## Done

- Update OpenStack on /info/release-end-of-life

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/info/release-end-of-life
- compare to the https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit?ts=5a98026f#gid=215258770

