### PR TITLE
Cleaned-up /pricing tables to look nicer

### DIFF
--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -110,38 +110,9 @@
     <div class="row">
       <h2>Pricing</h2>
     </div>
-    <div class="row u-equal-height">
-      <div class="col-6 p-card">
-        <h3 class="p-heading--four">Foundation Cloud Build</h3>
-        <p class="p-heading--three">$75,000 <span class="p-heading--six">one-off-fee</span></p>
-        <div class="p-card__footer">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">2-day on-site workshop</li>
-            <li class="p-list__item is-ticked">KVM and LXD hypervisors</li>
-          </ul>
-        </div>
-      </div>
-      <div class="col-6 p-card">
-        <h3 class="p-heading--four">Foundation Cloud Plus</h3>
-        <p class="p-heading--three">$150,000 <span class="p-heading--six">one-off-fee</span></p>
-        <div class="p-card__footer">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">4-day on-site workshop</li>
-            <li class="p-list__item is-ticked">KVM, LXD, and Hyper-V hypervisors</li>
-            <li class="p-list__item is-ticked">Control plane and storage encryption</li>
-          </ul>
-        </div>
-      </div>
-      <div class="col-6 p-card">
-        <h3 class="p-heading--four">Add-ons</h3>
-        <p class="p-heading--three">From $25,000 <span class="p-heading--six">one-off-fee</span></p>
-        <div class="p-card__footer">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">OpenStack and OS upgrade services</li>
-            <li class="p-list__item is-ticked">Custom architecture bundle with add-on components</li>
-            <li class="p-list__item is-ticked">Various additional storage options</li>
-          </ul>
-        </div>
+    <div class="row">
+      <div class="col-10">
+        {% include "shared/pricing/_openstack-consulting.html" %}
       </div>
     </div>
     <div class="row">

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -43,15 +43,15 @@
     <table>
       <tr>
         <td>Workload analysis (Artificial Intelligence, Machine Learning, <br />Blockchain, CI/CD, Serverless, Transcoding)</td>
-        <td class="p-table__cell--highlight u-align--center">+$9,000<sup>*</sup></td>
+        <td class="p-table__cell--highlight u-align--center">+$9,000 <sup><a href="#fn-kc-1">*</a></sup></td>
       </tr>
       <tr>
         <td>CI/CD Workload</td>
-        <td class="p-table__cell--highlight u-align--center">+$13,000<sup>*</sup></td>
+        <td class="p-table__cell--highlight u-align--center">+$13,000 <sup><a href="#fn-kc-1">*</a></sup></td>
       </tr>
       <tr>
         <td>Architecture design</td>
-        <td class="p-table__cell--highlight u-align--center">+$20,000<sup>*</sup></td>
+        <td class="p-table__cell--highlight u-align--center">+$20,000 <sup><a href="#fn-kc-1">*</a></sup></td>
       </tr>
       <tr>
         <td>Custom monitoring</td>
@@ -72,7 +72,7 @@
     </table>
   </div>
 </div>
-<div class="row">
+<div class="row" id="fn-kc-1">
   <div class="col-12">
     <p>
       <small><sup>*</sup> included in Kubernetes Discoverer</small>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -15,14 +15,14 @@
         <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
       </tr>
       <tr>
-        <th>Price per node (physical) *</th>
+        <th>Price per node (physical) <sup><a href="#fn-kes-1">*</a></sup></th>
         <td class="u-align--center">$0</td>
         <td class="p-table__cell--highlight u-align--center">$600/year</td>
         <td class="p-table__cell--highlight u-align--center">$1,200/year</td>
         <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
       </tr>
       <tr>
-        <th>Price per node (virtual) *</th>
+        <th>Price per node (virtual) <sup><a href="#fn-kes-1">*</a></sup></th>
         <td class="u-align--center">$0</td>
         <td class="p-table__cell--highlight u-align--center">$200/year</td>
         <td class="p-table__cell--highlight u-align--center">$400/year</td>
@@ -31,9 +31,9 @@
       <tr>
         <th>Phone and web ticket support</th>
         <td class="u-align--center">None</td>
-        <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
-        <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
-        <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+        <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
+        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
+        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
       </tr>
       <tr>
         <th>Industry-leading cloud operations tooling <br />(Ubuntu, MAAS, Juju, LXD)</th>
@@ -102,8 +102,10 @@
   </div>
 </div>
 
-<div class="row">
+<div class="row" id="fn-kes-1">
   <div class="col-12">
-    <p><small><sup>*</sup> Minimums apply</small></p>
+    <p>
+      <small><sup>*</sup> Minimums apply</small>
+    </p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -47,7 +47,7 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
-      <th>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day,<br />everyday</th>
+      <th>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day, everyday</th>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -15,7 +15,7 @@
     </tr>
     <tr>
       <th>Phone and web ticket support</th>
