### PR TITLE
Remove gnome from flavours page

### DIFF
--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -47,18 +47,12 @@
             <p class="p-matrix__desc">Mythbuntu is a standalone MythTV based PVR system. It can be a standalone system or integrated with an existing MythTV network.</p>
           </div>
         </li>
+
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}49e647f4-budgie-remix-logo-medium.svg" alt="Budgie icon">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://ubuntubudgie.org/">Ubuntu Budgie</a></h3>
             <p class="p-matrix__desc">Ubuntu Budgie provides the Budgie desktop environment which focuses on simplicity and elegance. It provides a traditional desktop metaphor based interface utilising a customisable panel based menu driven system.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}61f6a064-gnome.svg" alt="Ubuntu GNOME icon">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link--external" href="https://ubuntugnome.org/">Ubuntu GNOME</a></h3>
-            <p class="p-matrix__desc">Ubuntu GNOME uses GNOME Shell along with a plethora of applications from the GNOME Desktop Environment.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -68,7 +62,6 @@
             <p class="p-matrix__desc">The Ubuntu Kylin project is tuned to the needs of Chinese users, providing a thoughtful and elegant Chinese experience out-of-the-box.</p>
           </div>
         </li>
-
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}b89d0c93-mate.svg" alt="Ubuntu MATE icon">
           <div class="p-matrix__content">
@@ -76,6 +69,7 @@
             <p class="p-matrix__desc">Ubuntu MATE expresses the simplicity of a classic desktop environment. Ubuntu MATE is the continuation of the GNOME 2 desktop  which was Ubuntu's default desktop until October 2010.</p>
           </div>
         </li>
+
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}4a512076-ubuntustudio.svg" alt="Ubuntu Studio icon">
           <div class="p-matrix__content">
@@ -90,6 +84,7 @@
             <p class="p-matrix__desc">Xubuntu is an elegant and easy to use operating system. Xubuntu comes with Xfce, which is a stable, light and configurable desktop environment.</p>
           </div>
         </li>
+        <li class="p-matrix__item u-hide--small">&nbsp;</li>
       </ul>
       <p>A complete list of known flavours, editions and customizations is maintained on the <a href="https://wiki.ubuntu.com/DerivativeTeam/Derivatives">Ubuntu Wiki Derivatives Team page</a>.</p>
     </div>


### PR DESCRIPTION
## Done

Remove GNOME from flavours page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/flavours>
- Make sure GNOME isn't showing in the grid of flavours


## Issue / Card

Fixes #2904 
