### PR TITLE
Update Japan legal page

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description-ja/index.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja/index.html
@@ -138,7 +138,7 @@
         <li><a href="https://www.ubuntu.com/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a></li>
       </ul>
 
-      <h2>付録1 - サポート範囲</h2>
+      <h2 id="appendix-1">付録1 - サポート範囲</h2>
       <h3>Ubuntu Advantage OpenStack</h3>
       <ul class="p-list">
         <li>
@@ -881,7 +881,7 @@
         <li><a href="/legal/ubuntu-advantage/service-description#service-description">上へ戻る</a></li>
       </ul>
 
-      <h3>Ubuntu Advantageサポートプロセス</h3>
+      <h3 id="appendix-2">付録2 - Ubuntu Advantageサポートプロセス</h3>
       <ul class="p-list">
         <li>
           <p>1.サービスの開始</p>
@@ -1005,7 +1005,7 @@
       </ul>
       <p><a href="/legal/ubuntu-advantage/service-description#service-description">上へ戻る</a></p>
 
-      <h2>Ubuntu Advantage マネージメントへのエスカレーション</h2>
+      <h2 id="appendix-3">付録3 - Ubuntu Advantage マネージメントへのエスカレーション</h2>
       <p>サービスの種類を問わずCanonicalのサービスにご満足いただけない場合、その状況をCanonicalのマネージメントにエスカレーションする方法がいくつかあります。</p>
 
       <h3>サポートケース終了時のフィードバック</h3>
@@ -1035,17 +1035,17 @@
       <h3>追加情報</h3>
       <ul class="p-list">
         <li class="p-list__item">
-          <a href="/legal/ubuntu-advantage/service-description#appendix-1">
+          <a href="#appendix-1">
             付録1 - サポート範囲&nbsp;&rsaquo;
           </a>
         </li>
         <li class="p-list__item">
-          <a href="/legal/ubuntu-advantage/service-description#appendix-2">
+          <a href="#appendix-2">
             付録2 - サポートプロセス&nbsp;&rsaquo;
           </a>
         </li>
         <li class="p-list__item">
-          <a href="/legal/ubuntu-advantage/service-description#appendix-3">
+          <a href="#appendix-3">
             付録3 - マネージメントへのエスカレーション&nbsp;&rsaquo;
           </a>
         </li>

--- a/templates/legal/ubuntu-advantage/service-description-ja/index.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja/index.html
@@ -2,965 +2,984 @@
   {% block title %}Ubuntu Advantage service description{% endblock %}
 {% block content %}
 
+
 <div class="p-strip">
   <div class="row" id="service-description" lang="ja">
     <div class="col-8">
-      <h1>Ubuntu Advantageサービス記述書</h1>
-      <p>日本語版サービス記述書は参考訳としてご使用ください。</p>
-      <p>最新のサービス記述書は以下の英語版を参照ください。</p>
-      <p><a href="/legal/ubuntu-advantage/service-description">https://www.ubuntu.com/legal/ubuntu-advantage/service-description</a></p>
-      <h2 id="service-description-overview">1.概要</h2>
+      <h1>Ubuntu Advantage サービス記述書</h1>
+      <p>2018年2月26日より有効</p>
+
+      <h2>1.概要</h2>
       <ul class="p-list">
+        <li>1.1 この文書は、以下のサービスを定義します。Canonicalは本文書の定義に従い、お客様のご契約の対象となるサービスのみを提供します。</li>
         <li>
-          <p>1.1 本文書は以下のサービスを定義します。Canonicalは、本文書に定義される通り、顧客の契約の対象となるサービスのみを提供します。</p>
-        </li>
-        <li>
-          <p>1.2 プライマリーサービス：</p>
+          <p>1.2 プライマリーサービス</p>
           <ul>
             <li>Ubuntu Advantage OpenStack</li>
             <li>Ubuntu Advantage OpenStack Cloud Region</li>
             <li>Ubuntu Advantage Server (Essential/Standard/Advanced)</li>
-            <li>Ubuntu Advantage Virtual Guest (Standard/Advanced)</li>
+            <li>Ubuntu Advantage Virtual Guest (Essential/Standard/Advanced)</li>
             <li>Ubuntu Advantage Ceph Storage</li>
             <li>Ubuntu Advantage Swift Storage</li>
             <li>Ubuntu Advantage MAAS (Standard/Advanced)</li>
-            <li>Ubuntu Advantage Switch</li>
+            <li>Ubuntu Advantage Switch (Standard/Advanced)</li>
             <li>Ubuntu Advantage Desktop (Standard/Advanced)</li>
             <li>Ubuntu Advantage for Docker</li>
-            <li>The Canonical Distribution of Kubernetes</li>
-            <li>Extended Security Maintenance</li>
+            <li>Ubuntu Advantage Kubernetes (Standard/Advanced)</li>
+            <li>拡張セキュリティメンテナンス</li>
+            <li>Canonical Livepatchサービス</li>
+            <li>FIPS for Ubuntu</li>
           </ul>
-          <li>
-            <p>1.3 アドオンサービス</p>
-            <ul>
-              <li>Landscape Seats</li>
-              <li>Technical Account Manager</li>
-              <li>Dedicated Technical Account Manager</li>
-              <li>Landscape on-premises</li>
-            </ul>
-          </li>
         </li>
-      </ul>
-      <h2 id="ua-support-scope">2.サポート範囲</h2>
-      <p>各サービス製品には、Canonicalのナレッジベースおよび本文書の範囲内の下記のサポートへのアクセスが含まれます。ただし、以下のサポート範囲文書に記載の例外に従います：[URL]</p>
-      <p>2.1 リリース</p>
-      <ul>
         <li>
-          <p>Canonicalは、製品ライフサイクル中に公式ソースを使用してインストールされたUbuntuの全標準リリースのインストール、設定、保守、および管理に関するサポートを提供します。Ubuntuのバージョン別ライフサイクルについては、こちらをご覧ください：</p>
-          <p><a href="http://www.ubuntu.com/info/release-end-of-life">http://www.ubuntu.com/info/release-end-of-life</a></p>
+          <p>1.3 アドオンサービス：</p>
+          <ul>
+            <li>Landscape Seats</li>
+            <li>テクニカルアカウントマネージャー (TAM)</li>
+            <li>専任テクニカルアカウントマネージャー (DTAM)</li>
+            <li>専任サポートエンジニア (DSE)</li>
+            <li>Landscape on-premises</li>
+          </ul>
         </li>
       </ul>
-      <p>2.2 ハードウェア</p>
-      <ul>
+
+      <h2>2.サポート範囲</h2>
+      <p>各サービスには、Canonicalのナレッジベースへのアクセスおよび以下に説明するサポートの提供が含まれます。<a href="/legal/ubuntu-advantage/service-description#appendix-1">サポートの提供範</a>囲と例外については、サポート範囲文書に詳しく記載されており、その例外に従うことが条件となります。</p>
+      <ul class="p-list">
         <li>
-          <p>Ubuntu認定ハードウェアは、当社の広範なテストおよびレビュープロセスに合格しています。Ubuntu認定プロセスの詳細および認定ハードウェアの一覧については、Ubuntu認定ページをご覧ください：</p>
-          <p><a href="http://www.ubuntu.com/certification/">http://www.ubuntu.com/certification/</a></p>
-          <p>本サービスは、顧客の認定ハードウェアのみに適用されます。認定されていないハードウェアに関するサービスを顧客から依頼された場合、Canonicalはサポートサービスを提供するために合理的な努力を払いますが、本サービス記述書に記載された義務に従わない場合があります。</p>
+          <p>2.1 リリース</p>
+          <ul>
+            <li>Canonicalは、公式のソースを使用して製品ライフサイクル中にインストールされたUbuntuのすべての標準リリースについて、インストール、設定、メンテナンスおよび管理のサポートを提供します。Ubuntuの各バージョンのライフサイクルは、こちらに記載されています。</li>
+            <li><a href="https://www.ubuntu.com/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a></li>
+          </ul>
+        </li>
+        <li>
+          <p>2.2 ハードウェア</p>
+          <ul>
+            <li>Ubuntu認定ハードウェアは、当社の広範囲にわたるテストに合格し、レビュープロセスを終了したものです。Ubuntuの認定プロセスに関するさらに詳しい情報、認定ハードウェアのリストは、こちらの「Ubuntu認定 (Ubuntu Certification)」のページでご覧いただけます。<a href="https://www.ubuntu.com/certification">www.ubuntu.com/certification</a>本サービスは、お客様のUbuntu認定ハードウェアのみに限って適用されます。お客様から、認定外のハードウェアに関するサービスの依頼を受けた場合、Canonicalでは相応の努力によりサポートサービスの提供に努めますが、本サービス記述書に記載された義務に沿わない場合があります。</li>
+          </ul>
+        </li>
+        <li>
+          <p>2.3 パッケージ</p>
+          <ul>
+            <li>2.3.1 本サービスは、Ubuntu Mainリポジトリ内で取得可能なパッケージおよびUniverseリポジトリ内のCanonical所有パッケージのみに適用されます。ただし、(i) 「proposed（提案中）」および「backports（バックポート）」リポジトリポケット内のパッケージ、ならびに (ii) 該当するサポート範囲文書に記載された例外を除きます。</li>
+            <li>Universeリポジトリ内のサポート対象パッケージには、Jujuパッケージ、MAASパッケージ、nova-conductorパッケージ、ならびにこれらに関連して使用される範囲の各依存パッケージが含まれますが、それらに限定されません。</li>
+            <li>2.3.2 Canonicalでは、 Ubuntuのアーカイブ内にあるバージョンから修正されたパッケージのサポートは一切提供しません。</li>
+          </ul>
+        </li>
+        <li>
+          <p>2.4 カーネル</p>
+          <ul>
+            <li>2.4.1 Ubuntuの長期サポートバージョン (LTS) のリリース時に当初提供されたカーネルは、そのLTSのライフサイクル全体を通してサポートされます。</li>
+            <li>2.4.2 ハードウェアイネーブルメント (HWE) カーネルにより、LTSリリース内でより新しいハードウェアに関するサポートを提供します。これは、UbuntuのLTS以外のリリースと連携してリリースされます。HWEカーネルは、次回のLTSポイントリリース時までサポート対象となります。</li>
+            <li>2.4.3 カーネルのサポートについてさらに詳しい情報は、こちらからご覧ください。</li>
+            <li><a href="https://www.ubuntu.com/info/release-end-of-life">atwww.ubuntu.com/info/release-end-of-life</a></li>
+            <li>2.4.4 Canonical Livepatchサービスへのアクセスは、記載された例外を除き、全サポートサービスに含まれています。</li>
+          </ul>
+        </li>
+        <li>
+          <p>2.5 Landscape</p>
+          <ul>
+            <li>2.5.1 Landscape全製品は、Landscape on-premises（購入された場合）を含めて完全にサポートされます。</li>
+            <li>2.5.2 Landscape SaaSシステム管理ツールへのアクセスは、記載された例外を除き、全サポートサービスに含まれています。</li>
+          </ul>
         </li>
       </ul>
-      <p>2.3 パッケージ</p>
-      <ul>
-        <li>2.3.1 本サービスは、Ubuntu MainリポジトリにあるパッケージおよびUniverse RepositoryにあるCanonical所有のパッケージのみに適用されます。ただし、(i) 「proposed」および「backports」リポジトリポケット、および
-          (ii) 該当するサポート範囲文書に記載された除外事項は除きます。Universe Repositoryのサポート対象パッケージには、Jujuパッケージ、MAASパッケージ、nova-conductorパッケージ、およびこれらのパッケージと関連して使用される依存パッケージが含まれます。</li>
-        <li>2.3.2 Ubuntuアーカイブにあるバージョンから変更されているパッケージはサポート対象外です。</li>
-      </ul>
-      <p>2.4 カーネル</p>
-      <ul>
-        <li>2.4.1 Ubuntuの長期サポート (LTS) バージョンのリリースで最初に提供されたカーネルは、そのLTSの全ライフサイクルにおいてサポートされます。</li>
-        <li>2.4.2 ハードウェアイネーブルメント (HWE) カーネルは、LTSリリースでより新しいハードウェアをサポートするもので、Ubuntuの非LTSバージョンのリリースに合わせてリリースされます。HWEカーネルは、次回のLTSポイントリリースまでサポートされます。</li>
-        <li>2.4.3 カーネルのサポートについて、<a href="http://www.ubuntu.com/info/release-end-of-life">http://www.ubuntu.com/info/release-end-of-life</a>          にてさらに詳しくご覧いただけます。</li>
-        <li>2.4.4 カーネルのライブパッチ</li>
-        <ul>
-          <li>顧客には、Canonicalのカーネルライブパッチデーモンの使用許諾ライセンスを受ける権利、利用可能なカーネルライブパッチにアクセスする権利、ライブパッチ機能が利用可能でUbuntu Advantageが対応しているすべてのシステムについてライブパッチのサポートを受ける権利があります。</li>
-          <li>Canonicalは、緊急 (Critical) および高 (High) レベルのカーネル脆弱性CVE用ライブパッチを提供します。ただし、ライブパッチシステム内の技術的限界のため、脆弱性CVEの一部はライブパッチの対象外となる可能性がありますのでご注意ください。</li>
-          <li>Canonicalでは、カーネルのサポートの不具合修正をカーネルライブパッチとして提供することはできません。</li>
-          <li>Ubuntu 16.04については、ジェネリック用および低レイテンシで動作する64ビットIntel/AMD 4.4カーネル用のカーネルライブパッチが提供されています。</li>
-        </ul>
-      </ul>
-      <p>2.5 Landscape</p>
-      <ul>
-        <li>2.5.1 Landscape on-premises （購入された場合）を含むすべてのLandscape製品は完全にサポートされます。</li>
-        <li>2.5.2 別途記述がない限り、Landscape SaaSシステム管理ツールへのアクセスはすべてのサポート製品に含まれています。</li>
-      </ul>
-      <h2 id="response-times">3.応答時間</h2>
 
