### PR TITLE
Removed max-width from footer content

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -87,6 +87,7 @@
       background-size: 13px 13px;
       border-top: 1px solid $color-mid-light;
       font-size: .8125rem;
+      max-width: inherit;
       padding: $sp-medium 0;
 
       @media only screen and (min-width: $breakpoint-medium) {
@@ -207,6 +208,7 @@
 
     &__content {
       margin-bottom: $sp-xx-small;
+      max-width: inherit;
     }
 
     @media only screen and (min-width: $breakpoint-medium) {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -162,6 +162,7 @@
       display: block;
       left: auto;
       margin-bottom: -1px;
+      max-width: inherit;
       padding: $sp-small 0 $sp-small $sp-x-large;
       position: relative;
       z-index: 2;


### PR DESCRIPTION
## Done

- Removed max-width from footer content

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [any page](http://0.0.0.0:8001/)
  - on large screen, see that the copyright doesn’t wrap
  - on small screen, see that the footer is full width

## Issue / Card

Fixes #2615

## Screenshots

![image](https://user-images.githubusercontent.com/441217/37404663-6334f4aa-278a-11e8-9bfd-f6e55f4e740f.png)

![image](https://user-images.githubusercontent.com/441217/37404684-7005ee14-278a-11e8-8f6e-0c93cc4443b1.png)
