### PR TITLE
Add list of websites page

### DIFF
--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -1,0 +1,151 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Canonical websites{% endblock %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Canonical websites</h1>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="http://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://certification.ubuntu.com ">certification.ubuntu.com </a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://cloud-images.ubuntu.com">cloud-images.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://cloud-init.io">cloud-init.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://conjure-up.io">conjure-up.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://cn.ubuntu.com">cn.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://community.ubuntu.com">community.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://design.canonical.com">design.canonical.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://design.ubuntu.com">design.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://developer.ubuntu.com">developer.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://docs.conjure-up.io">docs.conjure-up.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://docs.maas.io">docs.maas.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://docs.ubuntu.com">docs.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://docs.snapcraft.io">docs.snapcraft.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://docs.vanillaframework.io">docs.vanillaframework.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://errors.ubuntu.com">errors.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://fridge.ubuntu.com">fridge.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://help.ubuntu.com  ">help.ubuntu.com  </a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://insights.ubuntu.com">insights.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://jp.ubuntu.com">jp.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://jujucharms.com">jujucharms.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://landscape.canonical.com">landscape.canonical.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://launchpad.net">launchpad.net</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://lists.ubuntu.com">lists.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://login.ubuntu.com">login.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="http://loco.ubuntu.com">loco.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://maas.io">maas.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://merges.ubuntu.com">merges.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://netplan.io">netplan.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="http://packaging.ubuntu.com">packaging.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://partners.ubuntu.com">partners.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="http://planet.ubuntu.com">planet.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://popcon.ubuntu.com">popcon.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="http://releases.ubuntu.com">releases.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://shop.canonical.com ">shop.canonical.com </a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://snapcraft.io">snapcraft.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://tutorials.ubuntu.com">tutorials.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://ubuntuforums.org">ubuntuforums.org</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://ubuntuonair.com">ubuntuonair.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://usn.ubuntu.com">usn.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://vanillaframework.io">vanillaframework.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://voices.canonical.com">voices.canonical.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://www.canonical.com">www.canonical.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://www.ubuntu.com">www.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="http://old-releases.ubuntu.com">old-releases.ubuntu.com</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## Done

Add list of websites page
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/websites>
- Check that the page matches [the copy doc](https://docs.google.com/document/d/1Zk2a1Lzxq592-iKVp3lJnmdbcGe2o9lnr7OiJUr0Xmo/edit)

## Issue / Card
Fixes #3117 