-      <p>3.1 Canonicalは、以下に規定する応答時間内に、該当するサービスレベルおよび重大度に基づき、顧客からのサポート要求に応答するための合理的な努力を払います。</p>
-      <p>3.2「営業時間」および「営業日」は下表に定義されます。すべての時間は祝日を除き、別の場所が合意されない限り、顧客の本社のある地域に基づくものです。</p>
+      <h2>3.応答時間</h2>
+      <ul class="p-list">
+        <li>3.1 Canonicalでは相応の努力により、お客様からのサポート依頼に対して、該当するサービスレベルおよび重大度レベルに基づき以下に規定した応答時間内に応答・対応するよう努めます。</li>
+        <li>3.2 「営業時間」とは、お客様の本社所在地の現地時間による月曜日から金曜日の午前8時～午後6時と定義します。ただし、別の所在地について合意する場合を除きます。すべての時間は、公休日を除きます。</li>
+      </ul>
 
-      <table>
+      <h4>応答時間表</h4>
+      <table class="p-table">
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            <th><strong>Standard</strong></th>
+            <th><strong>Advanced</strong></th>
+          </tr>
+        </thead>
         <tbody>
           <tr>
-            <td>
-              <p><strong>サービス</strong></p>
-            </td>
-            <td>
-              <p><strong>営業時間</strong></p>
-            </td>
+            <td>重大度レベル1</td>
+            <td>2営業時間以内</td>
+            <td>1時間以内</td>
           </tr>
           <tr>
-            <td>
-              <ul>
-                <li>Ubuntu Advantage Server Essential</li>
-                <li>Ubuntu Advantage Desktop Standard</li>
-              </ul>
-            </td>
-            <td>
-              <p>月曜～金曜 9:00～17:00</p>
-            </td>
+            <td>重大度レベル2</td>
+            <td>4営業時間内</td>
+            <td>4営業時間以内</td>
           </tr>
           <tr>
-            <td>
-              <ul>
-                <li>Ubuntu Advantage Server Standard</li>
-                <li>Ubuntu Advantage Virtual Guest Standard</li>
-                <li>Ubuntu Advantage MAAS Standard</li>
-              </ul>
-            </td>
-            <td>
-              <p>月曜～金曜 8:00～18:00</p>
-            </td>
+            <td>重大度レベル3</td>
+            <td>10営業時間以内</td>
+            <td>6営業時間以内</td>
           </tr>
           <tr>
-            <td>
-              <ul>
-                <li>Ubuntu Advantage OpenStack</li>
-                <li>Ubuntu Advantage OpenStack Cloud Region</li>
-                <li>Ubuntu Advantage Server Advanced</li>
-                <li>Ubuntu Advantage Virtual Guest Advanced</li>
-                <li>Ubuntu Advantage Ceph Storage</li>
-                <li>Ubuntu Advantage Swift Storage</li>
-                <li>Ubuntu Advantage MAAS Advanced</li>
-                <li>Ubuntu Advantage Switch</li>
-                <li>Landscape on-premises</li>
-                <li>Ubuntu Advantage Desktop Advanced</li>
-                <li>Ubuntu Advantage for Docker</li>
-                <li>The Canonical Distribution of Kubernetes</li>
-              </ul>
-            </td>
-            <td>
-              <p>月曜～金曜 8:00～18:00</p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-
-      <table>
-        <tbody>
-          <tr>
-            <td>
-              <p><strong>重大度 レベル1</strong></p>
-            </td>
-            <td>
-              <p><strong>重大度 レベル2</strong></p>
-            </td>
-            <td>
-              <p><strong>重大度 レベル3</strong></p>
-            </td>
-            <td>
-              <p><strong>重大度 レベル4</strong></p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li>Ubuntu Advantage Server Essential</li>
-                <li>Ubuntu Advantage Desktop Standard</li>
-              </ul>
-            </td>
-            <td>
-              <p>1営業日</p>
-            </td>
-            <td>
-              <p>1営業日</p>
-            </td>
-            <td>
-              <p>2営業日</p>
-            </td>
-            <td>
-              <p>4営業日</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li>Ubuntu Advantage Server Standard</li>
-                <li>Ubuntu Advantage Virtual Guest Standard</li>
-                <li>Ubuntu Advantage MAAS Standard</li>
-              </ul>
-            </td>
-            <td>
-              <p>2営業時間</p>
-            </td>
-            <td>
-              <p>4営業時間</p>
-            </td>
-            <td>
-              <p>1営業日</p>
-            </td>
-            <td>
-              <p>2営業日</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li>Ubuntu Advantage OpenStack</li>
-                <li>Ubuntu Advantage OpenStack Cloud Region</li>
-                <li>Ubuntu Advantage Server Advanced</li>
-                <li>Ubuntu Advantage Virtual Guest Advanced</li>
-                <li>Ubuntu Advantage Ceph Storage</li>
-                <li>Ubuntu Advantage Swift Storage</li>
-                <li>Ubuntu Advantage MAAS Advanced</li>
-                <li>Ubuntu Advantage Switch</li>
-                <li>Landscape on-premises</li>
-                <li>Ubuntu Advantage Desktop Advanced</li>
-                <li>Ubuntu Advantage for Docker</li>
-                <li>The Canonical Distribution of Kubernetes</li>
-              </ul>
-            </td>
-            <td>
-              <p>1時間</p>
-            </td>
-            <td>
-              <p>4営業時間</p>
-            </td>
-            <td>
-              <p>6営業時間</p>
-            </td>
-            <td>
-              <p>1営業日</p>
-            </td>
+            <td>重大度レベル4</td>
+            <td>20営業時間以内</td>
+            <td>10営業時間以内</td>
           </tr>
         </tbody>
       </table>
 
       <h2>4.サポートプロセス</h2>
-
-      <p>Canonicalは、サポートケースを解決できるよう合理的な努力を払いますが、回避策、解決策または解決時間は保証しません。</p>
-      <p>4.1 Canonicalは、サポートプロセスに従ってサービスを提供します：[URL]</p>
-      <p>4.2 顧客は、エスカレーションプロセスに従ってサポート問題をエスカレートできます：[URL]</p>
-
-      <h2 id="assurance">5.保証</h2>
-
-      <p>5.1 顧客は、利用規約に従って、Ubuntu保証プログラムに加入する権利を有します。Canonicalは、保証プログラムおよびその規約を定期的に更新することがあります。現在のUbuntu保証プログラムおよびそのIP免責条項はUbuntu保証ページでご覧いただけます：</p>
-      <p><a href="http://www.ubuntu.com/legal/ubuntu-advantage/assurance">http://www.ubuntu.com/legal/ubuntu-advantage/assurance</a></p>
-
-      <h2>参考文書</h2>
-
-      <ul>
-        <li><a href="#appendix-1">Appendix 1 - サポート範囲 &rsaquo;</a></li>
-        <li><a href="#appendix-2">Appendix 2 - サポートプロセス &rsaquo;</li>
-        <li><a href="#appendix-3">Appendix 3 - マネジメントエスカレーション &rsaquo;</li>
+      <p>Canonicalでは相応の努力を払ってサポートケースの解決に努めますが、問題の回避、解決または解決時間について保証するものではありません。</p>
+      <ul class="p-list">
+        <li>4.1 Canonicalは、以下の<a href="/legal/ubuntu-advantage/service-description#appendix-2">サポートプロセス</a>に従ってサービスを提供します。</li>
+        <li>4.2 お客様は、以下の<a href="/legal/ubuntu-advantage/service-description#appendix-3">エスカレーションプロセス</a>に従って、サポートの問題をエスカレーションすることができます。</li>
       </ul>
 
-      <h2 id="appendix-1">Ubuntu Advantage サポート範囲文書</h2>
+      <h2>5.保証</h2>
+      <ul class="p-list">
+        <li>5.1 お客様には、利用規約に従うことを条件として、Ubuntu保証プログラムに加入する資格があります。Canonicalでは、この保証プログラムとその規約を定期的に更新することがあります。現行のUbuntu保証プログラムおよびIP免責条項は、以下の「Ubuntu保証」のページでご覧いただけます。</li>
+        <li><a href="https://www.ubuntu.com/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a></li>
+      </ul>
 
+      <h2>付録1 - サポート範囲</h2>
       <h3>Ubuntu Advantage OpenStack</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「OpenStack」とは、CanonicalによりUbuntuと共に配布される「OpenStack」と呼ばれるクラウドコンピューティングソフトウェアを指します。</li>
-          <li>「OpenStackパッケージ」とは、Ubuntu ArchiveのUbuntu MainリポジトリにあるOpenStack関連パッケージを指し、これらのパッケージ用としてUbuntu Cloud Archive内で提供するアップデートを含みます。これには、
-            <a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a>            の一覧に記載されたチャームを含みます。</li>
-          <li>「リージョン」とは、専用APIエンドポイントを持つ個々のOpenStack環境を指し、通常、Identity (Keystone) サービスのみを他のリージョンと共有します。単一のデータセンターには必ず1つのOpenStackリージョンが含まれています。</li>
-          <li>「パブリッククラウド」とは、第三者がゲストインスタンスを作成・管理できるクラウド環境を指します。</li>
-          <li>「クラウドゲスト」とは、パブリッククラウドで実行されていないUbuntu Serverのインスタンスを指します。</li>
-          <li>「Full Stackサポート」とは、ユーザーおよびオペレーションレベルのOpenStack機能、パフォーマンスおよび可用性に関する問題に対処するサポートを指します。</li>
-          <li>「バグフィックスサポート」とは、OpenStackパッケージの有効なコードバグのみのサポートを指します。これには、バグが存在するかどうかを判定する際に生じる問題のトラブルシュートは含まれません。</li>
-          <li>「正当なカスタマイゼーション」とは、HorizonまたはOpenStackパッケージのOpenStack APIを通じて行われた設定を指します。疑問の生じないよう付言すると誤解が生じないよう補足説明しておくと、Canonicalが明示的に実行もしくは許可しなかったアーキテクチャ上の変更は、正当なカスタマイゼーションに含まれません。Foundation
-            OpenStack Build中に設定される設定オプションは、クラウドの正常な機能稼働に最も重要とされるものです。それに変更を加えると、クラウドがサポート対象外となる可能性があります。サポートを確実に継続するには、変更の要求をCanonicalが承認する必要があります。</li>
-        </ul>
-        <li>サポート対象となるOpenStackバージョン：</li>
-        <ul>
-          <li>Ubuntuの長期サポート (LTS) バージョンのリリースで最初に提供されたOpenStackのバージョンは、そのUbuntuバージョンの全ライフサイクルにおいてサポートされます。</li>
-          <li>UbuntuのLTSバージョン後にリリースされたOpenStackのリリースは、Ubuntu Cloud Archiveで公開されます。Ubuntu Cloud Archiveにある各OpenStackリリースは、該当するOpenStackバージョンを含むUbuntuバージョンのリリース日から最低18ヵ月間、Ubuntu
-            LTSバージョン上でサポートされます。
-          </li>
-          <li>OpenStackリリースのサポートスケジュールについては <a href="http://www.ubuntu.com/info/release-end-of-life">http://www.ubuntu.com/info/release-end-of-life</a>            をご覧ください。</li>
-        </ul>
-        <li>OpenStackのサポート</li>
-        <ul>
-          <li>OpenStackのサポートには、各リージョンが12以上のサポート対象ノードで構成されていることが必要です。OpenStack環境を構成するすべてのノードは、有効なサポート契約の対象となっていなければなりません。</li>
-          <li>2.2項に記載したハードウェア要件に加え、ハードウェアは<a href="https://assets.ubuntu.com/v1/22beff77-Foundation+Cloud+Build+Hardware+Requirements.pdf">Ubuntu OpenStack最低基準</a>を満たすものでなければなりません。</li>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
           <ul>
