### PR TITLE
Add VirtIO Drivers to pricing page

### DIFF
--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -58,6 +58,12 @@
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
+          <td>Certified VirtIO Drivers for Windows</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
           <td>3TB of Ceph and/or Swift usable storage per node</td>
           <td>&nbsp;</td>
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -71,6 +71,13 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
+      <td>Certified VirtIO Drivers for Windows</td>
+      <td>&nbsp;</td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+    </tr>
+    <tr>
       <td>Ubuntu Legal Assurance programme</td>
       <td>&nbsp;</td>
       <td class="p-table__cell--highlight">&nbsp;</td>


### PR DESCRIPTION
## Done

Add Certified VirtIO Drivers for Windows to both UA Server and OpenStack on the pricing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)


Copy doc: https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit


## Issue / Card

Fixes #2798 