### PR TITLE
Content update for the NUC desktop install page

### DIFF
--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -17,21 +17,17 @@
       <div class="u-equal-height p-divider">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Desktop</h2>
-          <p>As an alternative to Ubuntu Core, you can install Ubuntu Desktop 16.04 LTS, where you can use your favourite development tools to create and run snaps.</p>
+          <p>Use your favourite development tools, install snaps and access the vast Ubuntu ecosystem with your NUC.</p>
         </div>
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">An Ubuntu SSO account with an SSH key</li>
             <li class="p-list__item is-ticked">An Intel NUC with BIOS updated to the latest version (<a class="p-link--external" href="http://www.intel.com/content/www/us/en/support/boards-and-kits/000005850.html">update instructions</a>)</li>
-            <li class="p-list__item is-ticked">1 USB 2.0 or 3.0 flash drive (2GB minimum)</li>
-            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-            <li class="p-list__item is-ticked">A Mini HDMI to HDMI cable</li>
+            <li class="p-list__item is-ticked">1 USB 2.0 or 3.0 flash drive (4GB minimum for Dawson Canyon NUCs, 2GB for older generations)</li>
             <li class="p-list__item is-ticked">A USB keyboard and a mouse</li>
-            <li class="p-list__item is-ticked">A monitor with VGA or HDMI interface</li>
+            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
             <li class="p-list__item is-ticked">A VGA or HDMI cable</li>
             <li class="p-list__item is-ticked">A network connection with Internet access</li>
-            <li class="p-list__item is-ticked">An Ubuntu Desktop {{ lts_release_full_with_point }} image</li>
           </ul>
         </div>
       </div>
@@ -50,19 +46,21 @@
             Download Ubuntu Desktop
           </h3>
           <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
+            <p>Download the correct Ubuntu image for your device:</p>
             <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/nuc/ubuntu-server-16.04.1-20160817-0.iso">Intel NUC - Ubuntu Desktop 16.04 LTS image</a></li>
+              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso">Dawson Canyon NUC - Ubuntu Desktop 16.04 LTS image</a>
+              <br>Certified for these models: NUC7i7DNHE, NUC7i5DNHE, NUC7i3DNHE,  NUC7PJYH,  NUC7CJYH​.</li>
+              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/nuc/ubuntu-server-16.04.1-20160817-0.iso">Previous NUC generations - Ubuntu Server 16.04 LTS image</a></li>
             </ul>
           </div>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
             <span class="p-list-step__bullet">2</span>
-            Flash the USB stick with Ubuntu Core
+            Flash the USB flash drive
           </h3>
           <div class="p-list-step__content">
-            <p>Download and copy the image on an USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
+            <p>Copy the image on an USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
           </div>
         </li>
         <li class="p-list-step__item">
@@ -71,16 +69,15 @@
             Install Ubuntu Desktop
           </h3>
           <div class="p-list-step__content">
-            <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
+            <p>Booting the system from the USB flash drive will start the Ubuntu installer.</p>
             <ol class="u-no-margin--left">
               <li>Insert the USB flash drive in the NUC.</li>
               <li>Start the NUC and push F10 to enter the boot menu.</li>
               <li>Select the USB flash drive as a boot option.</li>
-              <li>The system will automatically execute the first stage of installation, including eMMC storage partitioning and image installation. After installation is complete, a prompt dialog will be shown and you will need to restart the system.</li>
-              <li>Boot the system on the eMMC storage and finish the install configuration.</li>
+              <li>The system will automatically execute the first stage of installation and prompt for an acknowledgement of a complete system recovery.</li>
               <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
               <li>Pick a hostname, user account and password.</li>
-              <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system.</li>
+              <li>Wait for the configuration to finish. If you are connected to an active network, it will take several minutes to download and apply additional updates.</li>
               <li>Ubuntu is installed. Use your account and password to log in.</li>
             </ol>
           </div>
@@ -89,10 +86,6 @@
     </div>
   </div>
 </section>
-
-{% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
-
-{% include "./_install-snaps-strip.html" %}
 
 {% include "download/shared/_get-ebook-security.html"%}
 

--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -57,10 +57,10 @@
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
             <span class="p-list-step__bullet">2</span>
-            Flash the USB flash drive
+            Flash the USB drive
           </h3>
           <div class="p-list-step__content">
-            <p>Copy the image on a USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
+            <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
           </div>
         </li>
         <li class="p-list-step__item">

--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -60,7 +60,7 @@
             Flash the USB flash drive
           </h3>
           <div class="p-list-step__content">
-            <p>Copy the image on an USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
+            <p>Copy the image on a USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
           </div>
         </li>
         <li class="p-list-step__item">

--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -26,7 +26,7 @@
             <li class="p-list__item is-ticked">1 USB 2.0 or 3.0 flash drive (4GB minimum for Dawson Canyon NUCs, 2GB for older generations)</li>
             <li class="p-list__item is-ticked">A USB keyboard and a mouse</li>
             <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-            <li class="p-list__item is-ticked">A VGA or HDMI cable</li>
+            <li class="p-list__item is-ticked">An HDMI cable</li>
             <li class="p-list__item is-ticked">A network connection with Internet access</li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

- New NUC image
- Adjusted content

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/iot/intel-nuc-desktop](http://0.0.0.0:8001/download/iot/intel-nuc-desktop)
- Ensure the content is accurate and Ubuntu image links are working
