### PR TITLE
Updated the secondary and footer navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1,5 +1,5 @@
 openstack:
-  title: Openstack
+  title: OpenStack
   path: /openstack
 
   children:
@@ -69,15 +69,6 @@ containers:
   children:
     - title: Overview
       path: /containers
-    - title: Kubernetes
-      path: /kubernetes
-    - title: Managed Kubernetes
-      path: /kubernetes/managed
-    - title: Install Kubernetes
-      path: /kubernetes/install
-    - title: Kubernetes partners
-      path: /kubernetes/partners
-
     - title: Contact us
       path: /containers/contact-us
       hidden: True
@@ -85,6 +76,53 @@ containers:
       children:
         - title: Thank you
           path: /containers/thank-you
+          hidden: True
+
+kubernetes:
+  title: Kubernetes
+  path: /kubernetes
+
+  children:
+    - title: Overview
+      path: /kubernetes
+    - title: Features
+      path: /kubernetes/features
+    - title: Managed
+      path: /kubernetes/managed
+    - title: Install
+      path: /kubernetes/install
+    - title: Partners
+      path: /kubernetes/partners
+
+    - title: Contact us
+      path: /kubernetes/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /kubernetes/thank-you
+          hidden: True
+
+
+ai:
+  title: AI
+  path: /ai
+
+  children:
+    - title: Overview
+      path: /ai
+    - title: Features
+      path: /ai/features
+    - title: Install
+      path: /ai/install
+
+    - title: Contact us
+      path: /ai/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /ai/thank-you
           hidden: True
 
 desktop:

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -5,8 +5,10 @@
 
   <ul class="second-level-nav">
     {% for child in section.children %}
+      {% if child.title != 'Overview' %}
       {% if not child.hidden %}
         <li><a href="{{ child.path }}">{{ child.title }}</a></li>
+      {% endif %}
       {% endif %}
     {% endfor %}
   </ul>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -46,7 +46,7 @@
     {% include "templates/_navigation-community-h.html" %}
     {% include "templates/_navigation-download-h.html" %}
   </div>
-  {% if breadcrumbs %}
+  {% if breadcrumbs and breadcrumbs.children and breadcrumbs.children|length > 1 or breadcrumbs.grandchildren %}
   <nav class="p-navigation--secondary">
     <div class="row">
       <a class="p-navigation--secondary__banner u-hide--nav-threshold-down" href="{{ breadcrumbs.section.path }}">
@@ -58,9 +58,11 @@
       <ul class="breadcrumbs--secondary col-12">
         {% for child in breadcrumbs.children %}
         <li class="breadcrumbs__item">
+          {% if child.title != 'Overview' %}
           <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">
             {{ child.title }}
           </a>
+          {% endif %}
           {% if breadcrumbs.grandchildren %}
           <ul class="breadcrumbs__tertiary">
             {% for grandchild in breadcrumbs.grandchildren %}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -6,17 +6,20 @@
     <nav id="main-navigation" class="p-footer__nav u-clearfix">
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          {% include 'templates/_footer_item.html' with section=nav_sections.openstack %} {% include 'templates/_footer_item.html' with section=nav_sections.juju %} {% include 'templates/_footer_item.html' with section=nav_sections.publiccloud %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.openstack %} {% include 'templates/_footer_item.html' with section=nav_sections.publiccloud %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          {% include 'templates/_footer_item.html' with section=nav_sections.server %} {% include 'templates/_footer_item.html' with section=nav_sections.containers %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.kubernetes %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.containers %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.ai %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
           {% include 'templates/_footer_item.html' with section=nav_sections.desktop %}
+          {% include 'templates/_footer_item.html' with section=nav_sections.server %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">


### PR DESCRIPTION
## Done

- Removed redundant Overview from all navigation
- Don't show a secondary nav for childless sections

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- look at the /openstack, /download/server, /public-cloud sections to see if the navigation and footer look correct


## Issue / Card

Fixes #3393
