### PR TITLE
Fix styling issues with inline definition list

### DIFF
--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -155,20 +155,18 @@
 
 @mixin ubuntu-p-inline-definition-list {
   .p-inline-definition-list {
-    margin: 0;
-    padding: 0;
-
     &__title {
       border: 0;
       float: left;
-      font-size: $sp-medium;
-      font-weight: 400;
       margin: 0 $sp-medium 0 0;
-      padding: 0;
     }
 
     &__item {
       margin: 0;
+    }
+
+    + p {
+      margin-top: $sp-medium;
     }
   }
 }


### PR DESCRIPTION
## Vanilla 1.7.0 alpha bugs

## Done

- Fixed styling issues with custom `.p-inline-definition-list` class

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/cloud/training
- Check that the inline definition list looks good

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1678
