### PR TITLE
Remove ebook section from server download thank you page

### DIFF
--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -35,8 +35,6 @@ Thanks for downloading Ubuntu Server
   </div>
 </div>
 
-{% include "download/shared/_get_ebook_maas.html"%}
-
 <div class="p-strip is-shallow">
   <div class="row">
     <div class="col-8">


### PR DESCRIPTION
## Done

Remove ebook section from server download thank you page.
Note: Variable change for Ubuntu Server guide link is addressed in [this PR](https://github.com/canonical-websites/www.ubuntu.com/pull/2911)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001//download/server/thank-you](http://0.0.0.0:8001//download/server/thank-you)
- Ensure that the ebook section is missing from the server download thank you page


## Issue / Card

Fixes #2920
