### PR TITLE
Updating insights to blog

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu resources</h1>
-      <h5>Selected resources from <a href="https://insights.ubuntu.com" class="p-link--external">insights.ubuntu.com</a></h5>
+      <h5>Selected resources from <a href="https://blog.ubuntu.com" class="p-link--external">blog.ubuntu.com</a></h5>
     </div>
   </div>
 </section>

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -18,18 +18,18 @@
 
 <div class="row {% if spotlight_articles %}p-divider{% endif %}">
   <div class="{% if spotlight_articles %}col-9 p-divider__block{% else %}col-12{% endif %}">
-    {# insights heading #}
+    {# blog heading #}
     <h2 class="p-link--external p-heading--insights__title">
-      <a href="https://insights.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
-        Latest news from Insights
+      <a href="https://blog.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+        Latest news from the blog
       </a>
     </h2>
 
-    {# insights news items #}
+    {# blog news items #}
     <div>
       {% for article in articles %}
         <div class="col-3">
-          <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
+          <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
           <p><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></p>
         </div>
       {% endfor %}
@@ -40,13 +40,13 @@
   {% if spotlight_articles %}
     <div class="col-3 p-divider__block">
       <h2 class="p-link--external p-heading--insights__title">
-        <a href="https://insights.ubuntu.com/tag/spotlight/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+        <a href="https://blog.ubuntu.com/tag/spotlight/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : '{{ gtm_event_label }} spotlight feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
           Spotlight
         </a>
       </h2>
       {% for article in spotlight_articles %}
       <div>
-        <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
+        <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
         <p><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></p>
       </div>
       {% endfor %}

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -21,7 +21,7 @@
     {# blog heading #}
     <h2 class="p-link--external p-heading--insights__title">
       <a href="https://blog.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
-        Latest news from the blog
+        Latest news from our blog
       </a>
     </h2>
 

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -24,4 +24,4 @@ def format_date(date):
 
 @register.filter
 def replace_admin(url):
-    return url.replace("admin.insights.ubuntu.com", "insights.ubuntu.com")
+    return url.replace("admin.insights.ubuntu.com", "blog.ubuntu.com")


### PR DESCRIPTION
## Done

Update filters on resources to blog from insights

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/resources>
- Make sure all feed links are to blog.ubuntu.com and not insights.ubuntu.com


## Issue / Card

Fixes [#513](https://github.com/ubuntudesign/web-squad/issues/513)