### PR TITLE
Updated further reading links on /legal section

### DIFF
--- a/templates/shared/contextual_footers/_cloud_further_reading.html
+++ b/templates/shared/contextual_footers/_cloud_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1706&per_paget=5" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1706&per_page=5" %}
 </div>

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=5" %}
 </div>


### PR DESCRIPTION
## Done

- Updated further reading links on /legal section
- Also fixed typo in page limit on /cloud section
- Missed in earlier clean-up

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: a [legal page](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description#appendix-management-escalation) and [cloud page](http://0.0.0.0:8001/cloud/partners)
- See that 5 articles appear in the list at the bottom of the page

## Issue / Card

Fixes #2809

## Screenshots

![image](https://user-images.githubusercontent.com/441217/37354792-60a6f9c8-26da-11e8-8889-5ad9da49478f.png)
