### PR TITLE
Re-add 18.04 variables to the base index file + misc fixes

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -198,8 +198,6 @@ download:
       path: /download/cloud
     - title: IoT
       path: /download/iot
-    - title: Core
-      path: /download/core
 
       children:
         - title: Raspberry Pi 2 or 3

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -14,7 +14,7 @@
 <div class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="row">
     <div class="col-12">
-      <div class="p-card--ubuntu-upgrade u-no-padding--bottom u-no-margin--bottom">
+      <div class="p-card--ubuntu-upgrade u-no-padding--bottom">
         <div class="row u-no-margin--top">
           <div class="col-12">
             <h2 class="p-card__title"><a href="/download/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a></h2>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -182,7 +182,7 @@
           <h3 class="p-heading-icon__title">Consultation services</h3>
         </div>
         <p>
-          <a href="/cloud/foundation-cloud">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
+          <a href="/openstack/consulting">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -193,7 +193,7 @@
           <h3 class="p-heading-icon__title">Managed cloud services</h3>
         </div>
         <p>
-          <a href="/cloud/managed-cloud">The BootStack service for a managed cloud operated for you to the highest standards&nbsp;&rsaquo;</a>
+          <a href="/openstack/managed">The BootStack service for a managed cloud operated for you to the highest standards&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,7 @@
       <img src="{{ ASSET_SERVER_URL }}0bfbd13b-cloud_section_bundle.svg?h=460" class="u-image-position--top u-hide--small" alt="" style="height: 100%; right: 47%;" />
     </div>
     <div class="col-5">
-      <h3><a href="/cloud/managed-cloud">The world’s most popular operating system across public clouds and OpenStack clouds&nbsp;&rsaquo;</a></h3>
+      <h3><a href="/openstack/managed">The world’s most popular operating system across public clouds and OpenStack clouds&nbsp;&rsaquo;</a></h3>
       <p>Find out more about Ubuntu’s cloud building software, tools and service packages.</p>
     </div>
   </div>

--- a/templates/legal/managed-services/index.html
+++ b/templates/legal/managed-services/index.html
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-8">
       <h1>Managed Services</h1>
-      <p>Canonical will build, support and manage your either your OpenStack cloud with our <a href="/cloud/managed-cloud">BootStack</a> service or a private Kubernetes cluster with our <a href="/kubernetes/managed">Managed Kubernetes</a> service. Then, when you&rsquo;re ready, we&rsquo;ll train your team and smoothly hand over operational control.</p>
+      <p>Canonical will build, support and manage your either your OpenStack cloud with our <a href="/openstack/managed">BootStack</a> service or a private Kubernetes cluster with our <a href="/kubernetes/managed">Managed Kubernetes</a> service. Then, when you&rsquo;re ready, we&rsquo;ll train your team and smoothly hand over operational control.</p>
       <p>If you&rsquo;re interested in BootStack or Kubernetes, or you&rsquo;re a reseller and you want to offer it to your customers, please <a href="/cloud/contact-us?product=cloud-managed-cloud">contact us</a>.</p>
     </div>
     <div class="col-4 prefix-1">

--- a/templates/shared/contextual_footers/_download_cloud_bootstack.html
+++ b/templates/shared/contextual_footers/_download_cloud_bootstack.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Buy an OpenStack cloud</h3>
   <p>Don&rsquo;t want to build a cloud yourself? With Bootstack, Canonical will set up and operate an OpenStack cloud for you from only &dollar;15 per server.</p>
-  <p><a href="/cloud/managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Bootstack', 'eventLabel' : 'Buy an OpenStack cloud', 'eventValue' : undefined });">Learn more about BootStack&nbsp;&rsaquo;</a></p>
+  <p><a href="/openstack/managed" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Bootstack', 'eventLabel' : 'Buy an OpenStack cloud', 'eventValue' : undefined });">Learn more about BootStack&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -71,7 +71,7 @@
       <div class="p-card__content">
         <p>Canonical&rsquo;s Foundation Cloud Build for telcos is a pre-tested, pre-integrated OpenStack cloud built using a proven reference architecture and tailored to the needs of CSPs.</p>
         <p>Think of it as a fixed price, NFV-ready cloud, deployed by Canonical on your premises in just a few weeks.</p>
