### PR TITLE
Use a white bg for the build OpenStack instructions strip

### DIFF
--- a/templates/download/cloud/build-openstack.html
+++ b/templates/download/cloud/build-openstack.html
@@ -34,7 +34,7 @@
 
 {% include "download/shared/_get_ebook.html"%}
 
-<div class="p-strip--light is-deep is-bordered" id="instructions">
+<div class="p-strip is-deep is-bordered" id="instructions">
   <div class="row">
     <div class="col-12">
       <h2>Installation instructions</h2>


### PR DESCRIPTION
## Done

Removing the `--light` class on the "build OpenStack" instructions strip 
https://www.ubuntu.com/download/cloud/build-openstack

This makes the page visually consistent with the other set of OpenStack instructions:
https://www.ubuntu.com/download/cloud/try-openstack

### Screenshots

* Before: https://user-images.githubusercontent.com/18480003/37453494-1c344958-2838-11e8-9a10-e50521b3e4e7.png 
* After: https://user-images.githubusercontent.com/18480003/37453508-24b3d2c4-2838-11e8-8c56-8e596bfa9ce1.png

### QA

http://www.ubuntu.com-pr-2822.run.demo.haus/download/cloud/build-openstack

