### PR TITLE
Spacing fixes and breakpoint updates

### DIFF
--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -1,4 +1,4 @@
-$breakpoint-navigation-threshold:    850px;
+$breakpoint-navigation-threshold:    875px;
 $viewport-threshold:      1281px;
 $color-brand:             #e95420;
 $sp-medium-small: 1rem * .85 !default;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -123,7 +123,7 @@
       }
 
       @media (min-width: $breakpoint-navigation-threshold + 1) {
-        padding: $spv-intra--expanded $grid-margin-width $spv-intra--expanded $sph-intra;
+        padding: $spv-intra--expanded 2rem $spv-intra--expanded $sph-intra;
       }
 
       &:focus,


### PR DESCRIPTION
## Done

- Fix spacing between navigation labels and chevrons on desktop
- Fix issue with overall alignment around navigation threshold breakpoint

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that the spacing between the navigation labels and their chevrons looks good on desktop
- Check that navigation doesn't wrap at 850px wide


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
