### PR TITLE
updated lxd page copy and logos

### DIFF
--- a/templates/containers/lxd.html
+++ b/templates/containers/lxd.html
@@ -57,19 +57,43 @@
     <h2 class="p-muted-heading u-align--center">Supported guest operating systems</h2>
     <ul class="p-inline-images p-inline-images--large no-margin">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}97e0563e-redhat.svg" alt="Redhat logo" />
+        <img class="p-inline-images__logo" src="https://alpinelinux.org/alpinelinux-logo.svg" alt="Alpine-Linux logo" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}31bd1765-centos.svg" alt="Walmart logo" />
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e0b23092-archlinux.svg" alt="Archlinux logo" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}9f61b97f-logo-ubuntu.svg" alt="Ubuntu logo" />
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}31bd1765-centos.svg" alt="CentOS logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}6947a9e3-redhat.svg" alt="Redhat logo" />
       </li>
       <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}2eafb62e-openlogo.svg" alt="Debian logo" width="150" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}08646a72-logo-oracle.svg" alt="Oracle-Linux logo" />
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1a53bedd-fedora.svg" alt="Fedora logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="https://www.gentoo.org/assets/img/logo/gentoo-logo.svg" alt="Gentoo-linux logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}583f0880-opensuse.png" alt="Opensuse logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}08646a72-logo-oracle.svg" alt="Oracle-linux logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="https://www.plamolinux.org/images/garland_logo.jpg" alt="Plamo logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="https://static.sabayon.org/logo/sabayonlogo1.svg" alt="Sabayon logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}9f61b97f-logo-ubuntu.svg" alt="Ubuntu logo" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e5202df6-ubuntu-core_black-orange_hex+copy.svg" alt="Ubuntu-core logo" />
       </li>
     </ul>
   </div>
@@ -142,7 +166,7 @@
             <div class="p-notification--caution">
               <div class="p-notification__response">
                 <p><span class="p-notification__status">Note:</span></p>
-                <p>LXD is on Ubuntu 16.04 LTS Server or greater by default. On Ubuntu Desktop LXD will need to be installed</p>
+                <p>LXD is on Ubuntu 16.04 LTS Server or greater by default. On other systems it can be installed with <code>snap install lxd</code>.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Done

- Updated install instructions copy
- added new "Supported OS" logos as per [copydoc](https://docs.google.com/document/d/1wBAeklBtadvh4jKuoPFSJxoX2k0zyWt07ZI4nytwYSA/edit#) 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/containers/lxd](http://0.0.0.0:8001/containers/lxd)
- Check that the changes match the [copydoc](https://docs.google.com/document/d/1wBAeklBtadvh4jKuoPFSJxoX2k0zyWt07ZI4nytwYSA/edit#)


## Issue / Card

Fixes: #3163 & #3164 
