### PR TITLE
Bugfix/use correct styles on download menu third col

### DIFF
--- a/templates/templates/_navigation-download.html
+++ b/templates/templates/_navigation-download.html
@@ -3,71 +3,71 @@
     <div class="col-6 p-divider__block">
       <h4><a class="p-link--soft" href='/download/desktop' alt=''>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
       <p>Download Ubuntu desktop and replace your current operating system whether it’s Windows or Mac OS, or, run Ubuntu alongside it.</p>
-      <a class='p-button--positive' href='/download/desktop/contribute?version=16.04.3&architecture=amd64' alt=''>16.04 LTS</a>
-      <a class='p-button--neutral u-no-margin--top' href='/download/desktop/contribute?version=17.10&architecture=amd64' alt=''>17.10</a>
+      <a class='p-button--positive' href='/download/desktop/contribute?version=16.04.3&architecture=amd64'>16.04 LTS</a>
+      <a class='p-button--neutral u-no-margin--top' href='/download/desktop/contribute?version=17.10&architecture=amd64'>17.10</a>
       <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
           <small>18.04 (dev edge)</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
           <small>Alternative downloads</small>
         </a></li>
       </ul>
-      <h4><a class="p-link--soft" href='/download/server' alt=''>Ubuntu Server&nbsp;&rsaquo;</a></h4>
+      <h4><a class="p-link--soft" href='/download/server' >Ubuntu Server&nbsp;&rsaquo;</a></h4>
       <p>The most popular server Linux in the cloud and data centre, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-      <a class='p-button--positive' href='/download/server/thank-you?version=16.04.3&architecture=amd64' alt=''>16.04 LTS</a>
-      <a class='p-button--neutral' href='/download/server/thank-you?version=17.10.1&architecture=amd64' alt=''>17.10</a>
+      <a class='p-button--positive' href='/download/server/thank-you?version=16.04.3&architecture=amd64' >16.04 LTS</a>
+      <a class='p-button--neutral' href='/download/server/thank-you?version=17.10.1&architecture=amd64' >17.10</a>
       <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
           <small>18.04 (dev edge)</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/arm' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/server/arm'>
           <small>ARM</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/power8' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/server/power8'>
           <small>Power8</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/linuxone' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/server/linuxone'>
           <small>LinuxONE</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
           <small>Alternative downloads</small>
         </a></li>
       </ul>
     </div>
     <div class="col-6 p-divider__block">
-      <h4><a class="p-link--soft" href="/download/core" alt=''>Ubuntu for IoT&nbsp;&rsaquo;</a></h4>
+      <h4><a class="p-link--soft" href="/download/core" >Ubuntu for IoT&nbsp;&rsaquo;</a></h4>
       <p>Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
       <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-2-3' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-2-3'>
           <small>Raspberry Pi 2 or 3</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-compute-module-3' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-compute-module-3'>
           <small>Raspberry Pi Compute Module 3</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-nuc' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-nuc'>
           <small>Intel NUC</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/kvm' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/core/kvm'>
           <small>KVM</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-joule' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-joule'>
           <small>Intel Joule</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/qualcomm-dragonboard-410c' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/core/qualcomm-dragonboard-410c'>
           <small>Qualcomm Dragonboard 410c</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/samsung-artik-5-10' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/core/samsung-artik-5-10'>
           <small>Samsung Artik 5 or 10</small>
         </a></li>
       </ul>
-      <h4><a class="p-link--soft" href="/download/cloud" alt=''>Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
+      <h4><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
       <p>Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
       <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='#' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='#'>
           <small>Try OpenStack</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='#' alt=''>
+        <li class='p-inline-list__item'><a class='p-link' href='#'>
           <small>Deploy OpenStack</small>
         </a></li>
       </ul>

--- a/templates/templates/_navigation-download.html
+++ b/templates/templates/_navigation-download.html
@@ -1,7 +1,7 @@
 <div class="p-strip--navigation is-bordered is-shallow u-hide" id="download-tab-content">
   <div class="row p-divider">
