### PR TITLE
Updates to legal page

### DIFF
--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -23,76 +23,57 @@
   <div class="row">
     <div class="u-equal-height">
       <div class="col-6 p-card">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/53640d35-picto-ubuntu-warmgrey.svg" alt="" />
-            <h3 class="p-heading-icon__title">
-          <a href="/legal/terms-and-policies">
-            Terms and policies&nbsp;&rsaquo;
-          </a>
+        <h3>
+          <a href="/legal/terms-and-policies">Terms and policies&nbsp;&rsaquo;</a>
         </h3>
-          </div>
-          <p>The main terms governing use of our software and websites, including links to privacy, intellectual property and copyright information.</p>
-        </div>
+        <p>The main terms governing use of our software and websites, including links to privacy, intellectual property and copyright information.</p>
       </div>
       <div class="col-6 p-card">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/03c5463a-picto-business-warmgrey.svg" alt="" />
-            <h3 class="p-heading-icon__title">
-              <a href="/legal/ubuntu-advantage">
-                Ubuntu Advantage terms&nbsp;&rsaquo;
-              </a>
-            </h3>
-          </div>
-          <p>A legal description of the services included in the Ubuntu Advantage support package.</p>
-        </div>
+        <h3>
+          <a href="/legal/dataprivacy">Data privacy&nbsp;&rsaquo;</a>
+        </h3>
+        <p>Information about how we collect and process personal data, including links to privacy notices.</p>
       </div>
     </div>
   </div>
   <div class="row">
     <div class="u-equal-height">
       <div class="col-6 p-card">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b06cbaa6-picto-canonical-warmgrey.svg" alt="" />
-            <h3 class="p-heading-icon__title">
-              <a href="/legal/contributors">
-                Contributor agreement&nbsp;&rsaquo;
-              </a>
-            </h3>
-          </div>
-          <p>Details of the agreement you need to send to us before you begin contributing to projects at Canonical.</p>
-        </div>
+        <h3>
+          <a href="/legal/trademarks">Trademarks&nbsp;&rsaquo;</a>
+        </h3>
+        <p>A list of trademarks used by Canonical.</p>
       </div>
       <div class="col-6 p-card">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/2a8cf960-picto-startfirst-warmgrey.svg" alt="" />
-            <h3 class="p-heading-icon__title">
-              <a href="/legal/managed-services">
-                Managed Services terms&nbsp;&rsaquo;
-              </a>
-            </h3>
-          </div>
-          <p>A legal description of the services included in Bootstack and Managed Kubernetes.</p>
-        </div>
+        <h3>
+          <a href="/legal/contributors">Contributor agreement&nbsp;&rsaquo;</a>
+        </h3>
+        <p>Details of the agreement you need to send to us before you begin contributing to  projects at Canonical.</p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 p-card">
+        <h3>
+          <a href="/legal/ubuntu-advantage">Ubuntu Advantage terms&nbsp;&rsaquo;</a>
+        </h3>
+        <p>A legal description of the services included in the Ubuntu Advantage support package.</p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>
+          <a href="/legal/managed-services">Managed Services terms&nbsp;&rsaquo;</a>
+        </h3>
+        <p>A legal description of the services included in Bootstack and Managed Kubernetes.</p>
       </div>
     </div>
   </div>
   <div class="row">
     <div class="col-12 p-card">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0838729a-picto-bookmark-warmgrey.svg" alt="" />
-          <h3 class="p-heading-icon__title">
-            <a href="/legal/short-terms">
-              Short terms&nbsp;&rsaquo;
-            </a>
-          </h3>
-        </div>
-        <p>This agreement sets out Canonical&rsquo;s standard service terms for both Ubuntu Advantage and Managed Services customers.</p>
-      </div>
+      <h3>
+        <a href="/legal/service-terms">Service terms&nbsp;&rsaquo;</a>
+      </h3>
+      <p>This agreement sets out Canonical&rsquo;s standard service terms for both Ubuntu Advantage and Managed Services customers.</p>
     </div>
   </div>
 </div>

--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -8,7 +8,7 @@
 <div class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <h1>Ubuntu legal</h1>
+      <h1>Legal Terms and Conditions</h1>
       <p>We have a number of legal agreements to protect your personal data and the contributions you make to the projects we manage. We also have agreements that enable us to share intellectual property (which includes our trademarks and content as well as code), plus legal descriptions of exactly what our support services cover.</p>
     </div>
     <div class="col-4">
@@ -64,7 +64,7 @@
         <h3>
           <a href="/legal/managed-services">Managed Services terms&nbsp;&rsaquo;</a>
         </h3>
-        <p>A legal description of the services included in Bootstack and Managed Kubernetes.</p>
+        <p>A legal description of the services included in Bootstack.</p>
       </div>
     </div>
   </div>

--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -1,14 +1,14 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Ubuntu legal terms and policies{% endblock %}
-{% block meta_description %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu. {% endblock %}
+{% block meta_description %}Ubuntu and Canonical Legal - legal terms and policies{% endblock %}
 
 {% block content %}
 
 <div class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <h1>Legal Terms and Conditions</h1>
+      <h1>Legal terms and conditions</h1>
       <p>We have a number of legal agreements to protect your personal data and the contributions you make to the projects we manage. We also have agreements that enable us to share intellectual property (which includes our trademarks and content as well as code), plus legal descriptions of exactly what our support services cover.</p>
     </div>
     <div class="col-4">


### PR DESCRIPTION
## Done

Updates to `/legal` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal](http://0.0.0.0:8001/legal)
- Check that page matches [the copy doc](https://docs.google.com/document/d/19yTLYWu7rEErPrO0xDsqMeN8tcWKBjHuarw0tjxRlhY/edit)


## Issue / Card
Fixes #3115 