### PR TITLE
Fix table styling on /support/plans-and-pricing page

### DIFF
--- a/static/sass/_pattern_table.scss
+++ b/static/sass/_pattern_table.scss
@@ -1,4 +1,11 @@
 @mixin ubuntu-p-tables {
+  // To be fixed upstream in the Vanilla 1.7.0 beta
+  thead th,
+  thead td {
+    padding-top: $sp-small;
+    vertical-align: middle;
+  }
+
   .p-table {
     &__cell--highlight {
       background: $color-x-light;

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -42,7 +42,7 @@
     <h3>Optional add-ons</h3>
     <table>
       <tr>
-        <td>Workload analysis (Artificial Intelligence, Machine Learning, <br />Blockchain, CI/CD, Serverless, Transcoding)</td>
+        <td>Workload analysis (Artificial Intelligence, Machine Learning, Blockchain, CI/CD, Serverless, Transcoding)</td>
         <td class="p-table__cell--highlight u-align--center">+$9,000 <sup><a href="#fn-kc-1">*</a></sup></td>
       </tr>
       <tr>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -1,19 +1,19 @@
 <div class="row">
   <div class="col-12" style="overflow-x: auto;">
     <table style="width: 100%;">
-      <tr>
-        <td width="35%">&nbsp;</td>
+      <thead>
+        <th width="35%">&nbsp;</th>
         <th width="15%" class="u-align--center">Ubuntu</th>
         <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for Kubernetes</th>
         <th class="p-table__cell--highlight u-align--center">BootStack</th>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
-        <td>&nbsp;</td>
+      </thead>
+      <thead>
+        <th>&nbsp;</th>
+        <th>&nbsp;</th>
         <th class="p-table__cell--highlight u-align--center">Standard</th>
         <th class="p-table__cell--highlight u-align--center">Advanced</th>
         <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
-      </tr>
+      </thead>
       <tr>
         <th>Price per node (physical) <sup><a href="#fn-kes-1">*</a></sup></th>
         <td class="u-align--center">$0</td>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -1,7 +1,7 @@
 <table style="width: 100%;">
   <thead>
     <tr>
-      <td>&nbsp;</td>
+      <th>&nbsp;</th>
       <th>Fully managed Kubernetes</th>
   </thead>
   <tbody>

--- a/templates/shared/pricing/_landscape.html
+++ b/templates/shared/pricing/_landscape.html
@@ -1,7 +1,7 @@
 <table>
   <thead>
     <tr>
-      <td>&nbsp;</td>
+      <th>&nbsp;</th>
       <th class="p-table__cell--highlight u-align--center">Landscape on-premises</th>
     </tr>
   </thead>

--- a/templates/shared/pricing/_openstack-consulting.html
+++ b/templates/shared/pricing/_openstack-consulting.html
@@ -1,7 +1,7 @@
 <table>
   <thead>
     <tr>
-      <td>&nbsp;</td>
+      <th>&nbsp;</th>
       <th class="p-table__cell--highlight u-align--center">Foundation Cloud</th>
       <th class="p-table__cell--highlight u-align--center">Foundation Cloud Plus</th>
     </tr>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -1,15 +1,15 @@
 <div class="row" style="overflow-x: auto;">
-  <div class="col-10">
+  <div class="col-12">
     <table>
       <thead>
         <tr>
-          <td style="width: 40%;">&nbsp;</td>
+          <th style="width: 40%;">&nbsp;</th>
           <th class="u-align--center" style="width: 20%;">OpenStack</th>
           <th class="p-table__cell--highlight  u-align--center">Ubuntu Advantage<br />for OpenStack</th>
           <th class="p-table__cell--highlight  u-align--center">BootStack</th>
         </tr>
         <tr>
-          <td>&nbsp;</td>
+          <th>&nbsp;</th>
           <th class="u-align--center" width="15%">Without support</th>
           <th class="p-table__cell--highlight u-align--center">Advanced</th>
           <th class="p-table__cell--highlight u-align--center">Fully Managed</th>

--- a/templates/shared/pricing/_storage-support.html
+++ b/templates/shared/pricing/_storage-support.html
@@ -1,7 +1,7 @@
 <table>
   <thead>
     <tr>
-      <td>&nbsp;</td>
+      <th>&nbsp;</th>
       <th class="p-table__cell--highlight u-align--center">Ubuntu Advantage Storage</th>
     </tr>
   </thead>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -3,12 +3,12 @@
     <table>
       <thead>
         <tr>
-          <td>&nbsp;</td>
+          <th>&nbsp;</th>
           <th class="u-align--center">Ubuntu</th>
           <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for desktops</th>
         </tr>
         <tr>
-          <td>&nbsp;</td>
+          <th>&nbsp;</th>
           <th class="u-align--center">Without support</th>
           <th class="p-table__cell--highlight u-align--center">Standard</th>
           <th class="p-table__cell--highlight u-align--center">Advanced</th>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -1,16 +1,16 @@
 <table class="p-table">
   <thead>
     <tr>
-      <td>&nbsp;</td>
+      <th>&nbsp;</th>
       <th class="u-align--center">Ubuntu</th>
       <th class="p-table__cell--highlight u-align--center" colspan="3">Ubuntu Advantage for servers</th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
-      <td class="u-align--center">Without support</td>
-      <td class="p-table__cell--highlight u-align--center">Essential</td>
-      <td class="p-table__cell--highlight u-align--center">Standard</td>
-      <td class="p-table__cell--highlight u-align--center">Advanced</td>
+      <th>&nbsp;</th>
+      <th class="u-align--center">Without support</th>
+      <th class="p-table__cell--highlight u-align--center">Essential</th>
+      <th class="p-table__cell--highlight u-align--center">Standard</th>
+      <th class="p-table__cell--highlight u-align--center">Advanced</th>
     </tr>
   </thead>
   <tbody>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -9,12 +9,10 @@
 
 <section class="p-strip is-deep is-bordered">
   <div class="row">
-    <div class="col-6">
-      <h1>Plans and pricing</h1>
-      <p>Ubuntu is always free to download, install, run, and upgrade. Free community support is available from <a href="https://usn.ubuntu.com/usn/">Ubuntu Security Notices</a>, <a href="http://askubuntu.com">AskUbuntu</a>, <a href="http://ubuntuforums.org">UbuntuForums</a>, <a href="http://launchpad.net/ubuntu">Launchpad</a>, <a href="http://planet.ubuntu.com">PlanetUbuntu</a>, <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC</a> and through <a href="https://lists.ubuntu.com">Mailing Lists</a>.</p>
-      <p>For enterprises with production workloads Canonical offers the following suite of Ubuntu Advantage tools, services and support packages.</p>
-      <p><a href="/support/contact-us?product=support-pricing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Learn more', 'eventLabel' : 'Get in touch - Top CTA' : undefined });" class="p-button--positive">Get in touch</a></p>
-    </div>
+    <h1>Plans and pricing</h1>
+    <p>Ubuntu is always free to download, install, run, and upgrade. Free community support is available from <a href="https://usn.ubuntu.com/usn/">Ubuntu Security Notices</a>, <a href="http://askubuntu.com">AskUbuntu</a>, <a href="http://ubuntuforums.org">UbuntuForums</a>, <a href="http://launchpad.net/ubuntu">Launchpad</a>, <a href="http://planet.ubuntu.com">PlanetUbuntu</a>, <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC</a> and through <a href="https://lists.ubuntu.com">Mailing Lists</a>.</p>
+    <p>For enterprises with production workloads Canonical offers the following suite of Ubuntu Advantage tools, services and support packages.</p>
+    <p><a href="/support/contact-us?product=support-pricing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Learn more', 'eventLabel' : 'Get in touch - Top CTA' : undefined });" class="p-button--positive">Get in touch</a></p>
   </div>
 </section>
 
@@ -92,7 +90,7 @@
 
 <section class="p-strip--light is-deep u-no-padding--bottom" id="ua-support">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>Ubuntu Advantage</h2>
       <p>Ubuntu Advantage is the professional package of tools, technology and expertise from Canonical, helping organisations around the world get the most out of their Ubuntu deployments. It includes access to:</p>
       <ul class="p-list">
@@ -110,7 +108,7 @@
 
 <section class="p-strip--light is-shallow">
   <div class="row" style="overflow-x: auto;">
-    <div class="col-10">
+    <div class="col-12">
       <h2>For servers</h2>
       {% include "shared/pricing/_ua-server-support.html" %}
     </div>
@@ -119,7 +117,7 @@
 
 <section class="p-strip--light is-shallow u-no-padding--bottom">
   <div class="row" style="overflow-x: auto;">
-    <div class="col-10">
+    <div class="col-12">
       <h2>For desktops</h2>
       {% include "shared/pricing/_ua-desktop-support.html" %}
     </div>
@@ -132,14 +130,14 @@
 
 <section class="p-strip--light is-deep is-bordered" id="maas">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>MAAS</h2>
       <p>MAAS is freely available, open source software from Canonical. Many enterprises depend on MAAS to automate and optimize provisioning for production hardware.  Canonical offers Standard and Advanced support plans priced per-machine-per-month or, for large volume and public clouds with dynamic scale, we offer per-region pricing with flexible node ranges.</p>
     </div>
   </div>
 
   <div class="row">
-    <div class="col-10" style="overflow-x: auto;">
+    <div class="col-12" style="overflow-x: auto;">
       {% include "shared/pricing/_maas-support.html" %}
     </div>
   </div>
@@ -147,14 +145,14 @@
 
 <section class="p-strip--light is-deep is-bordered" id="openstack">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>OpenStack</h2>
       <p>Canonical provides support services, management tools, and the Cloud Archive which keeps thousands of businesses productive with their own local OpenStack clouds.  For large volume and public clouds with dynamic scale, we&rsquo;re pleased to offer per-region pricing with flexible node ranges.</p>
     </div>
   </div>
   {% include "shared/pricing/_openstack-support.html" %}
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <p><a href="https://buy.ubuntu.com/" class="p-link--external">Buy Ubuntu Advantage</a></p>
     </div>
   </div>
@@ -162,18 +160,18 @@
 
 <section class="p-strip--light is-deep is-bordered" id="consulting">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>OpenStack consulting packages</h2>
       <p>Canonical delivers turnkey OpenStack software solutions, on-site, through its field consulting team. Two plans are offered: the Foundation Cloud, which is based on our award-winning reference architecture, and Foundation Plus, which packs in a complete set of enterprise features and  architectural flexibility.</p>
     </div>
   </div>
   <div class="row">
-    <div class="col-10">
+    <div class="col-12">
       {% include "shared/pricing/_openstack-consulting.html" %}
     </div>
   </div>
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <p>For more information about Foundation Cloud Build or if you are not sure which one is right for you, <a href="/cloud/contact-us?product=foundation-cloud">contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -181,7 +179,7 @@
 
 <section class="p-strip--light is-deep is-bordered" id="kubernetes">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>Kubernetes</h2>
       <p>Scale-out container management is top of mind for savvy cloud architects around the world.  Ubuntu is, by far, the world&rsquo;s leading platform for container-based workflows.  Canonical provides enterprise-caliber support for Kubernetes.</p>
       <p>For more information about Kubernetes support, <a href="/containers/contact-us">contact us&nbsp;&rsaquo;</a></p>
@@ -194,7 +192,7 @@
 
 <section class="p-strip--light is-deep is-bordered">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2 class="u-no-margin--bottom">Kubernetes consulting packages</h2>
     </div>
   </div>
@@ -203,7 +201,7 @@
 
 <section class="p-strip--light is-deep is-bordered" id="storage">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>Ceph and Swift Storage</h2>
       <p>Ubuntu Advantage Storage from Canonical embeds the proven open source software‐defined storage (SDS) technologies of Ceph and Swift into a 24x7 supported software solution with a unique usage-based pricing model.</p>
     </div>
@@ -228,7 +226,7 @@
 
 <section class="p-strip--light is-deep">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>Landscape Enterprise Systems Management</h2>
       <p>Reduce your team&rsquo;s efforts on day-to-day management with Landscape, the most cost-effective tool to support and monitor large and growing networks of desktops, servers and clouds.</p>
     </div>
@@ -239,7 +237,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <p><a href="https://landscape.canonical.com" class="p-link--external">Learn more about Landscape</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Added padding-top and centered vertical alignment to table cells in a `<thead>`
- Fixed incorrect markup on tables on pricing page
- Made larger tables col-12 to give more room for the cells

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support/plans-and-pricing
- Check that the table headers are styled well, and the the highlighted sections show up nicely

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1691
