### PR TITLE
/desktop remove "benefits for all industry sectors" strip

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -55,48 +55,6 @@
     </div>
   </section>
 
-  <section class="p-strip--light is-bordered is-deep">
-    <div class="row u-align--center">
-      <div class="col-12">
-        <h2 class="p-muted-heading u-align--center">Benefits for all industry sectors</h2>
-      </div>
-    </div>
-    <div class="row u-align--center u-vertically-center">
-      <div class="col-6">
-        <div class="row">
-          <div class="col-3">
-            <a class="p-link--grey" href="/desktop/enterprise">
-              <img src="{{ ASSET_SERVER_URL }}386e7e70-picto-businessasusual-midaubergine.svg" alt="Business pictogram" width="120" />
-              <p>Ubuntu for enterprise</p>
-            </a>
-          </div>
-          <div class="col-3">
-            <a class="p-link--grey" href="/desktop/education">
-              <img src="{{ ASSET_SERVER_URL }}5bac122e-picto-education-orange.svg" alt="Education pictogram" width="120" />
-              <p>Ubuntu for education</p>
-            </a>
-          </div>
-        </div>
-      </div>
-      <div class="col-6">
-        <div class="row">
-          <div class="col-3">
-            <a class="p-link--grey" href="/desktop/government">
-              <img src="{{ ASSET_SERVER_URL }}03c5463a-picto-business-warmgrey.svg" alt="Suit pictogram" width="120" />
-              <p>Ubuntu for government</p>
-            </a>
-          </div>
-          <div class="col-3">
-            <a class="p-link--grey" href="/desktop/developers">
-              <img src="{{ ASSET_SERVER_URL }}db764752-picto-developer-midaubergine.svg" alt="Developer pictogram" width="120" />
-              <p>Ubuntu for developers</p>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <section class="p-strip is-bordered">
     <div class="row">
       <div class="u-equal-height">


### PR DESCRIPTION
## Done

 - Removed the "benefits for all industry sectors" strip, as the links used to go to separate pages which have now been consolidated into one.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop](http://0.0.0.0:8001/desktop)
- Check that the strip has been removed


## Issue / Card

Fixes: #2997 


