### PR TITLE
Updated the Ubuntu 16.04 LTS torrent links

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -52,10 +52,10 @@
     <div class="col-4">
       <h3 class="p-link--external"><span>Ubuntu 16.04 LTS</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04-desktop-amd64.iso.torrent">Ubuntu 16.04 Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04-desktop-i386.iso.torrent">Ubuntu 16.04 Desktop (32-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso.torrent">Ubuntu 16.04 Server (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso.torrent">Ubuntu 16.04 Server (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-desktop-amd64.iso.torrent">Ubuntu 16.04 Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-desktop-i386.iso.torrent">Ubuntu 16.04 Desktop (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-amd64.iso.torrent">Ubuntu 16.04 Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-i386.iso.torrent">Ubuntu 16.04 Server (32-bit)</a></li>
       </ul>
     </div>
     <div class="col-4">


### PR DESCRIPTION
## Done 

- Updated the Ubuntu 16.04 LTS torrent links

## QA 

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
[alt-downloads](http://0.0.0.0:8001/download/alternative-downloads)
- See that the 16.04 torrent filed all download - it was missing the .4
point release in the name

## Issue / Card

Fixes #3090


