### PR TITLE
Remove ‘Ongoing enterprise support for Kubernetes after 30 days is optional.’

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -16,7 +16,7 @@
       <li class="p-list__item is-ticked">Reference architecture</li>
       <li class="p-list__item is-ticked">NodePort and Flannel networking</li>
       <li class="p-list__item is-ticked">8 hours hands-on, web-based training</li>
-      <li class="p-list__item is-ticked">30 days of phone support *</li>
+      <li class="p-list__item is-ticked">30 days of phone support included</li>
     </ul>
     <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us about Kubernetes Explorer', 'eventLabel' : 'Contact us about Kubernetes Explorer - consulting packages CTA' : undefined });">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
   </div>
@@ -32,7 +32,7 @@
       <li class="p-list__item is-ticked">Custom Kubernetes architecture optimised for your workloads</li>
       <li class="p-list__item is-ticked">Any CNI-compatible network (Calico, Canal, Flannel, Weave)</li>
       <li class="p-list__item is-ticked">4 days on-site  in-person training</li>
-      <li class="p-list__item is-ticked">30 days of phone support</li>
+      <li class="p-list__item is-ticked">30 days of phone support included</li>
     </ul>
     <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us about Kubernetes Discoverer', 'eventLabel' : 'Contact us about Kubernetes Discoverer - consulting packages CTA' : undefined });">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
   </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -32,14 +32,9 @@
       <li class="p-list__item is-ticked">Custom Kubernetes architecture optimised for your workloads</li>
       <li class="p-list__item is-ticked">Any CNI-compatible network (Calico, Canal, Flannel, Weave)</li>
       <li class="p-list__item is-ticked">4 days on-site  in-person training</li>
-      <li class="p-list__item is-ticked">30 days of phone support *</li>
+      <li class="p-list__item is-ticked">30 days of phone support</li>
     </ul>
     <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us about Kubernetes Discoverer', 'eventLabel' : 'Contact us about Kubernetes Discoverer - consulting packages CTA' : undefined });">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
-  </div>
-</div>
-<div class="row">
-  <div class="col-12">
-    <p class="u-padding-bottom--large"><small>* Ongoing enterprise support for Kubernetes after 30 days is optional.</small></p>
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
## Done

- Remove ‘Ongoing enterprise support for Kubernetes after 30 days is optional.’
- Updated the [copy doc](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [k8s page](http://0.0.0.0:8001/kubernetes)
- compare to the [copy doc](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#)

## Issue / Card

Fixes #2794

