### PR TITLE
Add toc to data privacy page

### DIFF
--- a/templates/legal/dataprivacy/_older-versions.html
+++ b/templates/legal/dataprivacy/_older-versions.html
@@ -1,0 +1,5 @@
+<h3>Older versions</h3>
+<ul class="p-list">
+  <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2013-03-25">25 March 2013&nbsp;&rsaquo;</a></li>
+  <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2016-02-08">08 February2016&nbsp;&rsaquo;</a></li>
+</ul>

--- a/templates/legal/dataprivacy/_toc.html
+++ b/templates/legal/dataprivacy/_toc.html
@@ -1,0 +1,42 @@
+<h3>Contents</h3>
+<ul class="p-list--divided">
+  <li class="p-list__item">
+    <a href="#privacy-notices">Privacy notices</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#information-we-collect-from-you">Information we collect from you</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#how-information-is-collected-from-you">How information is collected from you</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#what-do-we-do-with-your-personal-data">What do we do with your personal data</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#what-are-your-rights">What are your rights</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#cookies">Cookies</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#how-do-we-protect-the-information-we-collect">How do we protect the information we collect</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#how-we-use-the-information-we-collect">How we use the information we collect</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#disclosure-of-your-information">Disclosure of your information</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#where-we-transfer-and-store-your-information">Where we transfer and store your information</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#changes-to-our-privacy-policy">Changes to our privacy policy</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#contact">Contact</a>
+  </li>
+  <li class="p-list__item">
+    <a href="#your-right-to-complain">Your right to complain</a>
+  </li>
+</ul>

--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -8,6 +8,14 @@
   <div class="row">
     <div class="col-8">
       <h1>Data privacy</h1>
+      <div class="u-hide--medium u-hide--large">
+        <div class="p-card">
+          {% include 'legal/dataprivacy/_older-versions.html' %}
+        </div>
+        <div class="p-card">
+          {% include 'legal/dataprivacy/_toc.html' %}
+        </div>
+      </div>
       <p>Canonical collects personal information from you in a number of different ways. For example, when you download one of our products, receive services from us or use one of our websites (including <a href="https://www.canonical.com">www.canonical.com</a> and <a href="https://www.ubuntu.com">www.ubuntu.com</a>).</p>
       <p><a href="/legal/websites">Full list of websites&nbsp;&rsaquo;</a></p>
       <p>At Canonical, we consider your privacy to be extremely important to us. These are the fundamental principles that we follow in relation to your personal information:</p>
@@ -17,64 +25,6 @@
         <li class="p-list__item is-ticked">We don&rsquo;t store personal information unless required for the on-going operation of services to you, to provide you with products, to comply with law or to protect our rights.</li>
         <li class="p-list__item is-ticked">We will use personal information that you provide to us in accordance with this privacy policy.</li>
       </ul>
-    </div>
-    <div class="col-4">
-      <div class="p-card">
-        <h3>Older versions</h3>
-        <ul class="p-list">
-          <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2013-03-25">25 March 2013&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2016-02-08">08 February2016&nbsp;&rsaquo;</a></li>
-        </ul>
-      </div>
-
-      <div class="p-card">
-        <h3>Contents</h3>
-        <ul class="p-list--divided">
-          <li class="p-list__item">
-            <a href="#privacy-notices">Privacy notices</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#information-we-collect-from-you">Information we collect from you</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#how-information-is-collected-from-you">How information is collected from you</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#what-do-we-do-with-your-personal-data">What do we do with your personal data</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#what-are-your-rights">What are your rights</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#cookies">Cookies</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#how-do-we-protect-the-information-we-collect">How do we protect the information we collect</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#how-we-use-the-information-we-collect">How we use the information we collect</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#disclosure-of-your-information">Disclosure of your information</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#where-we-transfer-and-store-your-information">Where we transfer and store your information</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#changes-to-our-privacy-policy">Changes to our privacy policy</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#contact">Contact</a>
-          </li>
-          <li class="p-list__item">
-            <a href="#your-right-to-complain">Your right to complain</a>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
       <p>Canonical Group Limited (<strong>&ldquo;we&rdquo;</strong>, <strong>&ldquo;us&rdquo;</strong> and <strong>&ldquo;our&rdquo;</strong>) are committed to protecting and respecting your privacy. Information collected for or on behalf of the Canonical group of companies will be the responsibility of Canonical Group Limited.</p>
       <p><a href="/legal/companies">Full list of Canonical contracting entities&nbsp;&rsaquo;</a></p>
       <p>This policy  (together with our <a href="/legal/terms-and-policies/terms">terms of use</a> and any other documents referred to on it) sets out the basis on which any personal data we collect from you, or that you provide to us, will be processed by us. Please read the following carefully to understand our views and practices regarding your personal data and how we will treat it. By visiting a Canonical website you are accepting and consenting to the practices described in this policy.</p>
@@ -201,6 +151,15 @@
         <li class="p-list__item"><strong>Targeting cookies</strong>. These cookies record your visit to our website, the pages you have visited and the links you have followed. We will use this information to make our website and the advertising displayed on it more relevant to your interests. We may also share this information with third parties for this purpose.</li>
       </ul>
       <p>You can find more information about the individual cookies we use and the purposes for which we use them in the table below:</p>
