### PR TITLE
Differentiate the two "Install Ubuntu Core" on raspi links

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -21,7 +21,7 @@
             <a href="/download/iot/raspberry-pi-2-3"><img class="p-matrix__img--large" alt="Raspberry Pi logo" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=200"></a>
           </div>
           <p class="p-matrix__desc">Ubuntu allows you to install apps on your board in just a few clicks.</p>
-          <p><a class="p-matrix__link" href="/download/iot/raspberry-pi-2-3">Install Ubuntu Core&nbsp;&rsaquo;</a></p>
+          <p><a class="p-matrix__link" href="/download/iot/raspberry-pi-2-3">Install Ubuntu Core on Pi 2 or 3&nbsp;&rsaquo;</a></p>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -30,7 +30,7 @@
             <a href="/download/iot/raspberry-pi-compute-module-3"><img class="p-matrix__img--large" alt="Raspberry Pi logo" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=200" /></a>
           </div>
           <p class="p-matrix__desc">Ubuntu works on minimal setups, embed and go!</p>
-          <p><a class="p-matrix__link" href="/download/iot/raspberry-pi-compute-module-3">Install Ubuntu Core&nbsp;&rsaquo;</a></p>
+          <p><a class="p-matrix__link" href="/download/iot/raspberry-pi-compute-module-3">Install Ubuntu Core on CM 3&nbsp;&rsaquo;</a></p>
         </div>
       </li>
       <li class="p-matrix__item">


### PR DESCRIPTION
## Done

This change helps differentiating the two raspi links on the /download/iot page, since the Compute Module 3 doesn't have any specific logo we could use instead of the raspi one.

## QA

- check http://www.ubuntu.com-pr-3061.run.demo.haus/download/iot

## Screenshots

### Before

![screenshot from 2018-04-26 10-07-30](https://user-images.githubusercontent.com/18480003/39293632-a8586a0a-4939-11e8-8f97-8d38ee95ce8f.png)

### After

![screenshot from 2018-04-26 10-04-54](https://user-images.githubusercontent.com/18480003/39293584-884b6686-4939-11e8-96f3-a86fb7298b2f.png)
