### PR TITLE
Fix insight spotlight posts with sticky ones

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -380,7 +380,7 @@
   </div>
 </section>
 
-{% include "shared/_insights_news_strip.html" with insights_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477&tags=2226" insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477" strip_classes="p-strip--light is-deep is-bordered" gtm_event_label="ubuntu.com cloud overview" %}
+{% include "shared/_insights_news_strip.html" with insights_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477&sticky=true&per_page=1" insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?topic=1477&sticky=false&per_page=5" strip_classes="p-strip--light is-deep is-bordered" gtm_event_label="ubuntu.com cloud overview" %}
 
 <section class="p-strip">
   <div class="row">

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 
 {% include "takeovers/_iot-business.html" %}
 
-{% include "shared/_insights_news_strip.html" with insights_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=2226" insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
+{% include "shared/_insights_news_strip.html" with insights_spotlight_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=true&per_page=1" insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&per_page=4" strip_classes="" gtm_event_label="ubuntu.com homepage" %}
 
 <section class="p-strip--light is-bordered">
   <div class="row u-align--center">


### PR DESCRIPTION
## Done

- Fix insight spotlight posts with sticky ones

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
  - [homepage](http://0.0.0.0:8001/)
  - [cloud](http://0.0.0.0:8001/cloud)
- See that the spotlighted homepage post is the same as https://insights.ubuntu.com ’s and that cloud _currently_ has none

## Issue / Card

Fixes #2788

## Screenshots

![image](https://user-images.githubusercontent.com/441217/37404072-b7b2d896-2788-11e8-816c-15e1d4549a3c.png)
