### PR TITLE
Add online purchase privacy page

### DIFF
--- a/templates/legal/dataprivacy/online-purchase.html
+++ b/templates/legal/dataprivacy/online-purchase.html
@@ -1,0 +1,45 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Privacy notice | Online purchase{% endblock %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Privacy notice - Online purchase</h1>
+      <p>Version - April 2018</p>
+      <p>This privacy notice tells you about the information we collect from you when you purchase one or more of our products via our website. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.</p>
+      <h2 id="who-we-are">Who we are?</h2>
+      <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of &ldquo;Legal&rdquo;.</p>
+      <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
+      <h2 id="what-personal-data-do-we-collect">What personal data do we collect?</h2>
+      <p>When you purchase products from us online, we ask you for your name, address, contact telephone number, email address and credit card information.</p>
+      <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
+      <p>Your information will be used by our third party payment provider to verify your credit card details for your purchase and for Canonical or our third party supplier to process your order and to send you your goods. We will also send you a receipt via email and we or the third party supplier may use your telephone number to contact you regarding your delivery.</p>
+      <p>We require this information in order to process your payment, deliver your goods and fulfil our contract with you.</p>
+      <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
+      <p>Your information is stored in our order processing system and may be processed outside of the European Economic Area. It is shared with the third parties set out below and as reasonably required for Canonical to process and store your data.</p>
+      <p>Your credit card details are passed to a third-party payment processor who retains credit card details in the European Economic Area or where required, is certified to the EU-US Privacy Shield (which requires effective safeguards for your information). We do not retain your credit card information.</p>
+      <p>Our third-party payment processor is a company called Stripe Payments Europe, Limited, who we use to process and confirm your payments. We share with them your name, address and credit card information only for payment purposes. We do not retain credit card data but our payment service providers do. For your safety, we have in place agreement between us to protect, safeguard your information and prohibit any sharing for any reasons whatsoever.</p>
+      <p>We also use a third-party supplier called Shopify Inc. to provision your order and we share with them your name, address and telephone number in order to complete the delivery.</p>
+      <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>
+      <p>We keep your order information for so long as reasonably required in accordance with our record retention policy. Your personal information associated with the order will then be removed.</p>
+      <h2 id="your-rights-over-your-information">Your rights over your information</h2>
+      <p>By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.</p>
+      <p>You can also ask us to give you a copy of the information and to stop using your information for a period of time if you believe we are not doing so lawfully.</p>
+      <p>To submit a request by email, post or telephone, please use the contact information provided above.</p>
+      <h2 id="your-right-to-complain">Your right to complain</h2>
+      <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="http://www.ico.org/concerns">www.ico.org/concerns</a> or write to them at:</p>
+      <ul class="p-list">
+        <li class="p-list__item">Information Commissioner's Office</li>
+        <li class="p-list__item">Wycliffe House</li>
+        <li class="p-list__item">Water Lane</li>
+        <li class="p-list__item">Wilmslow</li>
+        <li class="p-list__item">Cheshire</li>
+        <li class="p-list__item">SK9 5AF</li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/legal/dataprivacy/online-purchase.html
+++ b/templates/legal/dataprivacy/online-purchase.html
@@ -10,7 +10,7 @@
       <h1>Privacy notice - Online purchase</h1>
       <p>Version - April 2018</p>
       <p>This privacy notice tells you about the information we collect from you when you purchase one or more of our products via our website. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.</p>
-      <h2 id="who-we-are">Who we are?</h2>
+      <h2 id="who-are-we">Who are we?</h2>
       <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of &ldquo;Legal&rdquo;.</p>
       <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
       <h2 id="what-personal-data-do-we-collect">What personal data do we collect?</h2>


### PR DESCRIPTION
## Done

Add new online purchase privacy notice page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/dataprivacy/online-purchase>
- Check that page matches [the copy doc](https://docs.google.com/document/d/1ZSNnMiLJl6SGSV0D_cr6MJAwpkf6xzbKYJdTL9MxLHc/edit#)


## Issue / Card

Fixes #3121 