### PR TITLE
Legal/T&C'/contact-us - Remove bullet points in form

### DIFF
--- a/templates/download/cloud/try-openstack.html
+++ b/templates/download/cloud/try-openstack.html
@@ -17,7 +17,7 @@
           <div class="col-6 p-divider__block">
             <h3>Requirements</h3>
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu 16.04 LTS, snapd and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
+              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu {{lts_release_full_with_point}}, snapd and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
               <li class="p-list__item is-ticked">An hour of your time</li>
             </ul>
           </div>

--- a/templates/download/cloud/try-openstack.html
+++ b/templates/download/cloud/try-openstack.html
@@ -17,7 +17,7 @@
           <div class="col-6 p-divider__block">
             <h3>Requirements</h3>
             <ul class="p-list">
-              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu {{lts_release_full_with_point}}, snapd and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
+              <li class="p-list__item is-ticked">Laptop, desktop or virtual machine with 16GB RAM, Ubuntu 16.04 LTS, snapd and <a href="/containers/lxd" title="More information about LXD">LXD</a> installed</li>
               <li class="p-list__item is-ticked">An hour of your time</li>
             </ul>
           </div>

--- a/templates/legal/terms-and-policies/contact-us.html
+++ b/templates/legal/terms-and-policies/contact-us.html
@@ -18,7 +18,7 @@
       <form method="post" action="https://www.tfaforms.com/responses/processor" class=" labelsLeftAligned" id="tfa_9631608629067" enctype="multipart/form-data">
         <fieldset>
           <h3>Your contact details</h3>
-          <ul>
+          <ul class="p-list">
             <li class="p-list__item">
               <label id="tfa_Firstname-L" for="tfa_Firstname">First name:</label>
               <input type="text" id="tfa_Firstname" name="tfa_Firstname" value="" size="60" placeholder="" required>
@@ -40,7 +40,7 @@
 
         <fieldset class="fieldset-2">
           <h3>Company information</h3>
-          <ul>
+          <ul class="p-list">
             <li class="p-list__item">
               <label id="tfa_Areyoumakingther-L" for="tfa_Areyoumakingther">Are you making the request on behalf of a company? (optional):</label>
               <select id="tfa_Areyoumakingther" name="tfa_Areyoumakingther" rel=" wfHandled">
@@ -319,7 +319,7 @@
           </ul>
         </fieldset>
         <fieldset class="fieldset-3">
-          <ul>
+          <ul class="p-list">
             <li class="p-list__item">
               <label id="tfa_Whataredoyouplan-L" for="tfa_Whataredoyouplan">In what capacity are you requesting to use the trademark? (optional):</label>
               <select id="tfa_Whataredoyouplan" name="tfa_Whataredoyouplan" rel=" wfHandled">
@@ -363,7 +363,7 @@
         </fieldset>
         <fieldset>
           <p>Data collected from this survey will be handled in accordance with the Canonical <a href="/legal/terms-and-policies/privacy-policy">privacy policy</a></p>
-          <ul>
+          <ul class="p-list">
             <li class="p-list__item">
               <label>If you would like to include an attachment with your request please add it here:</label>
               <input type="file" id="tfa_Ifyouwouldliketo" name="tfa_Ifyouwouldliketo" size="40">


### PR DESCRIPTION
## Done

- Removed bullet points in the /legal/terms-and-policies/contact-us page (by adding p-list class).

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/terms-and-policies/contact-us](http://0.0.0.0:8001/legal/terms-and-policies/contact-us)
- Check if the bullet points are now gone


## Issue / Card

Fixes: #3006 
