### PR TITLE
Beta nav - update enterprise overlay

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -11,10 +11,10 @@
 @import 'vanilla-framework/scss/build';
 
 // vendor
-@import '../global-nav/src/sass/main';
+// @import '../global-nav/src/sass/main';
 @import 'pattern_global-nav';
 @import 'vanilla-placeholders';
-// @include global-nav;
+@include global-nav;
 // import site specific patterns and overrides
 @import 'pattern_buttons';
 @import 'pattern_sun-animation';

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -8,77 +8,115 @@
       </div>
     </div>
     <div class="row">
+      <!-- OpenStack Solutions -->
       <div class="col-3">
-        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/containers" title="Visit the containers pages">Containers&nbsp;›</a></h4>
-        <p class="p-p--small">The base OS for both Google and Azure Kubernetes.</p>
-        <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item">Install and operate <a href="/kubernetes">Kubernetes</a></li>
-          <li class="p-list__item">Use <a href="https://linuxcontainers.org/" title="Visit the LXD - external site">LXD</a> for legacy apps in containers</li>
-          <li class="p-list__item">Learn about <a href="/containers/docker-ubuntu">Docker</a></li>
-          <li class="p-list__item">Kubernetes consulting and <a href="/kubernetes/managed">services</a></li>
+        <h4 class="p-heading-four is-dense">
+          <a href="/openstack">OpenStack Solutions&nbsp;&rsaquo;</a>
+        </h4>
+        <p class="p-p--small">
+          Canonical is the leading provider of managed OpenStack. We’ll build, operate, train your team, in your data center, on your preferred hardware.
+        </p>
+        <ul class="p-text-list--small is-dense is-bordered">
+          <li class="p-list__item"><a href="/openstack">Build private clouds</a></li>
+          <li class="p-list__item"><a href="/openstack/managed">Fully managed options</a></li>
+          <li class="p-list__item"><a href="/openstack/training">Transfer and training</a></li>
+          <li class="p-list__item"><a href="/openstack/consulting">Integration</a></li>
+          <li class="p-list__item"><a href="/support/plans-and-pricing#openstack">Support</a></li>
         </ul>
       </div>
+      <!-- Kubernetes Solutions -->
       <div class="col-3">
-        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/openstack" title="Visit the private cloud page">OpenStack&nbsp;›</a></h4>
-        <p class="p-p--small">The number one platform for OpenStack.</p>
-        <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="/openstack/foundation-cloud">Consulting</a> on cloud architecture</li>
-          <li class="p-list__item"><a href="/openstack/training">Training</a> on openstack operations</li>
-          <li class="p-list__item">Fully <a href="/openstack/managed">managed Openstack</a></li>
-          <li class="p-list__item">Step-by-step install instructions</li>
+        <h4 class="p-heading-four is-dense">
+          <a href="/kubernetes">Kubernetes Solutions&nbsp;&rsaquo;</a>
+        </h4>
+        <p class="p-p--small">
+          Canonical delivers the leading Kubernetes distribution and provides workshops, training, deployment and consulting services.
+        </p>
+        <ul class="p-text-list--small is-dense is-bordered">
+          <li class="p-list__item"><a href="/kubernetes">Bare metal, VMware, cloud</a></li>
+          <li class="p-list__item"><a href="/kubernetes">Upgrades, day 2 operations</a></li>
+          <li class="p-list__item"><a href="/kubernetes">GPGPU support for ML</a></li>
+          <li class="p-list__item"><a href="/kubernetes">CI/CD with Rancher &amp; Jenkins</a></li>
+          <li class="p-list__item"><a href="/kubernetes">AI and ML workflows</a></li>
+          <li class="p-list__item"><a href="/kubernetes/managed">Fully managed options</a></li>
         </ul>
       </div>
+      <!-- Enterprise Support -->
       <div class="col-3">
