### PR TITLE
Updated /resources to use correct insights url

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -101,16 +101,16 @@
         <header class="p-card__header--{{ resource.group.slug }}">
           <h4 class="p-muted-heading">
             {{ resource.group.name }}
-          </h4>  
+          </h4>
         {% endif %}
         </header>
         <div class="p-card__content">
           {% if resource.featuredmedia.source_url %}
-          <a href="{{resource.link}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Resources', 'eventAction' : 'Clicked resource', 'eventLabel' : '{{resource.title.rendered}}', 'eventValue' : undefined });" >
+          <a href="{{resource.link|replace_admin}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Resources', 'eventAction' : 'Clicked resource', 'eventLabel' : '{{resource.title.rendered}}', 'eventValue' : undefined });" >
             <img src="{{resource.featuredmedia.source_url}}" alt="{{resource.featuredmedia.alt_text}}" />
           </a>
           {% endif %}
-          <h3 class="p-heading--four"><a href="{{resource.link}}">{{resource.title.rendered | safe}}</a></h3>
+          <h3 class="p-heading--four"><a href="{{resource.link|replace_admin}}">{{resource.title.rendered | safe}}</a></h3>
           {% if not resource.featuredmedia.source_url %}
             {{resource.excerpt.rendered | truncatewords:25 | safe}}
           {% endif %}


### PR DESCRIPTION
## Done

- Updated /resources to use correct insights url, not admin.insights.ubuntu.com
- Uses the replace_admin filter used on other insights includes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/resources
- See that it points to insights.ubuntu.com articles, not admin.insights.ubuntu.com articles

## Issue / Card

Fixes #2840
