### PR TITLE
Additional clean-ups to further reading feeds

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -380,7 +380,7 @@
   </div>
 </section>
 
-{% include "shared/_insights_news_strip.html" with rss_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477&tags=2226" rss_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477" strip_classes="p-strip--light is-deep is-bordered" gtm_event_label="ubuntu.com cloud overview" %}
+{% include "shared/_insights_news_strip.html" with insights_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477&tags=2226" insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477" strip_classes="p-strip--light is-deep is-bordered" gtm_event_label="ubuntu.com cloud overview" %}
 
 <section class="p-strip">
   <div class="row">

--- a/templates/download/server/_other-ways.html
+++ b/templates/download/server/_other-ways.html
@@ -14,7 +14,7 @@
           <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" />
           <h3 class="p-heading-icon__title" style="font-size: 1.5rem;">Further OpenStack reading</h3>
         </div>
-          {% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/tag/openstack/feed" limit=3 %}
+          {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1327&per_page=3" %}
           {% else %}
           {% include "download/shared/_buy_a_usb.html" %}
           {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 
 {% include "takeovers/_ubuntu-product-month.html" %}
 
-{% include "shared/_insights_news_strip.html" with rss_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=2226" rss_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
+{% include "shared/_insights_news_strip.html" with insights_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=2226" insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
 
 <section class="p-strip--light is-bordered">
   <div class="row u-align--center">

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -1,12 +1,10 @@
-{# example include- include "shared/_insights_news_strip.html" with rss_spotlight_url="https://insights.ubuntu.com/tag/spotlight/feed" rss_news_url="https://insights.ubuntu.com/feed" strip_classes="" gtm_event_label="ubuntu.com homepage" #}
 
-
-{% get_json_feed rss_spotlight_url limit=1 as spotlight_feed %}
+{% get_json_feed insights_spotlight_url limit=1 as spotlight_feed %}
 
 {% if spotlight_feed %}
-  {% get_json_feed rss_news_url limit=3 as insights_feed %}
+  {% get_json_feed insights_news_url limit=3 as insights_feed %}
 {% else %}
-  {% get_json_feed rss_news_url limit=4 as insights_feed %}
+  {% get_json_feed insights_news_url limit=4 as insights_feed %}
 {% endif %}
 
 {% if insights_feed is False %}

--- a/templates/shared/contextual_footers/_cloud_further_reading.html
+++ b/templates/shared/contextual_footers/_cloud_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/group/cloud-and-server/feed" articles=5 %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1706&per_paget=5" %}
 </div>

--- a/templates/shared/contextual_footers/_desktop_further_reading.html
+++ b/templates/shared/contextual_footers/_desktop_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/group/desktop/feed" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1479&per_page=5" %}
 </div>

--- a/templates/shared/contextual_footers/_iot_further_reading.html
+++ b/templates/shared/contextual_footers/_iot_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/group/internet-of-things/feed/" articles=4 %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1666&per_page=4" %}
 </div>

--- a/templates/shared/contextual_footers/_security_further_reading.html
+++ b/templates/shared/contextual_footers/_security_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/tag/security/feed" articles=4 %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1364&per_page=4" %}
 </div>

--- a/templates/shared/contextual_footers/_telco_further_reading.html
+++ b/templates/shared/contextual_footers/_telco_further_reading.html
@@ -1,5 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/tag/telco/feed" articles=5 %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1500&per_page=5" %}
 </div>
-

--- a/templates/templates/_further_reading_links.html
+++ b/templates/templates/_further_reading_links.html
@@ -1,8 +1,4 @@
-{% if limit %}
-    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts" limit=limit as feed %}
-{% else %}
-    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts" limit=5 as feed %}
-{% endif %}
+{% get_json_feed insights_news_url as feed %}
 
 {% if feed is False %}
   <div class="p-notification--negative">


### PR DESCRIPTION
## Done

- Additional clean-ups to further reading feeds
- removed variables with rss in the name
- fixed feed links (they were all generic) to the correct feed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
  - [Further OpenStack reading](http://0.0.0.0:8001/download/cloud)
  - [server further reading](http://0.0.0.0:8001/server)
  - [telco further reading](http://0.0.0.0:8001/telecommunications)
  - [iot further reading](http://0.0.0.0:8001/internet-of-things)
  - [cloud further reading](http://0.0.0.0:8001/cloud/partners)
  - [desktop further reading](http://0.0.0.0:8001/desktop/government)
- see that the insights posts appear relevant

## Issue / Card

Fixes #2791

