### PR TITLE
changed hero link to use inverted style

### DIFF
--- a/templates/support/esm.html
+++ b/templates/support/esm.html
@@ -11,7 +11,7 @@
       <h1>Ubuntu 12.04 ESM</h1>
       <p>In April 2017, Ubuntu 12.04 LTS reached its end-of-life. For Ubuntu Advantage customers who can not upgrade to a newer version of Ubuntu Server, Canonical is offering Ubuntu 12.04 ESM (Extended Security Maintenance). ESM provides ongoing security fixes for the kernel and essential packages through April 2019.</p>
       <p><a href="https://buy.ubuntu.com/" class="p-button--positive">Buy Ubuntu Advantage</a></p>
-      <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/support" class="p-link--inverted">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" width="150" alt="" />


### PR DESCRIPTION
## Done

- Changed hero link on the /support/esm page to use inverted style so it is more legible against the aubergine background. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support/esm](http://0.0.0.0:8001/support/esm)
- Check that the link is now white


## Issue / Card

Fixes: #3003 

