### PR TITLE
Introducing canonical tags

### DIFF
--- a/templates/cloud/thank-you.html
+++ b/templates/cloud/thank-you.html
@@ -1,6 +1,8 @@
 {% extends "cloud/base_cloud.html" %}
 {% block title %}Thank you{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/cloud/contact-us{% endblock %}
+
 {% block content %}
 
 {% if product == 'cloud-training' %}

--- a/templates/contact-us/form/thank-you.html
+++ b/templates/contact-us/form/thank-you.html
@@ -2,6 +2,8 @@
 
 {% block title %}Thank you{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/form{% endblock %}
+
 {% block content %}
 
 <section class="p-strip is-deep is-bordered">

--- a/templates/contact-us/form/thank-you.html
+++ b/templates/contact-us/form/thank-you.html
@@ -2,7 +2,7 @@
 
 {% block title %}Thank you{% endblock %}
 
-{% block canonical_url %}https://www.ubuntu.com/form{% endblock %}
+{% block canonical_url %}https://www.ubuntu.com/contact-us/form{% endblock %}
 
 {% block content %}
 

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -2,6 +2,7 @@
 
 {% block title %}Thank you | Containers{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/containers/contact-us{% endblock %}
 
 {% block content %}
 {% if product == 'containers-kubernetes' %}

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -2,6 +2,7 @@
 
 {% block title %}Thank you | Ubuntu core{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/core/contact-us{% endblock %}
 
 {% block content %}
 <div class="p-strip is-bordered is-deep">

--- a/templates/desktop/thank-you.html
+++ b/templates/desktop/thank-you.html
@@ -2,6 +2,7 @@
 
 {% block title %}Thank you{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/desktop/contact-us{% endblock %}
 
 {% block content %}
   {% include "shared/_thank_you.html" with thanks_context="your interest in Ubuntu" %}

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -9,7 +9,7 @@ Thank you for your contribution
 {% endif %}
 {% endblock %}
 
-
+{% block canonical_url %}https://www.ubuntu.com/download/desktop{% endblock %}
 
 {% block content %}
 

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -4,6 +4,8 @@
 Thanks for downloading Ubuntu for LinuxONE and z Systems
 {% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/download/server/s390x{% endblock %}
+
 {% block head_extra %}
   <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release_with_point}}-server-s390x.iso">
 {% endblock %}

--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -4,7 +4,7 @@
 Thanks for downloading Ubuntu Server for IBM Z and LinuxONE
 {% endblock %}
 
-
+{% block canonical_url %}https://www.ubuntu.com/download/server/s390x{% endblock %}
 
 {% block head_extra %}
   <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release_with_point}}-server-s390x.iso">

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -5,7 +5,7 @@
 Thanks for downloading Ubuntu Server
 {% endblock %}
 
-
+{% block canonical_url %}https://www.ubuntu.com/download/server{% endblock %}
 
 {% block content %}
 <noscript>

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -1,6 +1,8 @@
 {% extends "internet-of-things/base_things.html" %}
 {% block title %}Thank you | Ubuntu for the Internet of Things{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/internet-of-things/contact-us{% endblock %}
+
 {% block content %}
 
 {% if product == 'newsletter' %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -1,7 +1,7 @@
 {% extends "openstack/base_openstack.html" %}
 
 {% block title %}OpenStack on Ubuntu is your scalable private cloud, by Canonical{% endblock %}
-
+{% block canonical_url %}https://beta.ubuntu.com/openstack{% endblock %}
 {% block meta_description %}Ubuntu OpenStack is the fastest, easiest and most robust way to build your cloud - and it includes a suite of tools to help you build and manage it.{% endblock meta_description %}
 
 {% block content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -1,7 +1,6 @@
 {% extends "openstack/base_openstack.html" %}
 
 {% block title %}OpenStack on Ubuntu is your scalable private cloud, by Canonical{% endblock %}
-{% block canonical_url %}https://beta.ubuntu.com/openstack{% endblock %}
 {% block meta_description %}Ubuntu OpenStack is the fastest, easiest and most robust way to build your cloud - and it includes a suite of tools to help you build and manage it.{% endblock meta_description %}
 
 {% block content %}

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -1,7 +1,6 @@
 {% extends "server/base_server.html" %}
 
 {% block title %}Ubuntu Server - for scale out workloads{% endblock %}
-{% block canonical_url %}https://beta.ubuntu.com/server{% endblock %}
 {% block meta_description %}Secure, fast and economically scalable, Ubuntu helps you make the most of your infrastructure. Whether you want to deploy a cloud or a web farm, Ubuntu Server supports the most popular hardware and software.{% endblock %}
 
 {% block content %}

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -1,8 +1,8 @@
 {% extends "server/base_server.html" %}
+
 {% block title %}Ubuntu Server - for scale out workloads{% endblock %}
+{% block canonical_url %}https://beta.ubuntu.com/server{% endblock %}
 {% block meta_description %}Secure, fast and economically scalable, Ubuntu helps you make the most of your infrastructure. Whether you want to deploy a cloud or a web farm, Ubuntu Server supports the most popular hardware and software.{% endblock %}
-
-
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/server/maas/thank-you.html
+++ b/templates/server/maas/thank-you.html
@@ -1,6 +1,8 @@
 {% extends "server/base_server.html" %}
 {% block title %}Thank you{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/server/maas/contact-us{% endblock %}
+
 {% block content %}
   {% include "shared/_thank_you.html" with thanks_context="enquiring about MAAS" %}
 {% endblock content %}

--- a/templates/server/thank-you.html
+++ b/templates/server/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "server/base_server.html" %}
 {% block title %}Thank you{% endblock %}
 
+{% block canonical_url %}https://www.ubuntu.com/server/contact-us{% endblock %}
 
 {% block content %}
 {% include "shared/_thank_you.html" with thanks_context="your interest in Ubuntu Server" %}

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -1,7 +1,6 @@
 {% extends "support/base_support.html" %}
 
 {% block meta_description %}Landscape, the systems management tool provided with Ubuntu Advantage, Canonical's service programme, allows you to manage large-scale deployments of Ubuntu machines as easily as one, making it far more cost-effective to support large networks of desktops, servers and cloud instances.{% endblock %}
-{% block canonical_url %}https://beta.ubuntu.com/support{% endblock %}
 {% block title %}Support and management{% endblock %}
 
 

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -1,7 +1,7 @@
 {% extends "support/base_support.html" %}
 
 {% block meta_description %}Landscape, the systems management tool provided with Ubuntu Advantage, Canonical's service programme, allows you to manage large-scale deployments of Ubuntu machines as easily as one, making it far more cost-effective to support large networks of desktops, servers and cloud instances.{% endblock %}
-
+{% block canonical_url %}https://beta.ubuntu.com/support{% endblock %}
 {% block title %}Support and management{% endblock %}
 
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -29,6 +29,7 @@
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
+    <link rel="canonical" href="{% block canonical_url %}{{ request.build_absolute_uri }}{% endblock %}">
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />
 

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -99,6 +99,7 @@ TEMPLATES = [
             'context_processors': [
                 'django_asset_server_url.asset_server_url',
                 'webapp.context_processors.navigation',
+                'django.template.context_processors.request',
             ],
         },
     },


### PR DESCRIPTION
This introduces canonical tags to www.ubuntu.com, for three reasons:
- Reinforcing the SEO value of selected pages by folding organic traffic from multiple pages back to one.
- Avoiding people to mistakenly reach thank-you pages without seeing their respective contextual information or form.
- Enabling easy splitting of traffic to beta.ubuntu.com on selected pages.

@frankiegranato, @pmahnke

## Done

- Added `<link rel=canonical />` tag to base template, using current URL as default `href` value, including parameters.
- Added `canonical_url` blocks to selected pages, to override the default `href` value of the tag:
  - ~to `/support`, `/openstack` and `/server` to split-test beta.ubuntu.com with organic traffic diversion~
  - to `thank-you` pages behind contact forms, to fold the organic traffic back to their respective forms
  - to `/download/server/thank-you-s390x` to avoid people mistakenly reaching the s390x download page from a search engine, without seeing the ToS form.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- verify the source of various pages to check the presence of a `link rel="canonical"` tag in the `<head>` (around line 40):
  - ~`/openstack` -> `<link rel="canonical" href="https://beta.ubuntu.com/openstack">`~
  - `/download/server/thank-you-s390x` -> `<link rel="canonical" href="[domain]/download/server/s390x">`
  - `/desktop/features` -> `<link rel="canonical" href="[domain]/desktop/features">`