### PR TITLE
Convert all .p-heading--five to .p-heading--four for new typescale

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -16,7 +16,7 @@
   <div class="row">
     <div class="col-10">
       <h1>The standard OS for cloud computing</h1>
-      <p class="p-heading--five">70% of public cloud workloads and 54% of OpenStack clouds<a href="#fn1" id="r1">*</a></p>
+      <p class="p-heading--four">70% of public cloud workloads and 54% of OpenStack clouds<a href="#fn1" id="r1">*</a></p>
       <p><a href="/download/cloud" class="p-button--positive">Install OpenStack</a></p>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <ul class="p-matrix is-trisected">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Fully managed cloud service</h3>
+            <h3 class="p-matrix__title p-heading--four">Fully managed cloud service</h3>
             <div class="p-matrix__desc">
               <p>Let us take full operational control your cloud remotely with our BootStack service &mdash; the fastest path to a private production OpenStack cloud.</p>
               <p class="p-matrix__desc"><a href="/cloud/managed-cloud">Learn more about BootStack&nbsp;&rsaquo;</a></p>
@@ -44,7 +44,7 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Consulting packages</h3>
+            <h3 class="p-matrix__title p-heading--four">Consulting packages</h3>
             <div class="p-matrix__desc">
               <p>With Foundation Cloud Build, we will build you a fixed-price cloud on your premises, with a proven reference architecture in 3 weeks.</p>
               <p class="p-matrix__desc"><a href="/cloud/foundation-cloud">Learn more about our consulting packages&nbsp;&rsaquo;</a></p>
@@ -53,7 +53,7 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Install now</h3>
+            <h3 class="p-matrix__title p-heading--four">Install now</h3>
             <div class="p-matrix__desc">
               <p>Spin up OpenStack or Kubernetes with conjure-up on a single laptop or on many racks.</p>
               <p class="p-matrix__desc"><a href="/download/cloud">Download&nbsp;&rsaquo;</a></p>
@@ -62,7 +62,7 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Automate physical servers</h3>
+            <h3 class="p-matrix__title p-heading--four">Automate physical servers</h3>
             <div class="p-matrix__desc">
               <p>Turn your data center into a physical cloud with MAAS bare-metal provisioning. On premises, open source and supported.</p>
               <p class="p-matrix__desc"><a href="/server/maas">Learn more about MAAS&nbsp;&rsaquo;</a></p>
@@ -71,7 +71,7 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Use Ubuntu on certified public clouds</h3>
+            <h3 class="p-matrix__title p-heading--four">Use Ubuntu on certified public clouds</h3>
             <div class="p-matrix__desc">
               <p>Ubuntu is the leading cloud guest OS, running most workloads in public clouds today.</p>
               <p class="p-matrix__desc"><a href="/download/server">Get started with Ubuntu server&nbsp;&rsaquo;</a></p>
@@ -80,7 +80,7 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Model and deploy with Juju</h3>
+            <h3 class="p-matrix__title p-heading--four">Model and deploy with Juju</h3>
             <div class="p-matrix__desc">
               <p>Hundreds of services and pre-configured applications available for single‐command deployment to any cloud.</p>
               <p class="p-matrix__desc"><a href="/cloud/juju">Get started with Juju&nbsp;&rsaquo;</a></p>
@@ -196,7 +196,7 @@
       </div>
     </div>
     <div class="col-8">
-      <h2>The Canonical Distribution of Kubernetes<sup class="p-heading--five">&reg;&nbsp;<a title="Jump to The Canonical Distribution of Kubernetes footnote" href="#fn3" id="r3">*</a></sup></h2>
+      <h2>The Canonical Distribution of Kubernetes<sup class="p-heading--four">&reg;&nbsp;<a title="Jump to The Canonical Distribution of Kubernetes footnote" href="#fn3" id="r3">*</a></sup></h2>
       <p>The easiest way to operate Kubernetes on AWS, Google Cloud, Azure, Oracle or your private VMware, OpenStack and bare metal.</p>
       <p>Canonical offers a distribution of upstream Kubernetes that is designed to work the same way on every infrastructure. Keep track of upstream changes through easy automated upgrades, and integrate your preferred monitoring system with a single command.</p>
       <p><a href="/kubernetes">Learn more about Kubernetes on Ubuntu&nbsp;&rsaquo;</a></p>

