### PR TITLE
Fixed aspect ratios on logo clouds

### DIFF
--- a/static/sass/_pattern_inline-images.scss
+++ b/static/sass/_pattern_inline-images.scss
@@ -5,6 +5,14 @@
     margin-left: 0;
     padding-left: 0;
 
+    // XXX Peter Mahnke 2018-03-01
+    // Extension of the inline images to add logo support
+    // This should be proposed up to vanilla-brochure-theme once approved
+    // see https://github.com/vanilla-framework/vanilla-framework/issues/1605
+    &__item {
+      overflow: visible;
+    }
+
     &__item--compact {
       margin: $sp-medium;
     }
@@ -15,16 +23,26 @@
     }
   }
 
-  // XXX Extension of the inline images to add logo support
+  // XXX Peter Mahnke 2018-03-01
+  // Extension of the inline images to add logo support
   // This should be proposed up to vanilla-brochure-theme once approved
+  // see https://github.com/vanilla-framework/vanilla-framework/issues/1605
   .p-inline-images__logo {
     max-height: $sp-xxx-large;
-    max-width: 7rem;
-    width: 100%;
+    width: auto;
+
+    &[src*="svg"] {
+      max-width: 7rem;
+      min-width: 3rem;
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        max-width: 9rem;
+        min-width: 5rem;
+      }
+    }
 
     @media only screen and (min-width: $breakpoint-medium) {
       max-height: 5.5rem;
-      max-width: 9rem;
     }
   }
 }


### PR DESCRIPTION
## Done

- Fixed aspect ratios on logo clouds
- Note, this is the css portion of #2776 that is going into the beta (yes @Caleb-Ellis  you were correct)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [containers](http://0.0.0.0:8001/containers)
- See that the k8s and docker logos look good

## Issue / Card

Fixes #2811

## Screenshots

![image](https://user-images.githubusercontent.com/441217/37451798-9d1ec290-282a-11e8-8f2b-e1911f8fdd2b.png)

