### PR TITLE
Add the private-cloud economics takeover

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -38,7 +38,7 @@
 @import 'pattern_takeunders';
 @import 'pattern_table';
 @import 'pattern_tabs';
-@import 'takeovers/openstack-queens';
+@import 'takeovers/private_cloud_economics';
 
 @include ubuntu-p-buttons;
 @include ubuntu-p-site-search;
@@ -65,7 +65,7 @@
 @include ubuntu-p-takeunders;
 @include ubuntu-p-tables;
 @include ubuntu-p-tabs;
-@include p-takeover-openstack-queens;
+@include p-takeover-private-cloud-economics;
 
 // Bug fixes
 // Each of the the rules below are bug fixes which need to be addressed further upstream

--- a/static/sass/takeovers/_private_cloud_economics.scss
+++ b/static/sass/takeovers/_private_cloud_economics.scss
@@ -1,0 +1,26 @@
+@mixin p-takeover-private-cloud-economics {
+  .p-takeover--private-cloud-economics {
+    background-image: linear-gradient(-36deg, #94310F 0%, rgba(233,84,32,0.90) 100%);
+    background-color: $color-brand;
+
+    @media (min-width: $breakpoint-medium) {
+      background-image: url('https://assets.ubuntu.com/v1/13fdbc5b-graph.png'), linear-gradient(36deg, #94310F 0%, rgba(233,84,32,0.90) 100%);
+      background-repeat: no-repeat;
+      background-position: right bottom;
+    }
+  }
+
+  .p-takeover__title {
+    font-weight: 100;
+    color: $color-x-light;
+  }
+
+  .p-takeover__text {
+    font-size: 1rem;
+    color: $color-x-light;
+
+    @media (min-width: $breakpoint-medium) {
+      font-size: 1.25rem;
+    }
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,13 @@
 {% extends "base_index.html" %}
 
-{% block takeover_body_class %}homepage-enterprise-kubernetes{% endblock takeover_body_class %}
+{% block takeover_body_class %}homepage-private-cloud-economics{% endblock takeover_body_class %}
 
 {% block head_extra %}
 {% endblock %}
 
 {% block takeover_content %}
 
-{% include "takeovers/_openstack-queens.html" %}
+{% include "takeovers/_private_cloud_economics.html" %}
 
 <section class="p-strip is-deep is-bordered">
   {% include "shared/_insights_news_strip.html" with gtm_event_label="ubuntu.com homepage" %}

--- a/templates/takeovers/_private_cloud_economics.html
+++ b/templates/takeovers/_private_cloud_economics.html
@@ -1,0 +1,17 @@
+<section class="p-strip is-deep p-takeover--private-cloud-economics">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h1 class="p-takeover__title">Busting the myth of private cloud economics</h1>
+      <p class="p-takeover__text">Analyst firm 451 Research, highlights TCO savings using BootStack, Canonical&rsquo;s private managed cloud service. </p>
+      <p class="u-hide--medium u-hide--large u-align--center">
+        <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}c54da84b-451-Research-NEG.png" alt="">
+      </p>
+      <p>
+        <a href="/engage/cloud-economics" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Busting the myth of private cloud economics', 'eventLabel' : 'Read the independent report', 'eventValue' : undefined });" class="p-button--neutral">Read the independent report</a>
+      </p>
+    </div>
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}c54da84b-451-Research-NEG.png" alt="">
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done
Add the private-cloud economics takeover template and styles.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check the copy matches the [copy doc](https://docs.google.com/document/d/1trccDAaYcapXudN-pvNKcUciRceIZhFA14uNSG3u8dg/edit?ts=5b0f2252)
- Check that the takeover matches [the design](https://github.com/ubuntudesign/www.ubuntu.com-design/issues/148#issuecomment-395081274)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3254