--- a/templates/cloud/managed-cloud.html
+++ b/templates/cloud/managed-cloud.html
@@ -201,55 +201,55 @@
       <ul class="p-matrix is-trisected">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Predictable CAPEX and OPEX</h3>
+            <h3 class="p-matrix__title p-heading--four">Predictable CAPEX and OPEX</h3>
             <p class="p-matrix__desc">Dedicated hardware is the most cost-effective for long-term workloads. BootStack operations costs are predictable, and the benefits of density accrue to your bottom line directly.</p>
           </div>
           </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Elasticity and agility</h3>
+            <h3 class="p-matrix__title p-heading--four">Elasticity and agility</h3>
             <p class="p-matrix__desc">We scale your cloud on demand. Just call to let us know there are additional racks in the DC. We’ll remotely test the hardware and expand your OpenStack to take advantage of the new capacity with zero down time.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">No distractions</h3>
+            <h3 class="p-matrix__title p-heading--four">No distractions</h3>
             <p class="p-matrix__desc">We operate the OpenStack, you run your apps. The real benefit of cloud is the ability to focus exclusively on your business, the things that differentiate you. Your private cloud should be the same &mdash; magical infrastructure on demand.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Cloud native storage</h3>
+            <h3 class="p-matrix__title p-heading--four">Cloud native storage</h3>
             <p class="p-matrix__desc">Use proven software‐defined storage like Ceph, Nexenta Edge, and Swift in your BootStack. Or integrate your existing storage solution or SAN.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">No lock-in</h3>
+            <h3 class="p-matrix__title p-heading--four">No lock-in</h3>
             <p class="p-matrix__desc">Your team can monitor every machine in the OpenStack cloud, and be trained to operate the cloud themselves. We will transfer operations to them on request.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Upgrades built-in</h3>
+            <h3 class="p-matrix__title p-heading--four">Upgrades built-in</h3>
             <p class="p-matrix__desc">As OpenStack evolves, your private cloud can be upgraded without down-time. Canonical guarantees upgrades to newer versions of OpenStack on request.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">App-store included</h3>
+            <h3 class="p-matrix__title p-heading--four">App-store included</h3>
             <p class="p-matrix__desc">Operate standard software workloads exactly the same way on public clouds and OpenStack. A large portfolio of open source solutions with best practices built&nbsp;in.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Directory integration</h3>
+            <h3 class="p-matrix__title p-heading--four">Directory integration</h3>
             <p class="p-matrix__desc">Real-time login integration with your corporate Active Directory or LDAP infrastructure means better security and happier users.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">SDN flexibility</h3>
+            <h3 class="p-matrix__title p-heading--four">SDN flexibility</h3>
             <p class="p-matrix__desc">Canonical works with the widest range of SDN’s, from Neutron OVS and flat provider networks to Cisco ACI, Calico and Contrail.</p>
           </div>
           </li>
@@ -270,37 +270,37 @@
       <ul class="p-matrix is-trisected">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Guaranteed SLA</h3>
+            <h3 class="p-matrix__title p-heading--four">Guaranteed SLA</h3>
             <p class="p-matrix__desc">Our expertise, based on data from hundreds of clouds, underpins your Service Level Agreement. Our operations are certified, with regular independent audits.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">NFV ready</h3>
+            <h3 class="p-matrix__title p-heading--four">NFV ready</h3>
             <p class="p-matrix__desc">BootStack is your fastest path to a modern VIM. As a VNF vendor, BootStack enables you to test your VNFs on the most widely used telco production OpenStack.</p>
           </div>
           </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Security</h3>
+            <h3 class="p-matrix__title p-heading--four">Security</h3>
             <p class="p-matrix__desc">Operated to the high standard of Canonical&rsquo;s own production OpenStack, supporting critical public services for 60m users and devices.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Full stack support</h3>
+            <h3 class="p-matrix__title p-heading--four">Full stack support</h3>
             <p class="p-matrix__desc">As the publisher of Ubuntu, Canonical uniquely supports the full stack. Complex problems in cloud infrastructure require analysis and fixes all the way down to the kernel. With us, there are no loose ends.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Log aggregation</h3>
+            <h3 class="p-matrix__title p-heading--four">Log aggregation</h3>
             <p class="p-matrix__desc">The BootStack team actively monitor your OpenStack 24/7, providing observability, alerting, capacity planning and continuous service checks to ensure your cloud is healthy and stays that way.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Transfer support</h3>
