### PR TITLE
Update desktop overview page

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -9,7 +9,7 @@
 
 {# 0 -180px #}
 
-<section class="p-strip--image is-light is-deep is-bordered" style="background-image:url('{{ ASSET_SERVER_URL }}364631d0-desktop-overview-hero.jpg?w=984'); background-position: 0 75%; padding: 6.25rem 0; min-height: 573px">
+<section class="p-strip--image is-light is-deep is-bordered" style="background-image:url('{{ ASSET_SERVER_URL }}50c18622-insitu-laptop-overview.jpg?w=984'); background-position: 0 75%; padding: 6.25rem 0; min-height: 573px">
   <div class="row">
     <div class="col-6">
       <div class="p-card--overlay">
@@ -25,14 +25,14 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="u-equal-height">
+      <div class="col-8 u-vertically-center u-hide--small">
+        <img src="{{ ASSET_SERVER_URL }}3a05fc34-Dell_XPS_Laptop_Front-news.png" alt="The Guardian website on Firefox in 16.04 LTS" />
+      </div>
       <div class="col-4">
         <h2>Complete</h2>
         <p>Ubuntu comes with everything you need to run your organisation, school, home or enterprise. All the essential applications, like an office suite, browsers, email and media apps come pre-installed and thousands more games and applications are available
           in the Ubuntu Software Centre.</p>
           <p><a href="/desktop/features">Explore features&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="col-8 u-vertically-center u-hide--small">
-          <img src="{{ ASSET_SERVER_URL }}0e7183ed-desktop-overview-complete.jpg" alt="The Guardian website on Firefox in 16.04 LTS" />
         </div>
       </div>
     </div>
@@ -101,7 +101,7 @@
     <div class="row">
       <div class="u-equal-height">
         <div class="col-7">
-          <img src="{{ ASSET_SERVER_URL }}5ea4959b-desktop-overview-video.jpg" alt="Whatsnew screenshot">
+          <img src="{{ ASSET_SERVER_URL }}d4f0c4b1-movie.png" alt="Whatsnew screenshot">
         </div>
         <div class="col-5 prefix-1 u-vertically-center">
           <div>
@@ -126,7 +126,7 @@
         <p><a href="http://partners.ubuntu.com/programmes/retail" class="p-link--external">Find out more about our retail partners</a></p>
       </div>
       <div class="col-5 u-vertically-center u-hide--small">
-        <img src="{{ ASSET_SERVER_URL }}f1d1b842-desktop-overview-hardware.jpg" alt="Photo of laptop running Ubuntu" />
+        <img src="{{ ASSET_SERVER_URL }}d9105909-Dell_XPS_Laptop_Left-Desktop.png" alt="Photo of laptop running Ubuntu" />
       </div>
     </div>
   </section>
@@ -134,24 +134,14 @@
   <section class="p-strip--light">
     <div class="row p-divider">
       <div class="col-6 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}e60711e6-pictogram-support-orange.svg">
-            <h3 class="p-heading-icon__title">Support and management</h3>
-          </div>
-          <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching, and compliance reporting on all your Ubuntu desktops.</p>
-          <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
-        </div>
+        <h3 class="p-heading-icon__title">Support and management</h3>
+        <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching, and compliance reporting on all your Ubuntu desktops.</p>
+        <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-6 p-divider__block">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg">
-            <h3 class="p-heading-icon__title">Backed by Canonical</h3>
-          </div>
-          <p>Canonical is a global software company and the number-one Ubuntu services provider. Companies can choose to receive expert training, support or consultancy for a fee that goes towards the continued development of Ubuntu.</p>
-          <p><a href="http://www.canonical.com" class="p-link--external">Learn more about Canonical</a></p>
-        </div>
+        <h3 class="p-heading-icon__title">Backed by Canonical</h3>
+        <p>Canonical is a global software company and the number-one Ubuntu services provider. Companies can choose to receive expert training, support or consultancy for a fee that goes towards the continued development of Ubuntu.</p>
+        <p><a href="http://www.canonical.com" class="p-link--external">Learn more about Canonical</a></p>
       </div>
     </div>
   </section>

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -9,7 +9,7 @@
 
 {# 0 -180px #}
 
-<section class="p-strip--image is-light is-deep is-bordered" style="background-image:url('{{ ASSET_SERVER_URL }}50c18622-insitu-laptop-overview.jpg?w=984'); background-position: 0 75%; padding: 6.25rem 0; min-height: 573px">
+<section class="p-strip--image is-light is-deep is-bordered" style="background-image:url('{{ ASSET_SERVER_URL }}50c18622-insitu-laptop-overview.jpg'); background-position: 0 75%; padding: 6.25rem 0; min-height: 573px">
   <div class="row">
     <div class="col-6">
       <div class="p-card--overlay">

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -134,12 +134,12 @@
   <section class="p-strip--light">
     <div class="row p-divider">
       <div class="col-6 p-divider__block">
-        <h3 class="p-heading-icon__title">Support and management</h3>
+        <h3>Support and management</h3>
         <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching, and compliance reporting on all your Ubuntu desktops.</p>
         <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-6 p-divider__block">
-        <h3 class="p-heading-icon__title">Backed by Canonical</h3>
+        <h3>Backed by Canonical</h3>
         <p>Canonical is a global software company and the number-one Ubuntu services provider. Companies can choose to receive expert training, support or consultancy for a fee that goes towards the continued development of Ubuntu.</p>
         <p><a href="http://www.canonical.com" class="p-link--external">Learn more about Canonical</a></p>
       </div>

--- a/templates/shared/contextual_footers/_desktop_download.html
+++ b/templates/shared/contextual_footers/_desktop_download.html
@@ -1,7 +1,4 @@
 <div class="col-4 p-divider__block">
-  <div class="u-align--center">
-    <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" alt="Download pictogram" class="p-contextual-footer__image" />
-  </div>
   <h3 class="p-heading--four">Download and install</h3>
   <p>Download Ubuntu desktop and replace your current operating system. It&rsquo;s easy to install on Windows or Mac OS, or, run Ubuntu alongside it.</p>
   <p><a href="/download/desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Download desktop', 'eventLabel' : 'Download and install', 'eventValue' : undefined });">Download now&nbsp;&rsaquo;</a></p>

--- a/templates/shared/contextual_footers/_desktop_flavours.html
+++ b/templates/shared/contextual_footers/_desktop_flavours.html
@@ -1,7 +1,4 @@
 <div class="col-4 p-divider__block">
-  <div class="u-align--center">
-    <img src="{{ ASSET_SERVER_URL }}e0c1999f-picto-generic-darkaubergine.svg" width="90" alt="" />
-  </div>
   <h3 class="p-heading--four">Ubuntu flavours</h3>
   <p>Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.</p>
   <p><a href="/download/ubuntu-flavours" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : '/download/ubuntu-flavours', 'eventLabel' : 'Ubuntu flavours', 'eventValue' : undefined });">Learn more about Ubuntu flavours&nbsp;&rsaquo;</a></p>

--- a/templates/shared/contextual_footers/_support-image.html
+++ b/templates/shared/contextual_footers/_support-image.html
@@ -1,7 +1,4 @@
 <div class="col-4 p-divider__block">
-  <div class="u-align--center">
-    <img src="{{ ASSET_SERVER_URL }}9f035e4a-picto-support-orange.svg" alt="Pictogram pictogram" style="height: 90px;" />
-  </div>
   <h3 class="p-heading--four">Professional support</h3>
   <p>Get professional support from Canonical to manage your Ubuntu desktop, cloud and server deployments.</p>
   <p><a class="p-button--neutral" href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Buy Ubuntu Advantage', 'eventLabel' : 'Buy Ubuntu Advantage', 'eventValue' : undefined });"><span class="p-link--external">Buy Ubuntu Advantage</span></a></p>


### PR DESCRIPTION
## Done

Update desktop overview page images

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/desktop>
- Check that page matches [the design](https://user-images.githubusercontent.com/36884067/38806101-16dd1772-4170-11e8-8586-1da1d75ce224.jpg)


## Issue / Card

Fixes #2881 