### PR TITLE
Added Snap Enterprise Proxy to /iot/appstore

### DIFF
--- a/static/sass/_pattern_contribution.scss
+++ b/static/sass/_pattern_contribution.scss
@@ -1,8 +1,43 @@
 /// download-desktop-contribution page
 /* Contribute page */
 
-@mixin ubuntu-p-contribute {
+// Styling Cross-Browser Compatible Range Inputs with Sass
+// Based off Darlan Rob's solution:
+// https://github.com/darlanrod/input-range-sass
 
+// Default settings
+$range-thumb-radius: 4px !default;
+$range-thumb-height: 18px !default;
+$range-thumb-width: 18px !default;
+$range-thumb-shadow-size: 0 !default;
+$range-thumb-shadow-blur: 3px !default;
+$range-thumb-shadow-color: rgba(0,0,0,0.4) !default;
+$range-thumb-border-width: 0 !default;
+$range-thumb-border-color: transparent !default;
+$range-track-height: 4px !default;
+$range-track-radius: 2px !default;
+
+@mixin ubuntu-p-contribute {
+  @include ubuntu-p-contribute_details;
+}
+
+@mixin ubuntu-p-contribute_range-track {
+  height: $range-track-height;
+  cursor: pointer;
+  transition: all .2s ease;
+}
+
+@mixin ubuntu-p-contribute_range-thumb {
+  box-shadow: $range-thumb-shadow-size $range-thumb-shadow-size $range-thumb-shadow-blur $range-thumb-shadow-color, 0 0 $range-thumb-shadow-size lighten($range-thumb-shadow-color, 5%);
+  border: $range-thumb-border-width solid $range-thumb-border-color;
+  height: $range-thumb-height;
+  width: $range-thumb-width;
+  border-radius: $range-thumb-radius;
+  background: $color-x-light;
+  cursor: pointer;
+}
+
+@mixin ubuntu-p-contribute_details {
 
   .contribute {
     .no-js & {
@@ -158,22 +193,6 @@
   $range-track-height: 4px !default;
   $range-track-radius: 2px !default;
 
-  @mixin _range-track {
-    height: $range-track-height;
-    cursor: pointer;
-    transition: all .2s ease;
-  }
-
-  @mixin _range-thumb {
-    box-shadow: $range-thumb-shadow-size $range-thumb-shadow-size $range-thumb-shadow-blur $range-thumb-shadow-color, 0 0 $range-thumb-shadow-size lighten($range-thumb-shadow-color, 5%);
-    border: $range-thumb-border-width solid $range-thumb-border-color;
-    height: $range-thumb-height;
-    width: $range-thumb-width;
-    border-radius: $range-thumb-radius;
-    background: $color-x-light;
-    cursor: pointer;
-  }
-
   %input-range {
     -webkit-appearance: none;
     margin: $range-thumb-height / 2 0;
@@ -184,13 +203,13 @@
     }
 
     &::-webkit-slider-runnable-track {
-      @include _range-track;
+      @include  ubuntu-p-contribute_range-track;
       background: $color-brand;
       border-radius: $range-track-radius;
     }
 
     &::-webkit-slider-thumb {
-      @include _range-thumb;
+      @include  ubuntu-p-contribute_range-thumb;
       -webkit-appearance: none;
       margin-top: $range-track-height / 2 - $range-thumb-height / 2;
     }
@@ -200,17 +219,17 @@
     }
 
     &::-moz-range-track {
-      @include _range-track;
+      @include  ubuntu-p-contribute_range-track;
       background: $color-brand;
       border-radius: $range-track-radius;
     }
 
     &::-moz-range-thumb {
-      @include _range-thumb;
+      @include  ubuntu-p-contribute_range-thumb;
     }
 
     &::-ms-track {
-      @include _range-track;
+      @include  ubuntu-p-contribute_range-track;
       background: transparent;
       border-color: transparent;
       border-width: $range-thumb-width 0;
@@ -228,7 +247,7 @@
     }
 
     &::-ms-thumb {
-      @include _range-thumb;
+      @include  ubuntu-p-contribute_range-thumb;
     }
 
     &:focus::-ms-fill-lower {

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -189,20 +189,40 @@
 
 <section class="p-strip--light is-deep">
   <div class="row">
+    <div class="col-8">
+      <h2>Enterprise support for IoT app stores</h2>
+      <p>Many enterprises and device manufacturers depend on Canonical’s freely available IoT app store to distribute software onto their devices in the field. Additionally, Canonical can provide commercial support plans for enterprises through Ubuntu Advantage.  And a Snap Enterprise Proxy for enterprises to control, speed updates and isolate their devices from the internet.</p>
+    </div>
+  </div>
+  <div class="row">
     <div class="u-equal-height">
-      <div class="col-7 equal-height__align-vertically">
-        <h2>Enterprise support for IoT app stores</h2>
-        <p>The public snap store is a freely available service delivered by Canonical. Many enterprises and device manufacturers depend on an IoT app store to distribute software onto their devices in the field.</p>
-        <p>Canonical offers commercial support plans for large enterprise deployments providing:</p>
+      <div class="col-6 p-card">
+        <h3>Commercial support</h3>
+        <p>
+          Canonical offers commercial support plans for large enterprise deployments providing
+        </p>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Private software repositories</li>
           <li class="p-list__item is-ticked">Guaranteed levels of service</li>
           <li class="p-list__item is-ticked">Enterprise proxy functionalities</li>
           <li class="p-list__item is-ticked">Own app ecosystem control and management</li>
+          <li class="p-list__item is-ticked">24/7 phone and web support</li>
+          <li class="p-list__item is-ticked">Access to our world-class technical team and library</li>
         </ul>
       </div>
-      <div class="col-5 u-align--right u-vertically-center u-hide--small">
-        <img src="{{ ASSET_SERVER_URL }}11da76f5-image-management.svg" style="width: 90%;" alt="" />
+      <div class="col-6 p-card">
+        <h3>Snap Enterprise Proxy</h3>
+        <p>
+          A proxy gives you all the benefits of an IoT app store with device, OS and application updates all within your firewall.
+        </p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Pin to specific version of software on your devices</li>
+          <li class="p-list__item is-ticked">Determine which devices connected to your proxy</li>
+          <li class="p-list__item is-ticked">Manage users allowed to override revisions</li>
+          <li class="p-list__item is-ticked">Maximised for bandwidth and speed</li>
+          <li class="p-list__item is-ticked">Devices only communicate with the proxy</li>
+          <li class="p-list__item is-ticked">The proxy security communicates with Canonical</li>
+        </ul>
       </div>
     </div>
   </div>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -191,7 +191,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Enterprise support for IoT app stores</h2>
-      <p>Many enterprises and device manufacturers depend on Canonical’s freely available IoT app store to distribute software onto their devices in the field. Additionally, Canonical can provide commercial support plans for enterprises through Ubuntu Advantage.  And a Snap Enterprise Proxy for enterprises to control, speed updates and isolate their devices from the internet.</p>
+      <p>Many enterprises and device manufacturers depend on Canonical’s freely available IoT app store to distribute software onto their devices in the field. Additionally, Canonical can provide commercial support plans for enterprises through Ubuntu Advantage. And a Snap Enterprise Proxy for enterprises to control, update and isolate their devices from the internet.</p>
     </div>
   </div>
   <div class="row">
@@ -199,7 +199,7 @@
       <div class="col-6 p-card">
         <h3>Commercial support</h3>
         <p>
-          Canonical offers commercial support plans for large enterprise deployments providing
+          Canonical offers commercial support plans for large enterprise deployments providing:
         </p>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Private software repositories</li>
@@ -216,12 +216,10 @@
           A proxy gives you all the benefits of an IoT app store with device, OS and application updates all within your firewall.
         </p>
         <ul class="p-list">
-          <li class="p-list__item is-ticked">Pin to specific version of software on your devices</li>
-          <li class="p-list__item is-ticked">Determine which devices connected to your proxy</li>
+          <li class="p-list__item is-ticked">Pin to a specific version of software on your devices</li>
+          <li class="p-list__item is-ticked">Determine which devices connect to your proxy</li>
           <li class="p-list__item is-ticked">Manage users allowed to override revisions</li>
-          <li class="p-list__item is-ticked">Maximised for bandwidth and speed</li>
-          <li class="p-list__item is-ticked">Devices only communicate with the proxy</li>
-          <li class="p-list__item is-ticked">The proxy security communicates with Canonical</li>
+          <li class="p-list__item is-ticked">Maximise bandwidth and speed by caching downloads</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added Snap Enterprise Proxy to /iot/appstore

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [appstore page](http://0.0.0.0:8001/internet-of-things/appstore)
- Compare to the [copy doc](https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit#)

## Issue / Card

Fixes #2846

## Screenshots

![image](https://user-images.githubusercontent.com/441217/37954416-9c0ac404-319d-11e8-81b0-d8b4a5e907fc.png)