+            <h3 class="p-matrix__title p-heading--four">Transfer support</h3>
             <p class="p-matrix__desc">Canonical offers training and on-premise Cloud Reliability Engineers to smooth your transition to internal operations when requested. Trust us to get you started in the best possible way.</p>
           </div>
         </li>

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -20,7 +20,7 @@
   <div class="row">
     <div class="col-12 p-card--highlighted p-divider u-equal-height">
       <div class="col-6 p-divider__block">
-        <p class="p-heading--five">Single machine</p>
+        <p class="p-heading--four">Single machine</p>
         <h2>Try OpenStack on a single&nbsp;machine</h2>
         <p class="p-card__content">
           Conjure-up is an ideal tool for people who want to build an
@@ -35,7 +35,7 @@
         </p>
       </div>
       <div class="col-6">
-        <p class="p-heading--five">Cluster</p>
+        <p class="p-heading--four">Cluster</p>
         <h2>Build your own production&nbsp;cloud</h2>
         <p class="p-card__content">
           The same conjure-up utility also deploys your production OpenStack

--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -28,7 +28,7 @@
         <fieldset class="contribute__options noscript">
           <section id="ubuntu-desktop">
             <label for="amount-desktop">
-            <p class="p-heading--five contribute__heading">Ubuntu Desktop</p>
+            <p class="p-heading--four contribute__heading">Ubuntu Desktop</p>
             <p class="contribute__description">Make the desktop even more amazing.</p>
           </label>
 
@@ -40,7 +40,7 @@
           </section>
           <section id="ubuntu-for-cloud">
             <label for="amount_cloud" class="contribute__option-label">
-              <p class="p-heading--five contribute__heading">Ubuntu for cloud computing</p>
+              <p class="p-heading--four contribute__heading">Ubuntu for cloud computing</p>
               <p class="contribute__description">I want Ubuntu running my cloud and as a guest in my cloud of choice.</p>
             </label>
 
@@ -52,7 +52,7 @@
           </section>
           <section id="ubuntu-for-things">
             <label for="amount_things">
-              <p class="p-heading--five contribute__heading">Ubuntu for things</p>
+              <p class="p-heading--four contribute__heading">Ubuntu for things</p>
               <p class="contribute__description">I want a secure, upgradeable Internet of Things, powered by Ubuntu.</p>
             </label>
 
@@ -64,7 +64,7 @@
           </section>
           <section id="community-projects">
             <label for="amount_community">
-              <p class="p-heading--five contribute__heading">Community projects</p>
+              <p class="p-heading--four contribute__heading">Community projects</p>
               <p class="contribute__description">I support LoCo teams,  UbuCons and other events, upstream projects and all the good work the community does.</p>
             </label>
 
@@ -76,7 +76,7 @@
           </section>
           <section id="tip-to-canonical">
             <label for="amount_canonical">
-              <p class="p-heading--five contribute__heading">Tip to Canonical</p>
+              <p class="p-heading--four contribute__heading">Tip to Canonical</p>
               <p class="contribute__description">Hats off for making Ubuntu possible. Keep it up.</p>
             </label>
 

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -102,56 +102,56 @@
       <ul class="p-matrix is-trisected">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Cloud Neutral</h3>
+            <h3 class="p-matrix__title p-heading--four">Cloud Neutral</h3>
             <p class="p-matrix__desc">Deploy and operate consistently on AWS, Azure, Google, Oracle, Rackspace, SoftLayer, or private VMware, OpenStack or bare metal.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Fresh</h3>
+            <h3 class="p-matrix__title p-heading--four">Fresh</h3>
             <p class="p-matrix__desc">Canonical enables upgrades to each new stable release as well as edge builds, so you can migrate to the latest version as soon as you want.</p>
           </div>
           </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Secure</h3>
+            <h3 class="p-matrix__title p-heading--four">Secure</h3>
             <p class="p-matrix__desc">Every component of Canonical K8s receives security maintenance automatically, and all components communicate with TLS encryption.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Supported</h3>
+            <h3 class="p-matrix__title p-heading--four">Supported</h3>
             <p class="p-matrix__desc">Enterprise support is provided by Canonical, options cover a range of SLA&rsquo;s and choice of physical / virtual / cloud. We support the full stack from kernel to k8s.</p>
           </div>
           </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Extensible</h3>
