### PR TITLE
Cloud economics campaign landing page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -38,7 +38,7 @@
 @import 'pattern_takeunders';
 @import 'pattern_table';
 @import 'pattern_tabs';
-@import 'takeovers/openstack-queens';
+@import 'takeovers/private_cloud_economics';
 
 @include ubuntu-p-buttons;
 @include ubuntu-p-site-search;
@@ -65,7 +65,7 @@
 @include ubuntu-p-takeunders;
 @include ubuntu-p-tables;
 @include ubuntu-p-tabs;
-@include p-takeover-openstack-queens;
+@include p-takeover-private-cloud-economics;
 
 // Bug fixes
 // Each of the the rules below are bug fixes which need to be addressed further upstream

--- a/static/sass/takeovers/_private_cloud_economics.scss
+++ b/static/sass/takeovers/_private_cloud_economics.scss
@@ -1,0 +1,26 @@
+@mixin p-takeover-private-cloud-economics {
+  .p-takeover--private-cloud-economics {
+    background-image: linear-gradient(-36deg, #94310F 0%, rgba(233,84,32,0.90) 100%);
+    background-color: $color-brand;
+
+    @media (min-width: $breakpoint-medium) {
+      background-image: url('https://assets.ubuntu.com/v1/13fdbc5b-graph.png'), linear-gradient(36deg, #94310F 0%, rgba(233,84,32,0.90) 100%);
+      background-repeat: no-repeat;
+      background-position: right bottom;
+    }
+  }
+
+  .p-takeover__title {
+    font-weight: 100;
+    color: $color-x-light;
+  }
+
+  .p-takeover__text {
+    font-size: 1rem;
+    color: $color-x-light;
+
+    @media (min-width: $breakpoint-medium) {
+      font-size: 1.25rem;
+    }
+  }
+}

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -368,7 +368,7 @@
               <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol"  value="Yes" type="hidden">
             </li>
             <li  class="mktField">
-              <button type="submit" class="mktoButton">Download the independent report</button><input name="formid" class="mktoField " value="3219" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
+              <button type="submit" class="mktoButton">Download the independent report</button><input name="formid" class="mktoField" value="3216" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
             </li>
           </ul>
         </fieldset>

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -362,13 +362,13 @@
               <label for="canonicalUpdatesOptIn" class="mktoLabel " >I agree to receive information about Canonical’s products and services.</label>
             </li>
             <li  class="mktField">
-              In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank" class="mchNoDecorate" id="">Canonical's Privacy Policy</a><input name="RichText" type="hidden">
+              In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank" class="mchNoDecorate">Canonical's Privacy Policy</a><input name="RichText" type="hidden">
             </li>
             <li  class="mktField">
               <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol"  value="Yes" type="hidden">
             </li>
             <li  class="mktField">
-              <button type="submit" class="mktoButton">Download the independent report</button></span><input name="formid" class="mktoField " value="3219" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
+              <button type="submit" class="mktoButton">Download the independent report</button><input name="formid" class="mktoField " value="3219" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
             </li>
           </ul>
         </fieldset>

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -40,23 +40,23 @@
           <ul class="p-list">
             <li  class="mktFormReq mktField p-list__item">
               <label for="FirstName" class="mktoLabel " >First Name:</label>
-              <input required  id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired"  type="text">
+              <input required  id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="First Name">
             </li>
             <li  class="mktFormReq mktField">
               <label for="LastName" class="mktoLabel " >Last Name:</label>
-              <input required  id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired"  type="text">
+              <input required  id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Last Name">
             </li>
             <li  class="mktFormReq mktField">
               <label for="Email" class="mktoLabel " >Work email:</label>
-              <input required  id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired"  type="email">
+              <input required  id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired"  type="email" aria-label="Email">
             </li>
             <li  class="mktFormReq mktField">
               <label for="Company" class="mktoLabel " >Company Name:</label>
-              <input required  id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired"  type="text">
+              <input required  id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Company Name">
             </li>
             <li  class="mktFormReq mktField">
               <label for="Job_Role__c" class="mktoLabel " >Job Role:</label>
-              <select required  id="Job_Role__c" name="Job_Role__c" class="mktoField  mktoRequired" >
+              <select required  id="Job_Role__c" name="Job_Role__c" class="mktoField  mktoRequired" aria-label="Job Role">
                 <option value="">Select...</option>
                 <option value="Press and Communications">Press and Communications</option>
                 <option value="CEO/Owner">CEO/Owner</option>
@@ -71,11 +71,11 @@
             </li>
             <li  class="mktFormReq mktField">
               <label for="Phone" class="mktoLabel " >Phone Number:</label>
-              <input required  id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired"  type="tel">
+              <input required  id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired"  type="tel" aria-label="Phone Number">
             </li>
             <li  class="mktFormReq mktField">
               <label for="Country" class="mktoLabel " >Country:</label>
-              <select required  id="Country" name="Country" class="mktoField  mktoRequired" ><option value="">Select...</option>
+              <select required  id="Country" name="Country" class="mktoField  mktoRequired" aria-label="Country"><option value="">Select...</option>
               <option value="FR">France</option>
               <option value="DE">Germany</option>
               <option value="JP">Japan</option>
@@ -334,11 +334,11 @@
             </li>
             <li  class="mktFormReq mktField">
               <label for="Title" class="mktoLabel " >Job Title:</label>
-              <input required  id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired"  type="text">
+              <input required  id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Job Title">
             </li>
             <li  class="mktFormReq mktField">
               <label for="Project_Stage__c" class="mktoLabel " >Are you working on a commercial cloud deployment?</label>
-              <select required  id="Project_Stage__c" name="Project_Stage__c" class="mktoField  mktoRequired" >
+              <select required  id="Project_Stage__c" name="Project_Stage__c" class="mktoField  mktoRequired" aria-label="Are you working on a commercial cloud deployment?">
                 <option value="">Select...</option>
                 <option value="Working on a commercial cloud deployment">Yes</option>
                 <option value="Not working on a commercial cloud deployment">No</option>
@@ -358,7 +358,7 @@
               <input name="utm_source" class="mktoField  mktoFormCol"  value="" type="hidden">
             </li>
             <li  class="mktField">
-              <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn"></label>
+              <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" aria-label="I agree to receive information about Canonical’s products and services."></label>
               <label for="canonicalUpdatesOptIn" class="mktoLabel " >I agree to receive information about Canonical’s products and services.</label>
             </li>
             <li  class="mktField">

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -1,0 +1,403 @@
+  {% extends "engage/base_engage.html" %}
+
+  {% block meta_description %}Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.{% endblock %}
+
+{% block title %}Busting the myth of private cloud economics{% endblock %}
+
+{% block content %}
+<section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'); background-position: 77% 0%;">
+  <div class="row">
+    <div class="col-8">
+      <div class="p-card--overlay">
+        <h1>Busting the myth of private cloud economics</h1>
+    </div>
+  </div>
+</div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <div class="u-align--center">
+        <img src="https://assets.ubuntu.com/v1/a5d0d583-451_research_logo.png?w=200" alt="451 Research cloud pricing">
+      </div>
+      <p>Canonical is well known as a pioneer in model-driven operations which reduce the amount of fragmentation and customisation required for diverse OpenStack architectures and deployments.</p>
+      <p>The new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.</p>
+      <p>Canonical’s managed private cloud, BootStack, was also priced competitively against other hosted private cloud providers, having the second lowest total cost for managed compute, block and object storage in the Cloud Price Index.</p>
+      <p>One of the significant issues with private cloud infrastructure is the up-front cost of consulting and integration required. Canonical addresses this with a fixed-price, highly automated but flexible OpenStack deployment process that greatly reduces the number of people required for both deployment and ongoing operations.</p>
+      <img src="https://assets.ubuntu.com/v1/cfb75828-Untitled_crop.png" alt="cloud pricing comparison">
+      <p>To find out more please download the report for further insights.</p>
+    </div>
+    <div class="col-6">
+<!-- MARKETO FORM -->
+      <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
+      <script  src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+      <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>‌​
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3216" style="margin-top:0;">
+        <fieldset>
+          <h3>Download the report</h3>
+          <ul class="p-list">
+            <li  class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel " >First Name:</label>
+              <input required  id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired"  type="text">
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="LastName" class="mktoLabel " >Last Name:</label>
+              <input required  id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired"  type="text">
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="Email" class="mktoLabel " >Work email:</label>
+              <input required  id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired"  type="email">
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="Company" class="mktoLabel " >Company Name:</label>
+              <input required  id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired"  type="text">
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="Job_Role__c" class="mktoLabel " >Job Role:</label>
+              <select required  id="Job_Role__c" name="Job_Role__c" class="mktoField  mktoRequired" >
+                <option value="">Select...</option>
+                <option value="Press and Communications">Press and Communications</option>
+                <option value="CEO/Owner">CEO/Owner</option>
+                <option value="VP/Director">VP/Director</option>
+                <option value="Manager">Manager</option>
+                <option value="Programming/Software Engineering">Programming/Software Engineering</option>
+                <option value="IT Administrator">IT Administrator</option>
+                <option value="Developer">Developer</option>
+                <option value="Student">Student</option>
+                <option value="Other">Other</option>
+              </select>
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="Phone" class="mktoLabel " >Phone Number:</label>
+              <input required  id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired"  type="tel">
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="Country" class="mktoLabel " >Country:</label>
+              <select required  id="Country" name="Country" class="mktoField  mktoRequired" ><option value="">Select...</option>
+              <option value="FR">France</option>
+              <option value="DE">Germany</option>
+              <option value="JP">Japan</option>
+              <option value="GB">United Kingdom</option>
+              <option value="US">United States of America</option>
+              <option value="------">------</option>
+              <option value="AF">Afghanistan</option>
+              <option value="AX">Åland Islands</option>
+              <option value="AL">Albania</option>
+              <option value="DZ">Algeria</option>
+              <option value="AS">American Samoa</option>
+              <option value="AD">Andorra</option>
+              <option value="AO">Angola</option>
+              <option value="AI">Anguilla</option>
+              <option value="AQ">Antarctica</option>
+              <option value="AG">Antigua and Barbuda</option>
+              <option value="AR">Argentina</option>
+              <option value="AM">Armenia</option>
+              <option value="AW">Aruba</option>
+              <option value="AU">Australia</option>
+              <option value="AT">Austria</option>
+              <option value="AZ">Azerbaijan</option>
+              <option value="BS">Bahamas</option>
+              <option value="BH">Bahrain</option>
+              <option value="BD">Bangladesh</option>
+              <option value="BB">Barbados</option>
+              <option value="BY">Belarus</option>
+              <option value="BE">Belgium</option>
+              <option value="BZ">Belize</option>
+              <option value="BJ">Benin</option>
+              <option value="BM">Bermuda</option>
+              <option value="BT">Bhutan</option>
+              <option value="BO">Bolivia (Plurinational State of)</option>
+              <option value="BQ">Bonaire, Sint Eustatius and Saba</option>
+              <option value="BA">Bosnia and Herzegovina</option>
+              <option value="BW">Botswana</option>
+              <option value="BV">Bouvet Island</option>
+              <option value="BR">Brazil</option>
+              <option value="IO">British Indian Ocean Territory</option>
+              <option value="BN">Brunei Darussalam</option>
+              <option value="BG">Bulgaria</option>
+              <option value="BF">Burkina Faso</option>
+              <option value="BI">Burundi</option>
+              <option value="KH">Cambodia</option>
+              <option value="CM">Cameroon</option>
+              <option value="CA">Canada</option>
+              <option value="CV">Cabo Verde</option>
+              <option value="KY">Cayman Islands</option>
+              <option value="CF">Central African Republic</option>
+              <option value="TD">Chad</option>
+              <option value="CL">Chile</option>
+              <option value="CN">China</option>
+              <option value="CX">Christmas Island</option>
+              <option value="CC">Cocos (Keeling) Islands</option>
+              <option value="CO">Colombia</option>
+              <option value="KM">Comoros</option>
+              <option value="CG">Congo</option>
+              <option value="CD">Congo (Democratic Republic of the)</option>
+              <option value="CK">Cook Islands</option>
+              <option value="CR">Costa Rica</option>
+              <option value="CI">Côte d'Ivoire</option>
+              <option value="HR">Croatia</option>
+              <option value="CU">Cuba</option>
+              <option value="CW">Curaçao</option>
+              <option value="CY">Cyprus</option>
+              <option value="CZ">Czech Republic</option>
+              <option value="DK">Denmark</option>
+              <option value="DJ">Djibouti</option>
+              <option value="DM">Dominica</option>
+              <option value="DO">Dominican Republic</option>
+              <option value="EC">Ecuador</option>
+              <option value="EG">Egypt</option>
+              <option value="SV">El Salvador</option>
+              <option value="GQ">Equatorial Guinea</option>
+              <option value="ER">Eritrea</option>
+              <option value="EE">Estonia</option>
+              <option value="ET">Ethiopia</option>
+              <option value="FK">Falkland Islands (Malvinas)</option>
+              <option value="FO">Faroe Islands</option>
+              <option value="FJ">Fiji</option>
+              <option value="FI">Finland</option>
+              <option value="FR">France</option>
+              <option value="GF">French Guiana</option>
+              <option value="PF">French Polynesia</option>
+              <option value="TF">French Southern Territories</option>
+              <option value="GA">Gabon</option>
+              <option value="GM">Gambia</option>
+              <option value="GE">Georgia</option>
+              <option value="DE">Germany</option>
+              <option value="GH">Ghana</option>
+              <option value="GI">Gibraltar</option>
+              <option value="GR">Greece</option>
+              <option value="GL">Greenland</option>
+              <option value="GD">Grenada</option>
+              <option value="GP">Guadeloupe</option>
+              <option value="GU">Guam</option>
+              <option value="GT">Guatemala</option>
+              <option value="GG">Guernsey</option>
+              <option value="GN">Guinea</option>
+              <option value="GW">Guinea-Bissau</option>
+              <option value="GY">Guyana</option>
+              <option value="HT">Haiti</option>
+              <option value="HM">Heard Island and McDonald Islands</option>
+              <option value="VA">Holy See</option>
+              <option value="HN">Honduras</option>
+              <option value="HK">Hong Kong</option>
+              <option value="HU">Hungary</option>
+              <option value="IS">Iceland</option>
+              <option value="IN">India</option>
+              <option value="ID">Indonesia</option>
+              <option value="IR">Iran (Islamic Republic of)</option>
+              <option value="IQ">Iraq</option>
+              <option value="IE">Ireland</option>
+              <option value="IM">Isle of Man</option>
+              <option value="IL">Israel</option>
+              <option value="IT">Italy</option>
+              <option value="JM">Jamaica</option>
+              <option value="JP">Japan</option>
+              <option value="JE">Jersey</option>
+              <option value="JO">Jordan</option>
+              <option value="KZ">Kazakhstan</option>
+              <option value="KE">Kenya</option>
+              <option value="KI">Kiribati</option>
+              <option value="KP">Korea (Democratic People's Republic of)</option>
+              <option value="KR">Korea (Republic of)</option>
+              <option value="KW">Kuwait</option>
+              <option value="KG">Kyrgyzstan</option>
+              <option value="LA">Lao People's Democratic Republic</option>
+              <option value="LV">Latvia</option>
+              <option value="LB">Lebanon</option>
+              <option value="LS">Lesotho</option>
+              <option value="LR">Liberia</option>
+              <option value="LY">Libya</option>
+              <option value="LI">Liechtenstein</option>
+              <option value="LT">Lithuania</option>
+              <option value="LU">Luxembourg</option>
+              <option value="MO">Macao</option>
+              <option value="MK">Macedonia (the former Yugoslav Republic of)</option>
+              <option value="MG">Madagascar</option>
+              <option value="MW">Malawi</option>
+              <option value="MY">Malaysia</option>
+              <option value="MV">Maldives</option>
+              <option value="ML">Mali</option>
+              <option value="MT">Malta</option>
+              <option value="MH">Marshall Islands</option>
+              <option value="MQ">Martinique</option>
+              <option value="MR">Mauritania</option>
+              <option value="MU">Mauritius</option>
+              <option value="YT">Mayotte</option>
+              <option value="MX">Mexico</option>
+              <option value="FM">Micronesia (Federated States of)</option>
+              <option value="MD">Moldova (Republic of)</option>
+              <option value="MC">Monaco</option>
+              <option value="MN">Mongolia</option>
+              <option value="ME">Montenegro</option>
+              <option value="MS">Montserrat</option>
+              <option value="MA">Morocco</option>
+              <option value="MZ">Mozambique</option>
+              <option value="MM">Myanmar</option>
+              <option value="NA">Namibia</option>
+              <option value="NR">Nauru</option>
+              <option value="NP">Nepal</option>
+              <option value="NL">Netherlands</option>
+              <option value="NC">New Caledonia</option>
+              <option value="NZ">New Zealand</option>
+              <option value="NI">Nicaragua</option>
+              <option value="NE">Niger</option>
+              <option value="NG">Nigeria</option>
+              <option value="NU">Niue</option>
+              <option value="NF">Norfolk Island</option>
+              <option value="MP">Northern Mariana Islands</option>
+              <option value="NO">Norway</option>
+              <option value="OM">Oman</option>
+              <option value="PK">Pakistan</option>
+              <option value="PW">Palau</option>
+              <option value="PS">Palestine, State of</option>
+              <option value="PA">Panama</option>
+              <option value="PG">Papua New Guinea</option>
+              <option value="PY">Paraguay</option>
+              <option value="PE">Peru</option>
+              <option value="PH">Philippines</option>
+              <option value="PN">Pitcairn</option>
+              <option value="PL">Poland</option>
+              <option value="PT">Portugal</option>
+              <option value="PR">Puerto Rico</option>
+              <option value="QA">Qatar</option>
+              <option value="RE">Réunion</option>
+              <option value="RO">Romania</option>
+              <option value="RU">Russian Federation</option>
+              <option value="RW">Rwanda</option>
+              <option value="BL">Saint Barthélemy</option>
+              <option value="SH">Saint Helena, Ascension and Tristan da Cunha</option>
+              <option value="KN">Saint Kitts and Nevis</option>
+              <option value="LC">Saint Lucia</option>
+              <option value="MF">Saint Martin (French part)</option>
+              <option value="PM">Saint Pierre and Miquelon</option>
+              <option value="VC">Saint Vincent and the Grenadines</option>
+              <option value="WS">Samoa</option>
+              <option value="SM">San Marino</option>
+              <option value="ST">Sao Tome and Principe</option>
+              <option value="SA">Saudi Arabia</option>
+              <option value="SN">Senegal</option>
+              <option value="RS">Serbia</option>
+              <option value="SC">Seychelles</option>
+              <option value="SL">Sierra Leone</option>
+              <option value="SG">Singapore</option>
+              <option value="SX">Sint Maarten (Dutch part)</option>
+              <option value="SK">Slovakia</option>
+              <option value="SI">Slovenia</option>
+              <option value="SB">Solomon Islands</option>
+              <option value="SO">Somalia</option>
+              <option value="ZA">South Africa</option>
+              <option value="GS">South Georgia and the South Sandwich Islands</option>
+              <option value="SS">South Sudan</option>
+              <option value="ES">Spain</option>
+              <option value="LK">Sri Lanka</option>
+              <option value="SD">Sudan</option>
+              <option value="SR">Suriname</option>
+              <option value="SJ">Svalbard and Jan Mayen</option>
+              <option value="SZ">Swaziland</option>
+              <option value="SE">Sweden</option>
+              <option value="CH">Switzerland</option>
+              <option value="SY">Syrian Arab Republic</option>
+              <option value="TW">Taiwan</option>
+              <option value="TJ">Tajikistan</option>
+              <option value="TZ">Tanzania, United Republic of</option>
+              <option value="TH">Thailand</option>
+              <option value="TL">Timor-Leste</option>
+              <option value="TG">Togo</option>
+              <option value="TK">Tokelau</option>
+              <option value="TO">Tonga</option>
+              <option value="TT">Trinidad and Tobago</option>
+              <option value="TN">Tunisia</option>
+              <option value="TR">Turkey</option>
+              <option value="TM">Turkmenistan</option>
+              <option value="TC">Turks and Caicos Islands</option>
+              <option value="TV">Tuvalu</option>
+              <option value="UG">Uganda</option>
+              <option value="UA">Ukraine</option>
+              <option value="AE">United Arab Emirates</option>
+              <option value="GB">United Kingdom</option>
+              <option value="US">United States of America</option>
+              <option value="UM">United States Minor Outlying Islands</option>
+              <option value="UY">Uruguay</option>
+              <option value="UZ">Uzbekistan</option>
+              <option value="VU">Vanuatu</option>
+              <option value="VE">Venezuela (Bolivarian Republic of)</option>
+              <option value="VN">Viet Nam</option>
+              <option value="VG">Virgin Islands (British)</option>
+              <option value="VI">Virgin Islands (U.S.)</option>
+              <option value="WF">Wallis and Futuna</option>
+              <option value="EH">Western Sahara</option>
+              <option value="YE">Yemen</option>
+              <option value="ZM">Zambia</option>
+              <option value="ZW">Zimbabwe</option></select>
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="Title" class="mktoLabel " >Job Title:</label>
+              <input required  id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired"  type="text">
+            </li>
+            <li  class="mktFormReq mktField">
+              <label for="Project_Stage__c" class="mktoLabel " >Are you working on a commercial cloud deployment?</label>
+              <select required  id="Project_Stage__c" name="Project_Stage__c" class="mktoField  mktoRequired" >
+                <option value="">Select...</option>
+                <option value="Working on a commercial cloud deployment">Yes</option>
+                <option value="Not working on a commercial cloud deployment">No</option>
+              </select>
+            </li>
+          </ul>
+        </fieldset>
+        <fieldset>
+          <ul class="p-list">
+            <li  class="mktField">
+              <input name="utm_campaign" class="mktoField  mktoFormCol"  value="" type="hidden">
+            </li>
+            <li  class="mktField">
+              <input name="utm_medium" class="mktoField  mktoFormCol"  value="" type="hidden">
+            </li>
+            <li  class="mktField">
+              <input name="utm_source" class="mktoField  mktoFormCol"  value="" type="hidden">
+            </li>
+            <li  class="mktField">
+              <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn"></label>
+              <label for="canonicalUpdatesOptIn" class="mktoLabel " >I agree to receive information about Canonical’s products and services.</label>
+            </li>
+            <li  class="mktField">
+              In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank" class="mchNoDecorate" id="">Canonical's Privacy Policy</a><input name="RichText" type="hidden">
+            </li>
+            <li  class="mktField">
+              <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol"  value="Yes" type="hidden">
+            </li>
+            <li  class="mktField">
+              <button type="submit" class="mktoButton">Download</button></span><input name="formid" class="mktoField " value="3219" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
+            </li>
+          </ul>
+        </fieldset>
+        <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/CloudEconomics_TY.html" />
+        <input type="hidden" name="retURL" value="https://pages.ubuntu.com/CloudEconomics_TY.html" />
+      </form>
+      <script>
+      $("#mktoForm_3216").validate({
+          errorElement: "span",
+          errorClass: "mktFormMsg mktError",
+          onkeyup: false,
+          onclick: false,
+          onblur: false
+      });
+
+        $(function(){$("#comments").hide()});
+
+        $('#Ubuntu_User__c').on('change',function(){
+
+         var selection = $(this).val();
+         if(selection == 'Commercially only') {
+            $('#comments').show();
+         } else {
+            $('#comments').hide();
+         }
+        });
+      </script>
+      <script  src="//assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
+<!-- /MARKETO FORM -->
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -5,15 +5,18 @@
 {% block title %}Busting the myth of private cloud economics{% endblock %}
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="background: url('https://assets.ubuntu.com/v1/13fdbc5b-graph.png') right bottom no-repeat, linear-gradient(-36deg, #94310F 0%, rgba(233,84,32,0.90) 100%);">
-  <div class="row">
+<section class="p-strip is-deep p-takeover--private-cloud-economics">
+  <div class="row u-equal-height">
     <div class="col-8">
-        <h1>Busting the myth of private cloud economics</h1>
+      <h1 class="p-takeover__title">Busting the myth of private cloud economics</h1>
+      <p class="u-hide--medium u-hide--large">
+        <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}c54da84b-451-Research-NEG.png" alt="">
+      </p>
+    </div>
+    <div class="col-4 u-hide--small u-align-center u-vertically-center">
+      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}c54da84b-451-Research-NEG.png" alt="">
+    </div>
   </div>
-  <div class="col-4">
-    <img src="https://assets.ubuntu.com/v1/c54da84b-451-Research-NEG.png" alt="451 Research cloud pricing">
-  </div>
-</div>
 </section>
 
 <section class="p-strip is-bordered">
@@ -23,7 +26,7 @@
       <p>The new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.</p>
       <p>Canonical’s managed private cloud, BootStack, was also priced competitively against other hosted private cloud providers, having the second lowest total cost for managed compute, block and object storage in the Cloud Price Index.</p>
       <p>One of the significant issues with private cloud infrastructure is the up-front cost of consulting and integration required. Canonical addresses this with a fixed-price, highly automated but flexible OpenStack deployment process that greatly reduces the number of people required for both deployment and ongoing operations.</p>
-      <img src="https://assets.ubuntu.com/v1/cfb75828-Untitled_crop.png" alt="cloud pricing comparison">
+      <img src="{{ ASSET_SERVER_URL }}cfb75828-Untitled_crop.png" alt="cloud pricing comparison">
       <p>To find out more please download the report for further insights.</p>
     </div>
     <div class="col-5">

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -5,22 +5,20 @@
 {% block title %}Busting the myth of private cloud economics{% endblock %}
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'); background-position: 77% 0%;">
+<section class="p-strip--image is-dark is-deep" style="background: url('https://assets.ubuntu.com/v1/13fdbc5b-graph.png') right bottom no-repeat, linear-gradient(-36deg, #94310F 0%, rgba(233,84,32,0.90) 100%);">
   <div class="row">
     <div class="col-8">
-      <div class="p-card--overlay">
         <h1>Busting the myth of private cloud economics</h1>
-    </div>
+  </div>
+  <div class="col-4">
+    <img src="https://assets.ubuntu.com/v1/c54da84b-451-Research-NEG.png" alt="451 Research cloud pricing">
   </div>
 </div>
 </section>
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <div class="col-6">
-      <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/a5d0d583-451_research_logo.png?w=200" alt="451 Research cloud pricing">
-      </div>
+    <div class="col-7">
       <p>Canonical is well known as a pioneer in model-driven operations which reduce the amount of fragmentation and customisation required for diverse OpenStack architectures and deployments.</p>
       <p>The new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.</p>
       <p>Canonical’s managed private cloud, BootStack, was also priced competitively against other hosted private cloud providers, having the second lowest total cost for managed compute, block and object storage in the Cloud Price Index.</p>
@@ -28,12 +26,12 @@
       <img src="https://assets.ubuntu.com/v1/cfb75828-Untitled_crop.png" alt="cloud pricing comparison">
       <p>To find out more please download the report for further insights.</p>
     </div>
-    <div class="col-6">
+    <div class="col-5">
 <!-- MARKETO FORM -->
       <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
       <script  src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
       <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>‌​
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3216" style="margin-top:0;">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3216" class="u-no-margin--top">
         <fieldset>
           <h3>Download the report</h3>
           <ul class="p-list">
@@ -367,7 +365,7 @@
               <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol"  value="Yes" type="hidden">
             </li>
             <li  class="mktField">
-              <button type="submit" class="mktoButton">Download</button></span><input name="formid" class="mktoField " value="3219" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
+              <button type="submit" class="mktoButton">Download the independent report</button></span><input name="formid" class="mktoField " value="3219" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
             </li>
           </ul>
         </fieldset>

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -55,21 +55,6 @@
               <input required  id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Company Name">
             </li>
             <li  class="mktFormReq mktField">
-              <label for="Job_Role__c" class="mktoLabel " >Job Role:</label>
-              <select required  id="Job_Role__c" name="Job_Role__c" class="mktoField  mktoRequired" aria-label="Job Role">
-                <option value="">Select...</option>
-                <option value="Press and Communications">Press and Communications</option>
-                <option value="CEO/Owner">CEO/Owner</option>
-                <option value="VP/Director">VP/Director</option>
-                <option value="Manager">Manager</option>
-                <option value="Programming/Software Engineering">Programming/Software Engineering</option>
-                <option value="IT Administrator">IT Administrator</option>
-                <option value="Developer">Developer</option>
-                <option value="Student">Student</option>
-                <option value="Other">Other</option>
-              </select>
-            </li>
-            <li  class="mktFormReq mktField">
               <label for="Phone" class="mktoLabel " >Phone Number:</label>
               <input required  id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired"  type="tel" aria-label="Phone Number">
             </li>
@@ -335,14 +320,6 @@
             <li  class="mktFormReq mktField">
               <label for="Title" class="mktoLabel " >Job Title:</label>
               <input required  id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Job Title">
-            </li>
-            <li  class="mktFormReq mktField">
-              <label for="Project_Stage__c" class="mktoLabel " >Are you working on a commercial cloud deployment?</label>
-              <select required  id="Project_Stage__c" name="Project_Stage__c" class="mktoField  mktoRequired" aria-label="Are you working on a commercial cloud deployment?">
-                <option value="">Select...</option>
-                <option value="Working on a commercial cloud deployment">Yes</option>
-                <option value="Not working on a commercial cloud deployment">No</option>
-              </select>
             </li>
           </ul>
         </fieldset>


### PR DESCRIPTION
## Done

- New cloud economics campaign landing page at `/engage/cloud-economics`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/engage/cloud-economics](http://0.0.0.0:8001/engage/cloud-economics)
- Ensure the content matches the [copy doc](https://docs.google.com/document/d/1NtRmAB4Pkphc8WTU8n4-b10knVqqFhMDc_FtGAwQ7nw/edit?usp=sharing)

## Screenshots

![](https://screenshotscdn.firefoxusercontent.com/images/1575af04-f8a2-4f74-96d8-2f05d82794cf.jpg)
