### PR TITLE
Add overlay and animation to products nav

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -34,16 +34,21 @@ navDropdowns.forEach(function(dropdown) {
 var globalNav = document.querySelector('.global-nav');
 var globalNavDropdown = document.querySelector('.global-nav__link--dropdown');
 var globalNavContent = document.querySelector('.global-nav__dropdown-content');
+var globalNavOverlay = document.querySelector('.global-nav__dropdown-overlay');
 
-globalNavDropdown.addEventListener('click', function(event) {
+globalNavDropdown.addEventListener('click', toggleGlobalNavContent);
+globalNavOverlay.addEventListener('click', toggleGlobalNavContent);
+
+function toggleGlobalNavContent(event) {
   event.stopPropagation();
   globalNavDropdown.classList.toggle('is-selected');
-  globalNavContent.classList.toggle('u-hide');
+  globalNavContent.classList.toggle('show-global-nav-content');
+  globalNavOverlay.classList.toggle('is-visible');
 
   if (window.innerWidth < navigationThresholdBreakpoint) {
     window.scrollTo(0, globalNav.offsetTop);
   }
-});
+}
 
 document.addEventListener('click', function(event) {
   if (globalNavDropdown.classList.contains('is-selected')) {

--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -45,6 +45,7 @@ $color-rule--light: transparentize($color-mid-light, .5);
       padding-left: $grid-margin-width;
       padding-right: $grid-margin-width;
       z-index: 5;
+      background-color: $global-nav-bg-color;
 
       @media (max-width: $breakpoint-navigation-threshold - 1) {
         display: block;
@@ -212,6 +213,35 @@ $color-rule--light: transparentize($color-mid-light, .5);
     .is-bordered:before {
       background-color: $color-mid-dark;
       margin-bottom: $sp-x-large;
+    }
+  }
+
+  .global-nav__dropdown-content {
+    transform: translateY(-100%);
+    transition: transform .75s ease-in-out;
+  }
+
+  .show-global-nav-content {
+    transform: translateY(0);
+  }
+
+  @media (min-width: $breakpoint-navigation-threshold) {
+    .global-nav__dropdown-overlay {
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      background-color: rgba(17,17,17, .4);
+      position: fixed;
+      z-index: 1;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .75s ease-in-out;
+
+      &.is-visible {
+        opacity: 1;
+        pointer-events: all;
+      }
     }
   }
 }

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -20,8 +20,9 @@
       </li>
     </ul>
   </div>
-  <div class="global-nav__dropdown-content u-hide">
-    <div class="p-strip--dark is-shallow u-no-padding--bottom">
+  <div class="global-nav__dropdown-overlay"></div>
+  <div class="global-nav__dropdown-content">
+    <div class="p-strip--dark is-shallow">
       <div class="row">
         <ul class="p-matrix">
           <li class="p-matrix__item">


### PR DESCRIPTION
## Done

Add animation and transparent overlay to products navigation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Click the products tab and see that the menu slides down
- Also see if you scroll past the menu there is a transparent overlay which closes the menu when you click it


## Issue / Card

Fixes #3316 