### PR TITLE
Updated HP section on /server/hyperscale

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -170,10 +170,10 @@
     <div class="u-equal-height">
       <div class="col-6 p-card">
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-          <img src="{{ ASSET_SERVER_URL }}cd5c35a3-partners-logo-hp.png" width="94" height="94" alt="" />
+          <img src="{{ ASSET_SERVER_URL }}f38c9ed1-hpe_pri_grn_pos_rgb.svg"  width="200" alt="Hewlett Packard Enterprise logo" />
         </div>
-        <p class="p-card__content">Canonical has been involved in the development of Moonshot, HP&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
-        <p class="p-card__content"><a href="http://partners.ubuntu.com/hp" class="p-link--external">Learn more</a></p>
+        <p class="p-card__content">Canonical has been involved in the development of Moonshot, Hewlett Packard Enterprise&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
+        <p class="p-card__content"><a href="http://partners.ubuntu.com/hewlett-packard-enterprise" class="p-link--external">Learn more</a></p>
       </div>
       <div class="col-6 p-card">
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">


### PR DESCRIPTION
## Done

- Updated HP section on /server/hyperscale
- Updated the logo, url and the text slightly
- Updated the [copy doc](https://docs.google.com/document/d/1f56CCzH519lIVa4KvxDt0QpxYFMK-bMdVlKo4TvPSIk/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/server/hyperscale](http://0.0.0.0:8001/server/hyperscale) at HP in the Hyperscale partners' section
- See that the URL goes to https://partners.ubuntu.com/hewlett-packard-enterprise
- See that it used the new name and new logo

## Issue / Card

Fixes #3001 

## Screenshot

![image](https://user-images.githubusercontent.com/441217/39235503-f16802ae-486d-11e8-8233-e02c73468882.png)
