### PR TITLE
Updated support page mentions of systems supported for Livepatch

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -105,13 +105,13 @@
 <div class="p-strip--light">
   <div class="row">
     <div class="u-height-equal">
-      <div class="col-7">
+      <div class="col-8">
         <h2>Got a question?</h2>
         <p>Exchange expertise and ideas with thousands of other IT professionals. Want to talk to other Ubuntu users straight away? Share ideas and get advice and help from our large, active community of IT professionals. As a community, we set high standards for friendliness and tolerance. We welcome your questions and contributions.</p>
         <p><a href="https://community.ubuntu.com/t/community-support/709" class="p-link--external">Finding community support</a></p>
       </div>
-      <div class="col-5 u-hide--small u-vertically-center u-align--center">
-        <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="175" alt="">
+      <div class="col-4 u-hide--small u-vertically-center u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="150" alt="">
       </div>
     </div>
   </div>

--- a/templates/shared/_case-study-itstrategen.html
+++ b/templates/shared/_case-study-itstrategen.html
@@ -1,12 +1,12 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row u-equal-height">
-    <div class="col-6">
+    <div class="col-8">
       <h2>Learn how ITstrategen keeps their applications secure with Ubuntu</h2>
       <p>The security of customer data is of the utmost importance to ITstrategen, which is why Ubuntu is their server operating system of choice.</p>
       <a class="p-button--neutral" href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html"><span class="p-link--external">Read the case study</span></a>
     </div>
-    <div class="col-6 prefix-2 suffix-1 u-vertically-center">
-      <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}16e21217-pictogram-safety-orange.svg" alt="" />
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}16e21217-pictogram-safety-orange.svg" width="150" alt="" />
     </div>
   </div>
 </section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -11,7 +11,7 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Ubuntu Advantage commercial support</h1>
-      <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Most packages include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu {{lts_release_full}} systems.</p>
+      <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Most packages include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu systems.</p>
       <p><a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -142,7 +142,7 @@
     </div>
     <div class="col-6">
       <h2>The Canonical Livepatch Service</h2>
-      <p>Available with an Ubuntu Advantage subscription, the Canonical Livepatch Service enables you to apply critical kernel security fixes to your Ubuntu 16.04 LTS system without rebooting, and it reduces downtime while maintaining compliance and security.</p>
+      <p>Available with an Ubuntu Advantage subscription, the Canonical Livepatch Service enables you to apply critical kernel security fixes to your Ubuntu systems without rebooting, and it reduces downtime while maintaining compliance and security.  Livepatch is available on LTS based systems, starting with Ubuntu 14.04 LTS, within its normal support cycle.</p>
       <p><a href="/server/livepatch">Learn more about the Canonical Livepatch Service&nbsp;&rsaquo;</a></p>
   </div>
 </section>
@@ -157,7 +157,7 @@
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1a062141-logo-bloomberg.svg" width="187" alt="Bloomburg logo">
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c7e83fc-atandt-logo.svg" width="61" alt="at&amp;t  logo">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c7e83fc-atandt-logo.svg" width="80" alt="at&amp;t  logo">
       </li>
       <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3161e6ba-logo-walmart.svg" width="210" alt="Walmart logo">


### PR DESCRIPTION
## Done

- Updated the livepatch systems definitions on the /support page
- Updated the [copy doc](https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit?ts=5b34e2bd#)
- Fixed the relative columns and picto sizes for both livepatch and support pages, as they looked off

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/support](http://0.0.0.0:8001/support)
- compare the header and livepatch text to the copy doc
- look at [livepatch](http://0.0.0.0:8001/server/livepatch) and see that the 'Learn how ITstrategen keeps their applications secure with Ubuntu' and 'Got a question?' - look at [livepatch](http://0.0.0.0:8001/server/livepatch) and see that the 'Learn how ITstrategen keeps their applications secure with Ubuntu' and 'Community support' sections look balanced

## Issue / Card

Fixes #3447