### PR TITLE
Updated download overlay text and links

### DIFF
--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -4,76 +4,70 @@
       <div class="col-3">
         <h4 class="p-heading-four is-dense"><a class="p-link--soft" href='/download/desktop'>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
         <p class="p-p--small">Download Ubuntu desktop and replace your current operating system whether it’s Windows or Mac OS, or, run Ubuntu alongside it.</p>
-        <a class='p-button--positive' href='/download/desktop/contribute?version=16.04.3&architecture=amd64'>16.04 LTS</a>
-        <a class='p-button--neutral' href='/download/desktop/contribute?version=17.10&architecture=amd64'>17.10</a>
-        <ul class='p-inline-list--middot' >
-          <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
-            18.04 (dev edge
-          </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
-            Alternative downloads
-          </a></li>
+        <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{lts_release_with_point}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{ lts_release_full }}</a>
+        <ul class='p-text-list--small is-bordered' >
+          <li class='p-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>Test 18.10 - dev only</a></li>
         </ul>
       </div>
       <div class="col-3">
         <h4 class="p-heading-four is-dense"><a class="p-link--soft" href='/download/server' >Ubuntu Server&nbsp;&rsaquo;</a></h4>
         <p class="p-p--small">The most popular server Linux in the cloud and data centre, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-        <a class='p-button--positive' href='/download/server/thank-you?version=16.04.3&architecture=amd64' >16.04 LTS</a>
-        <a class='p-button--neutral' href='/download/server/thank-you?version=17.10.1&architecture=amd64' >17.10</a>
-        <ul class='p-inline-list--middot' >
-          <li class='p-inline-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
-            18.04 (dev edge
+        <a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">{{ lts_release_full }}</a>
+        <ul class='p-text-list--small is-bordered' >
+          <li class='p-list__item'><a class='p-link' href='http://cdimage.ubuntu.com/daily-live/current/'>
+            Test 18.10 - dev only
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/server/arm'>
+          <li class="p-list__item"><a href="/download/alternative-downloads#alternate-ubuntu-server-installer">Use the traditional installer</a></li>
+          <li class='p-list__item'><a class='p-link' href='/download/server/arm'>
             ARM
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/server/power8'>
-            Power8
+          <li class='p-list__item'><a class='p-link' href='/download/server/power8'>
+            IBM Power
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/server/linuxone'>
-            LinuxONE
-          </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/alternative-downloads'>
-            Alternative downloads
+          <li class='p-list__item'><a class='p-link' href='/download/server/linuxone'>
+            s390x
           </a></li>
         </ul>
       </div>
       <div class="col-3">
-        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/download/core" >Ubuntu Core for IoT&nbsp;&rsaquo;</a></h4>
-        <p class="p-p--small">Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
-        <ul class='p-inline-list--middot' >
-          <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-2-3'>
+        <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/download/iot" >Ubuntu for IoT&nbsp;&rsaquo;</a></h4>
+        <p class="p-p--small">Are you a developer who wants to try snappy Ubuntu Core or classic Ubuntu on an IoT board?</p>
+        <ul class='p-text-list--small is-bordered'>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/raspberry-pi-2-3'>
             Raspberry Pi 2 or 3
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/core/raspberry-pi-compute-module-3'>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/raspberry-pi-compute-module-3'>
             Raspberry Pi Compute Module 3
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-nuc'>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/intel-nuc'>
             Intel NUC
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/core/kvm'>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/kvm'>
             KVM
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/core/intel-joule'>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/intel-joule'>
             Intel Joule
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/core/qualcomm-dragonboard-410c'>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/qualcomm-dragonboard-410c'>
             Qualcomm Dragonboard 410c
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/download/core/samsung-artik-5-10'>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/samsung-artik-5-10'>
             Samsung Artik 5 or 10
+          </a></li>
+          <li class='p-list__item'><a class='p-link' href='/download/iot/up-squared-iot-grove-server'>
+            UP<sup>2</sup> IoT Grove
           </a></li>
         </ul>
       </div>
       <div class="col-3">
         <h4 class="p-heading-four is-dense"><a class="p-link--soft" href="/download/cloud" >Ubuntu Cloud&nbsp;&rsaquo;</a></h4>
-        <p class="p-p--small">Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
-        <ul class='p-inline-list--middot' >
-          <li class='p-inline-list__item'><a class='p-link' href='/openstack/developer'>
-            Try OpenStack
+        <p class="p-p--small">Use Ubuntu optimised and certified server images on most major clouds.</p>
+        <ul class='p-text-list--small is-bordered'>
+          <li class='p-list__item'><a class='p-link' href='/download/cloud'>
+            Get started on Amazon AWS, Microsoft Azure, Google Cloud Platform and more&#8230;</a>
           </a></li>
-          <li class='p-inline-list__item'><a class='p-link' href='/openstack/install'>
-            Deploy OpenStack
+          <li class='p-list__item'><a class='p-link' href='http://cloud-images.ubuntu.com/' title='Visit cloud-images - external site'>
+            Download cloud images for local development and testing
           </a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

- Updated download overlay text and links
- Created a new [copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit?usp=sharing)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Compare to the copy doc

