### PR TITLE
Fix legal notice links

### DIFF
--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -60,11 +60,11 @@
       <p>Some webinars are directly hosted by Canonical on our sites. Where a webinars is operated by a third party provider you will be directed to a third party website and the third party provider may collects information as part of the webinar registration process. This data will be collected in accordance with the third party provider’s terms and conditions. Please see “Links and third-party content” in the Terms and Conditions for further details.</p>
       <h3>Non-personally identifying information</h3>
       <p>Canonical may collect non-personally-identifying information of the sort that web browsers and servers typically make available, such as the browser type, referring site, and the date and time of each visitor request. Our purpose in collecting non-personally identifying information is to better understand how visitors use our websites and services. For further information about how we use cookies, see the “cookie” section below.</p>
-      <p>Please note that Canonical may also collect system information during installation of Ubuntu and on first login to Ubuntu. This system information is subject to a <a href="/legal/legal-notice">Legal Notice</a>.</p>
+      <p>Please note that Canonical may also collect system information during installation of Ubuntu and on first login to Ubuntu. This system information is subject to a <a href="/legal/terms-and-policies/online-account-terms">Legal Notice</a>.</p>
       <h3>Error reports</h3>
       <p>When you chose to send an error report, it includes a unique identifier for your computer. This identifier does not identify you, unless you (or someone acting on your behalf) discloses it separately. An error report may include personal information such as the state of programs that were running at the time. You can block future error reports from the privacy panel of System Settings.</p>
       <h3>Ubuntu online accounts</h3>
-      <p>When you use Ubuntu online accounts, your personal information is stored on your PC and it can be accessed by some applications. Further information can be found in a <a href="/legal/legal-notice">Legal Notice</a>.</p>
+      <p>When you use Ubuntu online accounts, your personal information is stored on your PC and it can be accessed by some applications. Further information can be found in a <a href="/legal/terms-and-policies/online-account-terms">Legal Notice</a>.</p>
       <h3>Contacting us</h3>
       <p>If you contact us and provide us with information, we may keep a record of that correspondence and information.</p>
       <h2 id="what-do-we-do-with-your-personal-data">What do we do with your personal data</h2>


### PR DESCRIPTION
## Done

Fix legal notice links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/dataprivacy>
- Check that the 'Legal notice' links go to `/legal/terms-and-policies/online-account-terms`