### PR TITLE
Update forms for GDPR

### DIFF
--- a/templates/legal/terms-and-policies/contact-us.html
+++ b/templates/legal/terms-and-policies/contact-us.html
@@ -362,11 +362,13 @@
           </ul>
         </fieldset>
         <fieldset>
-          <p>Data collected from this survey will be handled in accordance with the Canonical <a href="/legal/terms-and-policies/privacy-policy">privacy policy</a></p>
           <ul class="p-list">
             <li class="p-list__item">
               <label>If you would like to include an attachment with your request please add it here:</label>
               <input type="file" id="tfa_Ifyouwouldliketo" name="tfa_Ifyouwouldliketo" size="40">
+            </li>
+            <li>
+              In submitting this form, I confirm that I have read and agree to <a href="/legal/dataprivacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.
             </li>
             <li class="p-list__item">
               <input type="submit" class="primaryAction" value="Submit">

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -57,9 +57,9 @@
             </li>
             <li class="mktField p-list__item">
               <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
             </li>
-            <li class="p-list__item">All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
+            <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/dataprivacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</li>
             <li class="mktField p-list__item">
               <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -61,10 +61,10 @@
           <ul class="p-list">
             <li class="mktField p-list__item">
               <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
             </li>
             <li class="p-list__item">
-              All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>.
+              In submitting this form, I confirm that I have read and agree to <a href="/legal/dataprivacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.
             </li>
             <li class="mktField p-list__item">
               <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>

--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -9,8 +9,11 @@
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">
           <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
-          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I would also like to receive other occasional updates from Canonical by email.</label>&nbsp;<span class="mktFormMsg"></span>
+          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>&nbsp;<span class="mktFormMsg"></span>
         </span>
+      </li>
+      <li class="p-list__item u-no-margin--top">
+        In submitting this form, I confirm that I have read and agree to <a href="/legal/dataprivacy/newsletter">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.
       </li>
       <li class="p-list__item">
         <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -11,6 +11,15 @@
         <label for="Email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
         <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
       </li>
+      <li class="mktField mktLblRight p-list__item">
+        <span class="mktInput mktLblRight">
+          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
+          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>&nbsp;<span class="mktFormMsg"></span>
+        </span>
+      </li>
+      <li class="p-list__item u-no-margin--top">
+        In submitting this form, I confirm that I have read and agree to <a href="/legal/dataprivacy/newsletter">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.
+      </li>
       <li class="mktField p-list__item">
         <button type="submit" class="mktoButton p-button--neutral">Submit</button><input type="hidden" name="formid" class="mktoField " value="1670"><input type="hidden" name="lpId" class="mktoField " value="3229"><input type="hidden" name="subId" class="mktoField "
           value="30">


### PR DESCRIPTION
## Done

Update forms with GDPR info

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Go to each of the following and check that the forms have the right text at the bottom according to [this doc](https://docs.google.com/document/d/1mTubEW_aq9ncckjYFBOOH2NIqee-cIPjPf_R2_I_REs/edit#):
- [/legal/terms-and-policies/contact-us](http://0.0.0.0:8001/legal/terms-and-policies/contact-us) (has no checkbox)
- [/cloud/contact-us](http://0.0.0.0:8001/cloud/contact-us)
- [/server/contact-us](http://0.0.0.0:8001/contact-us) 
- [/containers/contact-us?product=containers-overview](http://0.0.0.0:8001/containers/contact-us?product=containers-overview)
- [/internet-of-things/contact-us](http://0.0.0.0:8001/internet-of-things/contact-us)
- [/core/contact-us?product=core-overview](http://0.0.0.0:8001/core/contact-us?product=core-overview)
- [/support/contact-us](http://0.0.0.0:8001/support/contact-us)
- [/internet-of-things/digital-signage](http://0.0.0.0:8001/internet-of-things/digital-signage)
- [/internet-of-things/gateways](http://0.0.0.0:8001/internet-of-things/gateways)
- [/internet-of-things/robotics](http://0.0.0.0:8001/internet-of-things/robotics)
- [/internet-of-things/appstore](http://0.0.0.0:8001/internet-of-things/robotics)
- [/cloud/public-cloud](http://0.0.0.0:8001/cloud/public-cloud)
- [/cloud/storage](http://0.0.0.0:8001/cloud/storage)
- [/cloud/foundation-cloud](http://0.0.0.0:8001/cloud/foundation-cloud)
- [/telecommunications](http://0.0.0.0:8001/cloud/foundation-cloud)


## Issue / Card

Fixes #3124 