### PR TITLE
Link to data protection page in footer

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -342,6 +342,8 @@ legal:
           path: /legal/terms-and-policies/livepatch-terms-of-service
         - title: JAAS terms
           path: /legal/terms-and-policies/jaas-beta-terms-of-service
+        - title: Data protection
+          path: /legal/data-protection
 
     - title: Ubuntu Advantage
       path: /legal/ubuntu-advantage

--- a/templates/legal/data-protection/index.html
+++ b/templates/legal/data-protection/index.html
@@ -1,0 +1,6 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Data protection | Ubuntu and Canonical Legal{% endblock %}
+
+{% block content %}
+{% endblock %}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -67,7 +67,7 @@
               <a class="p-link--soft" accesskey="8" href="/legal"><small>Legal information</small></a>
             </li>
             <li class="p-inline-list__item">
-              <a class="p-link--soft" accesskey="9" href="/legal/terms-and-policies/privacy-policy"><small>Cookie policy</small></a>
+              <a class="p-link--soft" accesskey="9" href="/legal/data-protection"><small>Data privacy</small></a>
             </li>
             <li class="p-inline-list__item">
               <a class="p-link--soft" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" id="report-a-bug"><small>Report a bug on this site</small></a>


### PR DESCRIPTION
## Done

- Add data protection page template
- Change cookie policy link in footer to data privacy link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that there is no longer a 'Cookie policy' link in the footer
- Check that there is a 'Data privacy' link in the footer
- Check that clicking on the 'Data privacy' link goes to the data protection page (this page currently has no content)


## Issue / Card

Fixes #2827
