### PR TITLE
/cloud/storage copy update

### DIFF
--- a/templates/cloud/storage.html
+++ b/templates/cloud/storage.html
@@ -50,7 +50,7 @@
     <div class="col-8">
       <h2>Storage options</h2>
       <p>With Ubuntu Advantage Storage you chose between four leading open source Software&dash;defined storage technologies.</p>
-      <p>Both technologies are available within our fully&dash;supported reference architectures, deployed on Ubuntu {{ lts_release_full }} alongside our award&dash;winning cloud tools.</p>
+      <p>All these technologies are available within our fully&dash;supported reference architectures, deployed on Ubuntu {{ lts_release_full }} alongside our award&dash;winning cloud tools.</p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

- Changed copy in the storage section from "both technologies" to "all these technologies"

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud/storage](http://0.0.0.0:8001/cloud/storage)
- Check if the section matches the [copydoc](https://docs.google.com/document/d/1iw2SWNmoj4GZ2pUh0yB8gbtVXK0oXfyEaXT44bQbPlI/edit)


## Issue / Card

Fixes #3011 


