### PR TITLE
updated snap store image and link

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -52,7 +52,8 @@
   </div>
   <div class="row">
     <div class="col-12 u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}472914ed-Core-Snap-Store.jpg" alt="Snap store screenshot" />
+      <img src="{{ ASSET_SERVER_URL }}313be7a3-snapcraft.io_store.png" alt="Snap store screenshot" />
+      <p><a href="http://snapcraft.io/store" class="p-link--external">Visit the Snap Store</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updated the snap store screenshot to the new snapcraft store page, and added an external link, linking to that page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things](http://0.0.0.0:8001/internet-of-things)
- Check the screenshot and links are correct and matches [copydoc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit#)


## Issue / Card

Fixes: #3065

