### PR TITLE
1675: Fix styling issues with bespoke heading + icon markup/scss

### DIFF
--- a/static/sass/_pattern_heading-icon.scss
+++ b/static/sass/_pattern_heading-icon.scss
@@ -1,0 +1,22 @@
+@mixin ubuntu-p-heading-icon {
+  .p-heading-icon--muted {
+
+    .p-heading-icon__header {
+      margin-bottom: map-get($sp-after, small) - map-get($nudges, nudge--small);
+    }
+
+    .p-heading-icon__title {
+      @extend %muted-heading;
+      align-items: center;
+      display: flex;
+      line-height: 1.875rem;
+      margin-bottom: 0;
+    }
+  }
+
+  .p-heading-icon__img--small {
+    align-self: center;
+    height: auto;
+    max-width: 2rem;
+  }
+}

--- a/static/sass/_pattern_link.scss
+++ b/static/sass/_pattern_link.scss
@@ -6,7 +6,7 @@
   h5,
   h6 {
     &.p-link--external {
-      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left .2em no-repeat;
+      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left .75em no-repeat;
       background-size: .85em;
       padding-left: 1em;
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -26,6 +26,7 @@
 @import 'pattern_contribution';
 @import 'pattern_inline-images';
 @import 'pattern_testimonials';
+@import 'pattern_heading-icon';
 @import 'pattern_hero';
 @import 'pattern_pull_quotes';
 @import 'utility_full-width';
@@ -52,6 +53,7 @@
 @include ubuntu-p-contribute;
 @include ubuntu-p-inline-images;
 @include ubuntu-p-testimonials;
+@include ubuntu-p-heading-icon;
 @include ubuntu-p-hero;
 @include ubuntu-p-pull-quote;
 @include ubuntu-u-full-width;
@@ -114,8 +116,7 @@ abbr[title] {
 }
 
 .p-heading--insights__title {
-  color: $color-dark;
-  font-size: $sp-medium;
+  @extend %vf-heading-5;
   font-weight: 300;
   text-transform: uppercase;
 
@@ -183,17 +184,6 @@ abbr[title] {
 .u-no-background--small {
   @media (max-width: $breakpoint-medium) {
     background-image: none !important;
-  }
-}
-
-/// XXX Muted icon headers
-.p-heading-icon {
-  &__img--small {
-    max-width: 30px;
-  }
-
-  &__title--muted {
-    color: $color-mid-dark;
   }
 }
 

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -64,30 +64,30 @@
     <h2>Resources</h2>
     <div class="p-divider">
       <div class="col-4 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+            <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Why private open cloud makes financial&nbsp;sense</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/QTS_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Learn why Private Open Cloud Makes Financial Sense', 'eventValue' : undefined });">Why private open cloud makes financial&nbsp;sense</a></h3>
         </div>
       </div>
       <div class="col-4 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+            <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Cloudbase-webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Run Windows workloads on BootStack', 'eventValue' : undefined });">Run Windows workloads on BootStack</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Cloudbase-webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Run Windows workloads on BootStack', 'eventValue' : undefined });">Run Windows workloads on BootStack</a></h3>
         </div>
       </div>
       <div class="col-4 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}3769b4a7-webinar-icon.svg" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+            <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Supermicro_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Build a hyperconverged cloud with BootStack and Supermicro', 'eventValue' : undefined });">Hyperconverged cloud with BootStack and&nbsp;Supermicro</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Supermicro_webinar.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Watch the webinar Build a hyperconverged cloud with BootStack and Supermicro', 'eventValue' : undefined });">Hyperconverged cloud with BootStack and&nbsp;Supermicro</a></h3>
         </div>
       </div>
     </div>

--- a/templates/desktop/1710.html
+++ b/templates/desktop/1710.html
@@ -138,31 +138,31 @@
 <section class="p-strip--light is-deep is-bordered">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}908ee6a0-help.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Help</h3>
+          <h3 class="p-heading-icon__title">Help</h3>
         </div>
       </div>
-      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://launchpad.net/ubuntu/artful/+bugs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : '1710 report bug', 'eventLabel' : 'Help make 18.04 better by raising bugs', 'eventValue' : undefined });">Help make 18.04 better by raising bugs</a></h2>
+      <h2 class="p-heading--four"><a class="p-link--external" href="https://launchpad.net/ubuntu/artful/+bugs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : '1710 report bug', 'eventLabel' : 'Help make 18.04 better by raising bugs', 'eventValue' : undefined });">Help make 18.04 better by raising bugs</a></h2>
     </div>
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Article</h3>
+          <h3 class="p-heading-icon__title">Article</h3>
         </div>
       </div>
-      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/12/ubuntu-desktop-gnome-extensions-poll-results/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventLabel' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventValue' : undefined });">The making of 17.10 &mdash; Choosing your preferred GNOME Extensions</a></h2>
+      <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/12/ubuntu-desktop-gnome-extensions-poll-results/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventLabel' : 'The making of 17.10 - Choosing your preferred GNOME Extensions', 'eventValue' : undefined });">The making of 17.10 &mdash; Choosing your preferred GNOME Extensions</a></h2>
     </div>
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5913cd4c-visit-site-icon.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">News</h3>
+          <h3 class="p-heading-icon__title">News</h3>
         </div>
       </div>
