### PR TITLE
Add newsletter signup privacy notice page

### DIFF
--- a/templates/legal/dataprivacy/newsletter.html
+++ b/templates/legal/dataprivacy/newsletter.html
@@ -1,0 +1,44 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Privacy notice | Newsletter signup{% endblock %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Privacy notice - Newsletter signup</h1>
+      <p>Version - April 2018</p>
+      <p>This privacy notice tells you about the information we collect from you when you sign up to receive our regular newsletter via our website. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.</p>
+      <h2 id="who-are-we">Who are we?</h2>
+      <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of &ldquo;Legal&rdquo;.</p>
+      <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
+      <h2 id="what-personal-data-do-we-collect">What personal data do we collect?</h2>
+      <p>When you subscribe to our newsletter, we ask you for your name and your email address and related information.</p>
+      <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
+      <p>We will use your information to send you our newsletter, which contains information about our products. This may involve us calling you, where we have your phone number in order to do so.</p>
+      <p>We ask for your consent to do this, and we will only send you our newsletter for as long as you continue to consent.</p>
+      <p>Where you have agreed, we will also use your information to send you other news and product updates from Canonical. This may involve us calling you, where we have your phone number in order to do so.</p>
+      <p>We ask for your consent to do this, and we will only send you or tell you about news and product updates for as long as you continue to consent.</p>
+      <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
+      <p>Your information is stored in our database and is not shared with any third parties, except as reasonably required for Canonical to process and store your data. It is sent outside of the European Economic Area for our own internal processing purposes only.</p>
+      <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>
+      <p>Your information is kept for as long as you continue to consent to receive our newsletter and for so long as reasonably required thereafter in accordance with our record retention policy.</p>
+      <h2 id="your-rights-over-your-information">Your rights over your information</h2>
+      <p>By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.</p>
+      <p>You can also ask for it to be erased and you can ask for us to give you a copy of the information.</p>
+      <p>You can also ask us to stop using your information for newsletters, news or product updates – the simplest way to do this is to withdraw your consent, which you can do at any time, either by clicking the unsubscribe link at the end of any newsletter or email, or by emailing, writing or telephoning us using the contact details above.</p>
+      <h2 id="your-right-to-complain">Your right to complain</h2>
+      <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="http://www.ico.org/concerns">www.ico.org/concerns</a> or write to them at:</p>
+      <ul class="p-list">
+        <li class="p-list__item">Information Commissioner&rsquo;s Office</li>
+        <li class="p-list__item">Wycliffe House</li>
+        <li class="p-list__item">Water Lane</li>
+        <li class="p-list__item">Wilmslow</li>
+        <li class="p-list__item">Cheshire</li>
+        <li class="p-list__item">SK9 5AF</li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## Done

Add newsletter signup privacy notice page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/dataprivacy/newsletter>
- Make sure page matches the [copy doc](https://docs.google.com/document/d/1Et7uuP82vYgk-sXTOeLLlKi0NzwCdDHkSlfLS7IClzo/edit#)


## Issue / Card
Fixes #3119 