### PR TITLE
Remove br from title

### DIFF
--- a/templates/download/cloud/build-openstack.html
+++ b/templates/download/cloud/build-openstack.html
@@ -86,7 +86,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Register your hardware with<br /> MAAS</h3>
+          <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Register your hardware with MAAS</h3>
           <div class="p-list-step__content">
             <p>Now you need to enlist and commission machines:</p>
             <ul class="p-list">


### PR DESCRIPTION
## Done

Remove br from title

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001//download/cloud/build-openstack>
- Check that br mentioned in title is removed


## Issue / Card

Fixes #3076 