### PR TITLE
Add anchor for response times

### DIFF
--- a/templates/legal/shared/_severity-levels.html
+++ b/templates/legal/shared/_severity-levels.html
@@ -1,5 +1,5 @@
 <li class="p-list__item">
-  <h2 id="severity-levels">Severity levels and target response times</h2>
+  <h2 id="severity-levels"><span id="response-times">Severity levels and target response times</span></h2>
   <ul>
     <li class="p-list__item">Once a support request is opened, a Canonical Support Engineer will validate the case information and determine the severity level, working with the customer to assess the urgency of the case.</li>
     <li class="p-list__item">Response times will be as set forth in the Service Description for the applicable service offering.</li>


### PR DESCRIPTION
## Done

Add anchor to response times section so external links aren't broken

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: </legal/ubuntu-advantage/service-description#response-times>
- See that the browser loads on `Severity levels and target response times` section


## Issue / Card

Fixes #3249 