-            <li>OpenStack CloudのFull Stackサポートは、Foundation OpenStack Build業務によりデプロイされた場合に限り利用可能です。</li>
-            <ul>
-              <li>Canonicalは、Foundation OpenStack Buildを通じてデプロイされたチャームのサポートを提供します。</li>
-              <li>Canonicalとの契約に基づいてデプロイした結果、チャームのカスタマイズが必要になった場合、カスタマイズの有効期間はそのカスタマイズを含むチャームの公式リリース後90日間です。</li>
-              <li>Foundation OpenStack Build業務を通じてデプロイされるOpenStackの実行に必要なすべてのパッケージを対象とするサポートが含まれます。</li>
-              <li>Ubuntu LTSの定期保守サイクルの一部として行うOpenStackコンポーネントのアップグレードはサポートされます。</li>
-              <li>OpenStackのバージョン間（例：OpenStack NewtonからMitakaへ）またはUbuntu、Juju、MAASのバージョン間（例：Ubuntu 14.04 LTSからUbuntu 16.04 LTSへ）のアップグレードは、Foundation
-                OpenStack Buildの一部としてCanonicalの指定するとおり、文書化されたプロセスに従って実施する場合に限ってサポートされます。</li>
-              <li>新しいクラウドノードの追加、既存のノードと同等の容量の新しいノードとの交換は、いずれもサポートされます。</li>
-              <li>正当なカスタマイゼーションと見なされないカスタマイゼーションは、Full Stackサポートから除外されます。</li>
-              <li>クラウドゲスト向けUbuntu Advantage Virtual Guest Advancedサービス。</li>
-            </ul>
-            <li>Foundation OpenStack Buildを通じてデプロイされていないOpenStackクラウドは、バグフィックスサポートのみに限定されます。</li>
+            <li>「OpenStack」とは、「OpenStack」として知られ、CanonicalがUbuntuと併せて提供する原状のクラウドコンピューティングソフトウェアを指します。</li>
+            <li>「OpenStackパッケージ」とは、Ubuntuアーカイブ内のUbuntu Mainリポジトリ内に現存するOpenStackに関連するパッケージを指し、そのパッケージのアップデートとしてUbuntuクラウドアーカイブ内で提供されるものを含みます。これには、以下のリストに記載されたチャームが含まれます。</li>
+            <li><a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a></li>
+            <li>「リージョン」とは、専用APIエンドポイントがある個別のOpenStack環境を指し、通常はID (Keystone) サービスのみを他のリージョンと共有します。1つのOpenStackリージョンは、単一のデータセンターに収容しなければなりません。</li>
+            <li>「パブリッククラウド」とは、サードパーティがゲストインスタンスを作成および管理可能なクラウド環境を指します。</li>
+            <li>「クラウドゲスト」とは、Ubuntu サーバーのインスタンスで、パブリッククラウド上で稼働していないものを指します。</li>
+            <li>「フルスタック (Full Stack) サポート」とは、OpenStackのユーザーレベルおよび企業レベルの機能性、パフォーマンス、可用性に関する問題への対処を意味します。</li>
+            <li>「バグフィックスサポート」とは、OpenStackパッケージ内の正当なコードバグのみの限定サポートを意味します。これには、バグが存在するかどうかを判定するための問題のトラブルシューティングは含まれません。</li>
+            <li>「有効なカスタマイゼーション」とは、OpenStackパッケージのHorizonまたはOpenStack APIを使用して行われた設定を意味します。疑問の生じないよう付け加えると、有効なカスタマイゼーションには、Canonicalによる実施または許可が明確でないアーキテクチャ上の変更は含まれません。Foundation OpenStack Build中に設定された設定オプションは、クラウドの正常な稼働に最重要であるとお考えください。これに対する一切の変更は、クラウドのサポート停止につながる可能性があります。サポートを確実に継続するためには、変更の依頼をCanonicalが承認する必要があります。</li>
           </ul>
-          <li>OpenStackサポートには、OpenStackクラウドのデプロイメント中または設定中のバグフィックスサポートを超えるサポートは含まれません。</li>
-          <li>チャーム</li>
+        </li>
+        <li>
+          <p>OpenStackのサポート対象バージョン：</p>
           <ul>
-            <li>各チャームバージョンは、リリース日から1年間サポートされます。</li>
-            <li><a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a>              に記載のサポート対象バージョンから変更されているチャームはサポートされません。</li>
+            <li>Ubuntuの長期サポートバージョン (LTS) のリリース時に当初提供されたOpenStackのバージョンは、そのLTSのライフサイクル全体を通してサポートされます。</li>
+            <li>UbuntuのLTSバージョンのリリース後にリリースされるOpenStackの各リリースは、Ubuntuクラウドアーカイブから入手できます。Ubuntuクラウドアーカイブ内のOpenStackの各リリースは、Ubuntu LTSの1バージョン上で、該当するOpenStackのバージョンを含むUbuntuバージョンのリリース日から最低18ヵ月間サポートされます。</li>
+            <li>OpenStackリリースのサポートスケジュールは、こちらでご覧いただけます。</li>
+            <li><a href="http://www.ubuntu.com/info/release-end-of-life">http://www.ubuntu.com/info/release-end-of-life</a></li>
           </ul>
-          <li>CephもしくはSwiftのデプロイメントを対象とするサポートは、デプロイされるノード1つにつき使用可能なストレージの合計が最大3TBまで。この許容量は、Ubuntu Advantage Ceph、Ubuntu Advantage
-            Swift、またはこれらの組み合わせに対して使用できます。</li>
-          <li>Canonicalの提供する、入手可能なMicrosoft認定ドライバのWindows Guestインスタンスにおける使用許諾ライセンス。</li>
-          <li>Ceph Dash Monitoringツールの使用許諾ライセンス。</li>
-          <li>サービスから除外されるもの：</li>
+        </li>
+        <li>
+          <p>OpenStackのサポート</p>
           <ul>
-            <li>OpenStackデプロイメントの実行に必要でないワークロードに対するサポート。</li>
-            <li>クラウドゲスト以外のゲストインスタンスに対するサポート。</li>
+            <li>OpenStackのサポートは、Advanced対象の応答時間で提供します。</li>
+            <li>OpenStackのサポートを受けるには、各リージョンが12以上のサポート対象ノードで構成される必要があります。OpenStack環境内に配置されたすべてのノードは、有効なサポート契約の対象であることが必要です。</li>
+            <li>セクション2.2に規定するハードウェア要件に加え、ハードウェアはUbuntu OpenStack最低基準を満たしていることが必要です。</li>
+            <li>OpenStackクラウドの「フルスタック (Full Stack) サポート」は、Foundation</li>
+            <li>
+              <p>OpenStack Build委託によりデプロイされた場合に限って提供されます。</p>
+              <ul>
+                <li>Canonicalは、Foundation OpenStack Buildによりデプロイされたチャームのサポートを提供します。</li>
+                <li>Canonicalとの契約により実施したあらゆるデプロイメントについて、結果的にチャームがカスタマイズされた場合のカスタマイゼーションは、そのカスタマイゼーションが含まれるチャームの公式リリース後90日間有効です。</li>
+                <li>Foundation OpenStack Build委託によりデプロイされた原状でOpenStackを稼働するために必要なサポートは、すべてのパッケージに含まれています。</li>
+                <li>OpenStackのコンポーネントについて、Ubuntu LTSの定期メンテナンスサイクルの一環としてのアップグレードは、サポート対象です。</li>
+                <li>OpenStackのバージョン間のアップグレード（例：OpenStack MitakaからNewtonへ）またはUbuntu（例：Ubuntu 14.04 LTSからUbuntu 16.04 LTSへ）、JujuおよびMAASのバージョン間のアップグレードは、サポートされています。ただしそのアップグレードは、文書化されたプロセスに従ってCanonicalの指定どおり、Foundation</li> <li>OpenStack Buildの一環として行うことを条件とします。</li>
+                <li>新しいクラウドノードの追加、ならびに既存のノードと同等容量の新しいノードとの交換は、いずれもサポートされています。</li>
+                <li>フルスタックサポートは、有効なカスタマイゼーションと見なされないカスタマイゼーションを対象外とします。</li>
+                <li>クラウドゲスト用のUbuntu Advantage Virtual Guest Advanced サービス</li>
+              </ul>
+            </li>
+            <li>OpenStackクラウドで、Foundation OpenStack Buildを通じてデプロイされなかっ</li>
+            <li>たものについては、バグフィックスサポートのみに限定して提供します。</li>
           </ul>
-        </ul>
+        </li>
+        <li>OpenStackサポートには、OpenStackクラウドのデプロイ中または設定中のバグフィックスサポートを超えるサポートは含まれません。</li>
+        <li>
+          <p>チャーム</p>
+          <ul>
+            <li>チャームの各バージョンは、リリース日から1年間サポートされます。</li>
+            <li>Canonicalでは、<a href="https://wiki.ubuntu.com/OpenStack/OpenStackCharms">https://wiki.ubuntu.com/OpenStack/OpenStackCharms</a>のページに記載されたサポート対象バージョンの原状から改変されたチャームのサポートは一切提供しません。</li>
+          </ul>
+        </li>
+        <li>CephまたはSwiftのデプロイメントについて、デプロイされるノード1つにつき合計3TBまでの利用可能なストレージのサポート。この許容量は、Ubuntu Advantage Ceph、Ubuntu Advantage Swift、またはこれらの組み合わせに使用することができます。</li>
+        <li>Canonicalの提供する利用可能なMicrosoft認定ドライバをWindowsのゲストインスタンスで使用する許諾ライセンス</li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>OpenStackのデプロイメント実行に必要な作業負荷以外に関するサポート</li>
+            <li>クラウドゲスト以外のゲストインスタンスのサポート</li>
+          </ul>
+        </li>
       </ul>
 
-      <h3>Ubuntu Advantage OpenStack Cloud Region</h3>
-
-      <p>Ubuntu Advantage OpenStack Cloud Regionは、Ubuntu Advantage OpenStack Cloudと同一ですが、以下の点が異なります：</p>
-      <p>サポートは、1つのリージョンおよび購入されたUbuntu Advantage OpenStack Cloud Regionのサイズに基づくノードの最大数に限定されます。</p>
-      <ul>
-        <li>追加としてサービスに含まれるもの：</li>
-        <ul>
-          <li>Landscape on-premisesが含まれます。</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>Foundation OpenStack Buildを通じてデプロイされていないOpenStackプロジェクトまたは追加テクノロジーに対するサポート。</li>
-        </ul>
+      <h3>Ubuntu Advantage OpenStack クラウドリージョン</h3>
+      <p>Ubuntu Advantage OpenStack クラウドリージョンは、以下の点を除いてUbuntu</p>
+      <ul class="p-list">
+        <li>
+          <p>Advantage OpenStackと同一です。</p>
+          <ul>
+            <li>サポートは、単一のリージョンに限定され、購入されたUbuntu Advantage OpenStack クラウドリージョンのサイズに基づく最大ノード数が決められています。</li>
+            <li>Landscape on-premisesは含まれています。</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>OpenStackプロジェクトまたは追加テクノロジーで、Foundation OpenStack Buildによりデプロイされていないもののサポート</li>
+          </ul>
+        </li>
       </ul>
+
       <h3>Ubuntu Advantage Server</h3>
-
-      <p>それぞれのサービス (Essential、Standard、またはAdvanced) の範囲を以下に定めます。以下の項目は、Ubuntu Advantage Serverサービスの対象外です。</p>
+      <p>特定の各サービス範囲（Essential、Standard、Advanced）については、以下に定義し</p>
+      <p>ます。以下の項目は、どのUbuntu Advantageサーバーサービスにも含まれません。</p>
       <ul>
         <li>Ceph</li>
         <li>Swift</li>
         <li>OpenStack</li>
       </ul>
 
-      <h3>サービスの概要</h3>
-
-      <table>
+      <h4>サービス概要</h4>
+      <table class="p-table">
+        <thead>
+          <tr>
+            <th>機能</th>
+            <th>Essential</th>
+            <th>Standard</th>
+            <th>Advanced</th>
+          </tr>
+        </thead>
         <tbody>
           <tr>
             <td>
-              <p>内容</p>
+              <p>年中無休のセルフサービスのカスタマーケアポータルおよびナレッジベース1</p>
+              <p><small>1 本サービス記述書のセクション2をご覧ください。</small></p>
             </td>
             <td>
-              <p>Essential</p>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
             </td>
             <td>
-              <p>Standard</p>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
             </td>
             <td>
-              <p>Advanced</p>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
             </td>
           </tr>
           <tr>
             <td>
-              <p>24x7セルフサービスカスタマケアポータルおよびナレッジベース</p>
-
-              <p>（セクション2を参照）</p>
+              <p>Landscapeマネージメント 1</p>
+              <p><small>1 本サービス記述書のセクション2.5をご覧ください。</small></p>
             </td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
           </tr>
           <tr>
             <td>
-              <p>8x5 Ubuntu Serverイメージのデフォルトパッケージに対するチケットサポート</p>
-
-              <p>（セクション3を参照）</p>
+              <p>カーネルライブパッチング1</p>
+              <p><small>1 本サービス記述書のセクション2.4.4によります。</small></p>
             </td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
           </tr>
           <tr>
             <td>
