### PR TITLE
Updated /Robotics contact link

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -144,7 +144,7 @@
       </div>
       <div class="col-9">
         <h2>Will your next robot run on Ubuntu?</h2>
-        <p><a href="/internet-of-things/contact-us" class="p-button--positive">Contact us to find out more</a></p>
+        <p><a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive">Contact us to find out more</a></p>
       </div>
     </div>
   </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -144,7 +144,7 @@
       </div>
       <div class="col-9">
         <h2>Will your next robot run on Ubuntu?</h2>
-        <p><a href="https://pages.ubuntu.com/RoboticsContactUs.html" class="p-button--positive">Contact us to find out more</a></p>
+        <p><a href="/internet-of-things/contact-us" class="p-button--positive">Contact us to find out more</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Updated contact us link for robotics page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/robotics](http://0.0.0.0:8001/internet-of-things/robotics)
- Check that the contact link matches the [copy doc ](https://docs.google.com/document/d/1g8XpVzDkAdFETrfZvOf5Q6WlYwHCBYQ8Y6TgTlyTEYc/edit#)


## Issue / Card

Fixes: #3043 


