### PR TITLE
Service Description Header cleanup

### DIFF
--- a/templates/legal/bootstack/service-description.html
+++ b/templates/legal/bootstack/service-description.html
@@ -6,7 +6,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-9">
-      <h1>BootStack Services Description</h1>
+      <h1>BootStack services description</h1>
       <p>Valid since 15 February 2018</p>
       <ol class="p-list--ordered-legal">
         <li class="p-list__item">

--- a/templates/legal/bootstack/service-description.html
+++ b/templates/legal/bootstack/service-description.html
@@ -30,15 +30,15 @@
           <h2 id="service-offering">Service offering</h2>
           <p>The BootStack service offering includes access to Canonical’s knowledge base and the services as defined below.</p>
           <ol class="p-list--ordered-legal">
-            <li class="p-list__item">
-              <h3 id="service-initiation">Service initiation</h3>
+            <li class="p-list__item" id="service-initiation">
+              Service initiation
               <p>Following Canonical’s building and initializing of the Cloud (subject to separate service engagement), Canonical will re-deploy the Cloud to reset credentials and validate the deployment process. Canonical will also provide documentation providing further detail on the working relationship with Canonical.</p>
             </li>
-            <li class="p-list__item">
-              <h3 id="operate">Operate</h3>
+            <li class="p-list__item" id="operate">
+              Operate
               <ol class="p-list--ordered-legal">
                 <li class="p-list__item">
-                  <h4>General</h4>
+                  General
                   <p>Canonical will remotely operate, monitor, and manage the Cloud. Examples include:</p>
                   <ul>
                     <li class="p-list__item">Backing up and restoring of the management infrastructure suite</li>
@@ -47,7 +47,7 @@
                   </ul>
                 </li>
                 <li class="p-list__item">
-                  <h4>Patching and updates</h4>
+                  Patching and updates
                   <p>Canonical will install applicable (e.g. security) patches and updates from the Ubuntu Cloud Archive to:</p>
                   <ul>
                     <li class="p-list__item">The Ubuntu operating system</li>
@@ -57,7 +57,7 @@
                   </ul>
                 </li>
                 <li class="p-list__item">
-                  <h4>Administrative access</h4>
+                  Administrative access
                   <p>Canonical will provide customer with access to the following applications and/or services:</p>
                   <ul>
                     <li class="p-list__item">The OpenStack dashboard, API and CLI</li>
@@ -66,16 +66,16 @@
                   </ul>
                 </li>
                 <li class="p-list__item">
-                  <h4>Cloud size</h4>
+                  Cloud size
                   <p>Canonical will add or remove nodes from the Cloud as requested by the customer through a support ticket, provided that the Cloud does not go under the minimum size requirement. All Cloud nodes must be covered under the BootStack service,
                     so additional fees may apply.</p>
                 </li>
                 <li class="p-list__item">
-                  <h4>Ubuntu and OpenStack upgrades</h4>
+                  Ubuntu and OpenStack upgrades
                   <p>Canonical will ensure the customer’s Cloud remains on a supported version of Ubuntu and OpenStack. In most cases, Canonical will upgrade only to LTS releases. Support lifecycles can be found at: <a href="https://www.ubuntu.com/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a></p>
                 </li>
                 <li class="p-list__item">
-                  <h4>Out of scope</h4>
+                  Out of scope
                   <p>Canonical is not responsible for the following:</p>
                   <ul>
                     <li class="p-list__item">Relating to Guest Instances:
@@ -95,8 +95,8 @@
                 </li>
               </ol>
             </li>
-            <li class="p-list__item">
-              <h3 id="service-conclusion">Service conclusion</h3>
+            <li class="p-list__item" id="service-conclusion">
+              Service conclusion
               <p>
                 At the end of the BootStack service term, Canonical will initiate an operational transfer.
               </p>

--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -54,26 +54,26 @@
           </p>
           <ol class="p-list--ordered-legal">
             <li class="p-list__item" id="support-scope-releases">
-              <h3>Releases</h3>
+              Releases
               <ul>
                 <li class="p-list__item">Canonical will provide support for installation, configuration, maintenance, and management of any standard release of Ubuntu when installed using official sources and within its product life cycle. The life cycle for each version of Ubuntu are specified here: <a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a>.</li>
               </ul>
             </li>
             <li class="p-list__item" id="support-scope-hardware">
-              <h3>Hardware</h3>
+              Hardware
               <ul>
                 <li class="p-list__item">Ubuntu Certified hardware has passed our extensive testing and review process. More information about the Ubuntu certification process and a list of certified hardware can be found on the Ubuntu Certification page: <a href="https://certification.ubuntu.com">www.ubuntu.com/certification</a>.  The services apply only with respect to the customer&#39;s hardware which has been certified. In the event the customer requests the services with respect to hardware which is not certified, Canonical will use reasonable efforts to provide support services, but may not adhere to the obligations described in this service description.</li>
               </ul>
             </li>
             <li class="p-list__item" id="support-scope-packages">
-              <h3>Packages</h3>
+              Packages
               <ol class="p-list--ordered-legal">
                 <li class="p-list__item">The services apply only to packages found in the Ubuntu Main Repository and Canonical-owned packages in the Universe Repository except (i) the "proposed" and "backports" repository pockets, and (ii) the exclusions noted in the applicable support scope documentation.<br /> The supported packages from the Universe Repository include, but may not be limited to, Juju packages, MAAS packages, the nova-conductor package, and their dependencies to the extent used in connection with those packages.</li>
                 <li class="p-list__item">Canonical will not provide support for any packages that have been modified from the version in the Ubuntu archives.</li>
               </ol>
             </li>
             <li class="p-list__item" id="support-scope-kernels">
-              <h3>Kernels</h3>
+              Kernels
               <ol class="p-list--ordered-legal">
                 <li class="p-list__item">The kernel provided initially in the release of a long-term support (LTS) version of Ubuntu is supported for the entire lifecycle of the LTS.</li>
                 <li class="p-list__item">Hardware enablement (HWE) kernels provide support for newer hardware in an LTS release and are released in conjunction with the non-LTS Ubuntu releases. HWE kernels are supported until the next LTS point release.</li>
@@ -82,7 +82,7 @@
               </ol>
             </li>
             <li class="p-list__item" id="support-scope-landscape">
-              <h3>Landscape</h3>
+              Landscape
               <ol class="p-list--ordered-legal">
                 <li class="p-list__item">All Landscape products, including Landscape on-premises (when purchased) are fully supported.</li>
                 <li class="p-list__item">Access to the Landscape SaaS systems management tool is included with all support offerings, unless otherwise noted.</li>


### PR DESCRIPTION
## Done

Removed a number of headers being used where they didn't used to be.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- [List additional steps to QA the new features or prove the bug has been resolved]

http://www.ubuntu.com-pr-2807.run.demo.haus/legal/ubuntu-advantage/service-description
http://www.ubuntu.com-pr-2807.run.demo.haus/legal/bootstack/service-description

