### PR TITLE
Remove intel section from partners page

### DIFF
--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -29,7 +29,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>What our partners are saying</h2>

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -61,21 +61,6 @@
 </div>
 </section>
 
-<section class="p-strip--dark is-deep is-bordered" style="background-color: #007cc5;">
-  <div class="row">
-    <div class="u-equal-height">
-      <div class="col-6 suffix-1">
-        <h2>Intel<sup>&reg;</sup> Compute Stick with&nbsp;Ubuntu</h2>
-        <p>Ubuntu is now being offered preloaded on the Intel Compute Stick which enables users to transform their display into a fully functional computer. Just plug the Intel Compute Stick into any HDMI TV or monitor and you're ready to work, play or access media.</p>
-        <p><a href="http://www.intel.com/content/www/us/en/compute-stick/intel-compute-stick.html" class="p-link--external">Learn more</a></p>
-      </div>
-      <div class="col-6 u-align--center">
-        <img src="{{ ASSET_SERVER_URL }}847fdd06-image-intelonastick-device.png" alt="Intel Compute Stick" />
-      </div>
-    </div>
-  </div>
-</section>
-
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
## Done

Remove intel section from partners page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/desktop/partners>
- Ensure 'Intel Compute with stick' section is removed as per [copy doc](https://docs.google.com/document/d/1b4pwQYVHm8-R5_Wqx5zj09Qn8QsrKt3JblteauspmKI/edit#)


## Issue / Card

Fixes #2855 