-      <h2 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Stay in touch with the latest Ubuntu desktop news', 'eventLabel' : 'Stay in touch with the latest Ubuntu desktop news', 'eventValue' : undefined });">Stay in touch with the latest Ubuntu desktop news</a></h2>
+      <h2 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Stay in touch with the latest Ubuntu desktop news', 'eventLabel' : 'Stay in touch with the latest Ubuntu desktop news', 'eventValue' : undefined });">Stay in touch with the latest Ubuntu desktop news</a></h2>
     </div>
   </div>
 </section>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -42,15 +42,15 @@
     <div class="col-12">
       <h2>Resources</h2>
     </div>
-    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+    <div class="p-strip is-shallow row u-equal-height">
       <div class="col-8">
-        <div class="p-heading-icon u-no-margin--bottom">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+            <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
         </div>
-        <h3 class="u-no-margin--top">Hybrid cloud and financial services: How to compete on the cloud</h3>
+        <h3>Hybrid cloud and financial services: How to compete on the cloud</h3>
         <p>Learn how to keep up with the pace of change as you adopt new development methodologies, new technologies and new infrastructure.</p>
         <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/290063" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch now on demand', 'eventLabel' : 'Hybrid cloud and financial services: How to compete on the cloud', 'eventValue' : undefined });">Watch now on demand</a></p>
       </div>
@@ -59,15 +59,15 @@
       </div>
     </div>
     <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+    <div class="p-strip is-shallow row u-equal-height">
       <div class="col-8">
-        <div class="p-heading-icon u-no-margin--bottom">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Article</h4>
+            <h4 class="p-heading-icon__title">Article</h4>
           </div>
         </div>
-        <h3 class="u-no-margin--top">Bloomberg&rsquo;s OpenStack deployment</h3>
+        <h3>Bloomberg&rsquo;s OpenStack deployment</h3>
         <p>Find out why Bloomberg chooses Ubuntu-based OpenStack to handle customisation and integration with their internal systems.</p>
         <p><a class="p-link--external" href="http://superuser.openstack.org/articles/openstack-at-bloomberg/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read article', 'eventLabel' : 'Bloomberg’s OpenStack deployment', 'eventValue' : undefined });">Read article</a></p>
       </div>
@@ -76,15 +76,15 @@
       </div>
     </div>
     <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+    <div class="p-strip is-shallow row u-equal-height">
       <div class="col-8">
-        <div class="p-heading-icon u-no-margin--bottom">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h4>
+            <h4 class="p-heading-icon__title">Whitepaper</h4>
           </div>
         </div>
-        <h3 class="u-no-margin--top">Accelerate your business with containers</h3>
+        <h3>Accelerate your business with containers</h3>
         <p>Discover how Linux container technologies offer control and flexible provisioning while driving greater density, efficiency and manageability, without additional hardware or infrastructure investment.</p>
         <p><a class="p-link--external" href="https://insights.ubuntu.com/2017/02/27/the-no-nonsense-way-to-accelerate-your-business-with-containers/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download whitepaper', 'eventLabel' : 'Accelerate your business with containers', 'eventValue' : undefined });">Download whitepaper</a></p>
       </div>
@@ -93,15 +93,15 @@
       </div>
     </div>
     <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-margin--top">
+    <div class="p-strip is-shallow row u-equal-height">
       <div class="col-8">
-        <div class="p-heading-icon u-no-margin--bottom">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" alt="" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h4>
+            <h4 class="p-heading-icon__title">Case study</h4>
           </div>
         </div>
