### PR TITLE
Fix broken links in download navigation

### DIFF
--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -69,10 +69,10 @@
         <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
         <p class="p-p--small">Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
         <ul class='p-inline-list--middot' >
-          <li class='p-inline-list__item'><a class='p-link' href='#'>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/try-openstack'>
             Try OpenStack
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='#'>
+          <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/build-openstack'>
             Deploy OpenStack
           </a></li>
         </ul>

--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -69,10 +69,10 @@
         <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
         <p class="p-p--small">Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
         <ul class='p-inline-list--middot' >
-          <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/try-openstack'>
+          <li class='p-inline-list__item'><a class='p-link' href='/openstack/developer'>
             Try OpenStack
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/build-openstack'>
+          <li class='p-inline-list__item'><a class='p-link' href='/openstack/install'>
             Deploy OpenStack
           </a></li>
         </ul>

--- a/templates/templates/_navigation-download.html
+++ b/templates/templates/_navigation-download.html
@@ -64,10 +64,10 @@
       <h4 class="is-x-dense"><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
       <p class="p-p--small">Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
       <ul class='p-inline-list--middot' >
-        <li class='p-inline-list__item'><a class='p-link' href='#'>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/try-openstack'>
           <small>Try OpenStack</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='#'>
+        <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/build-openstack'>
           <small>Deploy OpenStack</small>
         </a></li>
       </ul>

--- a/templates/templates/_navigation-download.html
+++ b/templates/templates/_navigation-download.html
@@ -64,10 +64,10 @@
       <h4 class="is-x-dense"><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
       <p class="p-p--small">Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
       <ul class='p-inline-list--middot' >
-        <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/try-openstack'>
+        <li class='p-inline-list__item'><a class='p-link' href='/openstack/developer'>
           <small>Try OpenStack</small>
         </a></li>
-        <li class='p-inline-list__item'><a class='p-link' href='/download/cloud/build-openstack'>
+        <li class='p-inline-list__item'><a class='p-link' href='/openstack/install'>
           <small>Deploy OpenStack</small>
         </a></li>
       </ul>


### PR DESCRIPTION
## Done

Fix broken openstack links in download navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Click on the 'Download' navigation
- See that 'Try OpenStack' and 'Deploy OpenStack' are both working links


## Issue / Card

Fixes #3143 