### PR TITLE
Update copy on desktop page

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -14,7 +14,7 @@
     <div class="col-6">
       <div class="p-card--overlay">
         <h1>Ubuntu for desktops</h1>
-        <p>Learn how the Ubuntu desktop operating system powers millions of PCs and laptops around the world.</p>
+        <p>Learn how the open source Ubuntu desktop operating system powers millions of PCs and laptops around the world.</p>
         <p><a href="/download/desktop" class="p-button--positive">Download Ubuntu</a></p>
         <p><a href="/desktop/features">Take a look&nbsp;&rsaquo;</a></p>
       </div>
@@ -81,7 +81,7 @@
       <div class="col-7 suffix-1">
         <p>Canonical works with the world&rsquo;s leading computer manufacturers to certify that Ubuntu works on a huge range of devices. It means that Ubuntu is now available at thousands of retailers across China, India, South East Asia and Latin America.</p>
         <p>And Ubuntu isn&rsquo;t just for the desktop, it is used in data centres around the world powering every kind of server imaginable and is by far, the most popular operating system in the cloud.</p>
-        <p><a href="http://partners.ubuntu.com/programmes" class="p-link--external">Find out more about our partners</a></p>
+        <p><a href="https://partners.ubuntu.com/programmes" class="p-link--external">Find out more about our partners</a></p>
       </div>
       <div class="col-5 u-vertically-center u-hide--small">
         <img src="{{ ASSET_SERVER_URL }}d9105909-Dell_XPS_Laptop_Left-Desktop.png" alt="Photo of laptop running Ubuntu" />
@@ -99,7 +99,7 @@
       <div class="col-6 p-divider__block">
         <h3>Backed by Canonical</h3>
         <p>Canonical is a global software company and the number-one Ubuntu services provider. Companies can choose to receive expert training, support or consultancy for a fee that goes towards the continued development of Ubuntu.</p>
-        <p><a href="http://www.canonical.com" class="p-link--external">Learn more about Canonical</a></p>
+        <p><a href="https://www.canonical.com" class="p-link--external">Learn more about Canonical</a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

Update copy of 'Available on a huge range of hardware' section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop](http://0.0.0.0:8001/desktop)
- Make sure 'Available on a huge range of hardware' section matches [copy doc](https://docs.google.com/document/d/1ZhMkLlkXcimHTIe1taXy24vbbR9pBkZd49H2sJqeQH0/edit#heading=h.fz2fb0k52648)

## Issue / Card

Fixes #3031 