-        <h3 class="u-no-margin--top">OpenStack in the financial services sector</h3>
+        <h3>OpenStack in the financial services sector</h3>
         <p>Read about how Canonical ensured that City Network stood out from the crowd thanks to superb service quality and a unique focus on industry-specific regulatory compliance.</p>
         <p><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the case study', 'eventLabel' : 'OpenStack in the financial services sector', 'eventValue' : undefined });">Read the case study</a></p>
       </div>
@@ -120,23 +120,23 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}623e36f9-OpenStack_Logo_Mark+%281%29.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">OpenStack</h3>
+          <h3 class="p-heading-icon__title">OpenStack</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/openstack">As the number one platform for OpenStack, Canonical supports private and public clouds, at volume and at scale&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
-            <h3 class="p-heading-icon__title  p-heading--four">Kubernetes</h3>
+            <h3 class="p-heading-icon__title">Kubernetes</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/kubernetes">Canonical provides enterprise-calibre support for Kubernetes&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -144,23 +144,23 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}0de4fcd5-logo-maas-icon.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Server provisioning</h3>
+          <h3 class="p-heading-icon__title">Server provisioning</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/server">Use MAAS for automated and optimised provisioning for your production hardware&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Live automatic security fixes</h3>
+          <h3 class="p-heading-icon__title">Live automatic security fixes</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/server/livepatch">Use Livepatch for automatic kernel security hotfixes without rebooting&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -176,23 +176,23 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" alt="" />
-          <h3 class="p-heading-icon__title p-heading--four">Consultation services</h3>
+          <h3 class="p-heading-icon__title">Consultation services</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/cloud/foundation-cloud">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" style="max-height:30px;max-width: 50px;margin-top:9px;" />
-          <h3 class="p-heading-icon__title  p-heading--four">Managed cloud services</h3>
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" style="max-width: 3rem;" />
+          <h3 class="p-heading-icon__title">Managed cloud services</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/cloud/managed-cloud">The BootStack service for a managed cloud operated for you to the highest standards&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -200,23 +200,23 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Managed Kubernetes services</h3>
+          <h3 class="p-heading-icon__title">Managed Kubernetes services</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/kubernetes/managed">With the managed Kubernetes service, Canonical will set-up and operate your Kubernetes cluster for you&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
     <div class="col-6 p-card">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}e60711e6-pictogram-support-orange.svg" alt="" />
-          <h3 class="p-heading-icon__title  p-heading--four">Support</h3>
+          <h3 class="p-heading-icon__title">Support</h3>
         </div>
-        <p style="margin-top: 1rem;">
+        <p>
           <a href="/support">24-hour support services with FIPS certification for compliance requirements&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -228,7 +228,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <p class="p-heading--three">Talk to us about how Canonical can help you build a secure, agile infrastructure designed for scale.</p>
