### PR TITLE
Update form hidden fields

### DIFF
--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -18,6 +18,7 @@
       <li class="p-list__item">
         <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
         <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
         <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />
         <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />


### PR DESCRIPTION
## Done

Added new hidden field for marketing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Go to <http://0.0.0.0:8001/cloud/public-cloud> and make sure there is a hidden field in the sign up form called `Consent_to_Processing__c`