### PR TITLE
Remove global-nav symlink

### DIFF
--- a/static/global-nav
+++ b/static/global-nav
@@ -1,1 +1,0 @@
-../node_modules/global-nav/


### PR DESCRIPTION
Remove the symlink which was pointing to the previously used global-nav.
It is causing errors serving broken static files. For future use, we should
avoid symlinks and use build jobs to manage dependencies.

@steverydz 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- The nav bar shouldn't be affected

