### PR TITLE
Fix overlap on back to top link

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -31,6 +31,7 @@
 
       @media only screen and (min-width: $breakpoint-medium) {
         border: 0;
+        margin-top: 0 !important;
       }
 
       &.u-clearfix {


### PR DESCRIPTION
## Done

Fix back to top link overlap on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Look at the footer on a small screen and see that the back to top link does not overlap the nav beneath it


## Issue / Card

Fixes #3253 

## Screenshots

![screenshot from 2018-06-05 12-26-14](https://user-images.githubusercontent.com/501889/40973338-d0d995ac-68bb-11e8-887d-41157dff7997.png)