-      <p style="margin-top: 2rem;"><a href="/contact-us" class="p-button">Contact us</a></p>
+      <p><a href="/contact-us" class="p-button">Contact us</a></p>
     </div>
     <div class="col-4 prefix-1 suffix-1 u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" class="u-hide--small" alt="" />

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -38,37 +38,37 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Webinar</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h3>
       <!-- rtp section end -->
     </div>
 
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Webinar</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Data-triggered content and 4G base stations</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/211999?utm_source=ubuntuweb&amp;utm_medium=dspageboldmindbox&amp;utm_campaign=DSwebinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Data-triggered content and 4G base stations', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Data-triggered content and 4G base stations</a></h3>
       <!-- rtp section end -->
     </div>
 
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-digital-signage_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Case study</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspag' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });'><span hidden>Read the case study </span>Open Source Digital Signage with Ubuntu</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/FY17DS-WebForm_RiseVisionCaseStudy.html?from=dspag' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Open Source Digital Signage with Ubuntu', 'eventValue' : '1' });'><span hidden>Read the case study </span>Open Source Digital Signage with Ubuntu</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -32,35 +32,35 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Case study</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/AzetiCS.html?campaign=Device_FY17_IOT&amp;medium=edgegatewaycontentblock&amp;source=ubuntuwebsite&amp;content=azeticasestudy' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - left', 'eventLabel' : 'Case study - Azeti uses Ubuntu Core to improve deployment operations and security', 'eventValue' : '1' });'><span hidden>Read the case study </span>Azeti uses Ubuntu Core to improve deployment operations and security</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AzetiCS.html?campaign=Device_FY17_IOT&amp;medium=edgegatewaycontentblock&amp;source=ubuntuwebsite&amp;content=azeticasestudy' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - left', 'eventLabel' : 'Case study - Azeti uses Ubuntu Core to improve deployment operations and security', 'eventValue' : '1' });'><span hidden>Read the case study </span>Azeti uses Ubuntu Core to improve deployment operations and security</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Webinar</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - center', 'eventLabel' : 'Webinar - Watch CloudPlugs define Industry 4.0', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Watch CloudPlugs define Industry 4.0</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - center', 'eventLabel' : 'Webinar - Watch CloudPlugs define Industry 4.0', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Watch CloudPlugs define Industry 4.0</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-gateways_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>White paper</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>White paper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'White paper - The Eclipse IoT Working Group outlines the three required software stacks', 'eventValue' : '1' });'><span hidden>Read the white paper </span>The Eclipse IoT Working Group outlines the three required software stacks</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'White paper - The Eclipse IoT Working Group outlines the three required software stacks', 'eventValue' : '1' });'><span hidden>Read the white paper </span>The Eclipse IoT Working Group outlines the three required software stacks</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -42,35 +42,35 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Case study</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/AerolionCS.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - left', 'eventLabel' : 'Case study - Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places', 'eventValue' : '1' });'><span hidden>Read the case study </span>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/AerolionCS.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - left', 'eventLabel' : 'Case study - Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places', 'eventValue' : '1' });'><span hidden>Read the case study </span>Tunnel Drones &mdash; Aerolion provides easy access to inaccessible places</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Article</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Article</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/09/07/welcoming-the-parrot-s-l-a-m-dunk-the-new-drone-development-kit/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'robotics - center', 'eventLabel' : 'Article - S.L.A.M.dunk, the new drone development kit from Parrot', 'eventValue' : '1' });'><span hidden>Read the article </span>S.L.A.M.dunk, the new drone development kit from Parrot</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Article</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Article</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'Article - ROScon &mdash; the robotics conference for developers and entrepreneurs', 'eventValue' : '1' });'><span hidden>Read the article </span>ROScon &mdash; the robotics conference for developers and entrepreneurs</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='http://insights.ubuntu.com/2016/10/05/roscon-the-robotics-conference-for-developers/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'Article - ROScon &mdash; the robotics conference for developers and entrepreneurs', 'eventValue' : '1' });'><span hidden>Read the article </span>ROScon &mdash; the robotics conference for developers and entrepreneurs</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -163,31 +163,31 @@
 <section class="p-strip--light is-deep is-bordered">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-          <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+          <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
-      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/09/webinar-how-to-get-started-with-your-kubernetes-strategy/?_ga=2.160429757.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'How to get started with your Kubernetes strategy', 'eventValue' : undefined });">How to get started with your Kubernetes strategy</a></h3>
+      <h3 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/06/09/webinar-how-to-get-started-with-your-kubernetes-strategy/?_ga=2.160429757.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'How to get started with your Kubernetes strategy', 'eventValue' : undefined });">How to get started with your Kubernetes strategy</a></h3>
     </div>
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-          <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+          <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
-      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
+      <h3 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
     </div>
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon u-no-margin--bottom">
-        <div class="p-heading-icon__header u-no-margin--bottom">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
           <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" />
-          <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h4>
+          <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>
-      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/02/27/the-no-nonsense-way-to-accelerate-your-business-with-containers/?_ga=2.164082367.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
+      <h3 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/02/27/the-no-nonsense-way-to-accelerate-your-business-with-containers/?_ga=2.164082367.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -113,31 +113,31 @@
     <div class="row">
       <div class="row p-divider">
         <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Datasheet</h4>
+              <h4 class="p-heading-icon__title">Datasheet</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
         </div>
         <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+              <h4 class="p-heading-icon__title">Webinar</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the Enterprise', 'eventLabel' : 'Resources - Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://insights.ubuntu.com/2017/09/07/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the Enterprise', 'eventLabel' : 'Resources - Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
         </div>
         <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h4>
