### PR TITLE
Add hidden field to iot newsletter form

### DIFF
--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -31,6 +31,7 @@
     <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True">
     <input type="hidden" name="returnURL" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
     <input type="hidden" name="retURL" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
+    <input type="hidden" name="Consent_to_Processing__c" value="yes" />
   </form>
   <script>
     $("#mktoForm_1670").validate({


### PR DESCRIPTION
## Done

Add hidden field to iot newsletter form

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Go to any of these pages:
- <http://0.0.0.0:8001/internet-of-things/appstore>
- <http://0.0.0.0:8001/internet-of-things/digital-signage>
- <http://0.0.0.0:8001/internet-of-things/gateways>
- <http://0.0.0.0:8001/internet-of-things>
- <http://0.0.0.0:8001/internet-of-things/robotics>
- <http://0.0.0.0:8001/cloud/foundation-cloud>

Check that the newsletter form has a hidden field called `IoT_Newsletters__c`