### PR TITLE
Update documentation contextual footer

### DIFF
--- a/templates/shared/contextual_footers/_download_documentation.html
+++ b/templates/shared/contextual_footers/_download_documentation.html
@@ -1,10 +1,11 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Detailed documentation</h3>
-  <p><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation/UbuntuServerGuide" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c server guide', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server Guide</a></p>
 
-  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c latest', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{ latest_release }} documentation</a></p>
+  <ul class="p-list">
+    <li><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation/UbuntuServerGuide" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c server guide', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server Guide</a></li>
 
-  <p><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
+    <li><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></li>
 
-  <p><a href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'how to verify', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Verify your download</a></p>
+    <li><a href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'how to verify', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Verify your download</a></li>
+  </ul>
 </div>


### PR DESCRIPTION
## Done

Update contextual footer for download documentation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download](http://0.0.0.0:8001/download)
- Check issues addressed in issue below


## Issue / Card

Fixes #3072 
