### PR TITLE
Update download desktop page

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -38,6 +38,9 @@
             </script>
           </p>
           <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
+          <p>
+            <small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases. <a href="/download/alternative-downloads">See our alternative downloads</a></small>
+          </p>
         </div>
       </div>
     </div>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -39,7 +39,7 @@
           </p>
           <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
           <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases.</small></p>
-          <p><small><a href="/download/alternative-downloads">See our alternative downloads&nbsp;&rsaquo;</a></small></p>
+          <p class="u-no-margin--top"><small><a href="/download/alternative-downloads">See our alternative downloads&nbsp;&rsaquo;</a></small></p>
         </div>
       </div>
     </div>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -38,9 +38,8 @@
             </script>
           </p>
           <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
-          <p>
-            <small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases. <a href="/download/alternative-downloads">See our alternative downloads</a></small>
-          </p>
+          <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases.</small></p>
+          <p><small><a href="/download/alternative-downloads">See our alternative downloads&nbsp;&rsaquo;</a></small></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

Updated page inline with [copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/desktop>
- See that page matches [copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit#)


## Issue / Card

Fixes #2867 
