### PR TITLE
Updated the kernel image and table for /info/release-end-of-life

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -149,7 +149,7 @@
   <div class="row">
     <div class="col-10">
       <div>
-        <img src="{{ ASSET_SERVER_URL }}100060c2-r-eol-ubuntu-kernel-2018-02-28.png" alt="" class="u-hide--small " />
+        <img src="{{ ASSET_SERVER_URL }}3a8a15fc-2018-04-10_kernel-end-of-life.jpg" alt="" class="u-hide--small " />
       </div>
       <table class="u-hide--medium u-hide--large ">
         <thead>
@@ -157,193 +157,135 @@
             <th>Release</th>
             <th>Released</th>
             <th>End of life</th>
+            <th>Extended customer support</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Ubuntu 18.04.5</td>
+            <td><strong>Ubuntu 18.04.5 LTS</strong></td>
             <td>August 2020</td>
             <td>April 2023</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 20.04</td>
+            <td><strong>Ubuntu 20.04 LTS</strong></td>
             <td>April 2020</td>
-            <td>January 2021</td>
+            <td>April 2025</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 18.04.4</td>
+            <td><strong>Ubuntu 18.04.4 LTS</strong></td>
             <td>February 2020</td>
-            <td>July 2020</td>
+            <td>August 2020</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 19.10</td>
             <td>October 2019</td>
             <td>July 2020</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 18.04.3</td>
+            <td><strong>Ubuntu 18.04.3 LTS</strong></td>
             <td>August 2019</td>
-            <td>January 2020</td>
+            <td>February 2020</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 19.04</td>
             <td>April 2019</td>
             <td>January 2020</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 18.04.2</td>
+            <td><strong>Ubuntu 18.04.2 LTS</strong></td>
             <td>February 2019</td>
-            <td>July 2019</td>
+            <td>August 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 18.10</td>
             <td>October 2018</td>
             <td>July 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 18.04.1 (v.4.15)</td>
+            <td><strong>Ubuntu 18.04.1 LTS (v.4.15)</strong></td>
             <td>July 2018</td>
             <td>April 2023</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 16.04.5 (v.4.15)</td>
+            <td><strong>Ubuntu 16.04.5 LTS (v.4.15)</strong></td>
             <td>August 2018</td>
             <td>April 2021</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 18.04.0 (v.4.15)</td>
+            <td><strong>Ubuntu 18.04.0 LTS (v.4.15)</strong></td>
             <td>April 2018</td>
             <td>April 2023</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 16.04.4 (v.4.13)</td>
+            <td><strong>Ubuntu 16.04.4 LTS (v.4.13)</strong></td>
             <td>February 2018</td>
             <td>August 2018</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 17.10</td>
+            <td>Ubuntu 17.10 (v4.13)</td>
             <td>October 2017</td>
             <td>July 2018</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 16.04.3 (v.4.10)</td>
-            <td>August 2017</td>
-            <td>February 2018</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 17.04</td>
-            <td>April 2017</td>
-            <td>January 2018</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 16.04.2 (v4.8)</td>
-            <td>February 2017</td>
-            <td>August 2017</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 16.10</td>
-            <td>October 2016</td>
-            <td>July 2017</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 16.04.1 (v4.4)</td>
+            <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
             <td>August 2016</td>
             <td>April 2021</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 14.04.5</td>
+            <td><strong>Ubuntu 14.04.5 LTS LTS (v3.13)</strong></td>
             <td>August 2016</td>
-            <td>May 2019</td>
+            <td>April 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 16.04.0 (v4.4)</td>
+            <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
             <td>April 2016</td>
             <td>April 2021</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 14.04.4 (v4.2)</td>
-            <td>February 2016</td>
-            <td>August 2016</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 15.10 (v4.2)</td>
-            <td>October 2015</td>
-            <td>October 2015</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 14.04.3 (v3.19)</td>
-            <td>August 2015</td>
-            <td>August 2016</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 15.04 (v3.19)</td>
-            <td>April 2015</td>
-            <td>January 2016</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 14.04.2 (v3.16)</td>
-            <td>February 2015</td>
-            <td>February 2016</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 14.10 (v3.16)</td>
-            <td>October 2010</td>
-            <td>July 2011</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 14.04.1 (v3.13)</td>
+            <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
             <td>August 2014</td>
-            <td>February 2016</td>
+            <td>April 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 12.04.5 (v3.13)</td>
+            <td><strong>Ubuntu 12.04.5 LTS (v3.13)</strong></td>
             <td>August 2014</td>
-            <td>May 2017</td>
+            <td>April 2017</td>
+            <td>April 2019</td>
           </tr>
           <tr>
-            <td>Ubuntu 14.04.0 (v3.13)</td>
+            <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
             <td>April 2014</td>
-            <td>March 2019</td>
+            <td>April 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 12.04.4 (v3.11)</td>
-            <td>February 2014</td>
-            <td>August 2014</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 13.10 (v3.11)</td>
-            <td>October 2010</td>
-            <td>July 2011</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 12.04.3 (v3.8)</td>
-            <td>August 2013</td>
-            <td>August 2014</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 13.04 (v3.8)</td>
-            <td>April 2013</td>
-            <td>January 2014</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 12.04.2 (v3.5)</td>
-            <td>February 2013</td>
-            <td>August 2014</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 12.10 (v3.5)</td>
-            <td>October 2012</td>
-            <td>April 2014</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 12.04.1 (v3.2)</td>
+            <td><strong>Ubuntu 12.04.1 LTS (v3.2)</strong></td>
             <td>August 2012</td>
             <td>April 2017</td>
+            <td>April 2019</td>
           </tr>
           <tr>
-            <td>Ubuntu 12.04.0 (v3.2)</td>
+            <td><strong>Ubuntu 12.04.0 LTS (v3.2)</strong></td>
             <td>April 2012</td>
             <td>April 2017</td>
+            <td>April 2019</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Done

- Updated the kernel image and table for /info/release-end-of-life

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [page](http://0.0.0.0:8001/info/release-end-of-life)
- compare to the [spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit?ts=5a95e390#gid=1712489059)

## Issue / Card

Fixes #2875