-    <div class="col-6 p-divider__block">
-      <h4><a class="p-link--soft" href='/download/desktop' alt=''>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
+    <div class="col-4 p-divider__block">
+      <h4><a class="p-link--soft" href='/download/desktop'>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
       <p>Download Ubuntu desktop and replace your current operating system whether it’s Windows or Mac OS, or, run Ubuntu alongside it.</p>
       <a class='p-button--positive' href='/download/desktop/contribute?version=16.04.3&architecture=amd64'>16.04 LTS</a>
       <a class='p-button--neutral u-no-margin--top' href='/download/desktop/contribute?version=17.10&architecture=amd64'>17.10</a>
@@ -13,30 +13,7 @@
           <small>Alternative downloads</small>
         </a></li>
       </ul>
-      <h4><a class="p-link--soft" href='/download/server' >Ubuntu Server&nbsp;&rsaquo;</a></h4>
-      <p>The most popular server Linux in the cloud and data centre, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-      <a class='p-button--positive' href='/download/server/thank-you?version=16.04.3&architecture=amd64' >16.04 LTS</a>
-      <a class='p-button--neutral' href='/download/server/thank-you?version=17.10.1&architecture=amd64' >17.10</a>
-      <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
-          <small>18.04 (dev edge)</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/arm'>
-          <small>ARM</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/power8'>
-          <small>Power8</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/linuxone'>
-          <small>LinuxONE</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
-          <small>Alternative downloads</small>
-        </a></li>
-      </ul>
-    </div>
-    <div class="col-6 p-divider__block">
-      <h4><a class="p-link--soft" href="/download/core" >Ubuntu for IoT&nbsp;&rsaquo;</a></h4>
+      <h4><a class="p-link--soft" href="/download/core" >Ubuntu Core for IoT&nbsp;&rsaquo;</a></h4>
       <p>Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
       <ul class='p-inline-list--middot' style="margin-top: 1rem;">
         <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-2-3'>
@@ -61,6 +38,29 @@
           <small>Samsung Artik 5 or 10</small>
         </a></li>
       </ul>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4><a class="p-link--soft" href='/download/server' >Ubuntu Server&nbsp;&rsaquo;</a></h4>
+      <p>The most popular server Linux in the cloud and data centre, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
+      <a class='p-button--positive' href='/download/server/thank-you?version=16.04.3&architecture=amd64' >16.04 LTS</a>
+      <a class='p-button--neutral' href='/download/server/thank-you?version=17.10.1&architecture=amd64' >17.10</a>
+      <ul class='p-inline-list--middot' style="margin-top: 1rem;">
+        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
+          <small>18.04 (dev edge)</small>
+        </a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/server/arm'>
+          <small>ARM</small>
+        </a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/server/power8'>
+          <small>Power8</small>
+        </a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/server/linuxone'>
+          <small>LinuxONE</small>
+        </a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
+          <small>Alternative downloads</small>
+        </a></li>
+      </ul>
       <h4><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
       <p>Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
       <ul class='p-inline-list--middot' style="margin-top: 1rem;">
@@ -70,6 +70,29 @@
         <li class='p-inline-list__item'><a class='p-link' href='#'>
           <small>Deploy OpenStack</small>
         </a></li>
