### PR TITLE
update games to be more current

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -244,7 +244,7 @@
     <div class="col-12 prefix-6 p-gaming__content">
       <div class="p-card--overlay">
         <h2>Gaming</h2>
-        <p>From Sudoku to shoot-em-ups, we&rsquo;ve got loads of games that&rsquo;ll keep you busy for hours.  There are thousands of games available for Ubuntu, including titles from the Unity and Steam platforms.  Pick from critically acclaimed titles such as Dota 2, Civilization V, Kerbal Space Program, Football Manager 2015 and Borderlands&nbsp;2.</p>
+        <p>From Sudoku to shoot-em-ups, we&rsquo;ve got loads of games that&rsquo;ll keep you busy for hours.  There are thousands of games available for Ubuntu, including titles from the Unity and Steam platforms.  Pick from critically acclaimed titles such as Dota 2, Civilization V, Kerbal Space Program, Football Manager 2018 and Borderlands&colon; The Pre-Sequel.</p>
       </div>
     </div>
     <div class="u-hide--small p-gaming__flash"></div>


### PR DESCRIPTION
## Done

In the gaming section of the desktop/feature page, updated:

- "Football Manager 2015" to "2018"
- Changed Borderlands 2" to "Borderlands: The Pre-Sequel" (Newest version of game on Ubuntu)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/features](http://0.0.0.0:8001/desktop/features)
- Check if the copy matches the [copydoc](https://docs.google.com/document/d/1nLHJlZ3igDwAAOUDP03wp4iKLxZts8110EA2ZOF5uaU/edit)


## Issue / Card

Fixes: #2999 

