### PR TITLE
Updated strip color and added highlights

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -48,33 +48,40 @@
     <table>
       <tr>
         <td>Workload analysis (Artificial Intelligence, Machine Learning, <br />Blockchain, CI/CD, Serverless, Transcoding)</td>
-        <td>+$9,000 (Included in Kubernetes Discoverer)</td>
+        <td class="p-table__cell--highlight u-align--center">+$9,000<sup>*</sup></td>
       </tr>
       <tr>
         <td>CI/CD Workload</td>
-        <td>+$13,000 (Included in Kubernetes Discoverer)</td>
+        <td class="p-table__cell--highlight u-align--center">+$13,000<sup>*</sup></td>
       </tr>
       <tr>
         <td>Architecture design</td>
-        <td>+$20,000 (Included in Kubernetes Discoverer)</td>
+        <td class="p-table__cell--highlight u-align--center">+$20,000<sup>*</sup></td>
       </tr>
       <tr>
         <td>Custom monitoring</td>
-        <td>+$7,000</td>
+        <td class="p-table__cell--highlight u-align--center">+$7,000</td>
       </tr>
       <tr>
         <td>Disaster recovery</td>
-        <td>+$10,000</td>
+        <td class="p-table__cell--highlight u-align--center">+$10,000</td>
       </tr>
       <tr>
         <td>Alternate runtime</td>
-        <td>+$5,000</td>
+        <td class="p-table__cell--highlight u-align--center">+$5,000</td>
       </tr>
       <tr>
         <td>Additional customisation</td>
-        <td>+$1,500/day</td>
+        <td class="p-table__cell--highlight u-align--center">+$1,500/day</td>
       </tr>
     </table>
+  </div>
+</div>
+<div class="row">
+  <div class="col-12">
+    <p>
+      <small><sup>*</sup> included in Kubernetes Discoverer</small>
+    </p>
   </div>
 </div>
 <div class="row">

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -104,6 +104,6 @@
 
 <div class="row">
   <div class="col-12">
-    <p><small>* Minimums apply</small></p>
+    <p><small><sup>*</sup> Minimums apply</small></p>
   </div>
 </div>

--- a/templates/shared/pricing/_landscape.html
+++ b/templates/shared/pricing/_landscape.html
@@ -2,49 +2,49 @@
   <thead>
     <tr>
       <td>&nbsp;</td>
-      <th class="u-align--center">Landscape on-premises</th>
+      <th class="p-table__cell--highlight u-align--center">Landscape on-premises</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Price per Landscape server deployment on-premises</td>
-      <td class="u-align--center">$2,000/year</td>
+      <td class="p-table__cell--highlight u-align--center">$2,000/year</td>
     </tr>
     <tr>
       <td>Private instance, on-prem or in a public cloud</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Automated package updates</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Remote package installation, update, and rollback</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Security compliance and audit reports</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Scale out system monitoring</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Hardware inventory control</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Role-based access controls</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>High availability support</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Phone and ticket support for Landscape 24 hours a day, everyday</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
   </tbody>
 </table>

--- a/templates/shared/pricing/_openstack-consulting.html
+++ b/templates/shared/pricing/_openstack-consulting.html
@@ -2,45 +2,45 @@
   <thead>
     <tr>
       <td>&nbsp;</td>
-      <th>Foundation Cloud</th>
-      <th>Foundation Cloud Plus</th>
+      <th class="p-table__cell--highlight">Foundation Cloud</th>
+      <th class="p-table__cell--highlight">Foundation Cloud Plus</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>One-time price</td>
-      <td>$75,000</td>
-      <td>$150,000</td>
+      <td class="p-table__cell--highlight">$75,000</td>
+      <td class="p-table__cell--highlight">$150,000</td>
     </tr>
     <tr>
-      <td>Expert delivery of an Ubuntu OpenStack cloud</td>
-      <td>Reference architecture</td>
-      <td>Custom architecture</td>
+      <td>Expert delivery of an Ubuntu OpenStack&nbsp;cloud</td>
+      <td class="p-table__cell--highlight">Reference architecture</td>
+      <td class="p-table__cell--highlight">Custom architecture</td>
     </tr>
     <tr>
       <td>On-site workshop and training</td>
-      <td>2-days</td>
-      <td>4-days</td>
+      <td class="p-table__cell--highlight">2-days</td>
+      <td class="p-table__cell--highlight">4-days</td>
     </tr>
     <tr>
       <td>Hypervisor options</td>
-      <td>KVM and LXD</td>
-      <td>KVM, LXD, and Hyper-V</td>
+      <td class="p-table__cell--highlight">KVM and LXD</td>
+      <td class="p-table__cell--highlight">KVM, LXD, and Hyper-V</td>
     </tr>
     <tr>
       <td>Software Defined Networking options</td>
-      <td>OVS (GRE and/or VXLAN)</td>
-      <td>Calico, Juniper Contrail, Cplane, Cisco ACI, Nuage and more</td>
+      <td class="p-table__cell--highlight">OVS (GRE and/or VXLAN)</td>
+      <td class="p-table__cell--highlight">Calico, Juniper Contrail, Cplane, Cisco ACI, Nuage and more</td>
     </tr>
     <tr>
       <td>Software Defined Storage options</td>
