### PR TITLE
Update server download links

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -15,7 +15,7 @@
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>
-          <p class="p-card__content">This release uses our new installer, Subiquity.  If you require advanced networking and storage features, such as RAID and LVM, please use the traditional installer found on the <a href="/download/alternative-downloads">alternative downloads</a> page.</p>
+          <p class="p-card__content">This release uses our new installer, Subiquity.  If you require advanced networking and storage features, such as RAID and LVM, please use the traditional installer found on the <a href="/download/alternative-downloads#alternate-ubuntu-server-installer">alternative downloads</a> page.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ lts_release }} LTS release notes</a></p>
         </div>
         <div class="col-4">

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -9,7 +9,7 @@ Thanks for downloading Ubuntu Server
 
 {% block content %}
 <noscript>
-  <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-server-{{ architecture }}.iso">
+  <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-{{ architecture }}.iso">
 </noscript>
 
 <div class="p-strip is-deep is-bordered">
@@ -18,7 +18,7 @@ Thanks for downloading Ubuntu Server
       <h1>Thank you for downloading Ubuntu Server</h1>
       {% if version and architecture %}
       <p>Your download should start automatically. If it doesn&rsquo;t,
-        <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-server-{{ architecture }}.iso">
+        <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-{{ architecture }}.iso">
           download now</a>.
       </p>
       {% else %}
@@ -175,7 +175,7 @@ function startDownload(mirrors, version, architecture, defaultLocation) {
   if (selectedMirror && selectedMirror.link) {
     downloadLocation = selectedMirror.link;
   }
-  var downloadLink = downloadLocation + version + '/ubuntu-' + version + '-server-' + architecture + '.iso';
+  var downloadLink = downloadLocation + version + '/ubuntu-' + version + '-live-server-' + architecture + '.iso';
 
   // Start download
   delayStartDownload(downloadLink, 3000);

--- a/templates/shared/contextual_footers/_download_more_info_enterprise.html
+++ b/templates/shared/contextual_footers/_download_more_info_enterprise.html
@@ -1,7 +1,7 @@
 <div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">More information</h3>
-  <p>Learn more about management with Landscape.</p>
-  <p><a href="/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'management page', 'eventLabel' : 'More info', 'eventValue' : undefined });">Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+  <h3 class="p-heading--four">Enterprise ready</h3>
+  <p>Canonical delivers the leading Kubernetes distribution.</p>
+  <p><a href="/kubernetes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'kubernetes', 'eventLabel' : 'More info', 'eventValue' : undefined });">Canonical Kubernetes&nbsp;&rsaquo;</a></p>
   <p>Ubuntu OpenStack is the fastest way to build an enterprise-scale cloud.</p>
   <p><a href="/openstack" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'OpenStack page', 'eventLabel' : 'More info', 'eventValue' : undefined });">Ubuntu OpenStack&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

- update the /download/server page with the [copy doc](https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit)
- updated the /download/alternative-downloads page with the [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit#) for the contextual footer
- updated the /download/server/thank-you page with the correct url

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
  - [/download/server](http://0.0.0.0:8001/download/server)
    - see that the link to alt downloads goes right to that section of the alt-downloads page
  - [/download/server/thank-you](http://0.0.0.0:8001/download/server/thank-you)
    - see that it goes to the correct download page (with an error for now) `http://releases.ubuntu.com/18.04/ubuntu-18.04-live-server-amd64.iso` or another mirror
  - [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads#alternate-ubuntu-server-installer)
    - see that the bottom right contextual footer has the new text

## Issue / Card

Fixes #3041 and fixes #3052