+            <h3 class="p-matrix__title p-heading--four">Extensible</h3>
             <p class="p-matrix__desc">Canonical Kubernetes enables easy integration of custom monitoring, storage, networking, and container runtimes. We offer consulting for deeper customisation.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Fully managed</h3>
+            <h3 class="p-matrix__title p-heading--four">Fully managed</h3>
             <p class="p-matrix__desc">At your request, Canonical&rsquo;s remote operations team can build and operate Kubernetes. We will transfer control of the cluster to your ops team any time you want to take over.</p>
             <p><a href="/kubernetes/managed">Learn more about managed kubernetes&nbsp;&rsaquo;</a></p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">GPU and CUDA ready</h3>
+            <h3 class="p-matrix__title p-heading--four">GPU and CUDA ready</h3>
             <p class="p-matrix__desc">Automatically detect and configure GPGPU resources for accelerated machine learning, AI and transcoding workloads on K8s.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Converged</h3>
+            <h3 class="p-matrix__title p-heading--four">Converged</h3>
             <p class="p-matrix__desc">Storage, networking and compute are overlaid in our hyper-converged reference architecture, ensuring the efficient use resources and high availability failover.</p>
           </div>
           </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--five">Compliant</h3>
+            <h3 class="p-matrix__title p-heading--four">Compliant</h3>
             <p class="p-matrix__desc">Canonical Kubernetes has consistently been the leader in K8s test suite performance and API standards compliance &mdash; the reference k8s implementation.</p>
           </div>
         </li>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -47,7 +47,7 @@
 
   <section class="p-strip is-bordered">
     <div class="row">
-      <h2>Getting started with Canonical Distribution of Kubernetes<sup class="p-heading--five">&reg;&nbsp;<a href="#fn1" id="r1">*</a></sup></h2>
+      <h2>Getting started with Canonical Distribution of Kubernetes<sup class="p-heading--four">&reg;&nbsp;<a href="#fn1" id="r1">*</a></sup></h2>
     </div>
     <div class="row">
       <div class="col-12">

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu resources</h1>
-      <h5>Selected resources from <a href="https://insights.ubuntu.com" class="p-link--external">insights.ubuntu.com</a></h5>
+      <p class="p-heading--four">Selected resources from <a href="https://insights.ubuntu.com" class="p-link--external">insights.ubuntu.com</a></p>
     </div>
   </div>
 </section>

--- a/templates/search.html
+++ b/templates/search.html
@@ -54,7 +54,7 @@
       {% if results.items %}<ul class="p-list">{% endif %}
         {% for item in results.items %}
         <li class="p-list__item">
-          <span class="p-heading--five"><a href="{{ item.url }}" class="title-main">{{ item.title | safe}}</a></span><br />
+          <span class="p-heading--four"><a href="{{ item.url }}" class="title-main">{{ item.title | safe}}</a></span><br />
           <small><a href="{{ item.url }}">{{ item.url }}</a></small><br />
           {{ item.summary | safe }}</p>
         </li>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -279,7 +279,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Talk to a member of our team</h2>
-      <p class="p-heading--five">We can recommend a security solution that best suits the needs of your&nbsp;organisation.</p>
+      <p class="p-heading--four">We can recommend a security solution that best suits the needs of your&nbsp;organisation.</p>
       <ul class="p-inline-list">
         <li class="p-inline-list__item">
           <a href="/support/contact-us" class="p-button">Contact us</a>

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -4,7 +4,7 @@
       <img src="{{ ASSET_SERVER_URL }}00d6e773-contact_orange_phone.svg">
     </div>
     <div class="col-11 u-no-margin--left u-no-margin--bottom">
-      <p class="p-heading--five u-no-margin--bottom">Any questions? Call us <tel href="+17372040291">+1 737 204 0291</tel> (Americas), <tel href="+442036565291">+44 203 656 5291</tel> (RoW) or <a href="/support/contact-us">contact us online</a>.</p>
+      <p class="p-heading--four u-no-margin--bottom">Any questions? Call us <tel href="+17372040291">+1 737 204 0291</tel> (Americas), <tel href="+442036565291">+44 203 656 5291</tel> (RoW) or <a href="/support/contact-us">contact us online</a>.</p>
     </div>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -6,7 +6,7 @@
 <div class="row u-equal-height">
   <div class="p-card col-6">
     <div class="p-card__header">
