### PR TITLE
Fix styles of bottom section of manage cloud page

### DIFF
--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -377,40 +377,48 @@
       <h2>Shape it to your needs</h2>
     </div>
   </div>
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Hosting partners</h3>
-      <p><a href="https://insights.ubuntu.com/2017/04/18/unitas-global-and-canonical-provide-fully-managed-enterprise-openstack/" class="p-link--external">Unitas Global</a>, <a href="https://insights.ubuntu.com/2016/08/22/qts-and-canonical-unveil-private-fully-managed-openstack-cloud/" class="p-link--external">QTS</a> and <a href="https://insights.ubuntu.com/2016/07/05/e-shelter-and-canonical-launch-joint-managed-openstack-private-cloud/" class="p-link--external">eShelter</a> are certified partners, trained to handle the physical BootStack operations.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Build services</h3>
-      <p>We can build your cloud. Get started fast with our OpenStack reference architecture or a custom design to optimise your workloads.</p>
-      <p><a href="/cloud/foundation-cloud">OpenStack build service&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Fully managed Kubernetes</h3>
-      <p>Canonical will <a href="">build, operate and transfer a Kubernetes cluster</a> for you, on bare metal, OpenStack, VMware or public cloud.</p>
-      <p><a href="/cloud/kubernetes">Canonical Kubernetes&nbsp;&rsaquo;</a></p>
-    </div>
+  <div class="row">
+    <ul class="p-matrix u-clearfix">
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Hosting partners</h3>
+          <p class="p-matrix__desc"><a href="https://insights.ubuntu.com/2017/04/18/unitas-global-and-canonical-provide-fully-managed-enterprise-openstack/" class="p-link--external">Unitas Global</a>, <a href="https://insights.ubuntu.com/2016/08/22/qts-and-canonical-unveil-private-fully-managed-openstack-cloud/" class="p-link--external">QTS</a> and <a href="https://insights.ubuntu.com/2016/07/05/e-shelter-and-canonical-launch-joint-managed-openstack-private-cloud/" class="p-link--external">eShelter</a> are certified partners, trained to handle the physical BootStack operations.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Build services</h3>
+          <p class="p-matrix__desc">We can build your cloud. Get started fast with our OpenStack reference architecture or a custom design to optimise your workloads.</p>
+          <p class="p-matrix__desc"><a href="/cloud/foundation-cloud">OpenStack build service&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Fully managed Kubernetes</h3>
+          <p class="p-matrix__desc">Canonical will <a href="">build, operate and transfer a Kubernetes cluster</a> for you, on bare metal, OpenStack, VMware or public cloud.</p>
+          <p class="p-matrix__desc"><a href="/cloud/kubernetes">Canonical Kubernetes&nbsp;&rsaquo;</a></p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Enable containers</h3>
+          <p class="p-matrix__desc">Use <a href="https://linuxcontainers.org/" class="p-link--external">Linux Containers Project</a>, LXD, for pure-container guests in OpenStack. Faster to launch, with zero latency and amazing quality of service, LXD guests are a bridge between VMs and Docker.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Add Docker</h3>
+          <p class="p-matrix__desc">Full support for Enterprise Docker on BootStack means you have a single support line for Ubuntu, OpenStack and Docker. Use tenant separation to partition your cluster between teams using Docker for devops.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Custom integration</h3>
+          <p class="p-matrix__desc">Integrate your OpenStack with existing storage SANs, network and SDN controllers, authentication systems like LDAP or Active Directory, and monitoring systems using our <a href="/cloud/foundation-cloud">professional services and consulting</a> teams.</p>
+        </div>
+      </li>
+    </ul>
   </div>
-</section>
-<section class="p-strip is-deep u-no-margin--top u-no-padding--top">
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Enable containers</h3>
-      <p>Use <a href="https://linuxcontainers.org/" class="p-link--external">Linux Containers Project</a>, LXD, for pure-container guests in OpenStack. Faster to launch, with zero latency and amazing quality of service, LXD guests are a bridge between VMs and Docker.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Add Docker</h3>
-      <p>Full support for Enterprise Docker on BootStack means you have a single support line for Ubuntu, OpenStack and Docker. Use tenant separation to partition your cluster between teams using Docker for devops.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Custom integration</h3>
-      <p>Integrate your OpenStack with existing storage SANs, network and SDN controllers, authentication systems like LDAP or Active Directory, and monitoring systems using our <a href="/cloud/foundation-cloud">professional services and consulting</a> teams.</p>
-    </div>
-  </div>
-</section>
-<section class="p-strip is-shallow u-no-padding--top">
   <div class="row">
     <div class="col-12">
       <p><a href="/cloud/contact-us?product=cloud-managed-cloud" class="p-button--positive">Let&rsquo;s discuss your requirements</a></p>


### PR DESCRIPTION
## Done

Convert 'Shape it to your needs' section to vanilla matrix pattern

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/cloud/managed-cloud>
- Check that 'Shape it to your needs' section towards the bottom of the page matches [vanilla matrix pattern](https://docs.vanillaframework.io/en/patterns/matrix)


## Issue / Card

Fixes #2931 
