### PR TITLE
Updated lubuntu url and description on /download/flavours

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -121,7 +121,7 @@ category/product/enterprise-services/?: /support
 category/product/landscape/?: https://landscape.canonical.com/
 category/product/(server|ubuntu-server-edition)/?: /server
 category/product/ubuntu-advantage/?: /support
-category/product/ubuntu-light/?: http://lubuntu.net/
+category/product/ubuntu-light/?: https://lubuntu.me/
 cloud/awsome/?: "https://launchpad.net/awsome"
 cloud/azure/?: "/cloud/public-cloud"
 cloud/bootstack/?: "/cloud/managed-cloud"

--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -37,7 +37,7 @@
           <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}600c73c4-Lubuntu.svg" alt="Lubuntu icon">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="http://lubuntu.me/">Lubuntu</a></h3>
-            <p class="p-matrix__desc">Lubuntu is a fast, energy saving and lightweight variant of Ubuntu using LXDE. It is popular with PC and laptop users running on low-spec hardware.</p>
+            <p class="p-matrix__desc">Lubuntu is a light, fast, and modern Ubuntu flavor using LXQt as its default desktop environment. Lubuntu used to use LXDE as its default desktop environment.</p>
           </div>
         </li>
 


### PR DESCRIPTION
## Done

* Updated lubuntu url and description on /download/flavours
* Updated the [copy doc](https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit#heading=h.qksdjera3af7)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: - [flavours page](http://0.0.0.0:8001/download/flavours) and compare to the copy doc


## Issue / Card

Fixes #3161 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/40108862-0725ebc4-58f4-11e8-8a06-1f184891ffdb.png)