+      </ul>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4>Tutorials</h4>
+      <p>If you are already running Ubuntu - you can <a href='https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop'>upgrade</a> with the Software Updater</p>
+      <p>Burn a DVD on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows'>Windows</a>. <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Create a bootable USB stick on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows'>Windows</a></p>
+      <p>Installation guides for <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop'>Ubuntu Desktop</a> and <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server'>Ubuntu Server</a></p> 
+      <p>You can learn how to <a href='https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install'>try Ubuntu before you install</a></p>        
+      <h4>Read the docs</h4>
+      <p>Read the official docs for <a href='https://help.ubuntu.com/'>Ubuntu Desktop</a>, <a href='https://help.ubuntu.com/'>Ubuntu Server</a>, and <a href='http://docs.ubuntu.com/core'>Ubuntu Core</a></p>
+      <h4>Other ways to download</h4>
+      <p>Ubuntu is available via <a href='/download/alternative-downloads#bittorrents'>BitTorrents</a> and via a minimal <a href='/download/alternative-downloads#network-installer'>network installer</a> that allows you to customise what is installed, such as additional languages. You can also find <a href='http://releases.ubuntu.com/'>older releases</a>.</p>
+      <h4>Ubuntu flavours</h4>
+      <p>Find new ways to experience Ubuntu, each with their own choice of default applications and settings.</p>
+      <ul class='p-inline-list--middot' style="margin-top: 1rem;">
+        <li class='p-inline-list__item'><a class='p-link' href='https://www.kubuntu.org/'>Kubuntu</a></li>          
+        <li class='p-inline-list__item'><a class='p-link' href='http://lubuntu.me/'>Lubuntu</a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='http://www.mythbuntu.org/'>Mythbuntu</a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='https://ubuntubudgie.org/'>Ubuntu Budgie</a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='http://www.ubuntukylin.com/index.php?lang=en'>Ubuntu Kylin</a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='https://ubuntu-mate.org/'>Ubuntu MATE</a></li>
+        <li class='p-inline-list__item'><a class='p-link' href='https://ubuntustudio.org/'>Ubuntu Studio</a></li> 
+        <li class='p-inline-list__item'><a class='p-link' href='https://xubuntu.org/'>Xubuntu</a></li>
       </ul>
     </div>
   </div>

--- a/templates/templates/_navigation-download.html
+++ b/templates/templates/_navigation-download.html
@@ -72,17 +72,17 @@
           </a></li>
         </ul>
       </div>
-      <div class="col-4 p-divider__block">
-        <h4>Tutorials</h4>
+      <div class="col-4 resource-col">
+        <h4 class="p-muted-heading">Tutorials</h4>
         <p>If you are already running Ubuntu - you can <a href='https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop'>upgrade</a> with the Software Updater</p>
         <p>Burn a DVD on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows'>Windows</a>. <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Create a bootable USB stick on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows'>Windows</a></p>
         <p>Installation guides for <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop'>Ubuntu Desktop</a> and <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server'>Ubuntu Server</a></p> 
         <p>You can learn how to <a href='https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install'>try Ubuntu before you install</a></p>        
-        <h4>Read the docs</h4>
+        <h4 class="p-muted-heading">Read the docs</h4>
         <p>Read the official docs for <a href='https://help.ubuntu.com/'>Ubuntu Desktop</a>, <a href='https://help.ubuntu.com/'>Ubuntu Server</a>, and <a href='http://docs.ubuntu.com/core'>Ubuntu Core</a></p>
-        <h4>Other ways to download</h4>
+        <h4 class="p-muted-heading">Other ways to download</h4>
         <p>Ubuntu is available via <a href='/download/alternative-downloads#bittorrents'>BitTorrents</a> and via a minimal <a href='/download/alternative-downloads#network-installer'>network installer</a> that allows you to customise what is installed, such as additional languages. You can also find <a href='http://releases.ubuntu.com/'>older releases</a>.</p>
-        <h4>Ubuntu flavours</h4>
+        <h4 class="p-muted-heading">Ubuntu flavours</h4>
         <p>Find new ways to experience Ubuntu, each with their own choice of default applications and settings.</p>
         <ul class='p-inline-list--middot' style="margin-top: 1rem;">
           <li class='p-inline-list__item'><a class='p-link' href='https://www.kubuntu.org/'>Kubuntu</a></li>          

