### PR TITLE
Update the resource link on k8s overview

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -195,7 +195,7 @@
           <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Whitepaper</h4>
         </div>
       </div>
-      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://insights.ubuntu.com/2017/02/27/the-no-nonsense-way-to-accelerate-your-business-with-containers/?_ga=2.164082367.1298694829.1510572191-765379582.1510062947" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
+      <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Update the resource link on k8s overview

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Check that link "The no-nonsense way to accelerate your business with containers" goes to `https://pages.ubuntu.com/container-whitepaper.html`

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3389
