### PR TITLE
Updated a missing link to a contact form

### DIFF
--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -16,7 +16,7 @@
 
   {% elif product == 'cloud-training-server-admin' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/cloud/thank-you?product=cloud-training-server-admin" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/cloud/thank-you==" %}
 
   {% elif product == 'cloud-storage' %}
 

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -67,8 +67,6 @@
         <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">From 26 September 2016</dd>
       </dl>
       <p><a href="/openstack/contact-us?product=cloud-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
@@ -95,10 +93,8 @@
         <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">From 10 October 2016</dd>
       </dl>
-      <p><a href="/openstack/training">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/contact-us?product=cloud-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="row">
@@ -120,8 +116,6 @@
         <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">From 6 February 2017</dd>
       </dl>
       <p><a href="/openstack/contact-us?product=cloud-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>


### PR DESCRIPTION
## Done

* Removed old starting dates for classes
* Updated the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/cloud/training
- see that it matches the copy doc