+              <h4 class="p-heading-icon__title">Whitepaper</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The no-nonsense way to accelerate your business with containers', 'eventLabel' : 'Resources - The no-nonsense way to accelerate your business with containers ', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'The no-nonsense way to accelerate your business with containers', 'eventLabel' : 'Resources - The no-nonsense way to accelerate your business with containers ', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
         </div>
       </div>
     </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -187,35 +187,35 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_security_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Article</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Article</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://insights.ubuntu.com/2016/12/08/ubuntu-16-04-lts-security-a-comprehensive-overview/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - left', 'eventLabel' : 'Article - Ubuntu 16.04 LTS Security: A Comprehensive Overview', 'eventValue' : '1' });'><span hidden>Read the article </span>Ubuntu 16.04 LTS Security: A Comprehensive Overview</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2016/12/08/ubuntu-16-04-lts-security-a-comprehensive-overview/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - left', 'eventLabel' : 'Article - Ubuntu 16.04 LTS Security: A Comprehensive Overview', 'eventValue' : '1' });'><span hidden>Read the article </span>Ubuntu 16.04 LTS Security: A Comprehensive Overview</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_security_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>White paper</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>White paper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://pages.ubuntu.com/IoT-Security-whitepaper.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - center', 'eventLabel' : 'White paper - Read IoT Security Whitepaper', 'eventValue' : '1' });'><span hidden>Read the white paper </span>IoT Security Whitepaper</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/IoT-Security-whitepaper.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - center', 'eventLabel' : 'White paper - Read IoT Security Whitepaper', 'eventValue' : '1' });'><span hidden>Read the white paper </span>IoT Security Whitepaper</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_security_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>FAQ</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>FAQ</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://insights.ubuntu.com/2017/04/11/faqs-ensuring-the-ongoing-security-compliance-of-ubuntu/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'FAQ - Ensuring the ongoing security compliance of Ubuntu', 'eventValue' : '1' });'><span hidden>Read FAQ </span>Ensuring the ongoing security compliance of Ubuntu</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2017/04/11/faqs-ensuring-the-ongoing-security-compliance-of-ubuntu/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'FAQ - Ensuring the ongoing security compliance of Ubuntu', 'eventValue' : '1' });'><span hidden>Read FAQ </span>Ensuring the ongoing security compliance of Ubuntu</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/server/maas/index.html
+++ b/templates/server/maas/index.html
@@ -84,31 +84,31 @@
     <h2>Learn about MAAS</h2>
     <div class="row p-divider">
       <div class="col-4 p-divider__block">
-        <div class="p-heading-icon u-no-margin--bottom">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h4>
+            <h4 class="p-heading-icon__title">Ebook</h4>
           </div>
         </div>
-        <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Download the eBook - What you need to know about server provisioning', 'eventValue' : undefined });">What you need to know about server provisioning</a></h3>
+        <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Download the eBook - What you need to know about server provisioning', 'eventValue' : undefined });">What you need to know about server provisioning</a></h3>
       </div>
       <div class="col-4 p-divider__block">
-        <div class="p-heading-icon u-no-margin--bottom">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Video</h4>
+            <h4 class="p-heading-icon__title">Video</h4>
           </div>
         </div>
-        <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?source=maas_page&medium=Banner&campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the video - Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h3>
+        <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/install-maas.html?source=maas_page&medium=Banner&campaign=MAAS_videos&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the video - Learn how to install MAAS on your server', 'eventValue' : undefined });">Learn how to install MAAS on your server</a></h3>
       </div>
       <div class="col-4 p-divider__block">
-        <div class="p-heading-icon u-no-margin--bottom">
-          <div class="p-heading-icon__header u-no-margin--bottom">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
             <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-            <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+            <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
         </div>
-        <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?source=maas_page&medium=Banner&campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the webinar - Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h3>
+        <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Register_Cloud-Ready_Servers_in_minutes.html?source=maas_page&medium=Banner&campaign=MAAS_webinar&" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Server provisioning', 'eventLabel' : 'Watch the webinar - Get cloud-ready servers in minutes with MAAS ', 'eventValue' : undefined });">Get cloud-ready servers in minutes with MAAS </a></h3>
       </div>
     </div>
   </div>

--- a/templates/shared/_resources_openstack.html
+++ b/templates/shared/_resources_openstack.html
@@ -2,31 +2,31 @@
       <h2>Learn more about Openstack</h2>
       <div class="row p-divider">
         <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" alt="" />
-              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Webinar</h4>
+              <h4 class="p-heading-icon__title">Webinar</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'How to upgrade your OpenStack cloud easily without downtime', 'eventValue' : undefined });">How to upgrade your OpenStack cloud easily without downtime</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&amp;utm_medium=link&amp;utm_campaign=FY18_Cloud_StuckStack_WBN&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Upgrade your OpenStack', 'eventLabel' : 'How to upgrade your OpenStack cloud easily without downtime', 'eventValue' : undefined });">How to upgrade your OpenStack cloud easily without downtime</a></h3>
         </div>
         <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
