### PR TITLE
Minor Vanilla 1.7.0 fixes

### DIFF
--- a/static/sass/_pattern_testimonials.scss
+++ b/static/sass/_pattern_testimonials.scss
@@ -1,146 +1,25 @@
 // Pull quote styling
 @mixin ubuntu-p-testimonials {
-  %blockquote {
-    border: 0;
-    display: flex;
-    flex-wrap: wrap;
-    height: 100%;
-    padding-left: $sp-x-large;
-    padding-right: $sp-large;
-    position: relative;
-    quotes: '\201c' '\201d';
-  }
-
-  %image {
-    align-self: center;
-    border-radius: 50%;
-    margin-bottom: $sp-medium;
-  }
-
-  %quotes {
-    color: $color-brand;
-    font-size: $sp-x-large;
-    font-weight: bold;
-    line-height: 0;
-    max-width: $sp-large;
-  }
-
-  %quote {
-    padding-bottom: $sp-x-large;
-
-    &:first-of-type::before {
-      @extend %quotes;
-      content: open-quote;
-      margin-left: -$sp-large;
-      margin-top: $sp-medium;
-      position: absolute;
-    }
-
-    &:last-of-type {
-      margin-bottom: 0;
-    }
-
-    &:last-of-type::after {
-      @extend %quotes;
-      content: close-quote;
-      position: relative;
-      right: -$sp-x-small;
-      top: $sp-x-small;
-    }
-  }
-
-  %citation-wrap {
-    align-self: flex-end;
-    display: flex;
-    line-height: 1.4;
-    margin-top: auto;
-    min-height: 4.5rem;
-    width: 100%;
-  }
-
-  %citation {
-    display: flex;
-    font-size: $sp-medium;
-    font-style: italic;
-    width: 100%;
-  }
-
   .p-testimonial {
-    @extend %blockquote;
-    flex-direction: column;
+    display: flex;
 
-    &--large {
-      @extend %blockquote;
-      flex-direction: row;
-      justify-content: space-around;
-    }
-
-    // quote
-    &__quote {
-      @extend %quote;
-      font-size: 1.125rem;
-    }
-
-    &__quote--med {
-      @extend %quote;
-      font-size: 1.125rem;
-    }
-
-    &__quote--large {
-      @extend %quote;
-      flex: 1;
-      font-size: 1.375rem;
-      padding-bottom: $sp-medium;
-
-      @media only screen and (min-width: $breakpoint-medium + 1) {
-        font-size: 1$sp-x-small;
-      }
-    }
-
-    // profile image
     &__image {
-      @extend %image;
-      max-width: 4.5rem;
+      border-radius: 50%;
     }
 
-    &__image--large {
-      @extend %image;
-      display: inline-block;
-      max-width: 6.25rem;
-
-      @media only screen and (max-width: $breakpoint-medium) {
-        display: block;
-        margin: $sp-x-small auto 0;
-        width: 4.375rem;
-      }
-    }
-
-    // citation
-    &__citation-wrap {
-      @extend %citation-wrap;
-    }
-
-    &__citation-wrap--large {
-      @extend %citation-wrap;
-      align-items: center;
+    &__quote {
+      @extend .p-pull-quote;
+      margin: 0;
     }
 
     &__citation {
-      @extend %citation;
-      align-items: stretch;
-    }
-
-    &__citation--large {
-      @extend %citation;
       align-items: center;
+      display: flex;
+      margin-top: $spv-inter--regular;
     }
 
-    // logo
     &__logo {
-      align-self: flex-start;
-      margin-right: $sp-medium;
-      max-height: $sp-xx-large;
-      max-width: 6.25rem;
+      margin-right: $sph-intra--condensed;
     }
   }
 }

--- a/templates/cloud/storage.html
+++ b/templates/cloud/storage.html
@@ -7,12 +7,12 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="u-equal-height">
-      <div class="col-6">
-        <h1>Ubuntu&nbsp;Advantage&nbsp;Storage</h1>
+      <div class="col-7">
+        <h1>Ubuntu Advantage Storage</h1>
         <p>Ubuntu Advantage Storage from Canonical embeds the proven software&dash;defined storage (<abbr title="Software&dash;defined storage">SDS</abbr>) technologies of Ceph, NexentaEdge, Swift and SwiftStack, into a 24x7&dash;supported software solution with a unique metered pricing model.</p>
         <p><a class="p-button--positive" href="/cloud/contact-us?product=cloud-storage">Request a demo</a></p>
       </div>
-      <div class="col-6 prefix-1 u-align--center u-vertically-center u-hide--small">
+      <div class="col-5 u-align--center u-vertically-center u-hide--small">
         <img class="hero-image" width="100%" src="{{ ASSET_SERVER_URL }}c2d50399-storage.svg" alt="Lots of server pictos in a cloud" />
       </div>
     </div>

--- a/templates/containers/docker-ubuntu.html
+++ b/templates/containers/docker-ubuntu.html
@@ -86,21 +86,21 @@
 
 <div class="p-strip is-bordered">
   <div class="row">
-    <div class="u-equal-height">
-      <blockquote class="p-testimonial--large">
-        <div class="col-2">
-          <img class="p-testimonial__image--large" src="{{ ASSET_SERVER_URL }}8c4a1c18-d535298c-nick_stinemates_small.jpg" alt="" />
-        </div>
-        <div class="col-10">
-          <p class="p-testimonial__quote--large">Through our partnership, we provide users with more choice by bringing the agility, portability, and security benefits of the Docker Enterprise Edition to the larger Ubuntu community</p>
-          <div class="p-testimonial__citation-wrap--large">
-            <cite class="p-testimonial__citation--large">
-              <img class="p-testimonial__logo" src="{{ ASSET_SERVER_URL }}b12d2f83-docker_logo_h.svg" alt="" /> Nick Stinemates, VP, Business Development &amp; Technical Alliances at Docker, Inc</cite>
-            </div>
+    <div class="p-testimonial">
+      <div class="col-2 u-align--center">
+        <img class="p-testimonial__image" src="{{ ASSET_SERVER_URL }}8c4a1c18-d535298c-nick_stinemates_small.jpg" alt="" />
+      </div>
+      <div class="col-10">
+        <blockquote class="p-testimonial__quote">
+          <p>Through our partnership, we provide users with more choice by bringing the agility, portability, and security benefits of the Docker Enterprise Edition to the larger Ubuntu community</p>
+          <div class="p-testimonial__citation">
+            <img class="p-testimonial__logo" src="{{ ASSET_SERVER_URL }}b12d2f83-docker_logo_h.svg" alt="" />
+            <cite>Nick Stinemates, VP, Business Development &amp; Technical Alliances at Docker, Inc</cite>
           </div>
         </blockquote>
       </div>
     </div>
+  </div>
 </div>
 
   <div class="p-strip--light is-deep">


### PR DESCRIPTION
## Done

- Fixed a styling bug on /cloud/storage (unrelated to Vanilla 1.7.0)
- Rewrote and reduced the testimonial pattern (it mostly just reuses the pull quote pattern), which is currently only used in /containers/docker-ubuntu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Go to /cloud/storage
- Check that the hero strip title wraps on small screens
- Go to /containers/docker-ubuntu
- Check that the testimonial in the middle of the page looks good

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1775
Fixes vanilla-framework/vanilla-framework#1777

## Screenshots
### Before
![screenshot_1](https://user-images.githubusercontent.com/25733845/39359963-19912998-4a14-11e8-81b1-bbf23963f841.png)

### After
![screenshot](https://user-images.githubusercontent.com/25733845/39359958-16f3d276-4a14-11e8-80e0-d170bdcbe7ed.png)


