### PR TITLE
Stop word breaking in takeover heading

### DIFF
--- a/templates/takeovers/_1804-takeover.html
+++ b/templates/takeovers/_1804-takeover.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="p-takeover__body u-clearfix">
       <div class="col-8">
-        <h1 class="p-takeover__title">Ubuntu 18.04 LTS out now</h1>
+        <h1 class="p-takeover__title">Ubuntu 18.04 LTS out&nbsp;now</h1>
         <p class="p-heading--four">Optimised for multi-cloud infrastructure, machine learning, AI and software development</p>
         <p class="p-takeover__image u-hide--medium u-hide--large"><img src="{{ ASSET_SERVER_URL }}99cee55b-beaver.svg" alt=""></p>
         <p><a href="/download" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '18.04 takeover', 'eventLabel' : 'Download 18.04 now', 'eventValue' : undefined });" class="p-button--neutral"><span>Download 18.04 now</span></a></p>


### PR DESCRIPTION
## Done

Add `&nbsp;` to heading to prevent word dropping to next line

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Resize the browser so the takeover heading wraps
- See that the words "out now" are on the same line


## Issue / Card

Fixes [#539](https://github.com/ubuntudesign/web-squad/issues/539)