### PR TITLE
Remove margin-bottom from resources card header

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -47,6 +47,10 @@
   %resources-card-header {
     border-radius: 2px;
     padding: .875rem $sp-medium;
+
+    > .p-muted-heading {
+      margin-bottom: 0;
+    }
   }
 
   .p-card--resources {


### PR DESCRIPTION
## Done

- Removed margin-bottom from p-muted-heading inside a resources card

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/resources
- Check that the cards don't have a huge empty space in the header