-              <p>Landscape管理</p>
-
-              <p>（セクション2.5を参照）</p>
+              <p>拡張セキュリティメンテナンス1</p>
+              <p><small>1 本セクションで定義します。</small></p>
             </td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
           </tr>
           <tr>
             <td>
-              <p>Ubuntu法的保証プログラム</p>
-
-              <p>（セクション5を参照）</p>
-            </td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-          </tr>
-          <tr>
-            <td>
-              <p>カーネルのライブパッチ</p>
-
-              <p>（セクション2.4.4を参照）</p>
-            </td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-          </tr>
-          <tr>
-            <td>
-              <p>Extended Security Maintenance</p>
-
-              <p>本セクションの記載どおり</p>
-
-            </td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-          </tr>
-          <tr>
-            <td>
-              <p>10x5 Ubuntu Main内のすべてのパッケージに対する電話およびチケットサポート</p>
-
-              <p>（セクション3を参照）</p>
-              <p>ただし本セクションに記載されているものを除く</p>
+              <p>Ubuntu 法務部による保証プログラム1 </p>
+              <p><small>1 本サービス記述書のセクション5によります。</small></p>
             </td>
             <td>&nbsp;</td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
           </tr>
           <tr>
             <td>
-              <p>無制限のUbuntu LXD ゲストサポート</p>
-              <p>以下を参照</p>
+              <p>1日10時間、週5日の電話およびチケットサポート1　Ubuntuメインリポジトリ内の全パッケージが対象2</p>
+              <ul>
+                <li><small>1 本サービス記述書のセクション3をご覧ください。</small></li>
+                <li><small>2 ただし、本セクションで定義するものを除きます。</small></li>
+              </ul>
             </td>
             <td>&nbsp;</td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
           </tr>
           <tr>
             <td>
-              <p>24x7 Ubuntu Main内のすべてのパッケージに対する電話およびチケットサポートおよびバックポートおよびuniverse内のCanonical作成パッケージ。</p>
-
-              <p>（セクション3を参照）</p>
-              <p>ただし本セクションに記載されているものを除く</p>
+              <p>無制限のUbuntu LXDゲストサポート</p>
+              <p><small>1 以下をご覧ください。</small></p>
             </td>
             <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
           </tr>
           <tr>
             <td>
-              <p>無制限のUbuntu KVM ゲストサポート</p>
-              <p>以下を参照</p>
+              <p>年中無休の電話およびチケットサポート：Ubuntuメインリポジトリ内の全パッケージ、ならびにCanonicalの管理するバックポートおよびUniverse内のパッケージが対象2</p>
+              <ul>
+                <li><small>1 本サービス記述書のセクション3によります</small></li>
+                <li><small>2 ただし、本セクションで定義するものを除きます。</small></li>
+              </ul>
             </td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
-            <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>無制限のUbuntu KVMゲストサポート</p>
+              <p><small>1 以下をご覧ください。</small></p>
+            </td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>FIPS認定暗号化モジュール</p>
+            </td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>
+              <img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="">
+            </td>
           </tr>
         </tbody>
       </table>
 
-
-      <h3>Essential</h3>
-
-      <ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>サーバー/クラウドイメージマニフェストにあるパッケージに対するサポート。</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>サーバー/クラウドイメージマニフェストにないパッケージに対するサポート。</li>
-          <li>サーバー/クラウドイメージから提供されたパッケージに見つかったバグ以外の問題に対するサポート。</li>
-          <li>電話サポートへのアクセス。</li>
-        </ul>
-      </ul>
-
-      <h3>Standard</h3>
-
-      <ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>無制限の数のUbuntu LXDゲストに対するUbuntu Advantage Virtual Guest Standardサポート。</li>
-          <li>Extended Security Maintenance for Ubuntu</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>KVM関連パッケージおよびKVMゲストに対するサポート。</li>
-          <li>Ubuntu LXDゲストのLandscapeシステム管理ツールへのアクセス。ただしLandscape Seatsまたは Landscape on-premisesの対象となるものを除く。</li>
-        </ul>
-      </ul>
-
-      <h3>Advanced</h3>
-
-      <ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>無制限の数のUbuntu LXDおよびUbuntu KVMゲストに対するUbuntu Advantage Virtual Guest Advancedサポート。</li>
-          <li>Ubuntu Advantage Server Advancedの対象システム上におけるFIPS HMAC Checksumパッケージ使用許諾ライセンス。</li>
-          <li>Extended Security Maintenance for Ubuntu</li>
-        </ul>
-      </ul>
-      <ul>
-        <li>サービスから除外されるもの：</li>
-      </ul>
-      <ul>
-        <ul>
-          <li>Ubuntu LXDまたはUbuntu KVMゲストに対するLandscapeシステム管理ツールへのアクセス。ただしLandscape Seatsまたは Landscape on-premisesの対象となるものを除く。</li>
-        </ul>
-      </ul>
-
-      <h3>Ubuntu Advantage Virtual Guest</h3>
-
-      <ul>
-        <li>Ubuntu Serverに対してサービスが提供されるのは、物理ホスト上の仮想化された環境またはUbuntuの認定パブリッククラウドパートナーの環境でインストールおよび実行されている場合です。認定パブリッククラウドパートナーに関しては、Ubuntuパートナー一覧をご覧ください：
-          <a href="http://partners.ubuntu.com/find-a-partner">http://partners.ubuntu.com/find-a-partner</a>
+      <h4>Essential</h4>
+      <ul class="p-list">
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>Ubuntu用の拡張セキュリティメンテナンス</li>
+          </ul>
         </li>
-        <li>Extended Security Maintenance</li>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>KVM関連パッケージおよびKVMゲストに対するサポート。</li>
-          <li>追加として除外される項目は、該当するUbuntu Advantage Serverサービスの除外項目と同じです。</li>
-        </ul>
-      </ul>
-
-      <h3>Ubuntu Advantage Ceph Storage</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「クラスタ」とは、単一の物理データセンター内にある単一のCephインストールを指します。</li>
-        </ul>
-        <li>サポートは、Cephのすべてのストレージプールに格納されるデータ総量 (ギガバイト) により計量されます。これには、空き領域とすべての複製およびイレージャーコーディング用オーバーヘッドは含まれません。</li>
-        <li>&nbsp;</li>
-        <li>ストレージ容量を無制限とするUbuntu Advantage Ceph Storageを購入した顧客は、単一クラスタ内のサポートに限定されます。</li>
-        <li>追加としてサービスに含まれるもの：</li>
-        <ul>
-          <li>Cephデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
-          <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサ <br />ポート。これには、Cephモニターなどの補助（ストレージ以外の）ノードが含まれます。</li>
-          <li>Ceph Dashモニタリングツールの使用許諾ライセンス。</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>Cephデプロイメントの実行に必要でないワークロードに対するサポート。</li>
-        </ul>
-      </ul>
-
-      <h3>Ubuntu Advantage Swift Storage</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「クラスタ」とは、単一の物理データセンター内にある単一のSwiftインストールを指します。</li>
-        </ul>
-        <li>サポートは、Swiftのすべてのストレージプールに格納されるデータ総量 (ギガバイト) により計量されます。これには、空き領域とすべての複製およびイレージャーコーディング用オーバーヘッドは含まれません。</li>
-        <li>ストレージ容量を無制限とするUbuntu Advantage Swift Storageを購入した顧客は、単一クラスタ内のサポートに限定されます。</li>
-        <li>追加としてサービスに含まれるもの：</li>
-        <ul>
-          <li>Swiftデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
-          <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサ <br />ポート。これには、Swiftモニターなどの補助（ストレージ以外の）ノードが含まれます。</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>Swiftデプロイメントの実行に必要でないワークロードに対するサポート。</li>
-        </ul>
-      </ul>
-
-
-      <h3>Ubuntu Advantage MAAS</h3>
-
-      <ul>
-        <li>追加としてサービスに含まれるもの：</li>
-        <ul>
-          <li>文書化されたMAASデプロイメントアーキテクチャに従ってMAAS環境をホストするために必要なすべてのサーバーに対するサポート。</li>
-          <li>MAASの実行に必要なすべてのパッケージに対するサポート。</li>
-          <li>Canonicalの提供するオペレーティングシステムイメージを使用してマシンを起動する能力のサポート。</li>
-          <li>Canonicalの提供しない認定オペレーティングシステムイメージをMAASイメージに変換するために必要なツールのサポート。</li>
-          <li>標準の高可用性MAAS構成を適切に実装するために必要なツールのサポート。</li>
-          <li>MAAS Custom Imagingツールの使用許諾ライセンス。</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>MAASデプロイメントの実行に必要でないワークロード、パッケージおよび<br />サービスコンポーネントに対するサポート。</li>
-          <li>MAASを使用してデプロイされたノードのサポート。</li>
-          <li>MAASデプロイメントの設計および実装詳細のサポート。</li>
-        </ul>
-        <li>サポートされるMAASバージョン：</li>
-        <ul>
-          <li>MAASのバージョンは、Ubuntuアーカイブにリリースされた日付から1年間 、Ubuntu のLTSバージョン上でサポートされます。</li>
-        </ul>
-      </ul>
-
-      <h3>Ubuntu Advantage Switch</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「ホワイトボックススイッチ」とは、ODMメーカーが製造し、ベンダーがラベル添付および販売を行うx86 Broadcom ASICベースのスイッチを指します。</li>
-          <li>「BCOS」とは、ホワイトボックススイッチによるレイヤ2およびレイヤ3ネットワーキングの全機能を備えたソフトウェアのUbuntuに最適化したバージョンです。</li>
-        </ul>
-        <li>含まれるサービス：</li>
-        <ul>
-          <li>BCOSの実行に必要なUbuntuの特定バージョンに対するサポート。</li>
-          <li>BCOSソフトウェアに対するサポート。</li>
-        </ul>
-        <li>含まれないサービス：</li>
-        <ul>
-          <li>BCOSの実行に必要でないワークロードに対するサポート。</li>
-          <li>BCOSソフトウェアと共に提供されるバージョン以外のカーネルのサポート。</li>
-          <li>物理的ハードウェアのサポート。ハードウェアサポートはベンダーから提供されます。</li>
-          <li>Landscape SaaSおよびLandscape on-premises</li>
-        </ul>
-      </ul>
-
-      <h3>Ubuntu Advantage Desktop</h3>
-
-      <ul>
-        <li>サービスから除外されるもの：</li>
-      </ul>
-      <ul>
-        <li>仮想マシン</li>
-        <li>マシンコンテナ</li>
-        <li>アプリケーションコンテナ</li>
-        <li>デュアルブート（他のオペレーティングシステムとの共存)</li>
-        <li>Ubuntuでの使用が認定されていない周辺機器</li>
-        <li>デスクトップ以外のパッケージに対するサポート</li>
-        <li>Ubuntuの各種コミュニティフレイバー</li>
-        <li>x86_64以外のアーキテクチャに対するサポート</li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>Canonicalのナレッジベースを超えるサポート</li>
+            <li>Ubuntu保証プログラム</li>
+          </ul>
+        </li>
       </ul>
 
       <h4>Standard</h4>
-
-      <ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>SSSD、WinbindおよびNetworkManagerを使用した基本的なネットワーク認証および接続ならびにUbuntu Mainリポジトリ内のネットワークマネージャ関連プラグイン</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-      </ul>
-      <ul>
-        <ul>
-          <li>開発者ツール</li>
-          <li>Ubuntuの基本デスクトップイメージに含まれないパッケージのサポート</li>
-        </ul>
+      <ul class="p-list">
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>無制限の数のUbuntu LXDゲストに対するUbuntu</li> <li>Advantage Virtual Guest Standardサポート</li>
+            <li>Ubuntu用の拡張セキュリティメンテナンス</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>KVM関連パッケージおよびKVMゲストに関するサポート</li>
+            <li>Ubuntu LXDゲストのLandscapeシステム管理ツールへのアクセス。ただし、Landscape SeatsまたはLandscape on-premisesのサポート対象であるものを除く。</li>
+          </ul>
+        </li>
       </ul>
 
       <h4>Advanced</h4>
-
-      <ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>Canonicalツールによるデスクトップのプロビジョニング</li>
-        </ul>
+      <ul class="p-list">
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>無制限の数のUbuntu LXDおよびUbuntu KVMゲストに対するUbuntu Advantage Virtual Guest Advancedサポート</li>
+            <li>Ubuntu 用のFIPS</li>
+            <li>Ubuntu用の拡張セキュリティメンテナンス</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>Ubuntu LXDおよびUbuntu KVMゲストのLandscapeシステム管理ツールへのアクセス。ただし、Landscape SeatsまたはLandscape on-premisesのサポート対象であるものを除く。</li>
+          </ul>
+        </li>
       </ul>
 