-        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/internet-of-things">Internet of Things&nbsp;›</a></h4>
-        <p class="p-p--small">Ubuntu supports the <a href="/download/core">widest range of boards</a> on ARM and x86</p>
-        <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps</a> are secure Linux packages with automatic updates</li>
-          <li class="p-list__item"><a href="/core">Ubuntu Core</a> is a high-security version of Ubuntu with efficient over-the-air updates</li>
-          <li class="p-list__item">Robots, drones, gateways, switches, cars, smart displays and many more&#8230;</li>
+        <h4 class="p-heading-four is-dense">
+          <a href="/support">Enterprise Support&nbsp;&rsaquo;</a>
+        </h4>
+        <p class="p-p--small">
+          Canonical provides 24/7 enterprise support for Ubuntu, OpenStack, Docker and Kubernetes &mdash; in your data centre or on the cloud.
+        </p>
+        <ul class="p-text-list--small is-dense is-bordered">
+          <li class="p-list__item"><a href="/server/livepatch">Kernel Live Patch</a></li>
+          <li class="p-list__item"><a href="/support/esm">Extended Security</a></li>
+          <li class="p-list__item"><a href="/support">Optimised Windows VMs</a></li>
+          <li class="p-list__item"><a href="https://landscape.canonical.com/">Management System</a></li>
+          <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance Reporting</a></li>
         </ul>
       </div>
+      <!-- Internet of Things -->
       <div class="col-3">
-        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/cloud/public-cloud">Public cloud&nbsp;›</a></h4>
-        <p class="p-p--small">The leading cloud and container guest OS.</p>
+        <h4 class="p-heading-four is-dense"><a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a></h4>
+        <p class="p-p--small">
+          Ubuntu Core is a tiny, transactional version of Ubuntu that runs Snaps, a new breed of super-secure, remotely upgradeable apps.
+        </p>
         <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item">Optimised images on <a href="/download/cloud">AWS, Azure, Google, Oracle and IBM clouds</a></li>
-          <li class="p-list__item">Worker nodes for Google Kubernetes and Azure Kubernetes</li>
+          <li class="p-list__item"><a href="/core">Small and highly secure OS</a></li>
+          <li class="p-list__item"><a href="/download/iot">Runs on a wide range of boards</a></li>
+          <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps are secure and upgradeable</a></li>
+          <li class="p-list__item"><a href="/internet-of-things">Powers robots, drones, gateways, smart displays&#8230;</a></li>
         </ul>
       </div>
     </div>
     <div class="row"><hr></div>
     <div class="row">
+      <!-- Public cloud -->
       <div class="col-3">
-        <h4 class="p-heading-four is-dense">Data centre</h4>
-        <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item">Provision servers with <a href="https://maas.io" title="Visit Metal as a Service - external site">Metal as a Service</a> (MAAS)</li>
-          <li class="p-list__item"><a href="/server">Ubuntu Server</a> is the world&#39;s most widely used server Linux</li>
+        <h4 class="p-heading-four is-dense">
+          <a href="/cloud/public-cloud">Public cloud&nbsp;&rsaquo;</a>
+        </h4>
+        <p class="p-p--small">The leading cloud and container guest OS with optimised images for all the major public clouds and kubernetes.</p>
+        <ul class="p-text-list--small is-dense is-bordered">
+          <li class="p-list__item"><a href="/download/cloud">Use Ubuntu on AWS, Azure, Google, Oracle and IBM clouds</a></li>
+          <li class="p-list__item"><a href="/cloud/public-cloud">Use Ubuntu on Google Kubernetes and Azure Kubernetes</a></li>
         </ul>
       </div>
