### PR TITLE
Implement new download page design

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -8,17 +8,17 @@
 
   .p-card--ubuntu-upgrade {
     @extend .p-card;
-    padding: 1.333rem 0;
+    padding: 1.25rem 0;
 
     > .row {
       margin: 1rem 0;
-      padding: 0 1.33rem;
+      padding: 0 1.25rem;
     }
 
     &__footer {
       background-color: $color-light;
       margin-top: $sp-large;
-      padding: $sp-medium;
+      padding: 1.25rem;
     }
   }
 

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -16,10 +16,9 @@
     }
 
     &__footer {
-      background: $color-light url('#{$assets-path}f68488b1-picto-upgrade-warmgrey.svg') $sp-medium center no-repeat;
-      background-size: $sp-xx-large $sp-xx-large;
-      margin: 0;
-      padding: $sp-medium $sp-medium $sp-medium 5.25rem;
+      background-color: $color-light;
+      margin-top: $sp-large;
+      padding: $sp-medium;
     }
   }
 

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -2,90 +2,56 @@
 
 {% block title %}Get Ubuntu | Download{% endblock %}
 
-{% block content %}<div class="p-strip is-deep">
+{% block content %}
+<div class="p-strip is-shallow">
   <div class="row">
     <div class="col-12">
-      <h1>Get Ubuntu</h1>
-      <p>Ubuntu is completely free to download, use and share.</p>
+      <h1>Ubuntu downloads</h1>
     </div>
   </div>
 </div>
 
-<div class="p-strip u-no-padding--top">
+<div class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="row">
     <div class="col-12">
-      <div class="p-card--ubuntu-upgrade u-no-padding--bottom">
-        <div class="row u-equal-height">
-          <div class="col-2">
-            <a href="/download/desktop"><img src="{{ ASSET_SERVER_URL }}4cd0df1c-picto-download-orange.svg" alt="" width="113" height="113" /></a>
-          </div>
-          <div class="col-8">
+      <div class="p-card--ubuntu-upgrade u-no-padding--bottom u-no-margin--bottom">
+        <div class="row u-no-margin--top">
+          <div class="col-12">
             <h2 class="p-card__title"><a href="/download/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a></h2>
-            <p class="p-card__content u-no-margin--top">Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or Mac OS, or, run Ubuntu alongside it.</p>
+            <p class="p-card__content">Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or Mac OS, or, run Ubuntu alongside it.</p>
           </div>
         </div>
         <footer class="p-card--ubuntu-upgrade__footer">
-          Do you want to upgrade? <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
+          <strong>Do you want to upgrade?</strong> <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
         </footer>
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 u-equal-height u-no-margin--bottom">
-      <div class="col-6 p-card u-equal-height">
-        <div class="col-4">
-          <h2 class="p-card__title"><a href="/download/server">Ubuntu Server&nbsp;&rsaquo;</a></h2>
-          <p class="p-card__content">Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-        </div>
-        <div class="col-2 u-align--center u-vertically-center">
-          <a href="/download/server"><img src="{{ ASSET_SERVER_URL }}0fdf9cfe-picto-server-darkaubergine.svg" alt="" width="113" height="113" /></a>
-        </div>
+  <div class="row u-equal-height u-no-margin--bottom">
+    <div class="col-6 p-card u-equal-height">
+      <div>
+        <h2 class="p-card__title"><a href="/download/server">Ubuntu Server&nbsp;&rsaquo;</a></h2>
+        <p class="p-card__content">Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
       </div>
-      <div class="col-6 p-card u-equal-height">
-        <div class="col-4">
-          <h2 class="p-card__title"><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
-          <p class="p-card__content">Ubuntu is the reference OS for OpenStack. Try Canonical&rsquo;s OpenStack on a single machine or start building a production cloud on a cluster &mdash; just add servers.</p>
-        </div>
-        <div class="col-2 u-align--center u-vertically-center">
-          <a href="/download/cloud"><img src="{{ ASSET_SERVER_URL }}dfd42685-picto-cloud-darkaubergine.svg" alt="" width="113" height="113" /></a>
-        </div>
+    </div>
+    <div class="col-6 p-card u-equal-height">
+      <div>
+        <h2 class="p-card__title"><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
+        <p class="p-card__content">Ubuntu is the reference OS for OpenStack. Try Canonical&rsquo;s OpenStack on a single machine or start building a production cloud on a cluster &mdash; just add servers.</p>
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <div class="u-equal-height u-no-margin--bottom">
-        <div class="col-6 p-card u-equal-height">
-          <div class="col-4">
-            <h2 class="p-card__title"><a href="/download/ubuntu-flavours">Ubuntu flavours&nbsp;&rsaquo;</a></h2>
-            <p class="p-card__content">Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.</p>
-          </div>
-          <div class="col-2 u-align--center u-vertically-center">
-            <a href="/download/flavours"><img src="{{ ASSET_SERVER_URL }}ebfb7122-picto-generic-warmgrey.svg" alt="" height="112" width="112" /></a>
-          </div>
-        </div>
-        <div class="col-6 p-card u-equal-height">
-          <div class="col-4">
-            <h2 class="p-card__title"><a href="/download/core">Ubuntu Core&nbsp;&rsaquo;</a></h2>
-            <p class="p-card__content">Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
-          </div>
-          <div class="col-2 u-align--center u-vertically-center">
-            <a href="/download/core"><img src="{{ ASSET_SERVER_URL }}442ccba1-snappy-ubuntu-core-logo-01.svg" alt="Ubuntu core" height="112" width="112" /></a>
-          </div>
-        </div>
+  <div class="row u-equal-height u-no-margin--top u-no-margin--bottom">
+    <div class="col-6 p-card u-equal-height">
+      <div>
+        <h2 class="p-card__title"><a href="/download/ubuntu-flavours">Ubuntu flavours&nbsp;&rsaquo;</a></h2>
+        <p class="p-card__content">Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.</p>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <div class="p-card u-equal-height">
-        <div class="col-7">
-          <h2 class="p-card__title"><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></h2>
-          <p class="p-card__content">There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older releases.</p>
-        </div>
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
-          <a href="/download/alternative-downloads"><img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" alt="Chinese Ubuntu logo" height="112" width="112" /></a>
-        </div>
+    <div class="col-6 p-card u-equal-height">
+      <div>
+        <h2 class="p-card__title"><a href="/download/core">Ubuntu Core&nbsp;&rsaquo;</a></h2>
+        <p class="p-card__content">Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Implement new download page design

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download>
- Make sure page matches design


## Issue / Card

Fixes #2929