+          <div class="p-heading-icon--muted">
             <div class="p-heading-icon__header u-no-margin--bottom">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" alt="" />
-              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Case study</h4>
+              <h4 class="p-heading-icon__title">Case study</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping satisfy City Network customers', 'eventValue' : undefined });">Hear how Ubuntu is helping satisfy City Network customers</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Customer satisfaction', 'eventLabel' : 'Hear how Ubuntu is helping satisfy City Network customers', 'eventValue' : undefined });">Hear how Ubuntu is helping satisfy City Network customers</a></h3>
         </div>
         <div class="col-4 p-divider__block">
-          <div class="p-heading-icon u-no-margin--bottom">
-            <div class="p-heading-icon__header u-no-margin--bottom">
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" alt="" />
-              <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Ebook</h4>
+              <h4 class="p-heading-icon__title">Ebook</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to profiting from your OpenStack investment', 'eventValue' : undefined });">Our guide to profiting from your OpenStack investment</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/ebook_StuckStack.html?utm_source=Insights&amp;utm_medium=blog&amp;" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Escaping StuckStack', 'eventLabel' : 'Our guide to profiting from your OpenStack investment', 'eventValue' : undefined });">Our guide to profiting from your OpenStack investment</a></h3>
         </div>
       </div>
     </div>

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -178,35 +178,35 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_telco_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Whitepaper</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://insights.ubuntu.com/2016/06/15/special-report-low-latency-and-real-time-kernels-for-telco-and-nfv/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Telco - left', 'eventLabel' : 'Whitepaper - Read our report on low latency and real-time kernels for telco and NFV', 'eventValue' : '1' });'>Read our report on low latency and real-time kernels for telco and NFV</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2016/06/15/special-report-low-latency-and-real-time-kernels-for-telco-and-nfv/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Telco - left', 'eventLabel' : 'Whitepaper - Read our report on low latency and real-time kernels for telco and NFV', 'eventValue' : '1' });'>Read our report on low latency and real-time kernels for telco and NFV</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_telco_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Webinar</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://insights.ubuntu.com/2017/03/16/webinar-learn-the-secrets-to-innovative-and-scalable-vnf-deployment/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Telco - center', 'eventLabel' : 'Webinar - Learn the secrets to innovative and scalable VNF deployment', 'eventValue' : '1' });'>Learn the secrets to innovative and scalable VNF deployment</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2017/03/16/webinar-learn-the-secrets-to-innovative-and-scalable-vnf-deployment/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Telco - center', 'eventLabel' : 'Webinar - Learn the secrets to innovative and scalable VNF deployment', 'eventValue' : '1' });'>Learn the secrets to innovative and scalable VNF deployment</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_telco_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h4 class='p-heading-icon__title p-heading-icon__title--muted p-muted-heading'>Ebook</h4>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h4 class='p-heading-icon__title'>Ebook</h4>
         </div>
       </div>
-      <h3 class='p-heading--four u-no-margin--top'><a class='p-link--external' href='https://insights.ubuntu.com/2016/05/16/ebook-ctos-guide-to-sdn-nfv-vnf/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'Telco - right', 'eventLabel' : 'Ebook - CTO’s guide to SDN, NFV and VNF', 'eventValue' : '1' });'><span hidden>Read the ebook </span>CTO’s guide to SDN, NFV and VNF</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2016/05/16/ebook-ctos-guide-to-sdn-nfv-vnf/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'Telco - right', 'eventLabel' : 'Ebook - CTO’s guide to SDN, NFV and VNF', 'eventValue' : '1' });'><span hidden>Read the ebook </span>CTO’s guide to SDN, NFV and VNF</a></h3>
       <!-- rtp section end -->
     </div>
   </div>


### PR DESCRIPTION
## Done

- Split out custom `.p-heading-icon` modifiers into their own file, and updated to work with new Vanilla spacing
- Updated markup where bespoke heading icon classes were used to remove unnecessary utilities
- Updated `.p-heading--insights__title` to work with new Vanilla spacing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that the styling of the Insights strip looks good
- Go to http://0.0.0.0:8001/financial-services
- Check that the muted heading icons look good (e.g. Webinar, Article etc)
- Check that the small heading icons look good (e.g. "Products for the finance industry" strip)

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1675
