### PR TITLE
conform p-code-snippet instances to correct vanilla markup

### DIFF
--- a/templates/download/cloud/build-openstack.html
+++ b/templates/download/cloud/build-openstack.html
@@ -52,19 +52,19 @@
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Install MAAS</h3>
           <div class="p-list-step__content">
             <p>To install MAAS, start off on your Ubuntu Server 16.04 LTS machine and type the command below following the step-by-step instructions:</p>
-            <p class="p-code-snippet">
+            <div class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
-            </p>
-            <p class="p-code-snippet">
+            </div>
+            <div class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
-            </p>
+            </div>
             <p>Create your admin credentials and optionally import your SSH key by typing:</p>
-            <p class="p-code-snippet">
+            <div class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
-            </p>
+            </div>
             <p>Login to the MAAS UI at <code>http://&lt;maas.ip&gt;/MAAS/</code></p>
             <p>Fill in the details on the welcome page and import images for Ubuntu 14.04 LTS and 16.04 LTS. Importing images may take a while, but you can click &ldquo;continue&rdquo; as soon as it&rsquo;s started</p>
             <p>If you haven&rsquo;t imported your SSH key before, now is your chance to import one from Launchpad, GitHub or you can also upload it directly</p>
@@ -111,14 +111,14 @@
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Install and launch conjure-up</h3>
           <div class="p-list-step__content">
             <p>On the MAAS server, in a terminal window, install the conjure-up snap:</p>
-            <p class="p-code-snippet">
+            <div class="p-code-snippet">
               <input class="p-code-snippet__input" value="sudo snap install conjure-up --classic" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
-            </p>
-            <p class="p-code-snippet">
+            </div>
+            <div class="p-code-snippet">
               <input class="p-code-snippet__input" value="conjure-up" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
-            </p>
+            </div>
             <p>If successful you should see a screen as below:</p>
             <p>
               <a href="{{ ASSET_SERVER_URL }}b4a8693c-build-openstack-with-conjure-up-1.png">

--- a/templates/download/cloud/try-openstack.html
+++ b/templates/download/cloud/try-openstack.html
@@ -49,14 +49,14 @@
         <div class="p-list-step__content">
           <p>Getting OpenStack running on your computer is easy with conjure-up.</p>
           <p>From the command line type the commands below and follow the step-by-step instructions:</p>
-          <p class="p-code-snippet">
+          <div class="p-code-snippet">
             <input aria-label="code snippet" class="p-code-snippet__input" value="sudo snap install conjure-up --classic" readonly="readonly">
             <button class="p-code-snippet__action">Copy to clipboard</button>
-          </p>
-          <p class="p-code-snippet">
+          </div>
+          <div class="p-code-snippet">
             <input aria-label="code snippet" class="p-code-snippet__input" value="conjure-up" readonly="readonly">
             <button class="p-code-snippet__action">Copy to clipboard</button>
-          </p>
+          </div>
 
           <div class="p-notification--caution">
             <div class="p-notification__response">
@@ -66,21 +66,21 @@
               <p>
                 If above commands fail you’ll want to make sure snapd is installed on your system as it is not available in releases before Ubuntu 16.04 LTS or in the daily images from cdimage.ubuntu.com:
               </p>
-              <p class="p-code-snippet">
+              <div class="p-code-snippet">
                 <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt update && sudo apt upgrade" readonly="readonly">
                 <button class="p-code-snippet__action">Copy to clipboard</button>
-              </p>
-              <p class="p-code-snippet">
+              </div>
+              <div class="p-code-snippet">
                 <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt install snapd" readonly="readonly">
                 <button class="p-code-snippet__action">Copy to clipboard</button>
-              </p>
+              </div>
               <p>
                 Then relogin or run:
               </p>
-              <p class="p-code-snippet">
+              <div class="p-code-snippet">
                 <input aria-label="code snippet" class="p-code-snippet__input" value="source /etc/profile.d/apps-bin-path.sh" readonly="readonly">
                 <button class="p-code-snippet__action">Copy to clipboard</button>
-              </p>
+              </div>
               <p>
                 Now you can try installing conjure-up again.
               </p>

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -60,14 +60,14 @@
             Install MAAS
           </h3>
           <div class="p-list-step__content">
-            <p class="p-code-snippet">
+            <div class="p-code-snippet">
               <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
-            </p>
-            <p class="p-code-snippet">
+            </div>
+            <div class="p-code-snippet">
               <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
-            </p>
+            </div>
           </div>
         </li>
         <li class="p-list-step__item">
@@ -77,10 +77,10 @@
           </h3>
           <div class="p-list-step__content">
             <p>Create your admin credentials by typing.</p>
-            <p class="p-code-snippet">
+            <div class="p-code-snippet">
               <input aria-label="code snippet" class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
               <button class="p-code-snippet__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
-            </p>
+            </div>
             <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
           </div>
         </li>

--- a/templates/support/esm.html
+++ b/templates/support/esm.html
@@ -88,14 +88,14 @@
     <div class="col-8">
       <h2>How to enable ESM on your system</h2>
       <p>To enable ESM on your Ubuntu 12.04 systems, from the command line type the following commands and follow the step-by-step instructions:</p>
-      <p class="p-code-snippet">
+      <div class="p-code-snippet">
         <input class="p-code-snippet__input" value="sudo ubuntu-advantage enable-esm [ENTER TOKEN]" readonly="readonly">
         <button class="p-code-snippet__action">Copy to clipboard</button>
-      </p>
-      <p class="p-code-snippet">
+      </div>
+      <div class="p-code-snippet">
         <input class="p-code-snippet__input" value="sudo apt-get update" readonly="readonly">
         <button class="p-code-snippet__action">Copy to clipboard</button>
-      </p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Conform p-code-snippet instances to correct vanilla markup. 
Part of https://github.com/vanilla-framework/vanilla-framework/issues/1681
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
