### PR TITLE
Remove design.canonical.com from list of websites

### DIFF
--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -31,9 +31,6 @@
           <a href="https://community.ubuntu.com">community.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://design.canonical.com">design.canonical.com</a>
-        </li>
-        <li class="p-list__item">
           <a href="https://design.ubuntu.com">design.ubuntu.com</a>
         </li>
         <li class="p-list__item">

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -10,6 +10,9 @@
       <h1>Canonical websites</h1>
       <ul class="p-list">
         <li class="p-list__item">
+          <a href="https://blog.ubuntu.com">blog.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
           <a href="http://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
         </li>
         <li class="p-list__item">
@@ -59,9 +62,6 @@
         </li>
         <li class="p-list__item">
           <a href="https://help.ubuntu.com  ">help.ubuntu.com  </a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://insights.ubuntu.com">insights.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://jp.ubuntu.com">jp.ubuntu.com</a>


### PR DESCRIPTION
## Done

Remove design.canonical.com from list of websites

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/websites>
- Make sure design.canonical.com is not on the list of websites


## Issue / Card

Fixes #3193 