### PR TITLE
Update release variables

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04.1" latest_release_eol='July 2019' lts_release_name="Zesty Zapus" lts_release="17.04" lts_release_full='17.04 LTS' lts_release_with_point="17.04.1" lts_release_full_with_point='17.04.1 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2022' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
+{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04" latest_release_eol='April 2023' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04" lts_release_full_with_point='18.04 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Queens" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ArtfulAardvark" latest_release='17.10' latest_release_with_point="17.10.1" latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 LTS' lts_release_with_point="16.04.4" lts_release_full_with_point='16.04.4 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
+{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04.1" latest_release_eol='July 2019' lts_release_name="Zesty Zapus" lts_release="17.04" lts_release_full='17.04 LTS' lts_release_with_point="17.04.1" lts_release_full_with_point='17.04.1 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2022' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

Update release variables for 18.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/desktop>
- Make sure download link for 18.04 is present on the page


## Issue / Card

Fixes # 2865