+      <h3>Ubuntu Advantage Virtual Guest（バーチャルゲスト）</h3>
+      <ul class="p-list">
+        <li>本サービスの提供は、仮想環境でゲストとしてインストールおよび稼働するUbuntu サーバーについて、その仮想環境が (1) Ubuntu認定パブリッククラウドパートナーの環境内にある、または (2) 物理ホスト上にあり、そのゲストが以下のハイパーバイザーのいずれかで稼働中であることを条件とします。</li>
+        <li>
+          <p>（基礎となるテクノロジーのみをリストアップしてあります。これらは、OpenStackの</p>
+          <ul>
+            <li>
+              <p>ようなクラウド経由で提供することが可能です。ハイパーバイザーのベンダーからUbuntuのサポート対象バージョンを特定するリストが提示された場合、そのバージョンのみがUbuntu Advantageバーチャルゲストサービスの利用に適格です。）</p>
+              <ul>
+                <li>KVM | Qemu | Bochs</li>
+                <li>VMWare</li>
+                <li>LXD | LXC</li>
+                <li>Xen</li>
+                <li>Hyper-V</li>
+                <li>VirtualBox</li>
+                <li>z/VM</li>
+                <li>Docker</li>
+              </ul>
+            </li>
+            <li>認定パブリッククラウドパートナーは、以下のUbuntuパートナーリストでご確認ください。<a href="https://partners.ubuntu.com/find-a-partner">partners.ubuntu.com/find-a-partner</a></li>
+          </ul>
+        </li>
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>Ubuntu用の拡張セキュリティメンテナンス</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>ハイパーバイザーのサポート</li>
+            <li>選択されたハイパーバイザー用ネイティブイメージの提供</li>
+            <li>仮想ゲスト内での仮想ゲストの稼働（通常ネストと呼ばれます）</li>
+            <li>例外として追加されるものは、該当するUbuntu Advantageサーバーサービスの例外に対応する。</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h3>Ubuntu Advantage Ceph Storage（ストレージ）</h3>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「クラスタ」とは、単一の物理的データセンター内のCephの単一のインストールを指します。</li>
+          </ul>
+        </li>
+        <li>サポートは、Ceph内の全ストレージプールにわたって保管されるデータの総量からギガバイトで計量します。これには、空きスペースならびに複製および消去コーディング用オーバーヘッドは含まれません。</li>
+        <li>Ubuntu Advantage Cephストレージのストレージ容量を無制限でご購入のお客様については、単一クラスタ内のサポートに限定されます。</li>
+        <li>Cephのサポートは、Advanced対象の応答時間で提供します。</li>
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>Cephのデプロイメント実行に必要なすべてのパッケージのサポート</li>
+            <li>ストレージおよび複製の要件を満たすために必要な全サーバーのサポートこれには、Cephモニターなどの補助（ストレージ以外の）ノードが含まれる。</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>Cephのデプロイメント実行に必要な作業負荷以外に関するサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h3>Ubuntu Advantage Swift Storage（ストレージ）</h3>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「クラスタ」とは、単一の物理的データセンター内のSwiftの単一のインストールを指します。</li>
+          </ul>
+        </li>
+        <li>サポートは、Swift内の全ストレージプールにわたって保管されているデータの総量からギガバイトで計量します。これには、空きスペースならびに複製および消去コーディング用オーバーヘッドは含まれません。</li>
+        <li>Ubuntu Advantage Swift Storageのストレージ容量を無制限でご購入のお客様については、単一クラスタ内のサポートに限定されます。</li>
+        <li>Swiftのサポートは、Advanced対象の応答時間で提供します。</li>
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>Swiftのデプロイメント実行に必要なすべてのパッケージのサポート</li>
+            <li>ストレージおよび複製の要件を満たすために必要な全サーバーのサポート。これには、Swiftモニターなどの補助（ストレージ以外の）ノードが含まれる。</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>Swiftのデプロイメント実行に必要な作業負荷以外に関するサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h3>Ubuntu Advantage MAAS</h3>
+      <ul class="p-list">
+        <li>
+          <p>サービスに含まれるもの：</p>
+          <ul>
+            <li>文書化されたMAASデプロイメント用アーキテクチャに従い、MAAS環境をホストするために必要な全サーバーのサポート</li>
+            <li>MAASの実行に必要なすべてのパッケージのサポート</li>
+            <li>Canonicalの提供するオペレーティングシステムイメージを使用してマシンを起動する機能のサポート</li>
+            <li>Canonical以外が提供する認定オペレーティングシステムイメージをMAAS用イメージに変換するために必要なツールのサポート </li>
+            <li>MAASカスタマムイメージングツールの使用許諾ライセンス</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>MAASのデプロイメント実行に必要な作業負荷、パッケージおよびサービスコンポーネント以外に関するサポート</li>
+            <li>MAASを使用してデプロイされるノードのサポート</li>
+            <li>MAASデプロイメントの設計および実施の詳細に関するサポート</li>
+            <li>MAASでデプロイされたマシンのLandscape およびCanonical Livepatchサービスへのアクセス</li>
+          </ul>
+        </li>
+        <li>
+          <p>MAASのサポート対象バージョン：</p>
+          <ul>
+            <li>MAASの各バージョンは、Ubuntuアーカイブ内でリリースされた日から1年間、UbuntuのLTSバージョン上でサポートされます。</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h4>Standard</h4>
+      <ul class="p-list">
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>高可用性設定でデプロイされたMAASのサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h4>Advanced</h4>
+      <ul class="p-list">
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>標準のMAAS高可用性設定を正しく実施するために必要なツールのサポート</li>
+            <li>高可用性設定でデプロイされたMAASのサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h3>Ubuntu Advantage Switch（スイッチ）</h3>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「ホワイトボックススイッチ」とは、ブロードコム社のASICをベースとするx86スイッチで、ODM製造業者が製造し、ベンダーがブランディングおよび販売するものを指します。</li>
+            <li>「BCOS」とは、ホワイトボックススイッチによるフル装備L2・L3ネットワーキングソフトウェアのUbuntu最適化バージョンを指します</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれるもの：</p>
+          <ul>
+            <li>BCOSの実行に必要なUbuntuの特定バージョンのサポート</li>
+            <li>BCOSソフトウェアのサポート</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>BCOSの実行に必要な作業負荷以外に関するサポート</li>
+            <li>BCOSソフトウェアと一緒に提供されなかったバージョンのカーネルのサポート</li>
+            <li>物理的ハードウェアのサポート。ハードウェアのサポートはベンダーが提供する。</li>
+            <li>Landscape SaaSおよびLandscape on-premises</li>
+            <li>Canonical Livepatchサービスへのアクセス</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h3>Ubuntu Advantage Desktop（デスクトップ）</h3>
+      <ul class="p-list">
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>仮想マシン</li>
+            <li>マシンコンテナ</li>
+            <li>アプリケーションコンテナ</li>
+            <li>デュアルブート（他のオペレーティングシステムとの共存）</li>
+            <li>Ubuntuによる動作保証のない周辺機器</li>
+            <li>デスクトップ以外のパッケージのサポート</li>
+            <li>Ubuntuのコミュニティフレーバー</li>
+            <li>X86_64以外のアーキテクチャに関するサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h4>Standard</h4>
+      <ul class="p-list">
+        <li>
+          <p>サービスに含まれるもの：</p>
+          <ul>
+            <li>Ubuntu Mainリポジトリ内のsssd、winbind、ネットワークマネージャー、ネットワークマネージャー関連プラグインを使用する基本ネットワーク認証および接続</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>開発者用ツール</li>
+            <li>基礎となるUbuntuデスクトップイメージに含まれないパッケージのサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h4>Advanced</h4>
+      <ul class="p-list">
+        <li>
+          <p>サービスに含まれるもの：</p>
+          <ul>
+            <li>Canonicalのツールによるデスクトップのプロビジョニング</li>
+          </ul>
+        </li>
+      </ul>
 
       <h3>Ubuntu Advantage for Docker</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「Docker」とは、Docker Enterprise Edition Basicとして知られ、Docker, Inc.が公表するとおりのソフトウェアを指します。</li>
-        </ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>Ubuntuを実行するホストマシンに対するサポート。</li>
-          <li>DockerパッケージアーカイブにあるとおりのDockerを実行するために必要なすべてのパッケージに対するサポート。</li>
-          <li>無制限の数のDockerコンテナに対するサポート。</li>
-          <li>公式のソースからインストールされ、Ubuntuを実行するDockerコンテナに対するUbuntu Advantage Virtual Guest Advancedサービス。</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>ホストマシン上でDockerを実行するのに必要でないワークロードに対するサポート。</li>
-          <li>Dockerコンテナ用Landscape Seat。</li>
-        </ul>
-        <li>Dockerのリリースは、以下のDockerウェブサイトの記載どおりにサポートされます：</li>
-      </ul>
-      <p><a href="https://success.docker.com/Policies/Maintenance_Lifecycle">https://success.docker.com/Policies/Maintenance_Lifecycle</a></p>
-
-      <h3>Canonical Distribution of Kubernetes</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「Canonical Distribution of Kubernetes」とは、ベアメタル環境、クラウドゲスト環境または仮想マシン上で、Jujuおよび公式Canonical-Kubernetesバンドルを使用してデプロイされるKubernetesを指します。</li>
-          <li>「デプロイメント」とは、Canonical Distribution of Kubernetesをデプロイするプロセスを指します。すべてのアプリケーションは「起動済」状態であるとJujuが報告すれば、デプロイメントは成功したと見なされます。</li>
-          <li>「アップグレード」とは、Kubernetesのバージョン間で行うアップグレードのプロセスを指します。すべてのアプリケーションは「起動済」状態であるとJujuが報告すれば、アップグレードは成功したと見なされます。Canonicalは、アップグレードプロセス中に遭遇する正当なバグに対するサポートを提供します。</li>
-          <li>「サポート」とは、破損時補償およびKubernetesに関する基本的な質問への回答を指します。Kubernetesのデプロイメントおよびアップグレードの補助ならびに設定および最適化は、サポート対象外となります。</li>
-        </ul>
-        <li>Canonical Distribution of Kubernetesの最低限のデプロイメントは、Canonical-Kubernetesバンドルの基本設定です。サポート対象となるKubernetes環境のすべてのノードに対してサポートを購入しなければなりません。</li>
-        <li>Kubernetesのサポート対象バージョンには、以下の一覧の記載どおり、Kubernetesの最新安定版およびその直前のバージョンが含まれます。</li>
-        <ul>
-          <li>
-            <a href="https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions" https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions</a></li>
-        </ul>
-        <li>サポート対象は、Canonical Distribution of Kubernetesの実行に必要なソフトウェアパッケージおよびチャームのみに限定されます。</li>
-        <li>該当するCanonical Distribution of Kubernetesデプロイメント用の契約に基づいてCanonicalがデプロイメントを実施した結果、いずれかのチャームがカスタマイズされた場合、カスタマイズされるチャームの公式リリース後90日間、そのカスタマイズはサポートされます。</li>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「Docker」はDocker Enterprise Edition Basicとして知られ、ドッカー社の公表する原状のソフトウェアを指します。</li>
+          </ul>
+        </li>
+        <li>Dockerのサポートは、Advanced対象の応答時間で提供します。</li>
+        <li>
+          <p>サービスに含まれるもの：</p>
+          <ul>
+            <li>Ubuntuを稼働するホストマシンのサポート</li>
+            <li>Dockerパッケージアーカイブから取得可能な原状のDockerを稼働するために必要なすべてのパッケージのサポート</li>
+            <li>無制限の数のDockerコンテナのサポート</li>
+            <li>公式ソースからインストールされ、Ubuntuを稼働するDockerコンテナに関するUbuntu Advantage Virtual Guest</li> <li>Advancedサービス</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>ホストマシン上でDockerの実行に必要な作業負荷以外に関するサポート</li>
+            <li>DockerコンテナのLandscape Seats</li>
+          </ul>
+        </li>
+        <li>Dockerの各リリースは、以下のドッカー社ウェブサイトの定義に従ってサポートされています。</li>
+        <li><a href="https://success.docker.com/Policies/Maintenance_Lifecycle">https://success.docker.com/Policies/Maintenance_Lifecycle</a></li>
       </ul>
 
