### PR TITLE
Add pages for each nav dropdown to be shown on mobile

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -3,29 +3,36 @@ var dropdownWindow = document.querySelector('.dropdown-window');
 
 navDropdowns.forEach(function(dropdown) {
   dropdown.addEventListener('click', function(event) {
+    event.preventDefault();
+
     var clickedDropdown = this;
+    var navigationThresholdBreakpoint = 900;
 
-    if (dropdownWindow.classList.contains('fade-animation')) {
-      dropdownWindow.classList.remove('fade-animation');
-    }
-
-    navDropdowns.forEach(function(dropdown) {
-      var dropdownContent = document.getElementById(dropdown.id + "-content");
-
-      if (dropdown === clickedDropdown) {
-        if (dropdown.classList.contains('is-selected')) {
-          dropdown.classList.remove('is-selected');
-          dropdownWindow.classList.add('fade-animation');
-          dropdownContent.classList.add('fade-animation');
-        } else {
-          dropdown.classList.add('is-selected');
-          dropdownContent.classList.remove('fade-animation', 'u-hide');
-        }
-      } else {
-        dropdown.classList.remove('is-selected');
-        dropdownContent.classList.add('fade-animation', 'u-hide');
+    if (window.innerWidth >= navigationThresholdBreakpoint) {
+      if (dropdownWindow.classList.contains('fade-animation')) {
+        dropdownWindow.classList.remove('fade-animation');
       }
-    });
+
+      navDropdowns.forEach(function(dropdown) {
+        var dropdownContent = document.getElementById(dropdown.id + "-content");
+
+        if (dropdown === clickedDropdown) {
+          if (dropdown.classList.contains('is-selected')) {
+            dropdown.classList.remove('is-selected');
+            dropdownWindow.classList.add('fade-animation');
+            dropdownContent.classList.add('fade-animation');
+          } else {
+            dropdown.classList.add('is-selected');
+            dropdownContent.classList.remove('fade-animation', 'u-hide');
+          }
+        } else {
+          dropdown.classList.remove('is-selected');
+          dropdownContent.classList.add('fade-animation', 'u-hide');
+        }
+      });
+    } else {
+      window.location.href = this.querySelector('a').getAttribute('href');
+    }
   });
 });
 

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -138,10 +138,12 @@ core.siteSearch = function(){
   siteSearchToggle = document.querySelector('.search-toggle__link');
   siteSearchForm  = document.querySelector('.p-site-search__form');
 
-  siteSearchToggle.addEventListener('click', function(e) {
-    siteSearchForm.classList.toggle('u-visible');
-    e.preventDefault();
-  });
+  if (siteSearchToggle) {
+    siteSearchToggle.addEventListener('click', function(e) {
+      siteSearchForm.classList.toggle('u-visible');
+      e.preventDefault();
+    });
+  }
 };
 
 core.siteSearch();

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -215,18 +215,23 @@
 
   .dropdown-window {
     @extend .p-strip;
-    background-color: $color-x-light;
-    border-bottom: 1px solid $color-mid-light;
-    box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
-    color: $color-dark;
-    line-height: $sp-medium-large;
-    padding: 2.5rem 0;
-    position: relative;
-    transition: all .25s cubic-bezier(.215, .61, .355, 1);
-    z-index: 1;
+    display: none;
 
-    .row {
-      margin-top: 0;
+    @media only screen and (min-width: $breakpoint-navigation-threshold) {
+      display: block;
+      background-color: $color-x-light;
+      border-bottom: 1px solid $color-mid-light;
+      box-shadow: 0 1px 5px 1px transparentize($color-dark, .8);
+      color: $color-dark;
+      line-height: $sp-medium-large;
+      padding: 2.5rem 0;
+      position: relative;
+      transition: all .25s cubic-bezier(.215, .61, .355, 1);
+      z-index: 1;
+
+      .row {
+        margin-top: 0;
+      }
     }
   }
 
@@ -235,5 +240,16 @@
     transform: translateY(-1rem);
     transition-duration: .25s;
     visibility: hidden;
+
+    .u-visible-nav & {
+      opacity: 1;
+      transform: none;
+      visibility: visible;
+    }
   }
+}
+
+.u-visible-nav {
+  padding-top: $sp-large;
+  padding-bottom: $sp-large;
 }

--- a/templates/nav-community.html
+++ b/templates/nav-community.html
@@ -1,0 +1,9 @@
+{% extends "base_index.html" %}
+
+{% block content %}
+
+<div class="u-visible-nav">
+  {% include "templates/_navigation-community.html" %}
+</div>
+
+{% endblock %}

--- a/templates/nav-developer.html
+++ b/templates/nav-developer.html
@@ -1,0 +1,9 @@
+{% extends "base_index.html" %}
+
+{% block content %}
+
+<div class="u-visible-nav">
+  {% include "templates/_navigation-developer.html" %}
+</div>
+
+{% endblock %}

--- a/templates/nav-download.html
+++ b/templates/nav-download.html
@@ -1,0 +1,9 @@
+{% extends "base_index.html" %}
+
+{% block content %}
+
+<div class="u-visible-nav">
+  {% include "templates/_navigation-download.html" %}
+</div>
+
+{% endblock %}

--- a/templates/nav-enterprise.html
+++ b/templates/nav-enterprise.html
@@ -1,0 +1,9 @@
+{% extends "base_index.html" %}
+
+{% block content %}
+
+<div class="u-visible-nav">
+  {% include "templates/_navigation-enterprise.html" %}
+</div>
+
+{% endblock %}

--- a/templates/templates/_navigation-download.html
+++ b/templates/templates/_navigation-download.html
@@ -3,7 +3,7 @@
     <h4><a class="p-link--soft" href='/download/desktop'>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
     <p>Download Ubuntu desktop and replace your current operating system whether it’s Windows or Mac OS, or, run Ubuntu alongside it.</p>
     <a class='p-button--positive' href='/download/desktop/contribute?version=16.04.3&architecture=amd64'>16.04 LTS</a>
-    <a class='p-button--neutral u-no-margin--top' href='/download/desktop/contribute?version=17.10&architecture=amd64'>17.10</a>
+    <a class='p-button--neutral' href='/download/desktop/contribute?version=17.10&architecture=amd64'>17.10</a>
     <ul class='p-inline-list--middot' style="margin-top: 1rem;">
       <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
         <small>18.04 (dev edge)</small>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -15,10 +15,10 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__links">
-        <li class="p-navigation__dropdown-link" role="menuitem" id="enterprise-tab"><a>Enterprise</a></li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="developer-tab"><a>Developer</a></li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="community-tab"><a>Community</a></li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="download-tab"><a>Download</a></li>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="enterprise-tab"><a href="/nav-enterprise">Enterprise</a></li>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="developer-tab"><a href="/nav-developer">Developer</a></li>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="community-tab"><a href="/nav-community">Community</a></li>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="download-tab"><a href="/nav-download">Download</a></li>
       </ul>
       <div class="p-navigation__search" role="menuitem">
         <form action="/search" class="p-search-box" id="google-appliance-search-form">


### PR DESCRIPTION
## Done

Create a page for each dropdown to be shown on small screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- On a small screen (less than 900px wide) click on the navigation links and make sure you are taken to a page which mirrors the main menu


## Issue / Card

Fixes [#488](https://github.com/ubuntudesign/web-squad/issues/488)
Fixes [#489](https://github.com/ubuntudesign/web-squad/issues/489)
Fixes [#490](https://github.com/ubuntudesign/web-squad/issues/490)
Fixes [#491](https://github.com/ubuntudesign/web-squad/issues/491)