-      <td>Ceph</td>
-      <td>Ceph, Swift, Nexenta, Solidfire, Quobyte, ScaleIO and more</td>
+      <td class="p-table__cell--highlight">Ceph</td>
+      <td class="p-table__cell--highlight">Ceph, Swift, Nexenta, Solidfire, Quobyte, ScaleIO and more</td>
     </tr>
     <tr>
       <td>Encryption</td>
-      <td>&nbsp;</td>
-      <td>Control plane and storage</td>
+      <td class="p-table__cell--highlight">&nbsp;</td>
+      <td class="p-table__cell--highlight">Control plane and storage</td>
     </tr>
   </tbody>
 </table>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -4,8 +4,8 @@
       <thead>
         <tr>
           <td style="width: 40%;">&nbsp;</td>
-          <th class=" u-align--center" style="width: 20%;">OpenStack</th>
-          <th class=" u-align--center" colspan="2">Ubuntu Advantage for OpenStack</th>
+          <th class="u-align--center" style="width: 20%;">OpenStack</th>
+          <th class="p-table__cell--highlight  u-align--center" colspan="2">Ubuntu Advantage for OpenStack</th>
         </tr>
         <tr>
           <td>&nbsp;</td>

--- a/templates/shared/pricing/_storage-support.html
+++ b/templates/shared/pricing/_storage-support.html
@@ -7,51 +7,51 @@
   <tbody>
     <tr>
       <td>Up to 32 TB usable</td>
-      <td class="u-align--center">$5,000/year</td>
+      <td class="p-table__cell--highlight u-align--center">$5,000/year</td>
     </tr>
     <tr>
       <td>Up to 128 TB usable</td>
-      <td class="u-align--center">$15,000/year</td>
+      <td class="p-table__cell--highlight u-align--center">$15,000/year</td>
     </tr>
     <tr>
       <td>Up to 512 TB usable</td>
-      <td class="u-align--center">$45,000/year</td>
+      <td class="p-table__cell--highlight u-align--center">$45,000/year</td>
     </tr>
     <tr>
       <td>Up to 1,024 TB usable (1 PB)</td>
-      <td class="u-align--center">$75,000/year</td>
+      <td class="p-table__cell--highlight u-align--center">$75,000/year</td>
     </tr>
     <tr>
       <td>Unlimited storage</td>
-      <td class="u-align--center">$250,000/year</td>
+      <td class="p-table__cell--highlight u-align--center">$250,000/year</td>
     </tr>
     <tr>
       <td>Phone and web ticket support</td>
-      <td class="u-align--center">24 hours a day, everyday</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
     </tr>
     <tr>
       <td>Industry-leading cloud operations tooling (Ubuntu, MAAS, Juju)</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Deploy, run, scale, upgrade</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Landscape management</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Livepatch</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Knowledge Base</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
       <td>Production grade monitoring</td>
-      <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
   </tbody>
 </table>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -90,7 +90,7 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-deep u-no-padding--bottom" id="ua-support">
+<section class="p-strip--light is-deep u-no-padding--bottom" id="ua-support">
   <div class="row">
     <div class="col-8">
       <h2>Ubuntu Advantage</h2>
@@ -108,7 +108,7 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-shallow">
+<section class="p-strip--light is-shallow">
   <div class="row" style="overflow-x: auto;">
     <div class="col-10">
       <h2>For servers</h2>
@@ -117,7 +117,7 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-shallow u-no-padding--bottom">
+<section class="p-strip--light is-shallow u-no-padding--bottom">
   <div class="row" style="overflow-x: auto;">
     <div class="col-10">
       <h2>For desktops</h2>
@@ -126,7 +126,7 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-deep">
+<section class="p-strip--light is-deep">
   {% include "shared/pricing/_ua-server-support-add-ons.html" %}
 </section>
 
@@ -145,7 +145,7 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-deep is-bordered" id="openstack">
+<section class="p-strip--light is-deep is-bordered" id="openstack">
   <div class="row">
     <div class="col-8">
       <h2>OpenStack</h2>
@@ -179,7 +179,7 @@
   </div>
 </section>
 
-<section class="p-strip--x-light is-deep is-bordered" id="kubernetes">
+<section class="p-strip--light is-deep is-bordered" id="kubernetes">
   <div class="row">
     <div class="col-8">
       <h2>Kubernetes</h2>
@@ -201,7 +201,7 @@
   {% include "shared/pricing/_kubernetes-consulting.html" %}
 </section>
 
-<section class="p-strip--x-light is-deep is-bordered" id="storage">
+<section class="p-strip--light is-deep is-bordered" id="storage">
   <div class="row">
     <div class="col-8">
       <h2>Ceph and Swift Storage</h2>


### PR DESCRIPTION
## Done

- Updated strip color and added highlights on /pricing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [pricing page](http://0.0.0.0:8001/support/plans-and-pricing)
- See that all the pay for columns are highlighted and all the strips p-strip—light

## Issue / Card

Fixes #2806

## Screenshots

![image](https://user-images.githubusercontent.com/441217/37296787-e8312d36-2613-11e8-8bd4-47c68ee995cb.png)