-      <h3>Extended Security Maintenance</h3>
+      <h3>Ubuntu Advantage Kubernetes</h3>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「Canonical配布版Kubernetes」とは、JujuおよびCanonical-Kubernetes公式バンドルを使用して、ベアメタル、クラウドゲスト、または仮想マシン上でデプロイされたKubernetesを指します。</li>
+            <li>「デプロイメント」とは、「Canonical配布版Kubernetes」をデプロイするプロセスを指します。デプロイメントは、すべてのアプリケーションが「起動済 (started)」状態であるというJujuのレポートにより、正常に実行されたものと見なされます。</li>
+            <li>「アップグレード」とは、Kubernetesのバージョン間のアップグレードのプロセスを指します。アップグレードは、すべてのアプリケーションが「起動済 (started)」状態であるというJujuのレポートにより、正常に実行されたものと見なされます。Canonicalは、アップグレードのプロセス中に遭遇する正当なバグについて、サポートを提供します。</li>
+            <li>「サポート」とは、ブレークフィックスサポートおよびKubernetesに関する基本的な質問にお答えすることを指します。デプロイメントおよびアップグレードの支援、ならびにKubernetesの設定および最適化は、サポートの対象外です。</li>
+          </ul>
+        </li>
+        <li>Canonical配布版Kubernetesの最小限デプロイメントは、</li>
+        <li><a href="https://jujucharms.com/canonical-kubernetes/">https://jujucharms.com/canonical-kubernetes/</a> に記載されています。これは、</li>
+        <li>Canonical-Kubernetesバンドルの基本設定です。サポート対象となるKubernetes環境内のすべてのノードについて、サポートを購入する必要があります。</li>
+        <li>
+          <p>Kubernetesのサポート対象バージョンは、Kubernetesの現行安定バージョンならびに最新バージョンで、以下のページの記載どおりです。</p>
+          <ul>
+            <li><a href="https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions">https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions</a></li>
+          </ul>
+        </li>
+        <li>本サポートは、Canonical配布版Kubernetesを稼働するために必要なソフトウェアパッケージおよびチャームに限定されます。</li>
+        <li>Canonicalとの契約に従って実施したあらゆるCanonical配布版Kubernetesのデプロイメントについて、結果的にチャームがカスタマイズされた場合のカスタマイゼーションは、そのカスタマイゼーションを含むチャームの公式リリース後90日間有効です。</li>
+      </ul>
 
-      <ul>
-        <li>Extended Security Maintenanceには、Ubuntu Mainリポジトリ内の多数のサーバーパッケージを対象として2019年4月28日までに利用可能な緊急 (Critical) および高 (High) レベルの脆弱性CVEの修正が含まれます。Extended
-          Security Maintenanceに含まれる全パッケージのリストは、以下からご覧ください：　　　<a href="https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages">https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages</a></li>
-        <li>Extended Security Maintenanceは、64-bit x86 AMD/Intelのインストールを対象とするものに限って含まれます。</li>
-        <li>Extended Security Maintenanceから除外されるもの：</li>
-        <ul>
-          <li>Extended Security Maintenanceのセキュリティアップデートによって生じたバグを除き、ライフサイクル終了に達したリリースのパッケージ用バグフィックス。</li>
-          <li>Maintained Packagesリストに記載されていないパッケージ用のセキュリティ修正。</li>
-          <li>高 (High) または緊急 (Critical) レベルでない脆弱性CVEのセキュリティ修正。</li>
-        </ul>
-        <li>Extended Security Maintenanceは、ソフトウェアが安全であること、またはすべての高 (High) もしくは緊急 (Critical) レベルの脆弱性CVEが修正できることを保証するものではありません。</li>
+      <h4>Standard</h4>
+      <ul class="p-list">
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>高可用性設定でデプロイされたKubernetesのサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h4>Advanced</h4>
+      <ul class="p-list">
+        <li>
+          <p>追加サービスとして含まれるもの：</p>
+          <ul>
+            <li>高可用性設定でデプロイされたKubernetesのサポート</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h3>拡張セキュリティメンテナンス</h3>
+      <p>拡張セキュリティメンテナンスには、2019年4月28日までの期間、Ubuntu Mainリポジトリ内の複数のサーバーパッケージ用に利用可能な重大度レベル「高」および「クリティカル」のCVE用フィックスが含まれます。拡張セキュリティメンテナンスに含まれる全パッケージのリストは、以下のページでご覧いただけます。</p>
+      <p><a href="https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages">https://wiki.ubuntu.com/SecurityTeam/ESM/12.04#Maintained_Packages</a></p>
+      <p>拡張セキュリティメンテナンスには、64-bit x86 AMD/Intelのインストールが含まれます。</p>
+      <ul class="p-list">
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>製品ライフサイクルの終了したリリースのパッケージ用バグフィックス。ただし、バグが拡張セキュリティメンテナンスのセキュリティアップデートによって生じた場合を例外とする。</li>
+            <li>メンテナンス対象パッケージリストに記載されていないパッケージ用のセキュリティフィックス</li>
+            <li>重大度レベルが「高」および「クリティカル」でないCVEのセキュリティフィックス</li>
+          </ul>
+        </li>
+      </ul>
+      <p>拡張セキュリティメンテナンスは、重大度レベルが「高」および「クリティカル」であるすべてのCVEについて安全なソフトウェアやフィックスを保証するものではありません。</p>
+
+      <h3>Canonical Livepatchサービス</h3>
+      <p>Canonical Livepatch サービスには、Canonicalのカーネルライブパッチデーモンの使用許諾ライセンス、利用可能なカーネルライブパッチへのアクセス、ライブパッチング機能が利用可能なすべてのシステム上のライブパッチでLivepatchの対象となるもののサポートが含まれます。</p>
+      <p>Canonicalは、重大度レベルが「高」および「クリティカル」なカーネルのCVEについてライブパッチを提供します。CVEの一部は、ライブパッチングシステム内の技術的限界により、ライブパッチングに適格でない可能性がありますのでご注意ください。</p>
+      <p>Canonicalでは、カーネルのサポート用バグフィックスをカーネルライブパッチとして提供することはできません。</p>
+      <p>カーネルライブパッチングは、Ubuntu14.04上およびUbuntu16.04上のgenericおよびlowlatancyの64-bit Intel/AMD 4.4カーネルに利用可能です。</p>
+      <ul class="p-list">
+        <li>
+          <p>FIPS for Ubuntu</p>
+          <ul>
+            <li>Supermicro AMD64、IBM POWER8およびIBM Zの特定のハードウェア上でUbuntuと一緒に使用する際にFIPS 140-2レベル1基準適合に充分なパッケージへのアクセス（利用可能な場合）。</li>
+            <li>そのようなパッケージのライセンスで、オープンソースソフトウェアライセンスによりライセンス許諾されていない範囲のもの。</li>
+          </ul>
+        </li>
       </ul>
 
       <h3>Landscape Seats</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「Seats」とは、仮想マシンをLandscape SaaSまたはLandscape on-premisesに登録する能力を指します。</li>
-          <li>「仮想マシン」とは、仮想化された環境にインストールされ、そこで実行されるUbuntu Serverを指します。</li>
-        </ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>Ubuntu Advantageサービスの対象システムで実行されるSeats。</li>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>Landscapeクライアントのインストールおよび実行に必要なパッケージのサポートを超えるサポート。</li>
-        </ul>
-      </ul>
-      <p></p>
-
-      <h3>Technical Account Manager</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「TAM」とは、顧客の従業員や経営陣と直接連携してリモートで作業を行うCanonicalのサポートエンジニアを指します。</li>
-        </ul>
-        <li>Canonicalは、TAMを提供することによりサポートサービスを拡大強化します。TAMはサービス期間中、以下のサービスを週あたり最大10時間行います。</li>
-        <ul>
-          <li>該当するUbuntu Advantageサービスの対象プラットフォームおよび設定に関するサポートならびにベストプラクティスに関する助言を行います。</li>
-          <li>2週間に1回、双方が合意した時間のレビューコールに参加し、顧客が抱える運用上の問題に対応します。</li>
-          <li>TSANetまたはCanonicalの直接のパートナーシップ（該当する場合）により、複数ベンダー間の問題の調整を行います。根本的な原因が特定されると、そのサブシステムのベンダーの通常のサポートプロセスを通じて、TAMがそのベンダーと共に問題の解決に努めます。</li>
-        </ul>
-        <li>Canonicalは、四半期ごとに顧客とのサービスレビューミーティングを開き、サービスのパフォーマンスを評価し、改善領域を特定します。</li>
-        <li>TAMは顧客の施設を年1回訪問し、実地テクニカルレビューを行います。</li>
-        <li>TAMの稼働時間中は、TAMがサポートケースに対応します。稼働時間外は、Ubuntu Advantageサポートプロセスに従ってサポートが提供されます。</li>
+      <ul class="p-list">
+        <li>
+          <p>サービスに含まれるもの：</p>
+          <ul>
+            <li>物理的マシン、仮想マシンまたはコンテナ（ご購入により）をLandscape SaaSまたはLandscape on-premises上に登録する能力。登録可能なマシンの数は、ご購入いただく「Seats（シート）」の数</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>Landscapeクライアントのインストールおよび稼働に必要なパッケージのサポートを超えるサポート</li>
+          </ul>
+        </li>
       </ul>
 
-
-      <h3>Dedicated Technical Account Manager</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「DTAM」とは、単一の顧客のためにフルタイムで遠隔勤務をするCanonicalの専任サポートエンジニアを指します。</li>
-        </ul>
-        <li>Canonicalは、DTAMを提供することによりサポートサービスを拡大強化します。DTAMはサービス期間中、現地の営業時間中に以下のサービスを週あたり最大40時間行います（Canonicalの休暇に関する方針によります）。</li>
-        <ul>
-          <li>該当するUbuntu Advantageサービスの対象プラットフォームおよび設定に関するサポートならびにベストプラクティスに関する助言を行います。</li>
-          <li>DTAMは、担当する顧客部門からのすべてのサポート要求を最初に受け付ける窓口となります。</li>
-          <li>Canonicalの標準サポート応答定義および顧客のニーズに従い、サポートのエスカレーションおよび優先順位付けを管理します。</li>
-          <li>定期レビューコールに参加し、顧客が抱える運用上の問題に対応します。</li>
-          <li>TSANetまたはCanonicalの直接のパートナーシップ（該当する場合）により、複数ベンダー間の問題の調整を行います。根本的な原因が特定されると、そのサブシステムのベンダーの通常のサポートプロセスを通じて、DTAMがそのベンダーと共に問題の解決に努めます。</li>
-          <li>適切なCanonical社内トレーニングおよび開発活動に参加します（直接参加またはリモートによる）。</li>
-        </ul>
-        <li>Canonicalは、四半期ごとに顧客とのサービスレビューミーティングを開き、サービスのパフォーマンスを評価し、改善領域を特定します。</li>
-        <li>DTAMの稼働時間中は、DTAMがサポートケースに対応します。営業時間外は、Ubuntu Advantageサポートプロセスに従ってサポートが提供されます。</li>
+      <h3>テクニカルアカウントマネージャー (TAM)</h3>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「TAM」とはCanonicalのサポートエンジニアで、リモート方式で作業をする者、またはお客様のスタッフおよびマネージメントと直接共同して作業をする者を指します。</li>
+          </ul>
+        </li>
+        <li>
+          <p>CanonicalではTAMの提供によりサポートサービスを拡張し、サービス期間中に以下のサービスを週10時間まで行います。</p>
+          <ul>
+            <li>該当するUbuntu Advantageサービスの対象となるプラットフォームおよび設定について、サポートおよびベストプラクティスに関するアドバイスを提供する。</li>
+            <li>隔週で双方の同意する時刻にレビューコールに参加し、お客様のオペレーション上の問題に対応する。</li>
+            <li>複数のベンダーに関する問題の調整をTSANet経由で、またはCanonicalの直接的なパートナーシップ（該当する場合）によりオーガナイズ。根本原因が特定された場合、TAMはそのサブシステムのベンダーと共同して、そのベンダーの通常のサポートプロセスに従って問題の解決に努める。</li>
+          </ul>
+        </li>
+        <li>Canonicalは四半期ごとにお客様とサービスのレビューミーティングを行い、サービスパフォーマンスを評価し、改善するべき分野を判断します。</li>
+        <li>TAMはお客様の施設を年1回訪問し、実地テクニカルレビューを行います。</li>
+        <li>TAMはTAMの就業時間中、サポートケースに対応します。その時間外のサポートは、Ubuntu Advantageのサポートプロセスに従って提供されます。</li>
       </ul>
 
