### PR TITLE
Add snapd installation instructions to BETA @ /openstack/install/try-openstack

### DIFF
--- a/templates/openstack/install/try-openstack.html
+++ b/templates/openstack/install/try-openstack.html
@@ -17,7 +17,7 @@
           <div class="col-6 p-divider__block">
             <h3>Requirements</h3>
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu 16.04 LTS and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
+              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu 16.04 LTS, snapd and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
               <li class="p-list__item is-ticked">An hour of your time</li>
             </ul>
           </div>
@@ -55,6 +55,34 @@
             <input aria-label="code snippet" class="p-code-snippet__input" value="conjure-up" readonly="readonly">
             <button class="p-code-snippet__action">Copy to clipboard</button>
           </p>
+          <div class="p-notification--caution">
+            <div class="p-notification__response">
+              <p>
+                <span class="p-notification__status">Note:</span>
+              </p>
+              <p>
+                If above commands fail you’ll want to make sure snapd is installed on your system as it is not available in releases before Ubuntu 16.04 LTS or in the daily images from cdimage.ubuntu.com:
+              </p>
+              <p class="p-code-snippet">
+                <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt update && sudo apt upgrade" readonly="readonly">
+                <button class="p-code-snippet__action">Copy to clipboard</button>
+              </p>
+              <p class="p-code-snippet">
+                <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt install snapd" readonly="readonly">
+                <button class="p-code-snippet__action">Copy to clipboard</button>
+              </p>
+              <p>
+                Then relogin or run:
+              </p>
+              <p class="p-code-snippet">
+                <input aria-label="code snippet" class="p-code-snippet__input" value="source /etc/profile.d/apps-bin-path.sh" readonly="readonly">
+                <button class="p-code-snippet__action">Copy to clipboard</button>
+              </p>
+              <p>
+                Now you can try installing conjure-up again.
+              </p>
+            </div>
+          </div>
         </div>
       </li>
       <li class="p-list-step__item col-12">


### PR DESCRIPTION
## Done

- Add snapd installation instructions on /openstack/install/try-openstack
- Also adding to the beta

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/install/try-openstack](http://0.0.0.0:8001/openstack/install/try-openstack)
- compare it to the [copy doc](https://docs.google.com/document/d/1QIXOAlCDV2cyQqU5uEW2kpITobf7OkFHr-tsEvjd_1Q/edit)

## Issue / Card

Fixes #2718