-      <h3 class="p-heading--five">Kubernetes Explorer</h3>
+      <h3 class="p-heading--four">Kubernetes Explorer</h3>
       <p class="p-heading--two">$15,000 <span class="p-heading--six">one off fee</span></p>
     </div>
     <p>Get up and running quickly with minimal setup, predefined architecture and web-based training.</p>
@@ -22,7 +22,7 @@
   </div>
   <div class="p-card col-6">
     <div class="p-card__header">
-      <h3 class="p-heading--five">Kubernetes Discoverer</h3>
+      <h3 class="p-heading--four">Kubernetes Discoverer</h3>
       <p class="p-heading--two">$35,000 <span class="p-heading--six">one off fee</span></p>
     </div>
     <p>Get a customised architecture to fit your requirements, including bare-metal environments or custom integrations and on-site training.</p>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -21,7 +21,7 @@
     <div class="col-4 p-card">
       <h3>Server</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $75 per year <sup><a href="#fn-pnp-1">*</a></sup></p>
+        <p class="p-heading--four">From $75 per year <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#ua-support">Learn more&nbsp;&rsaquo;</a>
@@ -31,7 +31,7 @@
     <div class="col-4 p-card">
       <h3>MAAS</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $5 per month <sup><a href="#fn-pnp-1">*</a></sup></p>
+        <p class="p-heading--four">From $5 per month <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#maas">Learn more&nbsp;&rsaquo;</a>
@@ -41,7 +41,7 @@
     <div class="col-4 p-card">
       <h3>OpenStack</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $4 per day <sup><a href="#fn-pnp-1">*</a></sup></p>
+        <p class="p-heading--four">From $4 per day <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#openstack">Learn more&nbsp;&rsaquo;</a>
@@ -53,7 +53,7 @@
     <div class="col-4 p-card">
       <h3>Kubernetes</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $0.02 per hour <sup><a href="#fn-pnp-1">*</a></sup></p>
+        <p class="p-heading--four">From $0.02 per hour <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#kubernetes">Learn more&nbsp;&rsaquo;</a>
@@ -63,7 +63,7 @@
     <div class="col-4 p-card">
       <h3>Storage</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $0.01 per month <sup><a href="#fn-pnp-1">*</a></sup></p>
+        <p class="p-heading--four">From $0.01 per month <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#storage">Learn more&nbsp;&rsaquo;</a>
@@ -73,7 +73,7 @@
     <div class="col-4 p-card">
       <h3>Consulting packages</h3>
       <div class="p-card__footer">
-        <p class="p-heading--five">From $2,500 per day <sup><a href="#fn-pnp-1">*</a></sup></p>
+        <p class="p-heading--four">From $2,500 per day <sup><a href="#fn-pnp-1">*</a></sup></p>
       </div>
       <div class="p-card__footer">
         <a href="#consulting">Learn more&nbsp;&rsaquo;</a>

--- a/templates/takeovers/_iot-business.html
+++ b/templates/takeovers/_iot-business.html
@@ -2,7 +2,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
       <h1>How to pick a winning IoT business model</h1>
-      <p class="p-heading--five">Unravelling IoT monetisation, skills and security challenges.</p>
+      <p class="p-heading--four">Unravelling IoT monetisation, skills and security challenges.</p>
       <p class="u-align--center u-hide--medium u-hide--large">
         <img src="{{ ASSET_SERVER_URL }}ac9b8212-iot-business-model-takeover.svg" alt="" />
       </p>

--- a/templates/takeovers/_kubernetes-month.html
+++ b/templates/takeovers/_kubernetes-month.html
@@ -2,7 +2,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-8">
       <h1>Our new webinar series, Kubernetes month</h1>
-      <p class="p-heading--five">Learn how Canonical and partners are making Kubernetes a success across the public cloud and enterprise.</p>
+      <p class="p-heading--four">Learn how Canonical and partners are making Kubernetes a success across the public cloud and enterprise.</p>
       <p class="u-align--center u-hide--medium u-hide--large">
         <img src="{{ ASSET_SERVER_URL }}071489b4-K8s+logo+mobile.svg" alt="" />
       </p>

--- a/templates/takeovers/_maas_may_2017.html
+++ b/templates/takeovers/_maas_may_2017.html
@@ -3,7 +3,7 @@
     <div class="u-equal-height u-vertically-center">
     <div class="col-6">
       <h1>Maximise hardware efficiency</h1>
