### PR TITLE
3256 nav content updates

### DIFF
--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -20,7 +20,7 @@
   <div class="{% if spotlight_articles %}col-9 p-divider__block{% else %}col-12{% endif %}">
     {# insights heading #}
     <h2 class="p-link--external p-heading--insights__title">
-      <a href="https://blog.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+      <a href="https://blog.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
         Latest news
       </a>
     </h2>
@@ -29,7 +29,7 @@
     <div>
       {% for article in articles %}
         <div class="col-3">
-          <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
+          <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
           <p><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></p>
         </div>
       {% endfor %}

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -20,8 +20,8 @@
   <div class="{% if spotlight_articles %}col-9 p-divider__block{% else %}col-12{% endif %}">
     {# insights heading #}
     <h2 class="p-link--external p-heading--insights__title">
-      <a href="https://insights.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
-        Latest news from Insights
+      <a href="https://blog.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+        Latest news
       </a>
     </h2>
 
@@ -35,21 +35,4 @@
       {% endfor %}
     </div>
   </div>
-
-  {# spotlight heading #}
-  {% if spotlight_articles %}
-    <div class="col-3 p-divider__block">
-      <h2 class="p-link--external p-heading--insights__title">
-        <a href="https://insights.ubuntu.com/tag/spotlight/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
-          Spotlight
-        </a>
-      </h2>
-      {% for article in spotlight_articles %}
-      <div>
-        <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
-        <p><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></p>
-      </div>
-      {% endfor %}
-    </div>
-  {% endif %}
 </div>

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -17,7 +17,7 @@
 {% endif %}
 
 <div class="row {% if spotlight_articles %}p-divider{% endif %}">
-  <div class="{% if spotlight_articles %}col-9 p-divider__block{% else %}col-12{% endif %}">
+  <div class="col-12">
     {# insights heading #}
     <h2 class="p-link--external p-heading--insights__title">
       <a href="https://blog.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
@@ -33,6 +33,18 @@
           <p><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></p>
         </div>
       {% endfor %}
+
+      {# spotlight heading #}
+      {% if spotlight_articles %}
+        <div class="col-3 p-divider__block">
+          {% for article in spotlight_articles %}
+          <div>
+            <h3 class="p-heading--four"><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h3>
+            <p><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></p>
+          </div>
+          {% endfor %}
+        </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -46,7 +46,7 @@
       </div>
       <div class="col-3">
         <p class="p-p--small">
-          <a class="p-link--strong" href="https://insights.ubuntu.com" title="Visit the Insights blog - external site">Insights blog&nbsp;&rsaquo;</a>
+          <a class="p-link--strong" href="https://blog.ubuntu.com" title="Visit the Ubuntu blog - external site">Ubuntu blog&nbsp;&rsaquo;</a>
           <br>
             Stay up to date with the latest Ubuntu news stories and resources
         </p>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -89,11 +89,7 @@
             </div>
           </li>
           <li class="p-matrix__item">
-            <a class="p-matrix__img" href="https://github.com/CanonicalLtd/multipass"><img src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon"></a>
-            <div class="p-matrix__content">
-              <h4 class="p-matrix__title"><a class="p-link" href="https://github.com/CanonicalLtd/multipass">Multipass&nbsp;&rsaquo;</a></h4>
-              <p class="p-matrix__desc">Ubuntu virtual machines on demand for Linux, MacOS and Windows for development and cloud prototyping</p>
-            </div>
+            &nbsp;
           </li>
         </ul>
       </div>

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -24,7 +24,7 @@ def format_date(date):
 
 @register.filter
 def replace_admin(url):
-    return url.replace("admin.insights.ubuntu.com", "insights.ubuntu.com")
+    return url.replace("admin.insights.ubuntu.com", "blog.ubuntu.com")
 
 
 @register.filter


### PR DESCRIPTION
## Done

- Removed multipass from products menu
- Update reference to insights to blog in developer menu
- Update news feed on homepage to use blog instead of insights

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that multipass is not in the products menu
- Check that the developer menu says 'Ubuntu blog' instead of 'Insights blog'
- Check that the homepage news feed doesn't reference insights


## Issue / Card

Fixes #3256 
