### PR TITLE
Add quotation to gateways page

### DIFF
--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -66,6 +66,18 @@
   </div>
 </section>
 
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-10">
+      <blockquote class="p-pull-quote">
+        <p>As companies continue to embrace Internet of Things (IoT) solutions, security and quick, easy system updates are critical</p>
+        <cite class="p-pull-quote__citation">Jason Shepherd, Director of Strategy and Partnerships, IoT, Dell.
+        </cite>
+      </blockquote>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
## Done

Add quotation to `/internet-of-things/gateways` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/internet-of-things/gateways>
- Make sure quotation exists as specified in the [copy doc](https://docs.google.com/document/d/1hQon1vuYPDg_GojABIwbp2gFBkE2WApZTZJGT3yUdLU/edit#)


## Issue / Card

Fixes #2956 