### PR TITLE
Remove Hastexo section

### DIFF
--- a/templates/cloud/training.html
+++ b/templates/cloud/training.html
@@ -21,9 +21,6 @@
   <div class="row">
     <div class="col-7">
       <h2>OpenStack Fundamentals</h2>
-      <h3>Online training by Hastexo</h3>
-      <p>Independent providers of online OpenStack training materials, certified by&nbsp;Canonical.</p>
-      <p><a href="https://store.hastexo.com/catalogue/cloud-fundamentals-for-openstack_2/" class="p-link--external">OpenStack Fundamentals by Hastexo</a></p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

Remove Hastexo section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/cloud/training>
- Check that Hastexo section has been removed beneath 'OpenStack Fundamentals' heading


## Issue / Card

Fixes #3063 