### PR TITLE
Removed docker section from /containers

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -30,33 +30,34 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img src="{{ ASSET_SERVER_URL }}425efe3a-lxd.svg?w=80" alt="LXD logo" width="80" class="p-heading-icon__img" />
-          <h2 class="p-heading-icon__title">LXD, the pure-container hypervisor</h2>
+          <h2 class="p-heading-icon__title">LXD, the right container for legacy applications</h2>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="row p-divider">
-      <div class="col-4 p-divider__block">
-        <h3 class="p-heading--four">Lift-and-shift existing VM workloads</h3>
-        <p>Move your existing Linux VMs straight to containers, easily, without modifying the apps or your operations. LXD&rsquo;s machine containers operate just like virtual machines.</p>
-      </div>
-      <div class="col-4 p-divider__block">
-        <h3 class="p-heading--four">25% faster than legacy VMs</h3>
-        <p>Use VM-style commands to run your applications in an unmodified Linux operating system, at incredible speed, with zero latency.</p>
-      </div>
-      <div class="col-4 p-divider__block">
-        <h3 class="p-heading--four">10x the density of ESX</h3>
-        <p>LXD&rsquo;s pure-container approach to Linux virtualisation offers dramatic density advantages over VMware ESX and Linux KVM for private and public cloud infrastructure.</p>
-      </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">Lift-and-shift existing VM workloads</h3>
+      <p>Move your existing Linux VMs straight to containers, easily, without modifying the apps or your operations. LXD&rsquo;s machine containers operate just like virtual machines.</p>
     </div>
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">25% faster than legacy VMs</h3>
+      <p>Use VM-style commands to run your applications in an unmodified Linux operating system, at incredible speed, with zero latency.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">10x the density of ESX</h3>
+      <p>LXD&rsquo;s pure-container approach to Linux virtualisation offers dramatic density advantages over VMware ESX and Linux KVM for private and public cloud infrastructure.</p>
+    </div>
+  </div>
 
-    <div class="row">
-      <div class="col-8 u-vertically-spaced">
-        <p><a class="p-link--external" href="https://linuxcontainers.org/">Learn more about LXD</a></p>
-      </div>
+  <div class="row">
+    <div class="col-8">
+      <p><a class="p-link--external" href="https://linuxcontainers.org/">Learn more about LXD</a></p>
     </div>
   </div>
 </div>
+
 
 <div class="p-strip is-bordered is-deep">
   <div class="row">
@@ -86,7 +87,7 @@
   </div>
 
   <div class="row">
-    <div class="col-8 u-vertically-spaced">
+    <div class="col-8">
       <p><a href="/containers/kubernetes">Learn more about the Canonical Distribution of Kubernetes&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -112,8 +113,10 @@
           <li class="p-list__item is-ticked">IP assurance for your Ubuntu environment</li>
           <li class="p-list__item is-ticked">Kernel livepatching to ensure you have the latest kernel security&nbsp;updates</li>
         </ul>
-        <p><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
-        <p>Or <a href="/containers/contact-us?product=containers-overview">contact us&nbsp;&rsaquo;</a></p>
+        <ul class="p-inline-list">
+          <li class="p-inline-list__item"><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></li>
+          <li class="p-inline-list__item">or <a href="/containers/contact-us?product=containers-overview">contact us&nbsp;&rsaquo;</a></li>
+          </ul>
       </div>
       <div class="col-5 u-align--right u-vertically-center u-hide--small">
         <img src="{{ ASSET_SERVER_URL }}11da76f5-image-management.svg" style="width: 80%;" width="288" height="155" />

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -92,34 +92,6 @@
   </div>
 </div>
 
-<div class="p-strip--light is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          <img src="{{ ASSET_SERVER_URL }}1eb617a5-docker_logo.svg" alt="Docker logo" class="p-heading-icon__img" />
-          <h2 class="p-heading-icon__title">Docker Engine on Ubuntu</h2>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Enterprise ready Docker</h3>
-      <p>We work closely with Docker Inc. to deliver an integrated Commercially Supported Docker Engine offering on Ubuntu.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Reliable updates</h3>
-      <p>The Docker Engine images are published as snap package which update automatically and transactionally.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Single vendor solution</h3>
-      <p>Canonical provides Level 1 and Level 2 technical support for the CS Docker Engine and are backed by Docker Inc. for Level 3 support.</p>
-    </div>
-  </div>
-</div>
-
 <div class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">

--- a/templates/containers/shared/_whitepaper.html
+++ b/templates/containers/shared/_whitepaper.html
@@ -5,7 +5,7 @@
         <img src="{{ ASSET_SERVER_URL }}3aa7e9a6-picto-articles-white.svg" width="175" alt="" />
       </div>
       <div class="col-8">
-        <h2>The no-nonsense way to accelerate your business with containers</h2>
+        <h2>For CTOs: The no-nonsense way to accelerate your business with containers</h2>
         <p>This white paper explains why containers are so popular and how to leverage them in your organisation. Learn the benefits of process containers and machine containers. Deep-dive into the two main software tools, Docker and LXD, that are used to manipulate containers.</p>
         <p><a class="p-button--neutral" href="https://pages.ubuntu.com/container-whitepaper.html" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Container whitepaper: {{ level_1 }} {{ level_2 }}', 'eventLabel' : 'Download the white paper', 'eventValue' : undefined });"><span class="p-link--external">Download the white paper</span></a></p>
       </div>


### PR DESCRIPTION
## Done

- removed the docker section from the containers page
- updated the [copy doc](https://docs.google.com/document/d/1OtyfNeA--EJgpgvDzqcbJ8jqa6d9H5H9xyxHNxcKXvc/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the [containers](http://0.0.0.0:8001/containers) page and see that the docker section has been removed

