### PR TITLE
Fix blurry logo

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -64,7 +64,7 @@
       <li class="p-matrix__item">
         <div class="p-matrix__content">
           <div class="p-matrix__img-container u-vertically-center">
-            <a href="/download/iot/intel-joule"><img class="p-matrix__img--large" alt="Intel Joule Pi logo" src="{{ ASSET_SERVER_URL }}1f53b707-INTEL_JOULE-LOGO.png?w=200" /></a>
+            <a href="/download/iot/intel-joule"><img width="200" class="p-matrix__img--large" alt="Intel Joule Pi logo" src="{{ ASSET_SERVER_URL }}1f53b707-INTEL_JOULE-LOGO.png" /></a>
           </div>
           <p class="p-matrix__desc">Ubuntu lets you interact and control complex hardware and modules.</p>
           <p><a class="p-matrix__link" href="/download/iot/intel-joule">Install Ubuntu Core&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done

Fix blurry jouel logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/iot>
- Check that intel joule logo is not blurry


## Issue / Card

Fixes #3068