-        <p><a href="/cloud/foundation-cloud">Find out more<span class="u-off-screen"> about NFVI cloud build</span>&nbsp;&rsaquo;</a></p>
+        <p><a href="/openstack/consulting">Find out more<span class="u-off-screen"> about NFVI cloud build</span>&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -80,7 +80,7 @@
       <h2 class="p-card__title">A telco-grade managed cloud</h2>
       <div class="p-card__content">
         <p>A number of telcos rely on Canonical&rsquo;s fully managed cloud service. Get Telco Grade SLAs and predictable operational costs for your OpenStack cloud, on your servers at your locations. We build, operate, scale and upgrade your cloud, while you concentrate on building your applications in flexible and agile environments.</p>
-        <p><a href="/cloud/managed-cloud">Find out more<span class="u-off-screen"> about Canonical&rsquo;s managed cloud</span>&nbsp;&rsaquo;</a></p>
+        <p><a href="/openstack/consulting">Find out more<span class="u-off-screen"> about Canonical&rsquo;s managed cloud</span>&nbsp;&rsaquo;</a></p>
       </div>
     </div>
     <div class="col-6 p-card--highlighted">

--- a/templates/templates/_navigation-enterprise.html
+++ b/templates/templates/_navigation-enterprise.html
@@ -22,9 +22,9 @@
         <h4 class="p-heading--navigation"><a class="p-link--soft" href="/openstack" title="Visit the private cloud page">OpenStack</a></h4>
         <p class="p-small">The number one platform for OpenStack.</p>
         <ul class="p-text-list--small bordered">
-          <li class="p-list__item"><a href="/openstack/foundation-cloud">Consulting</a> on cloud architecture</li>
+          <li class="p-list__item"><a href="/openstack/consulting">Consulting</a> on cloud architecture</li>
           <li class="p-list__item"><a href="/openstack/training">Training</a> on openstack operations</li>
-          <li class="p-list__item">Fully <a href="/openstack/managed-cloud">managed Openstack</a></li>
+          <li class="p-list__item">Fully <a href="/openstack/managed">managed Openstack</a></li>
           <li class="p-list__item">Step-by-step install instructions</li>
         </ul>
       </div>
@@ -107,7 +107,7 @@
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot">
-          <li class="p-inline-list__item"><a href="/cloud/managed-cloud">OpenStack</a></li>
+          <li class="p-inline-list__item"><a href="/openstack/managed">OpenStack</a></li>
           <li class="p-inline-list__item"><a href="/kubernetes/managed">Kubernetes</a></li>
           <li class="p-inline-list__item">PostgreSQL</li>
         </ul>
@@ -153,7 +153,7 @@
       <div class="col-9">
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item"><a href="/support">Ubuntu</a></li>
-          <li class="p-inline-list__item"><a href="/cloud/foundation-cloud">OpenStack</a></li>
+          <li class="p-inline-list__item"><a href="/openstack/consulting">OpenStack</a></li>
           <li class="p-inline-list__item"><a href="/kubernetes">Kubernetes</a></li>
           <li class="p-inline-list__item"><a href="/server/livepatch">Canonical Livepatch</a></li>
           <li class="p-inline-list__item"><a href="https://snapcraft.io" title="Visit the Snapcraft - external site">Snapcraft</a></li>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="ArtfulAardvark" latest_release='17.10' latest_release_with_point="17.10.1" latest_release_eol='July 2018' lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 LTS' lts_release_with_point="16.04.4" lts_release_full_with_point='16.04.4 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2021' lts_openstack_version="Mitaka" latest_openstack_version="Pike" %}
+{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04" latest_release_eol='April 2023' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04" lts_release_full_with_point='18.04 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Queens" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

- Fixed small errors in the `beta-1.7.0` branch I made when trying to rebase
- Fixed broken links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Go to /download and check there is a margin below the main card (#3102)
- Go to /download/alternative-downloads and check the Network Installer links are for 18.04 and they work (#3103)
- Check the BitTorrent links includes 18.04 and they work (#3104)
- Go to /download/desktop and check that there is a link to 18.04 and it works (#3105)
- Go to /download/server and check that there is a link to 18.04 and it works (#3106)
- Check that Travis gives the OK

## Issue / Card

Fixes #3102, fixes #3103, fixes #3104, fixes #3105, fixes #3106
