### PR TITLE
Fix compact pull quote styling

### DIFF
--- a/static/sass/_pattern_pull_quotes.scss
+++ b/static/sass/_pattern_pull_quotes.scss
@@ -1,52 +1,43 @@
 @mixin ubuntu-p-pull-quote {
-  .p-pull-quote--accent {
-    @extend .p-pull-quote;
-
-    > p {
-      color: $color-x-light;
-    }
-
+  .p-pull-quote {
     > p:first-of-type::before,
-    > p:first-of-type::before,
-    > p:last-of-type::after,
     > p:last-of-type::after {
       color: $color-brand;
     }
-  }
 
-  .p-pull-quote--accent.is-compact,
-  .p-pull-quote.is-compact {
-    .p-pull-quote__item {
-      font-size: 1rem;
-      margin-bottom: 1.5rem;
-      margin-top: 0;
+    &.is-compact {
+      > p {
+        font-size: 1rem;
+        line-height: 1.5;
 
-      &:first-of-type::before,
-      &:last-of-type::after {
-        font-size: $sp-medium;
-        @media (min-width: $breakpoint-medium) {
+        &:first-of-type::before,
+        &:last-of-type::after {
           font-size: $sp-large;
+          @media (min-width: $breakpoint-medium) {
+            font-size: $sp-x-large;
+          }
         }
-        @media (min-width: $breakpoint-large) {
-          font-size: $sp-x-large;
+
+        &:first-of-type::before {
+          left: $sp-x-small;
+          @media (min-width: $breakpoint-medium) {
+            left: $sp-small;
+          }
+        }
+
+        &:last-of-type::after {
+          bottom: $sp-x-small;
+          @media (min-width: $breakpoint-medium) {
+            bottom: $sp-small;
+          }
+        }
+
+        .p-pull-quote__citation {
+          font-size: 1rem;
+          line-height: 1.15;
+          margin-top: 2rem;
         }
       }
-
-      &:first-of-type::before {
-        margin-left: -1.3rem;
-        padding-right: $sp-x-small;
-        top: 0;
-      }
-
-      &:last-of-type::after {
-        line-height: .4;
-      }
-    }
-
-    .p-pull-quote__citation {
-      font-size: 1rem;
-      line-height: 1.15;
-      margin-top: 2rem;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -151,14 +151,6 @@ abbr[title] {
   list-style-type: disc;
 }
 
-// XXX orange quotes in pull quotes
-.p-pull-quote > p:first-of-type::before,
-.p-pull-quote--accent > p:first-of-type::before,
-.p-pull-quote > p:last-of-type::after,
-.p-pull-quote--accent > p:last-of-type::after {
-  color: $color-brand;
-}
-
 // XXX add to grahams section page when live
 // flex to flow charm list around
 .p-list-flex {

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -54,8 +54,8 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3>The Andalusian Regional Government, Spain</h3>
-      <blockquote class="p-pull-quote--accent is-compact">
-        <p class="p-pull-quote__item">Students throughout Andalusia now have access to a stable and easy-to-use technology environment.</p>
+      <blockquote class="p-pull-quote is-compact">
+        <p>Students throughout Andalusia now have access to a stable and easy-to-use technology environment.</p>
       </blockquote>
       <p><a href="https://insights.ubuntu.com/2010/03/13/andalusia-deploys-220000-ubuntu-desktops-in-schools-throughout-the-region/" class="p-link--external p-link--inverted">Read the <span class="u-off-screen">'The Andalusian Regional Government, Spain' </span>case study</a></p>
     </div>

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -46,7 +46,7 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--four">Carbonado Intermedia and Auteuristic</h3>
-      <blockquote class="p-pull-quote--accent is-compact">
+      <blockquote class="p-pull-quote is-compact">
         <p>We simply wouldn&rsquo;t be able to deliver our work as fast and cost-effectively as this with any other platform&hellip; Ubuntu gives us wings!</p>
       </blockquote>
       <p><a href="https://insights.ubuntu.com/2015/02/10/ubuntu-delivers-a-bulletproof-workstation-platform-for-media-productio/" class="p-link--external p-link--inverted">Read the <span class="u-off-screen">'Carbonado Intermedia and Auteuristic' </span>case study</a></p>

--- a/templates/desktop/government.html
+++ b/templates/desktop/government.html
@@ -57,14 +57,14 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h3>La Gendarmerie Nationale, France</h3>
-      <blockquote class="p-pull-quote--accent is-compact">
+      <blockquote class="p-pull-quote is-compact">
         <p class="p-pull-quote__item">We realised that Windows would cost us &euro;2 million more than Ubuntu every year.</p>
       </blockquote>
       <p><a class="p-link--inverted p-link--external" href="https://insights.ubuntu.com/2010/11/10/la-gendarmerie-nationale-upgrades-85000-pcs-to-ubuntu-desktop-edition/">Read the <span class="u-off-screen">'La Gendarmerie Nationale, France' </span>case study</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>City of Munich, Germany</h3>
-      <blockquote class="p-pull-quote--accent is-compact">
+      <blockquote class="p-pull-quote is-compact">
         <p class="p-pull-quote__item">Ubuntu satisfies our requirements best by combining the low costs and freedom of open source software with ongoing support.</p>
       </blockquote>
       <p><a class="p-link--inverted p-link--external" href="https://insights.ubuntu.com/2014/07/07/ubuntu-and-open-source-help-the-city-of-munich-save-millions/">Read the <span class="u-off-screen">'City of Munich, Germany'</span> case study</a></p>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -148,7 +148,7 @@
 <section class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-12">
-      <blockquote class="p-pull-quote--accent">
+      <blockquote class="p-pull-quote">
         <p>This new app store is much more than an easy way for Orange Pi owners to find and install great applications.</p>
         <p>The store offers Orange Pi developers a powerful set of tools to go much faster from development to production with CI integration, cross-platform building and beta distribution.</p>
         <cite class="p-pull-quote__citation">Steven Zhao, the CEO of Xunlong / Orange Pi</cite>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -60,7 +60,7 @@
 <div class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-12">
-      <blockquote class="p-pull-quote--accent">
+      <blockquote class="p-pull-quote">
         <p>Snaps allow developers to build and deploy applications in a format that&rsquo;s easily portable and upgradeable across a number of IoT devices so that a cognitive relationship between the cloud and the edges of the network can be established.</p>
         <cite class="p-pull-quote__citation">Mac Devine, IBM Vice President &amp; CTO of Emerging Technology &amp; Advanced Innovation</cite>
       </blockquote>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -25,7 +25,7 @@
 <div class="p-strip--accent is-bordered">
   <div class="row">
     <div class="col-10 prefix-1">
-      <blockquote class="p-pull-quote--accent">
+      <blockquote class="p-pull-quote">
         <p>I think that Ubuntu Core 16, with the ability to deploy ROS applications as snaps, offers an opportunity to make the whole software management process easier and more secure, helping developers and organisations in their robotics deployment.</p>
         <cite class="p-pull-quote__citation">Brian Gerkey, CEO, Open Source Robotics Foundation (OSRF)</cite>
       </blockquote>

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -63,7 +63,7 @@
 <div class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-12">
-      <blockquote class="p-pull-quote--accent u-no-margin--bottom">
+      <blockquote class="p-pull-quote">
         <p>A new wave of workloads demand breakthrough efficiencies in density, energy, and operational costs which can be scaled to a customer&rsquo;s IT environment</p>
         <cite class="p-pull-quote__citation">Paul Santeler, VP &amp; GM, Hyperscale Business Unit, HP</cite>
       </blockquote>

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -96,7 +96,7 @@
 <div class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-12">
-      <blockquote class="p-pull-quote--accent">
+      <blockquote class="p-pull-quote">
         <p>We&rsquo;re reinventing how we scale by becoming simpler and modular, similar to how applications have evolved in cloud data centers. Open source and OpenStack innovations represent a unique opportunity to meet these requirements and Canonical&rsquo;s cloud and open source expertise make them a good choice for AT&amp;T.</p>
         <cite class="p-pull-quote__citation">Toby Ford, Assistant Vice President of Cloud Technology, Strategy and Planning at AT&amp;T</cite>
       </blockquote>


### PR DESCRIPTION
## Vanilla 1.7.0 alpha bugs

## Done

- Fixed styling issues with pull quotes that had a custom `.is-compact` class
- Removed all instances of `p-pull-quote--accent` because Vanilla is smart enough now to determine when to make text white or black

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/education
- Check that there isn't a huge amount of space between lines in the pull quote paragraph text
- Check that the styling looks good on small, medium and large screens

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1680