+      <h3>専任テクニカルアカウントマネージャー (DTAM)</h3>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「DTAM」とはCanonicalのサポートエンジニアで、単独のお客様のためにリモート方式でフルタイムの専任として仕事をする者を指します。</li>
+          </ul>
+        </li>
+        <li>
+          <p>CanonicalではDTAMの提供によりサポートサービスを拡張し、サービス期間中の現地営業時間中に以下のサービスを週40時間まで行います（Canonicalの休暇に関する方針に従うことを条件とします）。</p>
+          <ul>
+            <li>該当するUbuntu Advantageサービスの対象となるプラットフォームおよび設定について、サポートおよびベストプラクティスに関するアドバイスを提供する。</li>
+            <li>DTAMが責任を負うお客様の部署で発生するすべてのサポート依頼について、連絡担当者の役割を果たす。</li>
+            <li>Canonicalの標準サポート応答に関する定義とお客様のニーズに従い、サポートのエスカレーションおよび優先度の決定を管理する。</li>
+            <li>定期レビューコールに参加し、お客様のオペレーション上の問題に対応する。</li>
+            <li>複数のベンダーに関する問題の調整をTSANet経由で、またはCanonicalの直接的なパートナーシップ（該当する場合）によりオーガナイズ。根本原因が特定された場合、DTAMはそのサブシステムのベンダーと共同して、そのベンダーの通常のサポートプロセスに従って問題の解決に努める。</li>
+            <li>該当するCanonicalの社内トレーニングおよび能力開発活動に参加する（直接およびリモート方式）。</li>
+          </ul>
+        </li>
+        <li>Canonicalは四半期ごとにサービスのレビューミーティングをお客様と行い、サービスパフォーマンスを評価し、改善するべき分野を判断します。</li>
+        <li>DTAMはDTAMの就業時間中、サポートケースに対応します。営業時間外のサポートは、Ubuntu Advantageのサポートプロセスに従って提供されます。</li>
+        <li>DTAMの一人が連続5営業日以上の休暇を取る場合、Canonicalは一時的にリモート方式で作業する人材を休暇中の代理として指名します。Canonicalは、予測可能なDTAMの休暇についてお客様と調整します。</li>
+      </ul>
+
+      <h3>専任サポートエンジニア (DSE)</h3>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
+          <ul>
+            <li>「DSE」とはCanonicalのサポートエンジニアで、単独のお客様のためにリモート方式でフルタイムの専任として仕事をし、お客様のサポートチームの延長としてCanonicalのサービスをお客様の環境内に統合し、そこでサポートすることを主な課題とする者を指します。</li>
+          </ul>
+        </li>
+        <li>
+          <p>CanonicalではDSEの提供によりサポートサービスを拡張し、サービス期間中の現地営業時間中に以下のサービスを週40時間まで行います（Canonicalの休暇に関する方針に従うことを条件とします）。</p>
+          <ul>
+            <li>お客様のニーズを満たすため、必要に応じて実地で作業することができる。</li>
+            <li>お客様の環境内で利用され、Canonicalのサービスと統合する必要のある製品について理解し、最大の努力を払ってそれらの製品について支援を提供し、Canonicalのサービス利用を確実に成功に導く。</li>
+            <li>該当するUbuntu Advantageサービスの対象となるプラットフォームおよび設定について、サポートおよびベストプラクティスに関するアドバイスを提供する。</li>
+            <li>DSEが責任を負うお客様の部署で発生するすべてのサポート依頼について、連絡担当者の役割を果たす。</li>
+            <li>Canonicalの標準サポート応答に関する定義とお客様のニーズに従い、サポートのエスカレーションおよび優先度の決定を管理する。</li>
+            <li>定期レビューコールに参加し、お客様のオペレーション上の問題に対応する。</li>
+            <li>複数のベンダーに関する問題の調整をTSANet経由で、またはCanonicalの直接的なパートナーシップにより（該当する場合）体系化。根本原因が特定された場合、DSEはそのサブシステムのベンダーと共同で、そのベンダーの通常のサポートプロセスに従って問題の解決に努める。</li>
+            <li>該当するCanonicalの社内トレーニングおよび能力開発活動に参加する（直接およびリモート方式）。</li>
+          </ul>
+        </li>
+        <li>Canonicalは四半期ごとにお客様とサービスのレビューミーティングを行い、サービスパフォーマンスを評価し、改善するべき分野を判断します。</li>
+        <li>DSEはDSEの就業時間中、サポートケースに対応します。営業時間外のサポートは、Ubuntu Advantageのサポートプロセスに従って提供されます。</li>
+        <li>DSEの一人が連続5営業日以上の休暇を取る場合、Canonicalは一時的にリモート方式で作業する人材を休暇期間中の代理として指名します。Canonicalは、予測可能なDSEの休暇についてお客様と調整します。</li>
+      </ul>
 
       <h3>Landscape on-premises</h3>
-
-      <ul>
-        <li>定義：</li>
-        <ul>
-          <li>「Landscapeon-premises」とは、顧客のハードウェアにインストールされたCanonicalのLandscapeシステム管理ソフトウェアを指します。</li>
-        </ul>
-        <li>サービスに含まれるもの：</li>
-        <ul>
-          <li>Landscape on-premisesのインスタンスを1つダウンロードおよびインストールするためのライセンス。</li>
-          <li>Ubuntu Advantageサービス購入の対象（物理または仮想）マシンにLandscape on-premisesの管理およびモニタリングサービスを使用する能力。</li>
-          <li>デプロイ方式：</li>
+      <ul class="p-list">
+        <li>
+          <p>用語の定義：</p>
           <ul>
-            <li>「クイックスタート」インストール方式によりインストールする場合、Landscape on-premisesをインストールするマシンに対するサポートが含まれます。</li>
-            <li>マニュアルインストール方式によりインストールする場合、Landscape on-premisesをインストールする最大2台のサーバーに対するサポートが含まれます。</li>
-            <li>Jujuを使用してデプロイする場合、「高密度デプロイ」方式がサポートされます。</li>
+            <li>「Landscape on-premises」とは、お客様のハードウェアにインストールされるCanonicalのLandscapeシステム管理ソフトウェアを指します。</li>
           </ul>
-        </ul>
-        <li>サービスから除外されるもの：</li>
-        <ul>
-          <li>Landscape on-premisesパッケージのサポートを超えるサポート。</li>
-        </ul>
-        <li>サポート対象となるLandscape on-premisesのバージョン：</li>
-        <ul>
-          <li>Landscape on-premisesの各リリースは、リリース日から1年間サポートされます。</li>
-        </ul>
+        </li>
+        <li>Landscape on-premisesのサポートは、Advanced対象の応答時間で提供します。</li>
+        <li>
+          <p>サービスに含まれるもの：</p>
+          <ul>
+            <li>Landscape on-premisesをダウンロードし、単一のインスタンスをインストールする許諾ライセンス</li>
+            <li>お客様が購入したUbuntu Advantageサービスの対象とするマシン（物理的マシンと仮想マシンのどちらも）用として、Landscape on-premisesのマシン管理サービスおよびモニターサービス機能</li>
+          </ul>
+        </li>
+        <li>
+          <p>デプロイ方法：</p>
+          <ul>
+            <li>「Quickstart（クイックスタート）」によるインストール方式でインストールした場合、Landscape on-premisesがインストールされているマシンのサポートが含まれます。</li>
+            <li>マニュアルによるインストール方式でインストールした場合、Landscape on-premisesがインストールされているマシン上の最大2台のサーバーのサポートが含まれます。</li>
+            <li>Jujuを使用してデプロイされた場合、「高密度デプロイメント」方式がサポートされます。</li>
+          </ul>
+        </li>
+        <li>
+          <p>サービスに含まれないもの：</p>
+          <ul>
+            <li>Landscape on-premisesパッケージのサポートを超えるサポート</li>
+          </ul>
+        </li>
+        <li>
+          <p>サポート対象バージョンのLandscape on-premises</p>
+          <ul>
+            <li>Landscape on-premisesの各リリースは、リリース日から1年間サポートされます。</li>
+          </ul>
+        </li>
+        <li><a href="/legal/ubuntu-advantage/service-description#service-description">上へ戻る</a></li>
       </ul>
 
-      <h2 id="appendix-2">Ubuntu Advantageサポートプロセス</h2>
-      <h3>1.サービス開始</h3>
+      <h3>Ubuntu Advantageサポートプロセス</h3>
+      <ul class="p-list">
+        <li>
+          <p>1.サービスの開始</p>
+          <ul>
+            <li>1.1 サービスの開始時に、Canonicalからお客様の技術担当者一名に対して、Landscape、サポート用ポータルおよびオンラインのナレッジベースへのアクセスを提供します。</li>
+            <li>1.2 お客様は当初の技術担当者を通じて、以下の表に記載するとおり、サポート対象システムの数に基づいてCanonicalとの連絡を担当する複数の技術担当者を選定することができます。これらの技術担当者は、サポート用ポータルへのログイン資格を受け、サポート請求について連絡担当者の役割を果たします。</li>
+          </ul>
+        </li>
+      </ul>
 
-      <p>1.1 Canonicalはサービス開始と同時に、Landscape、サポートポータルおよびオンラインナレッジベースへのアクセス権を1人の技術担当者に付与します。</p>
-      <p>1.2 この当初の技術担当者を通じて、顧客は以下の表に記載した通り、サポート対象のシステム数に基づいてCanonicalとの接点となる技術担当者を選択できます。これらの技術担当者はサポートポータルへのアクセス資格情報を保持し、サポート要求の主要窓口となります。</p>
-
-      <table>
+      <table class="p-table">
+        <thead>
+          <tr>
+            <th>Ubuntu Advantageサポート対象マシン数</th>
+            <th>技術担当者</th>
+          </tr>
+        </thead>
         <tbody>
           <tr>
-            <td>
-              <p><strong>Ubuntu Advantageサポート対象のマシン数</strong></p>
-            </td>
-            <td>
-              <p><strong>技術担当者</strong></p>
-            </td>
+            <td>1～20</td>
+            <td>2</td>
           </tr>
           <tr>
-            <td>
-              <p>1-20</p>
-            </td>
-            <td>
-              <p>2</p>
-            </td>
+            <td>21~50</td>
+            <td>3</td>
           </tr>
           <tr>
-            <td>
-              <p>21-50</p>
-            </td>
-            <td>
-              <p>3</p>
-            </td>
+            <td>51~250</td>
+            <td>6</td>
           </tr>
           <tr>
-            <td>
-              <p>51-250</p>
-            </td>
-            <td>
-              <p>6</p>
-            </td>
+            <td>251~1000</td>
+            <td>9</td>
           </tr>
           <tr>
-            <td>
-              <p>251-1000</p>
-            </td>
-            <td>
-              <p>9</p>
-            </td>
+            <td>1001~5000</td>
+            <td>12</td>
           </tr>
           <tr>
-            <td>
-              <p>1001-5000</p>
-            </td>
-            <td>
-              <p>12</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <p>5001+</p>
-            </td>
-            <td>
-              <p>15</p>
-            </td>
+            <td>5001~</td>
+            <td>15</td>
           </tr>
         </tbody>
       </table>
 
-      <p>1.3 顧客は、サポートポータル経由でサポート要求を提出することにより、指定した技術担当者をいつでも変更できます。</p>
+      <p>1.3 お客様は、サポート用ポータル経由でサポート依頼を提出することにより、指定したお客様の技術担当者をいつでも変更することができます</p>
 
+      <ul class="p-list">
+        <li>
+          <p>2.サポート依頼の提出</p>
+          <ul>
+            <li>2.1 お客様のアカウントがサポート用ポータル内に設定されると、お客様はサポート依頼を開始することができます。</li>
+            <li>2.2 お客様は、サポートポータル経由で、または電話でサポートチームに連絡することにより、サポートケースを提出することができます（別途注記のある場合を除きます）。</li>
+            <li>2.3 サポートケースは、単一の個別の問題、トラブルまたは依頼に関するものである必要があります。</li>
+            <li>2.4 サポートケースにはチケット番号を割り当て、自動的に応答します。直接サポートケースに入力されないすべての通信連絡は、Eメールや電話を含め、品質保証を目的とするタイムスタンプを添付してサポートケースに記録されます。</li>
+            <li>2.5 サポートケースを報告する場合、Canonicalが適切な重大度レベルを判定するため、お客様は重大度の詳細を報告する必要があります。同時発生した複数のサポートケースがあるお客様には、ビジネスに与える影響の重大度に従い、サポートケースの優先順位を決定するようお願いすることがあります。</li>
+            <li>2.6 お客様は、問題の解決に向けてCanonicalが作業中にお願いするすべての情報を提供するよう求められます。</li>
+            <li>2.7 お客様がすべての現行サポートケースを追跡しそれについて応答すること、ならびに過去のサポートケースの再検討ができるよう、Canonicalは各サポートケースの記録をサポート用ポータル内に保管します。</li>
+          </ul>
+        </li>
+        <li>
+          <p>3.サポートの重大度レベル</p>
+          <ul>
+            <li>3.1 サポート依頼を開始すると、Canonicalのサポートエンジニアがサポートケース情報を検証し、お客様と一緒にそのサポートケースの緊急性を評価し、重大度レベルを決定します。</li>
+            <li>3.2 応答時間は、該当するサービスに関するサービス記述書の記載どおりです。</li>
+            <li>3.3 重大度レベルの設定に際して、Canonicalのサポートチームは以下に記載する定義を使用します。</li>
+          </ul>
+        </li>
+      </ul>
 
-      <h2>2.サポート要求の提出</h2>
+      <h4>重大度レベル1 — コア機能が利用できない</h4>
+      <p>Canonicalはご購入のサービスレベルに従い、適切なサポートエンジニアおよび／または開発エンジニアにより、問題の回避または恒久的解決の提供に向けて継続的に努力します。コア機能が利用可能となった時点で、重大度レベルは新たに適切なレベルに引き下げられます。</p>
 
