### PR TITLE
Remove chevron from cta

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -37,7 +37,7 @@
               downloadLink.href = contributeUrl;
             </script>
           </p>
-          <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads&nbsp;&rsaquo;</a></small></p>
+          <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads.</a></small></p>
         </div>
       </div>
     </div>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -37,7 +37,7 @@
               downloadLink.href = contributeUrl;
             </script>
           </p>
-          <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads.</a></small></p>
+          <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
         </div>
       </div>
     </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -20,7 +20,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content"><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
-          <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads&nbsp;&rsaquo;</a></small></p>
+          <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads.</a></small></p>
         </div>
       </div>
     </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -20,7 +20,7 @@
         </div>
         <div class="col-4">
           <p class="p-card__content"><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
-          <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads.</a></small></p>
+          <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

Remove chevron from alternative download cta

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/desktop>
- Check that alternative download cta has a fullstop and no chevron
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/server>
- Check that alternative download cta has a fullstop and no chevron
