### PR TITLE
Updated bootstack page title

### DIFF
--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -1,6 +1,6 @@
 {% extends "openstack/_base_openstack.html" %}
 {% load versioned_static  %}
-{% block title %}BootStack - your managed cloud | OpenStack{% endblock %}
+{% block title %}BootStack - managed OpenStack on Ubuntu | OpenStack{% endblock %}
 {% block meta_description %}With BootStack, Canonical will build, support and manage your cloud for only $15 per host per day.{% endblock meta_description %}
 
 {% block content %}


### PR DESCRIPTION
## Done

* Updated the title of the /openstack/managed page per comment in the  copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/managed/](http://0.0.0.0:8001/openstack/managed)
- compare to the title of the [copy doc](https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit#heading=h.uasr0ce2c7v3)
