### PR TITLE
Remove link as per copy doc

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -37,7 +37,6 @@
               downloadLink.href = contributeUrl;
             </script>
           </p>
-          <p class="p-card__content"><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
           <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases.</small></p>
           <p class="u-no-margin--top"><small><a href="/download/alternative-downloads">See our alternative downloads&nbsp;&rsaquo;</a></small></p>
         </div>


### PR DESCRIPTION
## Done

Remove second alternative downloads link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/desktop](http://0.0.0.0:8001/download/desktop)
- Check that the download section only has one link to alternative downloads


## Issue / Card

Fixes #2998 