-      <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
     </tr>
     <tr>
       <th>Industry-leading cloud operations tooling<br />
@@ -47,7 +47,7 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
-      <th>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day, everyday</th>
+      <th>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day,<br />everyday</th>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>

--- a/templates/shared/pricing/_landscape.html
+++ b/templates/shared/pricing/_landscape.html
@@ -43,7 +43,7 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
-      <td>Phone and ticket support for Landscape 24 hours a day,<br />everyday</td>
+      <td>Phone and ticket support for Landscape 24 hours a day, everyday</td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
   </tbody>

--- a/templates/shared/pricing/_landscape.html
+++ b/templates/shared/pricing/_landscape.html
@@ -43,7 +43,7 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
     <tr>
-      <td>Phone and ticket support for Landscape 24 hours a day, everyday</td>
+      <td>Phone and ticket support for Landscape 24 hours a day,<br />everyday</td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
     </tr>
   </tbody>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -31,8 +31,8 @@
     <tr>
       <td>Phone and ticket support</td>
       <td class="u-align--center">None</td>
-      <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
-      <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+      <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
     </tr>
 
     <tr>

--- a/templates/shared/pricing/_openstack-consulting.html
+++ b/templates/shared/pricing/_openstack-consulting.html
@@ -30,12 +30,12 @@
     <tr>
       <td>Software Defined Networking options</td>
       <td class="p-table__cell--highlight u-align--center">OVS (GRE and/or VXLAN)</td>
-      <td class="p-table__cell--highlight u-align--center">OVS with Provider Networks, BGP, DVR (Juniper Contrail, Cisco ACI, Nokia Nuage and more available as add-ons)</td>
+      <td class="p-table__cell--highlight u-align--center">OVS with Provider Networks,<br />BGP, DVR <sup><a href="#fn-oc-1">*</a></sup></td>
     </tr>
     <tr>
       <td>Software Defined Storage options</td>
       <td class="p-table__cell--highlight u-align--center">Ceph</td>
-      <td class="p-table__cell--highlight u-align--center">Ceph, Swift (Nexenta, Solidfire, Quobyte, ScaleIO and more available as add-ons)</td>
+      <td class="p-table__cell--highlight u-align--center">Ceph, Swift <sup><a href="#fn-oc-2">**</a></sup></td>
     </tr>
     <tr>
       <td>Encryption</td>
@@ -44,3 +44,10 @@
     </tr>
   </tbody>
 </table>
+
+<p id="fn-oc-1">
+  <small><sup>*</sup> Juniper Contrail, Cisco ACI, Nokia Nuage and more available as add-ons</small>
+</p>
+<p class="u-no-margin--top" id="fn-oc-2">
+  <small><sup>**</sup> Nexenta, Solidfire, Quobyte, ScaleIO and more available as add-ons</small>
+</p>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -17,13 +17,13 @@
       </thead>
       <tbody>
         <tr>
-          <td>Price per machine *</td>
+          <td>Price per machine <sup><a href="#fn-os-1">*</a></sup></td>
           <td class="u-align--center">$0</td>
           <td class="p-table__cell--highlight u-align--center">$1,500/year</td>
           <td class="p-table__cell--highlight u-align--center">$5,450/year</td>
         </tr>
         <tr>
-          <td>Or, price per region per year **</td>
+          <td>Or, price per region per year <sup><a href="#fn-os-2">**</a></sup></td>
           <td class="u-align--center">-</td>
           <td class="p-table__cell--highlight u-align--center"><small>Small: $95,000<br />Medium: $225,000<br />Large: $420,000</small></td>
           <td class="p-table__cell--highlight u-align--center">-</td>
@@ -97,7 +97,11 @@
       </tbody>
     </table>
 
-    <p><small>* Minimum of 12 supported nodes</small></p>
-    <p class="u-no-margin--top"><small>** Small region: Up to 99 nodes, Medium region: 100-499 nodes; Large region: 500+ nodes</small></p>
+    <p id="fn-os-1">
+      <small><sup>*</sup> Minimum of 12 supported nodes</small>
+    </p>
+    <p class="u-no-margin--top" id="fn-os-2">
+      <small><sup>**</sup> Small region: Up to 99 nodes, Medium region: 100-499 nodes; Large region: 500+ nodes</small>
+    </p>
   </div>
 </div>

--- a/templates/shared/pricing/_storage-support.html
+++ b/templates/shared/pricing/_storage-support.html
@@ -28,7 +28,7 @@
     </tr>
     <tr>
       <td>Phone and web ticket support</td>
