### PR TITLE
Update the k8s managed contact us link

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -406,7 +406,7 @@
     <div class="row">
       <div class="col-8">
         <p>Talk to Canonical&rsquo;s remote operations team about building and operating your Kubernetes cluster today.</p>
-        <p><a href="/containers/contact-us?product=containers-managed-kubernetes" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Schedule a Kubernetes demo', 'eventLabel' : 'Schedule a Kubernetes demo - Bottom CTA' : undefined });">Schedule a Kubernetes demo</a></p>
+        <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Schedule a Kubernetes demo', 'eventLabel' : 'Schedule a Kubernetes demo - Bottom CTA' : undefined });">Schedule a Kubernetes demo</a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done
Update the k8s managed contact us link

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/managed](http://0.0.0.0:8001/kubernetes/managed)
- Check that the 'Schedule a Kubernetes demo' button links to `/kubernetes/contact-us?product=kubernetes-managed` 

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3445
