### PR TITLE
Update /desktop/partners page for 18.04

### DIFF
--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -11,20 +11,11 @@
       <div class="col-7">
         <h1>Ubuntu for partners</h1>
         <p>We partner with the world&rsquo;s leading hardware manufacturers and silicon vendors to help deliver an extensive range of Ubuntu certified desktops, notebooks and servers. Becoming a partner means you work with our engineering and certification teams to guarantee the compatibility and optimised performance of all your hardware for the life of the OS.</p>
-        <p><a href="http://partners.ubuntu.com/programmes/hardware" class="p-link--external">Learn more about becoming a partner</a></p>
+        <p><a href="https://partners.ubuntu.com/find-a-partner" class="p-link--external">Learn more about our desktop partners</a></p>
       </div>
       <div class="col-5 u-align--center">
         <img src="{{ ASSET_SERVER_URL }}3ba54a27-picto-contact-midaubergine.svg" class="u-hide--small" width="200" alt="" />
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      {% include "shared/_partner-logos.html" with title="A selection of our desktop partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" feed_item_limit=10 %}
-      <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?service-offered=hardware-manufacturer" class="p-link--external">See all of our desktop partners</a></p>
     </div>
   </div>
 </section>
@@ -68,28 +59,18 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-4 p-heading-icon">
-      <div class="p-heading-icon__header">
-        <img src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg" class="p-heading-icon__img u-hide--small" alt="" />
-        <h3 class="p-heading-icon__title">Supported by Canonical</h3>
-      </div>
+    <div class="col-4">
+      <h3>Supported by Canonical</h3>
       <p>Ubuntu is a free and open source platform. There are no royalties, only a per unit service fee covering the engineering certification, maintenance, quality assurance, third-party licensing fees and Canonical consulting costs.</p>
     </div>
-    <div class="col-4 p-heading-icon">
-      <div class="p-heading-icon__header">
-        <img src="{{ ASSET_SERVER_URL }}521def9c-picto-engineering-warmgrey.svg" class="p-heading-icon__img u-hide--small" alt="" />
-        <h3 class="p-heading-icon__title">A complete solution</h3>
-      </div>
+    <div class="col-4">
+      <h3>A complete solution</h3>
       <p>Engagements cover component and system enablement as well as certification. Engagements are structured with baseline volume commitments, volume-based pricing for service fees and minimal recurrent engineering. Ubuntu Desktop is a complete solution for OEMs and ODMs.</p>
     </div>
-    <div class="col-4 p-heading-icon">
-      <div class="p-heading-icon__header">
-        <img src="{{ ASSET_SERVER_URL }}423e9265-picto-upgrade-orange.svg" class="p-heading-icon__img u-hide--small" alt="" />
-        <h3 class="p-heading-icon__title">Ongoing support</h3>
-      </div>
+    <div class="col-4">
+      <h3>Ongoing support</h3>
       <p>The ability to update your devices is central to your security and long-term competitiveness. Canonical takes care of all security and critical bug fixes to the base platform offering and provides the infrastructure to support your update management strategy. Ubuntu has a world-class track record maintaining a secure and stable operating system.</p>
     </div>
-  </div>
   <div class="row">
     <div class="col-12">
       <p><a href="http://partners.ubuntu.com/programmes/hardware" class="p-link--external">Learn more about working with Canonical</a></p>
@@ -105,22 +86,7 @@
       <p><a class="p-link--external" href="https://certification.ubuntu.com">Learn more about Ubuntu Certified hardware&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}f1d1b842-desktop-overview-hardware.jpg" alt="Photo of laptop running Ubuntu" />
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--accent is-deep">
-  <div class="row">
-    <div class="col-6 suffix-1 u-align--center u-vertically-center">
-      <img class="u-responsive-image" src="{{ ASSET_SERVER_URL }}1ae6ed1d-image-tenders-with-ubuntu.svg" alt=""  />
-    </div>
-    <div class="col-6">
-      <h2>Considering buying new devices with Ubuntu?</h2>
-      <p>An increasing number of private and public entities are migrating to Ubuntu, as it offers a robust solution with equivalent performance to other proprietary systems but at a much lower cost. Canonical is ready to share best practices with organisations wishing to deploy Ubuntu.</p>
-      <p>We have extensive experience helping companies worldwide. We have registered global deployments of over two million computers. Canonical can help to meet this growing demand by supporting organisations who are inviting requests for tender.</p>
-      <p><a href="https://www.ubuntu.com/desktop/tenders/contact-us?product=desktop-partners" class="p-button--neutral">Contact us about your tender</a></p>
-      <p><a href="https://insights.ubuntu.com/2015/04/17/tendering-with-ubuntu/" class="p-link--external p-link--inverted">Learn more about tendering with Ubuntu</a></p>
+      <img src="{{ ASSET_SERVER_URL }}d9105909-Dell_XPS_Laptop_Left-Desktop.png" alt="Photo of laptop running Ubuntu" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated Partners page to match [copydoc](https://docs.google.com/document/d/1b4pwQYVHm8-R5_Wqx5zj09Qn8QsrKt3JblteauspmKI/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/partners](http://0.0.0.0:8001//desktop/partners)
- Check if the page matches the [copydoc](https://docs.google.com/document/d/1b4pwQYVHm8-R5_Wqx5zj09Qn8QsrKt3JblteauspmKI/edit#)


## Issue / Card

Fixes: #2882 
