### PR TITLE
Corrects grammar error

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -12,7 +12,7 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Ubuntu Advantage commercial support</h1>
-      <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Ubuntu Advantage typically include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu {{lts_release_full}} systems.</p>
+      <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Most packages include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu {{lts_release_full}} systems.</p>
       <p><a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">


### PR DESCRIPTION
Changes “Ubuntu Advantage typically include” to “Most packages include”. (That they’re Ubuntu Advantage packages is spelled out in the previous sentence.)