### PR TITLE
Remove hardcoded beta search results

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -54,8 +54,8 @@
       {% if results.items %}<ul class="p-list">{% endif %}
         {% for item in results.items %}
         <li class="p-list__item">
-          <span class="p-heading--four"><a href="{{ item.url|add_beta }}" class="title-main">{{ item.title | safe}}</a></span><br />
-          <small><a href="{{ item.url|add_beta }}">{{ item.url|add_beta }}</a></small><br />
+          <span class="p-heading--four"><a href="{{ item.url }}" class="title-main">{{ item.title | safe}}</a></span><br />
+          <small><a href="{{ item.url }}">{{ item.url }}</a></small><br />
           {{ item.summary | safe }}</p>
         </li>
         {% endfor %}

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -25,8 +25,3 @@ def format_date(date):
 @register.filter
 def replace_admin(url):
     return url.replace("admin.insights.ubuntu.com", "blog.ubuntu.com")
-
-
-@register.filter
-def add_beta(url):
-    return url.replace("www.ubuntu.com", "beta.ubuntu.com")


### PR DESCRIPTION
## Done

Remove hardcoded beta search links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Search for ubuntu
- See that any results for www.ubuntu.com link to ubuntu.com and not beta.ubuntu.com


## Issue / Card
Fixes #3333 