### PR TITLE
Add initial copy for data protect section

### DIFF
--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -44,7 +44,7 @@
       </p>
 
       <h2>Data Protection Enquiries</h2>
-      <p>For any enquiry about how Canonical collects and processes personal data or for any other questions relating to privacy or data protection, please <a href="/legal/terms-and-policies/contact-us">submit an enquiry</a>. A member of our team will be in touch with you shortly. Alternatively please contact us on <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
+      <p>For any enquiry about how Canonical collects and processes personal data or for any other questions relating to privacy or data protection, please <a href="/legal/data-privacy-enquiry">submit an enquiry</a>. A member of our team will be in touch with you shortly. Alternatively please contact us on <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
     </div>
   </div>
 </section>

--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -42,6 +42,9 @@
       <p>
         To request an Ubuntu trademark licence, or to make any other trademark enquiry, please <a href="/legal/terms-and-policies/contact-us">submit an enquiry</a>. A member of our trademarks team will be in touch with you shortly.
       </p>
+
+      <h2>Data Protection Enquiries</h2>
+      <p>For any enquiry about how Canonical collects and processes personal data or for any other questions relating to privacy or data protection, please <a href="/legal/terms-and-policies/contact-us">submit an enquiry</a>. A member of our team will be in touch with you shortly. Alternatively please contact us on <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add new data protection enquiry copy to contact us page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/contact-us>
- Make sure 'Data Protection Enquiries' is present on page and matches [copy doc](https://docs.google.com/document/d/1v8mR0qE_AWVXBw0yQutdDaTmooodtMhc9dMzGqba4vg/edit#heading=h.duiqr4ih9y0w)


## Issue / Card
Fixes #2734 