### PR TITLE
Bespoke styling fixes for Vanilla 1.7.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "global-nav": "^0.2.2",
     "postcss-cli": "^4.1.0",
-    "vanilla-framework": "1.7.0-alpha-1"
+    "vanilla-framework": "1.7.0-beta-1"
   },
   "dependencies": {
     "autoprefixer": "^6.3.1",

--- a/static/sass/_pattern_link.scss
+++ b/static/sass/_pattern_link.scss
@@ -1,18 +1,30 @@
 @mixin ubuntu-p-link {
+  %external-link-heading {
+    background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') no-repeat;
+    background-size: .85em;
+    padding-left: 1em;
+
+    &::after {
+      display: none;
+    }
+  }
+
   h1,
   h2,
   h3,
-  h4,
-  h5,
-  h6 {
+  h4 {
     &.p-link--external {
-      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left .75em no-repeat;
-      background-size: .85em;
-      padding-left: 1em;
+      @extend %external-link-heading;
+      background-position: left;
+    }
+  }
 
-      &::after {
-        display: none;
-      }
+  h5,
+  h6,
+  .p-heading--insights__title {
+    &.p-link--external {
+      @extend %external-link-heading;
+      background-position: left .75em;
     }
   }
 

--- a/static/sass/_pattern_link.scss
+++ b/static/sass/_pattern_link.scss
@@ -10,21 +10,21 @@
   }
 
   h1,
-  h2,
-  h3,
-  h4 {
+  h2 {
     &.p-link--external {
       @extend %external-link-heading;
-      background-position: left;
+      background-position: left calc(100% - .25em);
     }
   }
 
+  h3,
+  h4,
   h5,
   h6,
   .p-heading--insights__title {
     &.p-link--external {
       @extend %external-link-heading;
-      background-position: left .75em;
+      background-position: left calc(100% - .33em);
     }
   }
 

--- a/static/sass/_pattern_matrix.scss
+++ b/static/sass/_pattern_matrix.scss
@@ -57,5 +57,16 @@
         }
       }
     }
+
+    &__img {
+      &-container {
+        min-height: 5rem;
+        padding: .5rem 0 1rem 0;
+      }
+
+      &--large {
+        max-width: 100%;
+      }
+    }
   }
 }

