### PR TITLE
Remove dead links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_script:
 
 script:
   - flake8 webapp
-  - sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources[?]page --no-warnings http://127.0.0.1:8000
+  - sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --no-warnings http://127.0.0.1:8000

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -32,7 +32,7 @@
           <p class="p-p--small">
             Canonical delivers the leading Kubernetes distribution and provides workshops, training, deployment and consulting services. On VMware, cloud, OpenStack and bare metal.
           </p>
-          <a href="kubernetes" class="p-button--small p-button--positive u-align--bottom u-align-text--left">
+          <a href="/kubernetes" class="p-button--small p-button--positive u-align--bottom u-align-text--left">
             Get Kubernetes
           </a>
         </div>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -133,10 +133,10 @@
       </div>
       <!-- machine learning -->
       <div class="col-3">
-        <h4 class="p-muted-heading"><a href="/ai">AI / Machine Learning</a></h4>
+        <h4 class="p-muted-heading"><a href="/">AI / Machine Learning</a></h4>
         <ul class="p-text-list--small">
-          <li class="p-list__item"><a href="ai/kubeflow" title="Visit TensorFlow - external site">Google TensorFlow and Kubeflow</a></li>
-          <li class="p-list__item"><a href="/ai/nvidia" title="Visit Nvidia developer - external site">Nvidia’s ML stack</a></li>
+          <li class="p-list__item"><a href="/" title="Visit TensorFlow - external site">Google TensorFlow and Kubeflow</a></li>
+          <li class="p-list__item"><a href="/" title="Visit Nvidia developer - external site">Nvidia’s ML stack</a></li>
           <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML toolchain on Ubuntu</a></li>
           <li class="p-list__item"><a href="https://developer.nvidia.com/nvidia-nsight-tegra" title="Visit Nvidia Tegra page - external site">Edge devices like Tegra running AI models</a></li>
         </ul>


### PR DESCRIPTION
## Done

Remove dead links that are making the build fail.

The `/ai` pages don't exist yet so have set them all to link to the homepage for now.

## QA

- See that the build passes