+    </div>
+    <div class="col-4">
+      <div class="p-card u-hide--small">
+        {% include 'legal/dataprivacy/_older-versions.html' %}
+      </div>
+
+      <div class="p-card u-hide--small">
+        {% include 'legal/dataprivacy/_toc.html' %}
+      </div>
     </div>
   </div>
   <div class="row">

--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -8,47 +8,6 @@
   <div class="row">
     <div class="col-8">
       <h1>Data privacy</h1>
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <a href="#privacy-notices">Privacy notices</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#information-we-collect-from-you">Information we collect from you</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#how-information-is-collected-from-you">How information is collected from you</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#what-do-we-do-with-your-personal-data">What do we do with your personal data</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#what-are-your-rights">What are your rights</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#cookies">Cookies</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#how-do-we-protect-the-information-we-collect">How do we protect the information we collect</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#how-we-use-the-information-we-collect">How we use the information we collect</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#disclosure-of-your-information">Disclosure of your information</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#where-we-transfer-and-store-your-information">Where we transfer and store your information</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#changes-to-our-privacy-policy">Changes to our privacy policy</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#contact">Contact</a>
-        </li>
-        <li class="p-list__item">
-          <a href="#your-right-to-complain">Your right to complain</a>
-        </li>
-      </ul>
       <p>Canonical collects personal information from you in a number of different ways. For example, when you download one of our products, receive services from us or use one of our websites (including <a href="https://www.canonical.com">www.canonical.com</a> and <a href="https://www.ubuntu.com">www.ubuntu.com</a>).</p>
       <p><a href="/legal/websites">Full list of websites&nbsp;&rsaquo;</a></p>
       <p>At Canonical, we consider your privacy to be extremely important to us. These are the fundamental principles that we follow in relation to your personal information:</p>
@@ -59,12 +18,59 @@
         <li class="p-list__item is-ticked">We will use personal information that you provide to us in accordance with this privacy policy.</li>
       </ul>
     </div>
-    <div class="col-4 p-card">
-      <h3>Older versions</h3>
-      <ul class="p-list">
-        <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2013-03-25">25 March 2013&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2016-02-08">08 February2016&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="col-4">
+      <div class="p-card">
+        <h3>Older versions</h3>
+        <ul class="p-list">
+          <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2013-03-25">25 March 2013&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="/legal/terms-and-policies/privacy-policy/2016-02-08">08 February2016&nbsp;&rsaquo;</a></li>
+        </ul>
+      </div>
+
+      <div class="p-card">
+        <h3>Contents</h3>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="#privacy-notices">Privacy notices</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#information-we-collect-from-you">Information we collect from you</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#how-information-is-collected-from-you">How information is collected from you</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#what-do-we-do-with-your-personal-data">What do we do with your personal data</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#what-are-your-rights">What are your rights</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#cookies">Cookies</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#how-do-we-protect-the-information-we-collect">How do we protect the information we collect</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#how-we-use-the-information-we-collect">How we use the information we collect</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#disclosure-of-your-information">Disclosure of your information</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#where-we-transfer-and-store-your-information">Where we transfer and store your information</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#changes-to-our-privacy-policy">Changes to our privacy policy</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#contact">Contact</a>
+          </li>
+          <li class="p-list__item">
+            <a href="#your-right-to-complain">Your right to complain</a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -8,6 +8,47 @@
   <div class="row">
     <div class="col-8">
       <h1>Data privacy</h1>
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          <a href="#privacy-notices">Privacy notices</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#information-we-collect-from-you">Information we collect from you</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#how-information-is-collected-from-you">How information is collected from you</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#what-do-we-do-with-your-personal-data">What do we do with your personal data</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#what-are-your-rights">What are your rights</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#cookies">Cookies</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#how-do-we-protect-the-information-we-collect">How do we protect the information we collect</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#how-we-use-the-information-we-collect">How we use the information we collect</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#disclosure-of-your-information">Disclosure of your information</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#where-we-transfer-and-store-your-information">Where we transfer and store your information</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#changes-to-our-privacy-policy">Changes to our privacy policy</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#contact">Contact</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#your-right-to-complain">Your right to complain</a>
+        </li>
+      </ul>
       <p>Canonical collects personal information from you in a number of different ways. For example, when you download one of our products, receive services from us or use one of our websites (including <a href="https://www.canonical.com">www.canonical.com</a> and <a href="https://www.ubuntu.com">www.ubuntu.com</a>).</p>
       <p><a href="/legal/websites">Full list of websites&nbsp;&rsaquo;</a></p>
       <p>At Canonical, we consider your privacy to be extremely important to us. These are the fundamental principles that we follow in relation to your personal information:</p>


### PR DESCRIPTION
## Done

Add a table of contents to the `/legal/dataprivacy` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/dataprivacy>
- See that there is a table of contents at the top of the page
- See that the table of contents links all go to the expected section


## Issue / Card
Fixes [#569](https://github.com/ubuntudesign/web-squad/issues/569)