### PR TITLE
453 move ebook

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -33,8 +33,6 @@
   </div>
 </section>
 
-{% include "download/shared/_get_ebook_maas.html"%}
-
 <section class="p-strip is-deep is-bordered" id="instructions">
   <div class="row">
     <div class="col-12">
@@ -161,6 +159,8 @@
     </div>
   </div>
 </section>
+
+{% include "download/shared/_get_ebook_maas.html"%}
 
 {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_maas_experts" second_item="_maas-juju" third_item="_support" %}
 


### PR DESCRIPTION
## Done

Move ebook section to bottom of page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/server/provisioning>
- Make sure the ebook section is at the bottom of the page, above the contextual footer


## Issue / Card

Fixes #453
