### PR TITLE
Move global nav overlay to stop it overlapping global nav bar

### DIFF
--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -132,7 +132,6 @@ $color-rule--light: transparentize($color-mid-light, .5);
     }
 
     &__dropdown-content {
-      box-shadow: 0 1px 32px 1px transparentize($color-dark, .8);
       margin-top: 0;
       position: absolute;
       top: 2rem;

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -1,3 +1,4 @@
+<div class="global-nav__dropdown-overlay"></div>
 <div class="global-nav">
   <div class="global-nav__row row">
     <div class="global-nav__logo"><a class="global-nav__logo-anchor" href="https://www.canonical.com"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Comp" xml:space="preserve" height="10px" viewBox="0 0 480 65" width="74px" version="1.1" y="0px" x="0px">
@@ -20,7 +21,6 @@
       </li>
     </ul>
   </div>
-  <div class="global-nav__dropdown-overlay"></div>
   <div class="global-nav__dropdown-content">
     <div class="p-strip--dark is-shallow">
       <div class="row">


### PR DESCRIPTION
## Done

Fix navigation overlay overlapping the navigation bar

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Open the products nav and see that there are not darker parts to the left and right of the global nav


## Issue / Card

Fixes #3370 

## Screenshots

![Screen Shot 2018-06-15 at 10.40.47.png](https://images.zenhubusercontent.com/5a9531ab4b5806bc2bc88d30/d4e15174-9b3d-440a-91ab-1d07180247ec)
