### PR TITLE
White background for instructions on /download/server/provisioning

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -35,7 +35,7 @@
 
 {% include "download/shared/_get_ebook_maas.html"%}
 
-<section class="p-strip--light is-deep is-bordered" id="instructions">
+<section class="p-strip is-deep is-bordered" id="instructions">
   <div class="row">
     <div class="col-12">
       <h2>Install MAAS in 7 easy steps</h2>


### PR DESCRIPTION
## Done

- White background for instructions on /download/server/provisioning

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/server/provisioning](http://0.0.0.0:8001/download/server/provisioning)
- See that the background is white

## Issue / Card

Fixes #2574

## Screenshots

![image](https://user-images.githubusercontent.com/441217/37432388-1454902a-27d0-11e8-8b79-d02aa205f0fb.png)
