### PR TITLE
Update global nav version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "postcss-cli": "^4.1.0",
     "vanilla-framework": "1.6.3",
-    "global-nav": "^0.1.3"
+    "global-nav": "^0.2.2"
   },
   "dependencies": {
     "watch-cli": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,9 +1045,9 @@ glob@~3.1.21:
     inherits "1"
     minimatch "~0.2.11"
 
-global-nav@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.1.3.tgz#98b997bbd701ab00bfc53e37c17469d80c04b519"
+global-nav@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.2.2.tgz#fc72aa66739e1a161fbaed4c71bb56d077371314"
 
 globals@^9.2.0:
   version "9.18.0"


### PR DESCRIPTION
## Done

Update version of global nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that clicking on 'Ubuntu' in the main navigation goes to ubuntu.com 


## Issue / Card

[Fixes #235](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/235)