-      <p class="p-heading--five">Build your data centre with <abbr title="Metal as a Service">MAAS</abbr>.</p>
+      <p class="p-heading--four">Build your data centre with <abbr title="Metal as a Service">MAAS</abbr>.</p>
       <div class="u-visible--small u-hide--medium u-hide--large"><img src="{{ ASSET_SERVER_URL }}3fb3f433-MAAS-takeover-illustration.svg" alt="MAAS service blocks illustration" /></div>
       <p><a href="https://pages.ubuntu.com/eBook-MAAS.html?source=ubuntu.com&amp;medium=takeover&amp;campaign=MAAS_eBook " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Maas takeover - 26-05-2017', 'eventLabel' : 'Download the eBook', 'eventValue' : undefined });" class="p-button--positive">Download the eBook</a></p>
       <p><a href="/server/maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'MAAS takeover', 'eventLabel' : 'Learn more about MAAS', 'eventValue' : undefined });">Learn more about MAAS &rsaquo;</a></p>

--- a/templates/takeovers/_tell-us-your-story.html
+++ b/templates/takeovers/_tell-us-your-story.html
@@ -2,7 +2,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-5">
       <h1>What’s your Ubuntu story?</h1>
-      <p class="p-heading--five">Tell us how you use Ubuntu in your business and get featured on this page!</p>
+      <p class="p-heading--four">Tell us how you use Ubuntu in your business and get featured on this page!</p>
       <p class="u-align--center u-hide--medium u-hide--large">
         <img class="u-vertically-spaced" src="{{ ASSET_SERVER_URL }}98943ac1-Ubuntu-story-illustration.svg" alt="" />
       </p>

--- a/templates/takeovers/_ubuntu-product-month.html
+++ b/templates/takeovers/_ubuntu-product-month.html
@@ -3,7 +3,7 @@
     <div class="u-equal-height u-vertically-center">
       <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
         <h1><span class="event-title" itemprop="name">Ubuntu product month</span></h1>
-        <p class="p-heading--five" style="line-height: 1.264;">Learn about OpenStack, LXD, Juju, and Snaps from&nbsp;the developers and teams behind them</p>
+        <p class="p-heading--four" style="line-height: 1.264;">Learn about OpenStack, LXD, Juju, and Snaps from&nbsp;the developers and teams behind them</p>
         <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://pages.ubuntu.com/ubuntu_product_month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeover', 'eventLabel' : 'Find out more', 'eventValue' : undefined });" class="p-button--positive">Find out more</a></p>
       </div>
       <div class="col-5 u-align--center">

--- a/templates/takeovers/_ues_takeover.html
+++ b/templates/takeovers/_ues_takeover.html
@@ -4,7 +4,7 @@
       <div class="col-6" itemscope="" itemtype="https://schema.org/Event">
         <h1 class="p-heading--two"><span class="event-title" itemprop="name">Ubuntu Enterprise Summit</span></h1>
         <h2 class="p-heading--three"><span class="event-date" itemprop="startDate" content="2017-12-05T16:00">5</span> – <span class="event-date" itemprop="endDate" content="2017-12-06T21:00">6 December 2017</span></h2>
-        <p class="p-heading--five">Find out how the world&rsquo;s top companies use Ubuntu to succeed</p>
+        <p class="p-heading--four">Find out how the world&rsquo;s top companies use Ubuntu to succeed</p>
         <p class="u-hide--small u-show--medium u-show--large"><a itemprop="url" href="https://ubuntu.brighttalk.com/summit/ubuntu-enterprise-summit/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'UES takeover', 'eventLabel' : 'View on demand', 'eventValue' : undefined });" class="p-button--positive">View on demand</a></p>
       </div>
       <div class="col-6 u-align--right">


### PR DESCRIPTION
## Done

- Blanket search-and-replaced `p-heading--five` with `p-heading--four` to fit in with the new typescale (you can see in the screenshots that the new h4 is almost identical to the old h5)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that the main takeover tagline is now a `p-heading--four`
- If you want to be really thorough you can check the ~50 instances where the changes have occurred.

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1716

## Screenshots
### Old typescale
![screenshot_1](https://user-images.githubusercontent.com/25733845/39055959-5b3a037c-44ad-11e8-9f76-2ad11b185a87.png)

### New typescale
![screenshot](https://user-images.githubusercontent.com/25733845/39055972-60823b92-44ad-11e8-9887-2f35ebe45df5.png)

