### PR TITLE
Fix resources tab alignment

### DIFF
--- a/static/sass/_pattern_tabs.scss
+++ b/static/sass/_pattern_tabs.scss
@@ -3,16 +3,4 @@
     @extend .p-tabs__list;
     display: flex;
   }
-
-  .p-tabs__item--select {
-    @extend .p-tabs__item;
-    margin: 3px 0 3px auto;
-
-    @media screen and (max-width: $breakpoint-medium - 1) {
-      height: 0;
-      margin: 0;
-      visibility: hidden;
-      width: 0;
-    }
-  }
 }

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -29,7 +29,7 @@
       <li class="p-tabs__item" role="presentation">
         <a href="?topic=desktop{% if content_slug %}&content={{ content_slug }}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Resources', 'eventAction' : 'Navigation', 'eventLabel' : 'Desktop', 'eventValue' : undefined });" class="p-tabs__link" role="tab" aria-controls="section2"{% if topic_slug == 'desktop' %} aria-selected="true"{% endif %}>Desktop</a>
       </li>
-      <li class="p-tabs__item--select">
+      <li class="u-align--right u-hide--small">
         <form action="" method="get" class="p-form p-form--inline">
           <div class="p-form__group">
             <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter:</label>


### PR DESCRIPTION
## Done

- Removed bespoke `.p-tabs__item--select` class
- **Note:** this does not fix all styling errors in the tabs pattern, only the one caused by ubuntu.com's custom scss (vanilla-framework/vanilla-framework#1682)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/resources
- Check that the tabs sit on the baseline properly
- Check that the Filter select sits properly on medium + large screens, and appears under the tabs on small screens