-      <p>2.1 顧客のアカウントがサポートポータルに作成されると、顧客はサポート要求をオープンできます。</p>
-      <p>2.2 別途記載がない限り、顧客はサポートポータル経由または電話でサポートチームに連絡することにより、サポートケースを提出できます。</p>
-      <p>2.3 サポートケースは、単一の独立した問題または要求である必要があります。</p>
-      <p>2.4 ケースにはチケット番号が割り当てられ、自動応答が返されます。品質保証のため、メールや電話などケースに直接入力されない連絡はすべてタイムスタンプ付きでケースに記録されます。</p>
-      <p>2.5 顧客がケースを報告する場合には、Canonicalが適切なサービスレベルを決定できるよう、顧客から影響に関する陳述書を提供する必要があります。複数のサポートケースを同時に抱える顧客は、ビジネスへの影響の重大度に従ってケースに優先順位を付けるよう求められる場合があります。</p>
-      <p>2.6 Canonicalがケースの解決に努める間、顧客は当社が要求するすべての情報を提供することが期待されます。</p>
-      <p>2.7 各ケースの記録は、Canonicalのサポートポータル内に保持されます。顧客には現行のすべてのケースの追跡と応答が可能で、これまでのケースを再確認することができます。</p>
+      <h4>重大度レベル2 — コア機能が大幅に低下している</h4>
+      <p>Canonicalは営業時間中、問題の回避または恒久的解決の提供に向けて一丸となって努力します。コア機能の大幅な低下が解消した時点で、重大度レベルはレベル3に引き下げられます。</p>
 
-      <h2>3.サポートの重大度レベル</h2>
+      <h4>重大度レベル3 — 標準サポート依頼</h4>
+      <p>Canonicalは営業時間中、問題の回避または恒久的解決の提供を出来る限り早く行うため、より重大度レベルの高いサポートケースとバランスを取りながら相応の努力をします。問題が回避された場合、Canonicalのサポートエンジニアはそのサポートケースに対する恒久的解決の開発作業を続行します。</p>
 
-      <p>3.1 サポート要求をオープンすると、Canonicalのサポートエンジニアがケース情報を検証して重大度レベルを決定し、顧客と共にケースの緊急性を評価します。</p>
-      <p>3.2 応答時間は、該当するサービスのサービス記述書に規定された通りです。</p>
-      <p>3.3 重大度レベルの決定に際して、Canonicalのサポートチームは下記の定義を使用します。</p>
+      <h4>重大度レベル4 — 緊急を要さない依頼</h4>
+      <p>レベル4の依頼には、外観上の問題、情報請求、機能の要求および同様の事項が含まれます。Canonicalは一切の機能の要求に対してタイムラインを提示せず、またその機能を仕様に含めることを保証しません。Canonicalは、レベル4の各サポートケースを検討し、それが製品の拡張強化として将来のリリース用に検討するべき課題か、現行リリースで修正するべき問題か、将来のリリースで修正するべき問題かを決定します。Canonicalは、相応レベルの努力を払い、対象時間内に情報請求を検討の上応答します。Canonicalは重大度レベル4の問題を生じたサポートケースについて応答した後、Canonicalが適切であると判断する場合、そのサポートケースを終了することがあります。</p>
 
-      <table>
-        <tbody>
-          <tr>
-            <td>
-              <ul>
-                <li><strong>重大度 レベル1</strong></li>
-              </ul>
-              <p>コア機能が</p>
-              <p>利用できない</p>
-            </td>
-            <td>
-              <p>Canonicalは、購入されたサービスレベルに従って、適切なサポートエンジニアまたは開発エンジニアを介して回避策または恒久的な解決策を提供するよう努力を継続します。コア機能が利用可能になった時点で、重大度レベルは新たに適切なサービスレベルに下がります。</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li><strong>重大度 レベル2</strong></li>
-              </ul>
-              <p>コア機能が著しく</p>
-              <p>低下している</p>
-            </td>
-            <td>
-              <p>Canonicalは、該当する営業時間中、回避策または恒久的な解決策を顧客に提供するよう一丸となって取り組みます。コア機能の著しい低下が解消された時点で、重大度レベルはレベル3に下がります。</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li><strong>重大度 レベル3</strong></li>
-              </ul>
-              <p>標準のサポート要求</p>
-            </td>
-            <td>
-              <p>Canonicalは、該当する営業時間中、回避策または恒久的な解決策をできるだけ早く顧客に提供するよう、上位の重大度レベルのケースとのバランスを取りつつ合理的な努力を払います。回避策が提供された場合、Canonicalのサポートエンジニアは、ケースに対する恒久的な解決策を開発するよう引き続き努力します。</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li><strong>重大度 レベル4</strong></li>
-              </ul>
-              <p>緊急性のない要求</p>
-            </td>
-            <td>
-              <p>レベル4の要求には、表面上の問題、情報の要求、機能要求などがあります。Canonicalは、いかなる機能要求についても、タイムラインまたは採用の保証は提供しません。Canonicalは、レベル4の各ケースをレビューし、それが将来のリリースに向けて検討すべき製品拡張であるか、現行リリースで修正すべき問題であるか、あるいは将来のリリースで修正すべき問題であるかを決定します。情報要求に関しては、サポート範囲の時間中、合理的なレベルの努力により検討して応答します。Canonicalが適切であると判断した場合は、レベル4の問題を示すケースに応答後、それをクローズできるものとします。</p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <h3>4.ホットフィックス</h3>
+      <p>クリティカルなサポートケースを一時的に解決するため、Canonicalは影響を受けたソフトウェア（例：パッケージ）にパッチを適用したバージョンを提供することがあります。このようなバージョンは、「ホットフィックス」と呼ばれます。Canonicalから提供するホットフィックスは、それに対応するパッチがUbuntuアーカイブ内のソフトウェアのリリースに統合されてから90日間有効です。しかし、該当する上流プロジェクトがパッチを却下した場合、そのホットフィックスのサポートは打ち切られ、サポートケースは続行します。</p>
 
+      <h3>5.言語</h3>
+      <p>Canonicalはサポートを英語で提供しますが、他の言語が利用可能となる場合もあります。</p>
 
-      <h2>4.ホットフィックス</h2>
+      <h3>6.リモートセッション</h3>
+      <p>6.1 Canonicalは、お客様のサポート対象システムへのリモートアクセスサービスによるアクセスを提案することがあります。このような場合、どのリモートアクセスサービスを使用するかについてはCanonicalが決定します。</p>
 
-      <p>Canonicalでは、重大度の高いサポートケースを暫定的に解決するため、影響を受けているソフトウェア （パッケージなど）のパッチ適用バージョンを提供する場合があります。このようなバージョンは「ホットフィックス」と呼ばれます。Canonicalが提供するホットフィックスは、そのパッチがUbuntu
-        Archives内のソフトウェアのリリースに適用された後、90日間有効です。ただし、該当する上流プロジェクトでパッチが拒否された場合、ホットフィックスのサポートは終了し、ケースはオープンの状態が継続します。
-      </p>
-
-      <h2>5.言語</h2>
-
-      <p>Canonicalは英語でサポートを提供します。ときによってはその他の言語が利用可能な場合があります。</p>
-
-      <h2>6.リモートセッション</h2>
-
-      <p>6.1 Canonicalは、リモートアクセスサービスを使用して顧客のサポート対象システムにアクセスし、サービスを提供できるものとします。この場合、使用するリモートアクセスサービスはCanonicalが決定します。</p>
-
-
-      <h2>7.サポート地域</h2>
-
-      <p>Canonicalは、以下の国を含むどこの場所からもサービスを提供することがあります。</p>
+      <h3>7.サポート地域</h3>
+      <p>Canonicaは以下の各国を含めたあらゆる地域からサービスを提供する可能性がありますが、以下の国に限定されません。</p>
       <ul>
         <li>オーストラリア</li>
+        <li>オーストリア</li>
         <li>ブラジル</li>
+        <li>ブルガリア</li>
         <li>カナダ</li>
         <li>チリ</li>
         <li>中国</li>
@@ -972,6 +991,8 @@
         <li>アイルランド</li>
         <li>イタリア</li>
         <li>日本</li>
+        <li>メキシコ</li>
+        <li>ニュージーランド</li>
         <li>ノルウェー</li>
         <li>ポーランド</li>
         <li>韓国</li>
@@ -979,46 +1000,55 @@
         <li>スウェーデン</li>
         <li>台湾</li>
         <li>トルコ</li>
-        <li>英国</li>
-        <li>米国</li>
+        <li>イギリス</li>
+        <li>アメリカ</li>
       </ul>
+      <p><a href="/legal/ubuntu-advantage/service-description#service-description">上へ戻る</a></p>
 
-      <h2 id="appendix-3">Ubuntu Advantageマネジメントエスカレーション</h2>
+      <h2>Ubuntu Advantage マネージメントへのエスカレーション</h2>
+      <p>サービスの種類を問わずCanonicalのサービスにご満足いただけない場合、その状況をCanonicalのマネージメントにエスカレーションする方法がいくつかあります。</p>
 
-      <p>サービスに不満がある場合は、いくつかの方法でその状況をCanonicalの経営陣にエスカレートできます。</p>
+      <h3>サポートケース終了時のフィードバック</h3>
+      <p>サポートケースが終了すると、サポートケース責任者宛にCanonicalのサポート体験全般に関するアンケートをメール送信します。すべてのアンケート結果は、マネージメントがレビューします。</p>
 
+      <h3>ピアレビューの依頼</h3>
+      <p>通常のビジネス慣行として、Canonicalは全サポートケースの一定の割合について、ピアレビューを実施しています。ケースに関するコメントとして、またはサポート用ポータルに記載の電話番号宛に、特にピアレビューを依頼することができます。中立的な立場のエンジニアが割り当てられ、サポートケースを再検討してフィードバックを提供します。</p>
 
-      <h2>ケース終了後のフィードバック</h2>
-
-      <p>ケースがクローズされると、Canonicalのサポートの全体的な経験に関するアンケートがケースオーナーにメールで送信されます。すべてのアンケートは経営陣によってレビューされます。</p>
-
-
-      <h2>ピアレビューの依頼</h2>
-
-      <p>Canonicalでは、全ケースの一定の割合に対してピアレビューを行っています。顧客は、ケースコメントまたはサポートポータルに記載の電話番号へ電話することで、ケースのピアレビューを要求できます。偏見のないエンジニアがケースレビューに任命され、フィードバックを提供します。</p>
-
-      <h2>マネジメントエスカレーション</h2>
-
-      <ul>
-        <li>緊急でないニーズ</li>
-        <ul>
-          <li>ケース自体の中でマネジメントエスカレーションを要求してください。マネージャーは、ケースをレビューして1営業日以内に応答する必要がある旨の連絡を受け取ります。</li>
-        </ul>
-        <li>緊急なニーズ：</li>
-        <ul>
-          <li>Canonicalのサポートおよびテクニカルサービスマネージャーにメール (<a href="mailto:support-manager@canonical.com">support-manager@canonical.com</a>)
-            でエスカレートできます。
-          </li>
-          <li>さらにエスカレーションが必要な場合は、Canonicalのサポートおよびテクニカルサービスディレクターにメール (<a href="mailto:operations-director@canonical.com">operations-director@canonical.com</a>)
-            でご連絡ください。
-          </li>
-        </ul>
+      <h3>マネージメントへのエスカレーション</h3>
+      <ul class="p-list">
+        <li>
+          <p>緊急以外のニーズについて：</p>
+          <ul>
+            <li>そのサポートケース内で、マネージメントへのエスカレーションをご依頼ください。マネージャーが連絡を受けてサポートケースを再検討し、1営業日以内に応答します</li>
+          </ul>
+        </li>
+        <li>
+          <p>緊急のニーズについて：</p>
+          <ul>
+            <li>Canonicalのサポート・テクニカルサービス担当マネージャーに対して、<a href="mailto:support-manager@canonical.com">support-manager@canonical.com</a> 宛のメールでエスカレーションすることができます。</li>
+            <li>さらにエスカレーションが必要な場合は、Canonialのサポート・テクニカルサービス担当ディレクターに対して、<a href="mailto:operations-director@canonical.com">operations-director@canonical.com</a> 宛のメールでご連絡ください。</li>
+          </ul>
+        </li>
       </ul>
     </div>
     <nav class="col-4 p-card">
-      <h3>Older versions</h3>
+      <h3>追加情報</h3>
       <ul class="p-list">
-        <li class="p-list__item"><a href="/legal/ubuntu-advantage/service-description-ja/2017-02-09">9 February 2017&nbsp;›</a></li>
+        <li class="p-list__item">
+          <a href="/legal/ubuntu-advantage/service-description#appendix-1">
+            付録1 - サポート範囲&nbsp;&rsaquo;
+          </a>
+        </li>
+        <li class="p-list__item">
+          <a href="/legal/ubuntu-advantage/service-description#appendix-2">
+            付録2 - サポートプロセス&nbsp;&rsaquo;
+          </a>
+        </li>
+        <li class="p-list__item">
+          <a href="/legal/ubuntu-advantage/service-description#appendix-3">
+            付録3 - マネージメントへのエスカレーション&nbsp;&rsaquo;
+          </a>
+        </li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
## Done

Update copy of Japan legal page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/ubuntu-advantage/service-description-ja>
- Check page matches the [copy doc](https://docs.google.com/document/d/1LtJa74IBi6MLORJJLgfDrQkfDWU2YFvKhLhITQw_qNA/edit#heading=h.gjdgxs)


## Issue / Card

Fixes [#484](https://github.com/ubuntudesign/web-squad/issues/484)
