### PR TITLE
Added robots noindex to search results page

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -1,5 +1,7 @@
 {% extends "templates/one-column.html" %}
 
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block title %}Search results{% if query %} for "{{query}}"{% endif %} | Ubuntu{% endblock %}
 
 


### PR DESCRIPTION
## Done

- Added robots noindex to search results page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [a search](http://0.0.0.0:8001/search?q=juju)
- see ` <meta name="robots" content="noindex" />` in the head

## Issue / Card

Fixes #3142 on www.ubuntu.com

