### PR TITLE
Replace old Juju logo in cloud partners page

### DIFF
--- a/templates/cloud/partners.html
+++ b/templates/cloud/partners.html
@@ -19,18 +19,18 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-4 u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}d2041fee-juju_black-orange_hex+(Alex+Milazzo's+conflicted+copy+2016-07-18).svg" alt="Juju" />
+  <div class="row u-equal-height ">
+    <div class="col-4 u-hide--small u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}e2ac88af-juju_black-orange_hex.svg" alt="Juju" />
     </div>
-    <div class="col-8">
+    <div class="col-8 prefix-1">
       <h2>Charm partner programme</h2>
       <p>Canonical&rsquo;s Charm partner programme helps you leverage the power of Juju, the ground-breaking service modelling tool, by helping you create Juju charms for your products. Charms encapsulate all the important configuration information, defining
         how your services will be deployed and how they will work with other services.</p>
       <p><a href="http://partners.ubuntu.com/partner-programmes/software#charm-partner-programme">Learn more about the Charm partner programme&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-visible--small u-hide--medium u-hide--large u-align--center">
-      <img src="{{ ASSET_SERVER_URL }}f7bff337-logo-juju-171x174.png" width="171" height="171" alt="Juju" />
+      <img src="{{ ASSET_SERVER_URL }}e2ac88af-juju_black-orange_hex.svg" width="171" height="171" alt="Juju" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Replace the Juju logo used on the cloud/partners page

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud/partners](http://0.0.0.0:8001/cloud/partners)
- Check that the Juju log used is the one in the issue

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3039

## Screenshots
![screenshot-2018-4-24 partners cloud ubuntu](https://user-images.githubusercontent.com/1413534/39213907-bbaaf80a-480a-11e8-97f1-ee1a0142ed66.png)

