### PR TITLE
Update redirect url for linuxone download

### DIFF
--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -93,8 +93,8 @@
                 </li>
               </ul>
             </fieldset>
-            <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-linuxone" />
-            <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-linuxone" />
+            <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s360x" />
+            <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s360x" />
           </form>
           <script>
             $("#mktoForm_1400").validate({


### PR DESCRIPTION
## Done

Add correct redirect URL to marketo form for downloading linuxone

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/server/linuxone>
- Fill out form and make sure you are redirected to https://www.ubuntu.com/download/server/thank-you-s360x
- Note that the page will be a 404 as that page only exists in this branch currently


## Issue / Card

Fixes #2982
