### PR TITLE
Corrects typo in Kubernetes promo

### DIFF
--- a/templates/takeovers/_kubernetes-month.html
+++ b/templates/takeovers/_kubernetes-month.html
@@ -13,7 +13,7 @@
         'eventAction' : 'Kubernetes Month - 03/2018',
         'eventLabel' : 'Sign-up today',
         'eventValue' : undefined
-      });" class="p-button--neutral">Sign-up today</a></p>
+      });" class="p-button--neutral">Sign up today</a></p>
     </div>
     <div class="u-hide--small col-4">
       <img class="p-takeover--kubernetes-logo" src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="" />


### PR DESCRIPTION
Changes “Sign-up today” to “Sign up today”.

“Sign-up” is an adjective, for example, “the sign-up form”.

To avoid disrupting anything I have not changed the `eventLabel`.