### PR TITLE
Remove Suse OS

### DIFF
--- a/templates/containers/lxd.html
+++ b/templates/containers/lxd.html
@@ -78,9 +78,6 @@
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}a27eaf1d-gentoolinux-logo.svg" alt="Gentoo-linux logo" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}583f0880-opensuse.png" alt="Opensuse logo" />
-      </li>
-      <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}08646a72-logo-oracle.svg" alt="Oracle-linux logo" />
       </li>
       <li class="p-inline-images__item">

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -35,7 +35,7 @@
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Metal as a Service (MAAS) offers cloud style provisioning for physical servers</li>
           <li class="p-list__item is-ticked">Designed for building data centres with complex networks</li>
-          <li class="p-list__item is-ticked">Supports Windows, Ubuntu, CentOS, RHEL and SUSE</li>
+          <li class="p-list__item is-ticked">Supports Windows, Ubuntu, CentOS and RHEL</li>
         </ul>
         <p><a href="https://maas.io" class="p-link--external">Get MAAS</a></p>
       </div>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -92,7 +92,7 @@ Thanks for downloading Ubuntu Server
         <li class="p-list__item is-ticked">
           Designed for building data centres with complex networks
         </li>
-        <li class="p-list__item is-ticked">Supports Windows, Ubuntu, CentOS, RHEL and SUSE</li>
+        <li class="p-list__item is-ticked">Supports Windows, Ubuntu, CentOS and RHEL</li>
       </ul>
       <p>
         <a href="https://maas.io/" class="p-button--neutral">

--- a/templates/legal/trademarks/index.html
+++ b/templates/legal/trademarks/index.html
@@ -27,7 +27,6 @@
       <p>KUBERNETES ® is a registered trademark of the Linux Foundation in the United States and other countries, and is used pursuant to a license from the Linux Foundation</p>
       <p>LINUX FOUNDATION and YOCTO PROJECT are registered trademarks of the Linux Foundation. Linux® is the registered trademark of Linus Torvalds in the U.S. and other countries.</p>
       <p>OPENWRT trademark is a registered United States trademark of Software in the Public Interest, Inc., managed by the OpenWrt project.</p>
-      <p>OPENSUSE is a trademark of SUSE LLC.</p>
       <p>MANJARO LINUX, copyright © 2011-2017 Philip Müller and the Manjaro Developers</p>
       <p>SOLUS is a trademark of Solus Software and Systems.</p>
       <p>C/C++, copyright © 1997-2017 Cprogramming.com</p>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -309,13 +309,6 @@
             <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
           </tr>
           <tr>
-            <td scope="row">OpenSUSE</td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-            <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
-          </tr>
-          <tr>
             <td scope="row">Debian</td>
             <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
             <td class="u-align--center"><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
@@ -358,9 +351,6 @@
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eda6b94a-redhat-logo.svg" width="140" alt="Redhat logo">
-        </li>
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}6697a21a-suse-logo.png" width="100" alt="Suse logo">
         </li>
       </ul>
     </div>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -66,7 +66,7 @@
     </tr>
 
     <tr>
-      <td>Windows, RHEL, SUSE, and custom image<br /> creation and deployment</td>
+      <td>Windows, RHEL, and custom image<br /> creation and deployment</td>
       <td>&nbsp;</td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>


### PR DESCRIPTION
## Done

Removed any mention of Suse OS on the website

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Search for Suse on the github repo, and find anywhere that mentions Suse. 
- Check the PR removes everywhere that mentions Suse.

## Issue / Card

Fixes #3394 