+      <!-- Containers -->
+      <div class="col-3">
+        <h4 class="p-heading-four is-dense"><a href="/containers" title="Visit the containers pages">Containers&nbsp;&rsaquo;</a></h4>
+        <p class="p-p--small">Ubuntu is the base OS for both Google and Azure Kubernetes. Perfect with Docker and LXD for legacy apps.</p>
+        <ul class="p-text-list--small is-bordered">
+          <li class="p-list__item"><a href="/kubernetes">Install and operate Kubernetes</a></li>
+          <li class="p-list__item"><a href="https://linuxcontainers.org/" title="Visit the LXD - external site">LXD for legacy apps in containers</a></li>
+          <li class="p-list__item"><a href="/containers/docker-ubuntu">Run the Docker Engine on Ubuntu</a></li>
+          <li class="p-list__item"><a href="/kubernetes">Get Canonical Kubernetes</a></li>
+        </ul>
+      </div>
+      <!-- data centre -->
+      <div class="col-3">
+        <h4 class="p-heading-four is-dense"><a href="/server">Data centre&nbsp;&rsaquo;</a></h4>
+        <p class="p-p--small">
+          Ubuntu Server is the world&#39;s most widely used server Linux. Canonical has tooling to setup, manage and run the most Ubuntu at scale.
+        </p>
+        <ul class="p-text-list--small is-bordered">
+          <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">Provision servers with Metal as a Service (MAAS)</a></li>
+          <li class="p-list__item"><a href="https://jujucharms.io" title="Visit jujucharms.io - external site">Juju manages multi-cloud deployment and operations</a></li>
+        </ul>
+      </div>
+      <!-- machine learning -->
       <div class="col-3">
         <h4 class="p-heading-four is-dense">Machine Learning</h4>
-        <p class="p-p--small">Optimised ML, AI and inferencing</p>
+        <p class="p-p--small">
+          Use Ubuntu to optimise your ML, AI and inferencing.
+        </p>
         <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="https://www.tensorflow.org/" title="Visit TensorFlow - external site">Google TensorFlow</a> and Kubeflow</li>
+          <li class="p-list__item"><a href="https://www.tensorflow.org/" title="Visit TensorFlow - external site">Google TensorFlow and Kubeflow</a></li>
           <li class="p-list__item"><a href="https://developer.nvidia.com/deep-learning-software" title="Visit Nvidia developer - external site">Nvidia’s ML stack</a></li>
-          <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML</a> toolchain on Ubuntu.</li>
-          <li class="p-list__item">Edge devices like Tegra running AI models</li>
-        </ul>
-      </div>
-      <div class="col-3">
-        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/security" title="Visit the security page">Security&nbsp;›</a></h4>
-        <p class="p-p--small">Ubuntu includes five years free <a href="https://usn.ubuntu.com" title="Visit the Ubuntu security notifications website - external site">security updates</a> for common packages</p>
-        <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="/support/esm ">Extended Security Maintenance</a> for up to 10 years coverage</li>
-          <li class="p-list__item"><a href="/server/livepatch">Canonical Livepatch</a> applies critical kernel security fixes without reboot</li>
-        </ul>
-      </div>
-      <div class="col-3">
-        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/support" title="Visit the Ubuntu Advantage support page">Management&nbsp;›</a></h4>
-        <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="/support">Enterprise support</a> from Canonical</li>
-          <li class="p-list__item"><a href="https://jujucharms.io" title="Visit Juju - external site">Juju</a> manages multi-cloud deployment and operations</li>
-          <li class="p-list__item"><a href="https://landscape.canonical.com" title="Visit the Landscape - external site">Landscape</a>, rated the best Linux management system</li>
+          <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML toolchain on Ubuntu</a></li>
+          <li class="p-list__item"><a href="https://developer.nvidia.com/nvidia-nsight-tegra" title="Visit Nvidia Tegra page - external site">Edge devices like Tegra running AI models</a></li>
         </ul>
       </div>
     </div>
@@ -109,7 +147,6 @@
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="/openstack/managed">OpenStack</a></li>
           <li class="p-inline-list__item"><a href="/kubernetes/managed">Kubernetes</a></li>
-          <li class="p-inline-list__item">PostgreSQL</li>
         </ul>
       </div>
     </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -67,7 +67,7 @@
       <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
     <!-- end google tag manager -->
-
+    {% include "templates/global-nav.html" %}
     {% include "templates/_navigation.html" %}
 
     <div class="wrapper u-no-margin--top">
