### PR TITLE
Remove hidden field with hardcoded yes value

### DIFF
--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -18,7 +18,6 @@
       <li class="p-list__item">
         <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
         <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
-        <input type="hidden" name="canonicalUpdatesOptIn" value="yes" />
         <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
         <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />
         <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />


### PR DESCRIPTION
# Done

- Remove hidden field with hard coded value of yes as it was causing confusion in Marketo

# QA
- View source of <http://0.0.0.0:8001/cloud/public-cloud> sign up form and confirm that there is no hidden field named `canonicalUpdatesOptIn`