### PR TITLE
Add related boxes to iot contact us page

### DIFF
--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -22,7 +22,7 @@
 
   {% else %}
 
-    {% include "shared/_client-contact-us-form.html" with h1="Contact us" intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch."  formid="1266" lpId="2551"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=iot"  %}
+    {% include "shared/_client-contact-us-form.html" with h1="Contact us" intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch."  formid="1266" lpId="2551"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=iot" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html"  %}
 
   {% endif %}
 

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -10,7 +10,7 @@
   {% include "shared/_thank_you.html" with thanks_context="your interest in IoT app stores!" thanks_message="A member of our team will follow up with you shortly." %}
 
 {% else %}
-  {% include "shared/_thank_you.html" with thanks_context="your interest in Ubuntu for IoT" thanks_message="A member of our team will follow up with you shortly. In the meantime, explore <a href='http://snapcraft.io' class='p-link--external'>snapcraft.io</a>, where vendors and the open source community collaborate to deliver great software, securely, to a wide range of devices and cloud." %}
+  {% include "shared/_thank_you.html" with thanks_context="your interest in Ubuntu for the Internet of Things" thanks_message="A member of our team will follow up with you shortly. In the meantime, explore <a href='http://snapcraft.io' class='p-link--external'>snapcraft.io</a>, where vendors and the open source community collaborate to deliver great software, securely, to a wide range of devices and cloud." %}
 {% endif %}
 
 {% endblock content %}

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -96,6 +96,7 @@
       </div>
       <div class="p-card" />
         <h3 class="p-card__title">Need help with Ubuntu?</h3>
+        <p>If you are just looking for some free support for yourself, you can try:</p>
         <ul class="p-list--divided">
           <li class="p-list__item"><a class="p-link--external" href="http://askubuntu.com/">Ask Ubuntu</a></li>
           <li class="p-list__item"><a class="p-link--external" href="http://ubuntuforums.org/">The Ubuntu forum</a></li>

--- a/templates/shared/forms/_desktop_help.html
+++ b/templates/shared/forms/_desktop_help.html
@@ -1,5 +1,6 @@
 <div class="p-card">
   <h3 class="p-card__title">Need help with Ubuntu?</h3>
+  <p>If you are just looking for some free support for yourself, you can try:</p>
   <ul class="p-list">
     <li class="p-list__item"><a class="p-link--external" href="http://askubuntu.com/">Ask Ubuntu</a></li>
     <li class="p-list__item"><a class="p-link--external" href="http://ubuntuforums.org/">The Ubuntu forum</a></li>


### PR DESCRIPTION
## Done
Add related boxes to IOT content us page and update thank you content.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/contact-us](http://0.0.0.0:8001/internet-of-things/contact-us)
- See there are boxes of info on the right that match the [copy doc](https://docs.google.com/document/d/1Se-fD5hhb7EaR75jd_1D-JkADmg6aLjUs7_bScATvwE/edit)
- Few content updates to that section to match the copy docs


## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3009
