### PR TITLE
Removed dup 'install' from openstack menu

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -9,8 +9,6 @@ openstack:
       path: /openstack/features
     - title: Managed
       path: /openstack/managed
-    - title: Install
-      path: /openstack/install
     - title: Consulting
       path: /openstack/consulting
     - title: Training
@@ -433,7 +431,7 @@ security:
 
   children:
     - title: Overview
-      path: /security      
+      path: /security
 
 licensing:
   title: Licensing


### PR DESCRIPTION
## Done

- removed duplicate 'install' from the openstack menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [openstack](http://0.0.0.0:8001/openstack)
- see there is only 1 install

## Issue / Card

Fixes #3484
