### PR TITLE
/download/cloud/try-openstack - update copy

### DIFF
--- a/templates/download/cloud/try-openstack.html
+++ b/templates/download/cloud/try-openstack.html
@@ -17,7 +17,7 @@
           <div class="col-6 p-divider__block">
             <h3>Requirements</h3>
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu 16.04 LTS, snapd and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
+              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu {{lts_release_full_with_point}}, snapd and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
               <li class="p-list__item is-ticked">An hour of your time</li>
             </ul>
           </div>


### PR DESCRIPTION
## Done

-  Updated the LTS version in the requirements section, it was hard-coded,  so I changed it to use the LTS variable. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/cloud/try-openstack](http://0.0.0.0:8001//download/cloud/try-openstack)
- Check the [copydoc](https://docs.google.com/document/d/1TXnoE_RZCgms1K3beJNjzYLNzZEIjfeuNYg_zhkYQTA/edit) and see if it matches


## Issue / Card

Fixes: #2996 