-      <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
     </tr>
     <tr>
       <td>Industry-leading cloud operations tooling (Ubuntu, MAAS, Juju)</td>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -24,8 +24,8 @@
         <tr>
           <td>Phone and ticket support</td>
           <td class="u-align--center">None</td>
-          <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
-          <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+          <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
+          <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
         </tr>
         <tr>
           <td>Download, install, run, use, update, secure, upgrade</td>

--- a/templates/shared/pricing/_ua-server-support-add-ons.html
+++ b/templates/shared/pricing/_ua-server-support-add-ons.html
@@ -6,15 +6,15 @@
 
 <div class="row u-equal-height">
   <div class="col-4 p-card">
-    <h4>Feature Sponsorships <span style="font-size: 1.25rem;">*</span></h4>
+    <h4>Feature Sponsorships <sup><a href="#fn-fs">*</a></sup></h4>
     <p>Enterprises can support the quicker development of certain features, packages, or changes to Ubuntu for everyone’s benefit.</p>
   </div>
   <div class="col-4 p-card">
-    <h4>Custom Hardware Certification <span style="font-size: 1.25rem;">*</span></h4>
+    <h4>Custom Hardware Certification <sup><a href="#fn-fs">*</a></sup></h4>
     <p>Get Canonical to certify specific hardware you are running that isn’t officially supported on Ubuntu.</p>
   </div>
   <div class="col-4 p-card">
-    <h4>Custom OS Images <span style="font-size: 1.25rem;">*</span></h4>
+    <h4>Custom OS Images <sup><a href="#fn-fs">*</a></sup></h4>
     <p>Have Canonical create and maintain images that have the customisations your company requires.</p>
   </div>
 </div>
@@ -33,8 +33,8 @@
   </div>
 </div>
 
-<div class="row">
+<div class="row" id="fn-fs">
   <div class="col-12">
-    <p><small>* Requires a site-wide UA subscription</small></p>
+    <p><small><sup>*</sup> Requires a site-wide UA subscription</small></p>
   </div>
 </div>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -32,11 +32,11 @@
       <td>Phone and ticket support</td>
       <td class="u-align--center">None</td>
       <td class="p-table__cell--highlight u-align--center">None</td>
-      <td class="p-table__cell--highlight u-align--center">8am - 6pm on weekdays</td>
-      <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+      <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
     </tr>
     <tr>
-      <td>Download, install, run, use, update, secure, upgrade</td>
+      <td>Download, install, run, use,<br />update, secure, upgrade</td>
       <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -23,7 +23,7 @@
     <div class="col-4 p-card">
       <h3>Server</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $75 per year <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $75 per year <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#ua-support">Learn more&nbsp;&rsaquo;</a>
@@ -33,7 +33,7 @@
     <div class="col-4 p-card">
       <h3>MAAS</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $5 per month <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $5 per month <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#maas">Learn more&nbsp;&rsaquo;</a>
@@ -43,7 +43,7 @@
     <div class="col-4 p-card">
       <h3>OpenStack</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $4 per day <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $4 per day <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#openstack">Learn more&nbsp;&rsaquo;</a>
@@ -55,7 +55,7 @@
     <div class="col-4 p-card">
       <h3>Kubernetes</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $0.02 per hour <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $0.02 per hour <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#kubernetes">Learn more&nbsp;&rsaquo;</a>
@@ -65,7 +65,7 @@
     <div class="col-4 p-card">
       <h3>Storage</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $0.01 per month <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $0.01 per month <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#storage">Learn more&nbsp;&rsaquo;</a>
@@ -75,7 +75,7 @@
     <div class="col-4 p-card">
       <h3>Consulting packages</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $2,500 per day <span style="font-size: 1rem;">*</span></p>
+        <p class="p-heading--five">From $2,500 per day <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#consulting">Learn more&nbsp;&rsaquo;</a>
@@ -83,9 +83,9 @@
     </div>
   </div>
 
-  <div class="row">
+  <div class="row" id="fn-pnp-1">
     <div class="col-12">
-      <p><small>* Minimums apply</small></p>
+      <p><small><sup>*</sup> Minimums apply</small></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Cleaned-up pricing tables to look nicer
  - updated the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit)
- Used FCB pricing table in /cloud/foundation-cloud page
  - updated the [copy doc](https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit#)
- Made use of footnotes cleaner

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
  - [the pricing page](http://0.0.0.0:8001/support/plans-and-pricing)
    - note the tables are cleaner
    - note the footnotes are links
  - [the fcb page](http://0.0.0.0:8001/cloud/foundation-cloud)
    - note the pricing is the same as on /pricing

## Issue / Card

Fixes #2818 and Fixes #2817 