--- a/static/sass/_pattern_pull_quotes.scss
+++ b/static/sass/_pattern_pull_quotes.scss
@@ -9,6 +9,7 @@
       > p {
         font-size: 1rem;
         line-height: 1.5;
+        position: relative;
 
         &:first-of-type::before,
         &:last-of-type::after {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -278,18 +278,3 @@ select {
 p + pre {
   margin-top: $sp-medium;
 }
-
-// XXX Caleb 06/02/2018 Modifier to Matrix pattern so images can be large
-.p-matrix {
-  &__img {
-    &-container {
-      min-height: 5rem;
-      padding: .5rem 0 1rem 0;
-    }
-
-    &--large {
-      @extend .p-matrix__img; // sass-lint:disable-line placeholder-in-extend
-      max-width: 100%;
-    }
-  }
-}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -249,29 +249,6 @@ p {
   }
 }
 
-// XXX Ant: 06.12.17 This can be removed when this is fixed
-// https://github.com/vanilla-framework/vanilla-framework/issues/1484
-
-.p-pagination {
-  &__previous {
-    text-align: left !important;
-
-    &:only-child {
-      &::after {
-        display: none;
-      }
-    }
-  }
-
-  &__next {
-    &:only-child {
-      &::before {
-        display: none;
-      }
-    }
-  }
-}
-
 // XXX Ant: 11.12.17 This can be removed when this is fixed
 // https://github.com/vanilla-framework/vanilla-framework/issues/1491
 .is-dark .p-button--base {

--- a/templates/download/core/index.html
+++ b/templates/download/core/index.html
@@ -21,7 +21,7 @@
             <a href="/download/core/raspberry-pi-2-3"><img class="p-matrix__img--large" alt="Raspberry Pi logo" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=200"></a>
           </div>
           <p class="p-matrix__desc">Ubuntu Core allows you to install apps on your board in just a few clicks.</p>
-          <p><a class="p-matrix__link" href="/download/core/raspberry-pi-2-3">Install on a Raspberry Pi 2 or&nbsp;3&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/raspberry-pi-2-3">Install on a Raspberry Pi 2 or&nbsp;3&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -30,7 +30,7 @@
             <a href="/download/core/raspberry-pi-compute-module-3"><img class="p-matrix__img--large" alt="Raspberry Pi logo" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=200" /></a>
           </div>
           <p class="p-matrix__desc">Ubuntu Core works on minimal setups, embed and go!</p>
-          <p><a class="p-matrix__link" href="/download/core/raspberry-pi-compute-module-3">Install on a Raspberry Pi Compute Module&nbsp;3&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/raspberry-pi-compute-module-3">Install on a Raspberry Pi Compute Module&nbsp;3&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -39,7 +39,7 @@
             <a href="/download/core/orange-pi-zero"><img class="p-matrix__img--large" alt="Orange Pi logo" src="{{ ASSET_SERVER_URL }}02251698-orange-pi-logo.png" /></a>
           </div>
           <p class="p-matrix__desc">Ubuntu Core also runs on the AllWinner H2 SoC used on Orange Pi boards.</p>
-          <p><a class="p-matrix__link" href="/download/core/orange-pi-zero">Install on an Orange Pi Zero&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/orange-pi-zero">Install on an Orange Pi Zero&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -48,7 +48,7 @@
             <a href="/download/core/qualcomm-dragonboard-410c"><img class="p-matrix__img--large" alt="Dragonboard logo" src="{{ ASSET_SERVER_URL }}d9ccf84b-qualcoom.png?w=230" /></a>
           </div>
           <p class="p-matrix__desc">Ubuntu Core helps you harness the power of boards tailored for the IoT ecosystem.</p>
-          <p><a class="p-matrix__link" href="/download/core/qualcomm-dragonboard-410c">Install on a Qualcomm DragonBoard 410c&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/qualcomm-dragonboard-410c">Install on a Qualcomm DragonBoard 410c&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -57,7 +57,7 @@
             <a href="/download/core/intel-nuc"><img class="p-matrix__img--large" alt="Intel NUC logo" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg" width="150"/></a>
           </div>
           <p class="p-matrix__desc">Ubuntu Core can be easily installed on other architectures like Intel&reg; 64 bits.</p>
-          <p><a class="p-matrix__link" href="/download/core/intel-nuc">Install on an Intel NUC&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/intel-nuc">Install on an Intel NUC&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -66,7 +66,7 @@
             <a href="/download/core/intel-joule"><img class="p-matrix__img--large" alt="Intel Joule Pi logo" src="{{ ASSET_SERVER_URL }}1f53b707-INTEL_JOULE-LOGO.png?w=200" /></a>
           </div>
           <p class="p-matrix__desc">Ubuntu Core lets you interact and control complex hardware and modules.</p>
-          <p><a class="p-matrix__link" href="/download/core/intel-joule">Install on an Intel Joule&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/intel-joule">Install on an Intel Joule&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -75,7 +75,7 @@
             <a href="/download/core/samsung-artik-5-10"><img class="p-matrix__img--large" alt="Samsung Artik logo" src="{{ ASSET_SERVER_URL }}c5dfb2cb-samsung-artik.png?w=150" /></a>
           </div>
           <p class="p-matrix__desc">Ubuntu Core runs smoothly on both small and large footprint boards.</p>
-          <p><a class="p-matrix__link" href="/download/core/samsung-artik-5-10">Install on a Samsung Artik 5 or&nbsp;10&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/samsung-artik-5-10">Install on a Samsung Artik 5 or&nbsp;10&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -84,7 +84,7 @@
             <a href="/download/core/kvm"><img class="p-matrix__img--large" alt="KVM logo" src="{{ ASSET_SERVER_URL }}aa0e2566-kvm-logo.png?w=120" /></a>
           </div>
           <p class="p-matrix__desc">Develop on target or on your Linux desktop, run Ubuntu Core in a virtual environment.</p>
-          <p><a class="p-matrix__link" href="/download/core/kvm">Install on a KVM&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/kvm">Install on a KVM&nbsp;&rsaquo;</a>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -93,7 +93,7 @@
             <a href="/download/core/up-squared-iot-grove"><img class="p-matrix__img--large" alt="Up Squared logo" src="{{ ASSET_SERVER_URL }}8cb47950-g46.png?w=70" /></a>
           </div>
           <p class="p-matrix__desc">Build snaps using the UP<sup>2</sup> IoT Grove development kit running Ubuntu Server.</p>
-          <p><a class="p-matrix__link" href="/download/core/up-squared-iot-grove">Install on an UP<sup>2</sup> IoT Grove&nbsp;&rsaquo;</a></p>
+          <a href="/download/core/up-squared-iot-grove">Install on an UP<sup>2</sup> IoT Grove&nbsp;&rsaquo;</a>
         </div>
       </li>
     </ul>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -105,10 +105,10 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block" id="ubuntu-com_appstore_left">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>White paper</h3>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
+          <h3 class='p-heading-icon__title'>White paper</h3>
         </div>
       </div>
       <h2 class='p-heading--four'>
@@ -118,10 +118,10 @@
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_appstore_center">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Webinar</h3>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' alt='' />
+          <h3 class='p-heading-icon__title'>Webinar</h3>
         </div>
       </div>
       <h2 class='p-heading--four'>
@@ -131,10 +131,10 @@
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_appstore_right">
       <!-- rtp section start -->
-      <div class='p-heading-icon u-no-margin--bottom'>
-        <div class='p-heading-icon__header u-no-margin--bottom'>
-          <img class='p-heading-icon__img' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' style='max-width: 30px;' />
-          <h3 class='p-heading-icon__title p-muted-heading' style='color: #666;'>Case study</h3>
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg' alt='' />
+          <h3 class='p-heading-icon__title'>Case study</h3>
         </div>
       </div>
       <h2 class='p-heading--four'>

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -29,7 +29,7 @@
       <li class="p-tabs__item" role="presentation">
         <a href="?topic=desktop{% if content_slug %}&content={{ content_slug }}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Resources', 'eventAction' : 'Navigation', 'eventLabel' : 'Desktop', 'eventValue' : undefined });" class="p-tabs__link" role="tab" aria-controls="section2"{% if topic_slug == 'desktop' %} aria-selected="true"{% endif %}>Desktop</a>
       </li>
-      <li class="u-align--right u-hide--small">
+      <li class="u-align-text--right u-hide--small">
         <form action="" method="get" class="p-form p-form--inline">
           <div class="p-form__group">
             <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter:</label>

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -136,20 +136,21 @@
     </div>
   {% endif %}
 
-    <footer class="p-pagination">
+  <div class="row">
+    <div class="p-pagination">
       {% if pagination.previous_enable %}
-      <a class="p-pagination__link p-pagination__previous" href="{{ pagination.previous_link }}">
+      <a class="p-pagination__link--previous" href="{{ pagination.previous_link }}">
         <span class="p-pagination__label">Previous</span>
         <span class="p-pagination__title">Go to page {{ pagination.previous_index }}</span>
       </a>
       {% endif %}
       {% if pagination.next_enable %}
-      <a class="p-pagination__link p-pagination__next" href="{{ pagination.next_link }}">
+      <a class="p-pagination__link--next" href="{{ pagination.next_link }}">
         <span class="p-pagination__label">Next</span>
         <span class="p-pagination__title">Go to page {{ pagination.next_index }}</span>
       </a>
       {% endif %}
-    </footer>
+    </div>
   </div>
 </section>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,9 +2959,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.7.0-alpha-1:
-  version "1.7.0-alpha-1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0-alpha-1.tgz#cbf6ce65c97a3cece65a0bb6274904cf81918b94"
+vanilla-framework@1.7.0-beta-1:
+  version "1.7.0-beta-1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0-beta-1.tgz#eb08e1e1c1b698f5ddb5f092da6fc97458db857e"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Done

- Updated to Vanilla 1.7.0-beta-1
- Fixed pagination styling on /resources
- Fixed external link heading image background alignment for all heading sizes (h1, h2, h3 etc)
- Fixed compact pull quote positioning
- Fixed muted heading icons on /iot/appstore (missed this one on the last PR about this)
- Fixed alignment of filter tab on /resources (issue with separation of u-align and u-align-text)
- Fixed bespoke matrix on /download/core

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/resources
- Check that the filter dropdown is aligned to the right of the tabstrip
- Check that the pagination at the bottom is styled correctly (with chevron, and aligned appropriately to left/right)
- Go to /cloud/juju and check that the external link icon on headings is aligned properly for all heading sizes (can just change in dev tools)
- Go to /desktop/partners and check that the closing quotation marks on the pull quotes are aligned properly (was originally aligning relative to the whole pull quote container, rather than the paragraph tag)
- Go to /internet-of-things/appstore and check that the muted heading icons look okay (middle of the page, with Webinar etc.)
- Go to /download/core and check that the matrix descriptions doesn't cut into the image

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1718
Fixes vanilla-framework/vanilla-framework#1719
Fixes vanilla-framework/vanilla-framework#1720
Fixes vanilla-framework/vanilla-framework#1722
Fixes vanilla-framework/vanilla-framework#1724
Fixes vanilla-framework/vanilla-framework#1725
