### PR TITLE
Fixes marketo redirect on linuxone download

### DIFF
--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -93,8 +93,8 @@
                 </li>
               </ul>
             </fieldset>
-            <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/linuxone-thank-you" />
-            <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/linuxone-thank-you" />
+            <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-linuxone" />
+            <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-linuxone" />
           </form>
           <script>
             $("#mktoForm_1400").validate({


### PR DESCRIPTION

## Done

- Fix marketo redirect on linuxone download
- was going to the wrong thank you page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/server/linuxone/](http://0.0.0.0:8001/download/server/linuxone)
- Fill out the form and see that you go to a thank you page and that it starts a download (download/server/thank-you-linuxone)

