### PR TITLE
Update NUC image listing as per Intel request

### DIFF
--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -47,10 +47,11 @@
           </h3>
           <div class="p-list-step__content">
             <p>Download the correct Ubuntu image for your device:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso">Dawson Canyon NUC - Ubuntu Desktop 16.04 LTS image</a>
-              <br>Certified for these models: NUC7i7DNHE, NUC7i5DNHE, NUC7i3DNHE,  NUC7PJYH,  NUC7CJYH​.</li>
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/nuc/ubuntu-server-16.04.1-20160817-0.iso">Previous NUC generations - Ubuntu Server 16.04 LTS image</a></li>
+            <ul class="u-no-margin--left u-no-margin--top">
+              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
+              <br>Certified for these models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE and NUC7i3DNBE</li>
+              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
+                <br>Certified for these models: NUC7PJYH and NUC7CJYH</li>
             </ul>
           </div>
         </li>


### PR DESCRIPTION
## Done

Update NUC image download listing as per partner request.
- We have one ISO image certified for two NUC series. These series are now clearly identified with a link for each.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/iot/intel-nuc-desktop](http://0.0.0.0:8001/download/iot/intel-nuc-desktop) (or http://www.ubuntu.com-pr-3399.run.demo.haus/download/iot/intel-nuc-desktop)
- Ensure changes look good.