### PR TITLE
Add links to enterprise navgation

### DIFF
--- a/templates/templates/_navigation-enterprise.html
+++ b/templates/templates/_navigation-enterprise.html
@@ -10,14 +10,14 @@
     <div class="row u-equal-height">
       <div class="col-4 p-card--navigation u-no-padding--bottom">
         <h4 class="is-x-dense">
-          OpenStack Solutions
+          <a href="/openstack">OpenStack Solutions&nbsp;&rsaquo;</a>
         </h4>
         <ul class="p-text-list--small is-dense is-bordered">
-          <li class="p-list__item">Build private clouds</li>
-          <li class="p-list__item">Fully managed options</li>
-          <li class="p-list__item">Transfer and training</li>
-          <li class="p-list__item">Integration</li>
-          <li class="p-list__item">Support</li>
+          <li class="p-list__item"><a href="/openstack">Build private clouds</a></li>
+          <li class="p-list__item"><a href="/openstack/managed">Fully managed options</a></li>
+          <li class="p-list__item"><a href="/openstack/training">Transfer and training</a></li>
+          <li class="p-list__item"><a href="/openstack/consulting">Integration</a></li>
+          <li class="p-list__item"><a href="/support/plans-and-pricing#openstack">Support</a></li>
         </ul>
         <p class="p-p--small">
           Canonical is the leading provider of managed OpenStack. We’ll build, operate, train your team and transfer your cloud to your control, in your data center, on your preferred hardware.
@@ -26,7 +26,7 @@
       </div>
       <div class="col-4 p-card--navigation u-no-padding--bottom">
         <h4 class="is-x-dense">
-          Kubernetes Solutions
+          <a href="/kubernetes">Kubernetes Solutions&nbsp;&rsaquo;</a>
         </h4>
         <ul class="p-text-list--small is-dense is-bordered">
           <li class="p-list__item">Bare metal, VMware, cloud</li>
@@ -34,22 +34,23 @@
           <li class="p-list__item">GPGPU support for ML</li>
           <li class="p-list__item">CI/CD with Rancher &amp; Jenkins</li>
           <li class="p-list__item">AI and ML workflows</li>
+          <li class="p-list__item"><a href="/kubernetes/managed">Fully managed options</a></li>
         </ul>
         <p class="p-p--small">
-          Canonical delivers the leading Kubernetes distribution and provides workshops, training, deployment and consulting services. Canonical supports the  Google GKE and Azure AKS cloud k8s services which use Ubuntu.
+          Canonical delivers the leading Kubernetes distribution and <a href="/kubernetes/managed">provides workshops, training, deployment and consulting services</a>. Canonical supports the  Google GKE and Azure AKS cloud k8s services which use Ubuntu.
         </p>
         <a href="/kubernetes/" class="p-button--neutral u-align-text--right u-align--bottom">More</a>
       </div>
       <div class="col-4 p-card--navigation u-no-padding--bottom">
         <h4 class="is-x-dense">
-          Enterprise Support
+          <a href="/support">Enterprise Support&nbsp;&rsaquo;</a>
         </h4>
         <ul class="p-text-list--small is-dense is-bordered">
-          <li class="p-list__item">Kernel Live Patch</li>
-          <li class="p-list__item">Extended Security</li>
+          <li class="p-list__item"><a href="/server/livepatch">Kernel Live Patch</a></li>
+          <li class="p-list__item"><a href="/support/esm">Extended Security</a></li>
           <li class="p-list__item">Optimised Windows VMs</li>
-          <li class="p-list__item">Management System</li>
-          <li class="p-list__item">Compliance Reporting</li>
+          <li class="p-list__item"><a href="https://landscape.canonical.com/">Management System</a></li>
+          <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance Reporting</a></li>
         </ul>
         <p class="p-p--small">
           Canonical provides 24/7 enterprise support for Ubuntu, OpenStack, Docker and Kubernetes. From the desktop to the cloud, get more from your Ubuntu estate with our tools and insights.


### PR DESCRIPTION
## Done

Add missing links to the enterprise navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Open the enterprise navigation menu and see that links match [the copy doc](https://docs.google.com/document/d/14EJRVoh2Hfc_K3ZFZbPPRkqeZ_NQUwDJp9vnyIuadf4/edit#)


## Issue / Card

Fixes #3150 