### PR TITLE
Ubuntu flavours

### DIFF
--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -40,13 +40,6 @@
             <p class="p-matrix__desc">Lubuntu is a fast, energy saving and lightweight variant of Ubuntu using LXDE. It is popular with PC and laptop users running on low-spec hardware.</p>
           </div>
         </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}2a8f9030-mythbuntu.svg" alt="Mythbuntu icon">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link--external" href="http://www.mythbuntu.org/">Mythbuntu</a></h3>
-            <p class="p-matrix__desc">Mythbuntu is a standalone MythTV based PVR system. It can be a standalone system or integrated with an existing MythTV network.</p>
-          </div>
-        </li>
 
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}49e647f4-budgie-remix-logo-medium.svg" alt="Budgie icon">
@@ -84,6 +77,7 @@
             <p class="p-matrix__desc">Xubuntu is an elegant and easy to use operating system. Xubuntu comes with Xfce, which is a stable, light and configurable desktop environment.</p>
           </div>
         </li>
+        <li class="p-matrix__item u-hide--small">&nbsp;</li>
         <li class="p-matrix__item u-hide--small">&nbsp;</li>
       </ul>
       <p>A complete list of known flavours, editions and customizations is maintained on the <a href="https://wiki.ubuntu.com/DerivativeTeam/Derivatives">Ubuntu Wiki Derivatives Team page</a>.</p>


### PR DESCRIPTION
## Done

- Removed Mythbuntu from Ubuntu Flavours matrix.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/flavours
- Check the page matches the [copydoc](https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit#)


## Issue / Card

Fixes: #2930 

