### PR TITLE
update the homepage takeover to iot business whitepaper

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -94,7 +94,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="u-equal-height">
-      {% include "takeovers/takeunders/_iot-business-report-08-2017.html" %}
+      {% include "takeovers/takeunders/_ubuntu-product-month.html" %}
       {% include "takeovers/takeunders/_openstack-ebook.html" %}
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_ubuntu-product-month.html" %}
+{% include "takeovers/_iot-business.html" %}
 
 {% include "shared/_insights_news_strip.html" with rss_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=2226" rss_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
 

--- a/templates/takeovers/_iot-business.html
+++ b/templates/takeovers/_iot-business.html
@@ -10,7 +10,7 @@
       onclick="dataLayer.push({
         'event' : 'GAEvent',
         'eventCategory' : 'Homepage Link',
-        'eventAction' : 'IoT business model takeover - 07/2017',
+        'eventAction' : 'IoT business model takeover - 03/2018',
         'eventLabel' : 'Download the whitepaper',
         'eventValue' : undefined
       });" class="p-button--positive">Download the whitepaper</a></p>

--- a/templates/takeovers/takeunders/_ubuntu-product-month.html
+++ b/templates/takeovers/takeunders/_ubuntu-product-month.html
@@ -1,0 +1,15 @@
+<div class="col-6 p-takeunder" style="background-color: #111111;">
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-4 u-align--center u-vertically-center u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/b0bd120e-UPM-Illustration.svg" width="180" />
+      </div>
+      <div class="col-8">
+        <h3><a href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeunder', 'eventLabel' : 'Find out more', 'eventValue' : undefined });"></a>Ubuntu product month&nbsp;&rsaquo;</a></h3>
+        <p>
+          Learn about OpenStack, LXD, Juju, and Snaps from&nbsp;the developers and teams behind them
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/takeovers/takeunders/_ubuntu-product-month.html
+++ b/templates/takeovers/takeunders/_ubuntu-product-month.html
@@ -5,7 +5,7 @@
         <img src="https://assets.ubuntu.com/v1/b0bd120e-UPM-Illustration.svg" width="180" />
       </div>
       <div class="col-8">
-        <h3><a href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeunder', 'eventLabel' : 'Find out more', 'eventValue' : undefined });"></a>Ubuntu product month&nbsp;&rsaquo;</a></h3>
+        <h3><a href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeunder', 'eventLabel' : 'Find out more', 'eventValue' : undefined });"></a>Ubuntu product month omnibus&nbsp;&rsaquo;</a></h3>
         <p>
           Learn about OpenStack, LXD, Juju, and Snaps from&nbsp;the developers and teams behind them
         </p>

--- a/templates/takeovers/takeunders/_ubuntu-product-month.html
+++ b/templates/takeovers/takeunders/_ubuntu-product-month.html
@@ -2,10 +2,10 @@
   <div class="row">
     <div class="u-equal-height">
       <div class="col-4 u-align--center u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/b0bd120e-UPM-Illustration.svg" width="180" />
+        <img src="https://assets.ubuntu.com/v1/b0bd120e-UPM-Illustration.svg" width="180" alt="" />
       </div>
       <div class="col-8">
-        <h3><a href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeunder', 'eventLabel' : 'Find out more', 'eventValue' : undefined });"></a>Ubuntu product month omnibus&nbsp;&rsaquo;</a></h3>
+        <h3><a href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeunder', 'eventLabel' : 'Find out more', 'eventValue' : undefined });">Ubuntu product month omnibus&nbsp;&rsaquo;</a></h3>
         <p>
           Learn about OpenStack, LXD, Juju, and Snaps from&nbsp;the developers and teams behind them
         </p>


### PR DESCRIPTION
## Done

- update the homepage takeover to iot business whitepaper

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
  - See that the takeover is now the IoT ‘How to pick a winning IoT business model’ one
  - See that you can download the whitepaper

## Issue / Card

Fixes #2795

## Screenshots
![image](https://user-images.githubusercontent.com/441217/37144686-16f3424c-22bf-11e8-81ff-889607568e93.png)
