### PR TITLE
Use the K8s logo on the overview hero

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -16,8 +16,8 @@
         </a>
       </p>
     </div>
-    <div class="col-4 u-align--center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}96d35aa4-certified-kubernetes-logo.svg?w=300" alt="Kubernetes Certified Service Provider" />
+    <div class="col-4 prefix-1 u-align--center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}dba11aee-kubernetes.svg?w=275" alt="" width="275" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Update the logo hero image on /kubernetes page to the K8s logo.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Check that the hero image is the kubernetes logo

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3460
