### PR TITLE
Add common query params to context

### DIFF
--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -62,13 +62,13 @@
               <input required  id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired"  type="tel" aria-label="Phone Number">
             </li>
             <li  class="mktField">
-              <input name="utm_campaign" class="mktoField  mktoFormCol"  value="" type="hidden">
+              <input name="utm_campaign" class="mktoField  mktoFormCol"  value="{{utm_campaign}}" type="hidden">
             </li>
             <li  class="mktField">
-              <input name="utm_medium" class="mktoField  mktoFormCol"  value="" type="hidden">
+              <input name="utm_medium" class="mktoField  mktoFormCol"  value="{{utm_medium}}" type="hidden">
             </li>
             <li  class="mktField">
-              <input name="utm_source" class="mktoField  mktoFormCol"  value="" type="hidden">
+              <input name="utm_source" class="mktoField  mktoFormCol"  value="{{utm_source}}" type="hidden">
             </li>
             <li  class="mktField">
               <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" aria-label="I agree to receive information about Canonical’s products and services."></label>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -25,8 +25,11 @@ class UbuntuTemplateFinder(TemplateFinder):
         # Get any existing context
         context = super(UbuntuTemplateFinder, self).get_context_data(**kwargs)
 
-        # Add product query param to context
+        # Add common URL query params to context
         context['product'] = self.request.GET.get('product')
+        context['utm_source'] = self.request.GET.get('utm_source')
+        context['utm_campaign'] = self.request.GET.get('utm_campaign')
+        context['utm_medium'] = self.request.GET.get('utm_medium')
 
         # Add level_* context variables
         clean_path = self.request.path.strip('/')


### PR DESCRIPTION
## Done

- Add common UTM query params to render context
- Use them in cloud eco form

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Click on takeover CTA
- On the cloud economics landing page, ensure the hidden fields in the form contain the right query params values (`utm_source`, `utm_campaign`)