### PR TITLE
Update copy for provisioning page

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -50,7 +50,7 @@
             <span class="p-list-step__bullet">2</span>
             Install Ubuntu Server
           </h3>
-          <p class="p-list-step__content"><a aria-label="External link to download Ubuntu Server 16.04 LTS" href="/download/server">Download Ubuntu Server 16.04 LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
+          <p class="p-list-step__content"><a aria-label="External link to download Ubuntu Server {{lts_release}} LTS" href="/download/server">Download Ubuntu Server {{lts_release}} LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">


### PR DESCRIPTION
## Done

Update the release variable

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/server/provisioning>
- Make sure step 2 of 'Install MAAS in 7 easy steps' has the correct version of Ubuntu (18.04)


## Issue / Card

Fixes #2995 