@@ -85,8 +85,9 @@
     {% include "shared/_polyfill.html" %}
     <script src="{% versioned_static 'js/navigation.js' %}"></script>
     <script src="{% versioned_static 'js/core.js' %}"></script>
+    <!-- hide common global nav
     <script src="{% versioned_static 'global-nav/build/js/global.js' %}"></script>
-    <script>ubuntu.globalNav.setup();</script>
+    <script>ubuntu.globalNav.setup();</script> -->
     <script src="{% versioned_static 'js/scratch.js' %}"></script>
     <script src="{{ ASSET_SERVER_URL }}f5bf3854-respond.min.js"></script>
     {% block footer_extra %}{% endblock %}

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -1,0 +1,154 @@
+<div class="global-nav">
+  <div class="global-nav__row row">
+    <div class="global-nav__logo"><a class="global-nav__logo-anchor" href="https://www.canonical.com"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Comp" xml:space="preserve" height="10px" viewBox="0 0 480 65" width="74px" version="1.1" y="0px" x="0px">
+          <g fill="#fff">
+            <path d="m28.216 63.831c-4.213 0-8.049-0.692-11.511-2.077s-6.435-3.419-8.914-6.102c-2.482-2.683-4.401-5.957-5.756-9.824-1.357-3.864-2.035-8.308-2.035-13.328s0.75-9.477 2.25-13.372c1.499-3.894 3.548-7.169 6.145-9.823 2.596-2.653 5.596-4.674 9.001-6.059 3.404-1.383 7.011-2.076 10.819-2.076 2.596 0 4.919 0.172 6.967 0.519 2.048 0.346 3.822 0.75 5.323 1.211 1.499 0.462 2.711 0.924 3.635 1.385 0.923 0.462 1.558 0.808 1.905 1.038l-2.511 6.925c-0.519-0.347-1.269-0.721-2.25-1.125-0.982-0.403-2.12-0.807-3.419-1.212-1.299-0.402-2.726-0.735-4.284-0.995-1.557-0.259-3.202-0.389-4.933-0.389-2.943 0-5.626 0.549-8.049 1.645-2.424 1.097-4.501 2.683-6.232 4.76-1.731 2.078-3.072 4.602-4.024 7.573-0.952 2.972-1.428 6.305-1.428 9.996 0 3.579 0.418 6.838 1.255 9.781 0.835 2.943 2.105 5.467 3.808 7.573 1.701 2.107 3.808 3.736 6.318 4.89 2.511 1.155 5.466 1.731 8.872 1.731 3.808 0 6.967-0.404 9.477-1.212 2.511-0.807 4.399-1.528 5.669-2.164l2.164 6.924c-0.404 0.289-1.125 0.649-2.164 1.082s-2.337 0.853-3.895 1.254c-1.557 0.404-3.375 0.75-5.453 1.04-2.077 0.287-4.327 0.431-6.75 0.431z"/>
+            <path d="m81.529 2.554c2.077 4.328 4.068 8.698 5.972 13.112s3.822 9.044 5.755 13.891 3.908 9.969 5.929 15.363c2.019 5.396 4.182 11.267 6.491 17.613h-9.174c-0.982-2.596-1.904-5.163-2.77-7.702s-1.761-5.106-2.683-7.703h-27.18l-5.453 15.406h-8.742c2.307-6.346 4.471-12.217 6.491-17.613 2.019-5.394 3.995-10.515 5.929-15.363 1.933-4.847 3.851-9.477 5.755-13.891 1.904-4.415 3.895-8.785 5.972-13.112l7.704-0.001zm-4.067 9.607c-2.02 4.328-3.937 8.828-5.756 13.502-1.817 4.673-3.621 9.551-5.409 14.627h22.33c-1.847-5.019-3.678-9.881-5.496-14.584-1.818-4.702-3.709-9.218-5.669-13.545z"/>
+            <path d="m155.27 62.533c-1.27-2.134-2.726-4.529-4.371-7.184-1.645-2.653-3.419-5.409-5.324-8.266-1.904-2.855-3.88-5.755-5.929-8.698-2.048-2.943-4.082-5.785-6.102-8.526s-3.981-5.324-5.885-7.747c-1.904-2.423-3.666-4.558-5.279-6.405v46.823h-8.222v-59.976h6.664c2.712 2.885 5.611 6.246 8.698 10.083 3.086 3.838 6.145 7.789 9.174 11.857s5.885 8.064 8.568 11.988c2.683 3.925 4.947 7.415 6.795 10.472v-44.4h8.222v59.978l-7.01 0.001z"/>
+            <path d="m286.3 62.533c-1.271-2.134-2.726-4.529-4.371-7.184-1.645-2.653-3.419-5.409-5.323-8.266-1.905-2.855-3.881-5.755-5.929-8.698-2.049-2.943-4.083-5.785-6.102-8.526-2.019-2.74-3.981-5.324-5.885-7.747s-3.665-4.558-5.279-6.405v46.823h-8.222v-59.976h6.664c2.713 2.885 5.612 6.246 8.699 10.083 3.087 3.838 6.145 7.789 9.174 11.857 3.029 4.067 5.885 8.064 8.568 11.988 2.683 3.925 4.947 7.415 6.795 10.472v-44.4h8.222v59.978l-7.02 0.001z"/>
+            <path d="m308.55 2.554h8.396v59.978h-8.396v-59.978z"/>
+            <path d="m357.97 63.831c-4.213 0-8.049-0.692-11.512-2.077-3.461-1.385-6.435-3.419-8.914-6.102-2.482-2.683-4.402-5.957-5.756-9.824-1.355-3.865-2.034-8.309-2.034-13.329s0.75-9.477 2.25-13.372c1.5-3.894 3.549-7.169 6.145-9.823 2.596-2.653 5.597-4.674 9.001-6.059 3.404-1.383 7.011-2.076 10.819-2.076 2.596 0 4.918 0.172 6.967 0.519 2.048 0.346 3.822 0.75 5.323 1.211 1.5 0.462 2.711 0.924 3.635 1.385 0.921 0.462 1.558 0.808 1.904 1.038l-2.509 6.925c-0.519-0.347-1.271-0.721-2.251-1.125-0.982-0.403-2.12-0.807-3.418-1.212-1.298-0.402-2.726-0.735-4.284-0.995-1.558-0.259-3.202-0.389-4.933-0.389-2.942 0-5.626 0.549-8.049 1.645-2.424 1.097-4.5 2.683-6.232 4.76-1.731 2.078-3.073 4.602-4.024 7.573-0.952 2.972-1.429 6.305-1.429 9.996 0 3.579 0.418 6.838 1.254 9.781s2.106 5.467 3.808 7.573c1.701 2.107 3.808 3.736 6.318 4.89 2.511 1.155 5.467 1.731 8.872 1.731 3.808 0 6.967-0.404 9.478-1.212 2.509-0.807 4.399-1.528 5.668-2.164l2.164 6.924c-0.405 0.289-1.125 0.649-2.164 1.082s-2.336 0.853-3.894 1.254c-1.558 0.404-3.375 0.75-5.453 1.04-2.1 0.288-4.35 0.432-6.77 0.432z"/>
+            <path d="m411.28 2.554c2.077 4.328 4.068 8.698 5.973 13.112 1.904 4.414 3.822 9.044 5.754 13.891 1.933 4.847 3.909 9.969 5.93 15.363 2.018 5.396 4.182 11.267 6.491 17.613h-9.175c-0.982-2.596-1.904-5.163-2.77-7.702s-1.76-5.106-2.683-7.703h-27.176l-5.454 15.406h-8.741c2.307-6.346 4.47-12.217 6.491-17.613 2.019-5.394 3.995-10.515 5.929-15.363 1.933-4.847 3.851-9.477 5.756-13.891 1.904-4.415 3.894-8.785 5.972-13.112l7.71-0.001zm-4.07 9.607c-2.02 4.328-3.939 8.828-5.756 13.502-1.817 4.673-3.622 9.551-5.409 14.627h22.33c-1.848-5.019-3.678-9.881-5.497-14.584-1.81-4.702-3.7-9.218-5.66-13.545z"/>
+            <path d="m480 55.522v7.011h-36.091v-59.979h8.396v52.968h27.69z"/>
+            <path d="m203.74 52.45c-11.018 0-19.95-8.929-19.95-19.95 0-11.019 8.932-19.949 19.95-19.949 11.019 0 19.95 8.931 19.95 19.949 0 11.021-8.93 19.95-19.95 19.95z"/>
+            <path d="m235.07 32.501c0 17.303-14.028 31.33-31.331 31.33-17.304 0-31.331-14.028-31.331-31.33 0-17.304 14.026-31.331 31.331-31.331 17.3 0 31.33 14.027 31.33 31.331zm-31.33-23.71c-13.095 0-23.709 10.616-23.709 23.71 0 13.096 10.614 23.709 23.709 23.709s23.709-10.613 23.709-23.709c0-13.095-10.62-23.71-23.71-23.71z"/>
+          </g>
+        </svg></a></div>
+    <ul class="global-nav__links p-inline-list">
+      <li class="global-nav__link--dropdown p-inline-list__item">
+        <a class="global-nav__link-anchor" href="#canonical-products">Products</a>
+      </li>
+      <li class="global-nav__link p-inline-list__item">
+        <a class="global-nav__link-anchor" href="https://www.canonical.com">Company</a>
+      </li>
+      <li class="global-nav__link p-inline-list__item">
+        <a class="global-nav__link-anchor" href="#">Login</a>
+      </li>
+    </ul>
+  </div>
+  <div class="global-nav__dropdown-content u-hide">
+    <div class="p-strip--dark is-shallow">
+      <div class="row">
+        <ul class="p-matrix">
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="https://www.ubuntu.com">
+             <img src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon">
+              <div class="p-matrix__content">
+                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
+                <p class="p-matrix__desc">The world’s most popular Linux for servers, desktops and things, with enterprise support and enhanced security by Canonical</p>
+              </div>
+            </a>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="https://maas.io/"><img src="{{ ASSET_SERVER_URL }}0de4fcd5-logo-maas-icon.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://maas.io/">MAAS&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">Create a bare-metal cloud with Metal as a Service for IPAM and provisioning</p>
+            </div>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="http://landscape.canonical.com/"><img src="{{ ASSET_SERVER_URL }}4964d639-landscape-logo.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://landscape.canonical.com/">Landscape&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">Systems management for Ubuntu - updates, package management, repositories, security, and regulatory compliance dashboards</p>
+            </div>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="https://jujucharms.com/"><img src="{{ ASSET_SERVER_URL }}31c507a5-logo-juju-icon.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://jujucharms.com/">Juju&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">Model-driven multi-cloud operations for applications. On-premise or on-cloud SAAS app store, with big data, k8s and openstack solutions</p>
+            </div>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="https://linuxcontainers.org/"><img src="{{ ASSET_SERVER_URL }}425efe3a-lxd.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://linuxcontainers.org/">LXD&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">A pure-container hypervisor. Replace legacy app VMs with containers for speed and density</p>
+            </div>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="https://snapcraft.io/"><img src="{{ ASSET_SERVER_URL }}82dc2022-snapcraft-primary-icon.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://snapcraft.io/">Snaps&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">A single secure package and auto-update system for Ubuntu, Debian, Arch, Centos, Amazon Linux</p>
+            </div>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="https://www.ubuntu.com/openstack"><img src="{{ ASSET_SERVER_URL }}a7916513-picto-openstack.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">The world’s first choice for OpenStack - the leader in density and cost per VM</p>
+            </div>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="http://www.ubuntu.com/kubernetes"><img src="{{ ASSET_SERVER_URL }}b81a45e4-kubernetes.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">Canonical works with Google GKE and Azure AKS for app portability between private and public infra</p>
+            </div>
+          </li>
+          <li class="p-matrix__item">
+            <a class="p-matrix__img" href="https://github.com/CanonicalLtd/multipass"><img src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon"></a>
+            <div class="p-matrix__content">
+              <h4 class="p-matrix__title"><a class="p-link" href="https://github.com/CanonicalLtd/multipass">Multipass&nbsp;&rsaquo;</a></h4>
+              <p class="p-matrix__desc">Ubuntu virtual machines on demand for Linux, MacOS and Windows for development and cloud prototyping</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="p-strip--light is-shallow">
+      <div class="row">
+        <div class="col-9">
+          <h5 class="p-muted-heading">Other websites</h5>
+          <div class="row">
+            <div class="col-3">
+              <h5><a class="p-link--soft" href="http://www.ubuntu.com/support">Enterprise Support&nbsp;&rsaquo;</a></h5>
+              <p>Canonical supports Ubuntu for clouds, data centers and devices</p>
+              <h5><a class="p-link--soft" href="https://wiki.ubuntu.com/Mir">Mir&nbsp;&rsaquo;</a></h5>
+              <p>Ultra-fast and light Wayland compositor for secure device display management</p>
+            </div>
+            <div class="col-3">
+              <h5><a class="p-link--soft" href="https://cloud-images.ubuntu.com/">Image Service&nbsp;&rsaquo;</a></h5>
+              <p>A stream of hardened custom Ubuntu images on AWS, Google, KVM, VMware, MAAS, LXD</p>
+              <h5><a class="p-link--soft" href="https://conjure-up.io/">Conjure-up&nbsp;&rsaquo;</a></h5>
+              <p>Summon up a big-software stack as a “spell” using conjure-up to get you a fully installed and usable stack</p>
+            </div>
+            <div class="col-3">
+              <h5><a class="p-link--soft" href="https://cloud-init.io/">Cloud-init&nbsp;&rsaquo;</a></h5>
+              <p>Apply user data to your instances automatically</p>
+              <h5><a class="p-link--soft" href="http://www.netplan.io/">Netplan&nbsp;&rsaquo;</a></h5>
+              <p>Easily configure your networks using Netplan, a YAML network configuration abstraction for various backends</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-3 p-divider__block">
+          <h5 class="p-muted-heading">Resources</h5>
+          <ul class="p-list is-split">
+            <li class="p-list__item"><a href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
+            <li class="p-list__item"><a href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
+            <li class="p-list__item"><a href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
+            <li class="p-list__item"><a href="https://insights.ubuntu.com/category/case-studies" title="Visit the Case studies - external site">Case studies</a></li>
+            <li class="p-list__item"><a href="https://insights.ubuntu.com/category/white-papers" title="Visit the White papers - external site">White papers</a></li>
+            <li class="p-list__item"><a href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
+            <li class="p-list__item"><a href="/cloud/training">Training</a></li>
+            <li class="p-list__item"><a href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
+            <li class="p-list__item"><a href="https://developer.ubuntu.com">Developer</a></li>
+            <li class="p-list__item"><a href="https://www.ubuntu.com/download/cloud">Install</a></li>
+            <li class="p-list__item"><a href="https://www.ubuntu.com/download">Download</a></li>
+          </ul>
+          <h5 class="p-muted-heading">About</h5>
+          <ul class="p-list is-split">
+            <li class="p-list__item"><a href="https://www.ubuntu.com">Ubuntu</a></li>
+            <li class="p-list__item"><a href="https://www.canonical.com">Canonical</a></li>
+            <li class="p-list__item"><a href="https://insights.ubuntu.com/press-centre">Press centre</a></li>
+            <li class="p-list__item"><a href="https://partners.ubuntu.com">Partners</a></li>
+            <li class="p-list__item"><a href="https://shop.canonical.com/">Merchandise</a></li>
+            <li class="p-list__item"><a href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Update enterprise overlay
- Created a new [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit?usp=sharing)
- turned back on the new global nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- compare the text to the copy doc