--- a/templates/templates/_navigation-download.html
+++ b/templates/templates/_navigation-download.html
@@ -1,76 +1,100 @@
 <div class="p-strip--navigation is-bordered is-shallow u-hide" id="download-tab-content">
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h4><a class="p-link--soft" href='/download/desktop'>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
-      <p>Download Ubuntu desktop and replace your current operating system whether it’s Windows or Mac OS, or, run Ubuntu alongside it.</p>
-      <a class='p-button--positive' href='/download/desktop/contribute?version=16.04.3&architecture=amd64'>16.04 LTS</a>
-      <a class='p-button--neutral u-no-margin--top' href='/download/desktop/contribute?version=17.10&architecture=amd64'>17.10</a>
-      <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
-          <small>18.04 (dev edge)</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
-          <small>Alternative downloads</small>
-        </a></li>
-      </ul>
-      <h4><a class="p-link--soft" href="/download/core" >Ubuntu Core for IoT&nbsp;&rsaquo;</a></h4>
-      <p>Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
-      <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-2-3'>
-          <small>Raspberry Pi 2 or 3</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-compute-module-3'>
-          <small>Raspberry Pi Compute Module 3</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-nuc'>
-          <small>Intel NUC</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/kvm'>
-          <small>KVM</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-joule'>
-          <small>Intel Joule</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/qualcomm-dragonboard-410c'>
-          <small>Qualcomm Dragonboard 410c</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/core/samsung-artik-5-10'>
-          <small>Samsung Artik 5 or 10</small>
-        </a></li>
-      </ul>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h4><a class="p-link--soft" href='/download/server' >Ubuntu Server&nbsp;&rsaquo;</a></h4>
-      <p>The most popular server Linux in the cloud and data centre, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-      <a class='p-button--positive' href='/download/server/thank-you?version=16.04.3&architecture=amd64' >16.04 LTS</a>
-      <a class='p-button--neutral' href='/download/server/thank-you?version=17.10.1&architecture=amd64' >17.10</a>
-      <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
-          <small>18.04 (dev edge)</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/arm'>
-          <small>ARM</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/power8'>
-          <small>Power8</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/server/linuxone'>
-          <small>LinuxONE</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
-          <small>Alternative downloads</small>
-        </a></li>
-      </ul>
-      <h4><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
-      <p>Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
-      <ul class='p-inline-list--middot' style="margin-top: 1rem;">
-        <li class='p-inline-list__item'><a class='p-link' href='#'>
-          <small>Try OpenStack</small>
-        </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='#'>
-          <small>Deploy OpenStack</small>
-        </a></li>
-      </ul>
+    <div class="row p-divider">
+      <div class="col-4 p-divider__block">
+        <h4><a class="p-link--soft" href='/download/desktop'>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
+        <p>Download Ubuntu desktop and replace your current operating system whether it’s Windows or Mac OS, or, run Ubuntu alongside it.</p>
+        <a class='p-button--positive' href='/download/desktop/contribute?version=16.04.3&architecture=amd64'>16.04 LTS</a>
+        <a class='p-button--neutral u-no-margin--top' href='/download/desktop/contribute?version=17.10&architecture=amd64'>17.10</a>
+        <ul class='p-inline-list--middot' style="margin-top: 1rem;">
+          <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
+            <small>18.04 (dev edge)</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
+            <small>Alternative downloads</small>
+          </a></li>
+        </ul>
+        <h4><a class="p-link--soft" href="/download/core" >Ubuntu Core for IoT&nbsp;&rsaquo;</a></h4>
+        <p>Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
+        <ul class='p-inline-list--middot' style="margin-top: 1rem;">
+          <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-2-3'>
+            <small>Raspberry Pi 2 or 3</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-compute-module-3'>
+            <small>Raspberry Pi Compute Module 3</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-nuc'>
+            <small>Intel NUC</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/core/kvm'>
+            <small>KVM</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-joule'>
+            <small>Intel Joule</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/core/qualcomm-dragonboard-410c'>
+            <small>Qualcomm Dragonboard 410c</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/core/samsung-artik-5-10'>
+            <small>Samsung Artik 5 or 10</small>
+          </a></li>
+        </ul>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h4><a class="p-link--soft" href='/download/server' >Ubuntu Server&nbsp;&rsaquo;</a></h4>
+        <p>The most popular server Linux in the cloud and data centre, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
+        <a class='p-button--positive' href='/download/server/thank-you?version=16.04.3&architecture=amd64' >16.04 LTS</a>
+        <a class='p-button--neutral' href='/download/server/thank-you?version=17.10.1&architecture=amd64' >17.10</a>
+        <ul class='p-inline-list--middot' style="margin-top: 1rem;">
+          <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
+            <small>18.04 (dev edge)</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/server/arm'>
+            <small>ARM</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/server/power8'>
+            <small>Power8</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/server/linuxone'>
+            <small>LinuxONE</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
+            <small>Alternative downloads</small>
+          </a></li>
+        </ul>
+        <h4><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
+        <p>Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
+        <ul class='p-inline-list--middot' style="margin-top: 1rem;">
+          <li class='p-inline-list__item'><a class='p-link' href='#'>
+            <small>Try OpenStack</small>
+          </a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='#'>
+            <small>Deploy OpenStack</small>
+          </a></li>
+        </ul>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h4>Tutorials</h4>
+        <p>If you are already running Ubuntu - you can <a href='https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop'>upgrade</a> with the Software Updater</p>
+        <p>Burn a DVD on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows'>Windows</a>. <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Create a bootable USB stick on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows'>Windows</a></p>
+        <p>Installation guides for <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop'>Ubuntu Desktop</a> and <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server'>Ubuntu Server</a></p> 
+        <p>You can learn how to <a href='https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install'>try Ubuntu before you install</a></p>        
+        <h4>Read the docs</h4>
+        <p>Read the official docs for <a href='https://help.ubuntu.com/'>Ubuntu Desktop</a>, <a href='https://help.ubuntu.com/'>Ubuntu Server</a>, and <a href='http://docs.ubuntu.com/core'>Ubuntu Core</a></p>
+        <h4>Other ways to download</h4>
+        <p>Ubuntu is available via <a href='/download/alternative-downloads#bittorrents'>BitTorrents</a> and via a minimal <a href='/download/alternative-downloads#network-installer'>network installer</a> that allows you to customise what is installed, such as additional languages. You can also find <a href='http://releases.ubuntu.com/'>older releases</a>.</p>
+        <h4>Ubuntu flavours</h4>
+        <p>Find new ways to experience Ubuntu, each with their own choice of default applications and settings.</p>
+        <ul class='p-inline-list--middot' style="margin-top: 1rem;">
+          <li class='p-inline-list__item'><a class='p-link' href='https://www.kubuntu.org/'>Kubuntu</a></li>          
+          <li class='p-inline-list__item'><a class='p-link' href='http://lubuntu.me/'>Lubuntu</a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='http://www.mythbuntu.org/'>Mythbuntu</a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='https://ubuntubudgie.org/'>Ubuntu Budgie</a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='http://www.ubuntukylin.com/index.php?lang=en'>Ubuntu Kylin</a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='https://ubuntu-mate.org/'>Ubuntu MATE</a></li>
+          <li class='p-inline-list__item'><a class='p-link' href='https://ubuntustudio.org/'>Ubuntu Studio</a></li> 
+          <li class='p-inline-list__item'><a class='p-link' href='https://xubuntu.org/'>Xubuntu</a></li>
+        </ul>
+      </div>
     </div>
     <div class="col-4 p-divider__block">
       <h4>Tutorials</h4>
@@ -96,4 +120,4 @@
       </ul>
     </div>
   </div>
-</div>
+  


### PR DESCRIPTION
## Done

- Apply correct styles for third column of beta download menu 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)

## Issue / Card
- [Fixes #412](https://app.zenhub.com/workspace/o/ubuntudesign/web-squad/issues/412) 

## Screenshots
![screenshot-2018-03-06-10-50-58](https://user-images.githubusercontent.com/501889/37025541-4c38a652-212c-11e8-8432-9d94752de915.png)

