### PR TITLE
Updated /licensing per the copy doc

### DIFF
--- a/templates/licensing/index.html
+++ b/templates/licensing/index.html
@@ -17,7 +17,7 @@
       <p>Each of these programs may come under a different licence. This licence policy describes the process that we follow in determining which software will be included by default in the Ubuntu operating system.</p>
       <p>Copyright licensing and trademarks are two different areas of law, and we consider them separately in Ubuntu. The following policy applies only to copyright licences. We evaluate trademarks on a case-by-case basis.</p>
       <h3>Categories of software in Ubuntu</h3>
-      <p>The thousands of software packages available for Ubuntu are organised into four key groups or components: main, restricted, universe and multiverse. Software is published in one of these components based on whether or not it meets our free software philosophy, and the level of support we can provide for it.</p>
+      <p>The thousands of software packages available for Ubuntu are organised into four key groups or components: <code>main</code>, <code>restricted</code>, <code>universe</code> and <code>multiverse</code>. Software is published in one of these components based on whether or not it meets our free software philosophy, and the level of support we can provide for it.  In addition, software may be published for Ubuntu as a universal Linux snap package, in which case licenses are determined by the snap publisher and documented in the <a href="https://snapcraft.io/store/" class="p-link--external">snap store</a>.</p>
       <p>This policy only addresses the software that you will find in main and restricted, which contain software that is fully supported by the Ubuntu team and must comply with this policy.</p>
       <h4>Ubuntu 'main' component licence policy</h4>
       <p>All application software included in the Ubuntu main component:</p>


### PR DESCRIPTION
## Done

* Updated /licensing per the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [[licensing page](http://0.0.0.0:8001/licensing) and compare it to the [copy
doc](https://docs.google.com/document/d/1cqzDlgJERp7BuNO-yWKz96hAQp8W4-8_5ETb_Il6x4I/edit#) and accept all the changes, please

## Issue / Card

Fixes #3177 
