### PR TITLE
Add snap store privacy notice

### DIFF
--- a/templates/legal/dataprivacy/snap-store.html
+++ b/templates/legal/dataprivacy/snap-store.html
@@ -1,0 +1,46 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Privacy notice | Snap store{% endblock %}
+
+{% block content %}
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>Privacy notice - Snap store</h1>
+      <p>Version - April 2018</p>
+      <p>This privacy notice tells you about the information we collect from you when you download and install and purchase snaps and software (“Software”) on Ubuntu Core and any compatible supported systems. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.</p>
+      <h2 id="who-are-we">Who are we?</h2>
+      <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of &ldquo;Legal&rdquo;.</p>
+      <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
+      <h2 id="what-personal-data-do-we-collect">What personal data do we collect?</h2>
+      <p>When you purchase Software from us online, we ask you for your name, address, contact telephone number, your email address and credit card information.</p>
+      <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
+      <p>Your information will be used by our third party payment provider to verify your credit card details for your purchase and for Canonical or our third party suppliers to process your order for the Software. We will also send you a receipt via email and we or a third party supplier may use your telephone number to contact you regarding your purchase.</p>
+      <p>We require this information in order to process your payment, provide you with Software and fulfil our contract with you.</p>
+      <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
+      <p>Your information is stored in our order processing system and may be processed outside of the European Economic Area.</p>
+      <p>Your credit card details are passed to a third-party payment processor who retains credit card details in the European Economic Area or where required, is certified to the EU-US Privacy Shield (which requires effective safeguards for your information). We do not retain your credit card information.</p>
+      <p>Our third-party payment processor is a company called Stripe who we use to process and confirm your payments. We share with them your name, address and credit card information only for payment purposes. We do not retain credit card data but our payment service providers do. For your safety, we have in place agreement between us to protect, safeguard your information and prohibit any sharing for any reasons whatsoever.</p>
+      <p>We will not use the information you provide to make any automated decisions that might affect you.</p>
+      <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>
+      <p>Unless you create an account with us, we keep your order information for so long as reasonably required thereafter in accordance with our record retention policy. Your personal information associated with the order will then be removed.</p>
+      <h2 id="your-rights-over-your-information">Your rights over your information</h2>
+      <p>By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.</p>
+      <p>You can also ask us to give you a copy of the information and to stop using your information for a period of time if you believe we are not doing so lawfully.</p>
+      <p>To submit a request by email, post or telephone, please use the contact information provided above.</p>
+      <h2 id="your-right-to-complain">Your right to complain</h2>
+      <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="http://www.ico.org/concerns">www.ico.org/concerns</a> or write to them at:</p>
+      <ul class="p-list">
+        <li class="p-list__item">Information Commissioner&rsquo;s Office</li>
+        <li class="p-list__item">Wycliffe House</li>
+        <li class="p-list__item">Water Lane</li>
+        <li class="p-list__item">Wilmslow</li>
+        <li class="p-list__item">Cheshire</li>
+        <li class="p-list__item">SK9 5AF</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

Add snap store privacy notice page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/dataprivacy/snap-store>
- Check that page matches the [copy doc](https://docs.google.com/document/d/1rEyCOZWoKKJRPIg5jhANfWVibZJ9QVfqj4MkeNIJp4M/edit#heading=h.30j0zll)


## Issue / Card

Fixes #3122 
