### PR TITLE
Fix zindex of dropdowns

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -327,7 +327,7 @@
     position: absolute;
     top: 58px;
     width: 200px;
-    z-index: 1;
+    z-index: 10;
 
     &::before {
       //Remove the chevron


### PR DESCRIPTION
## Done

Fix overlap of dropdown menus

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that you can't see the takeover through the dropdowns


## Issue / Card
Fixes #3229 

## Screenshot
![screenshot from 2018-05-24 09-16-20](https://user-images.githubusercontent.com/501889/40474476-0d9f6b94-5f37-11e8-9a76-5ba2d1bb2237.png)
