### PR TITLE
Add modern slavery statement

### DIFF
--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -69,11 +69,19 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-12 p-card">
-      <h3>
-        <a href="/legal/service-terms">Service terms&nbsp;&rsaquo;</a>
-      </h3>
-      <p>This agreement sets out Canonical&rsquo;s standard service terms for both Ubuntu Advantage and Managed Services customers.</p>
+    <div class="u-equal-height">
+      <div class="col-6 p-card">
+        <h3>
+          <a href="/legal/service-terms">Service terms&nbsp;&rsaquo;</a>
+        </h3>
+        <p>This agreement sets out Canonical&rsquo;s standard service terms for both Ubuntu Advantage and Managed Services customers.</p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>
+          <a href="https://assets.ubuntu.com/v1/505a21c3-Canonicals+Modern+Slavery+Statement+2018.pdf" class="p-link--external">Modern slavery statement</a>
+        </h3>
+        <p>This is Canonical&rsquo;s modern slavery statement.</p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done
Add the modern slavery statement

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal](http://0.0.0.0:8001/legal)
- Check that there is a link to the modern slavery statement PDF at the bottom of the page

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3211

