### PR TITLE
AI index K8's add-ons include

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -132,35 +132,7 @@
     <p><a href="/kubernetes">Learn more about our Kubernetes packages&nbsp;&rsaquo;</a></p>
     <h3 style="max-width: 100%;">AI add-on for Kubernetes Discoverer and Discoverer Plus</h3>
   </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <h3 class="p-card__title">Workshop</h3>
-      <hr>
-      <p>One day on Kubeflow, including  Tensorflow and JupyterHub, covering everything your business needs to know to have a full on-prem off-prem AI/ML game plan.</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">On site or remote options</li>
-        <li class="p-list__item is-ticked">Hands-on K8s and Kubeflow</li>
-        <li class="p-list__item is-ticked">Full pipeline view</li>
-        <li class="p-list__item is-ticked">ML / Data science assessment</li>
-      </ul>
-      <p><a class="p-button--positive" href="/ai/contact-us?product=ai-index-workshop">Contact us</a></p>
-      <p><span class="p-heading--four">$40,000</span> one off fee</p>
-    </div>
-    <div class="col-6 p-card">
-      <h3 class="p-card__title">ML / Data science assessment</h3>
-      <hr>
-      <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Understand AI Lifecycle</li>
-        <li class="p-list__item is-ticked">Preliminary AI Discovery</li>
-        <li class="p-list__item is-ticked">Development Assessment</li>
-        <li class="p-list__item is-ticked">Deploy and Operate Analysis</li>
-        <li class="p-list__item is-ticked">Finalize Initial AI Strategy</li>
-      </ul>
-      <p><a class="p-button--positive" href="/ai/contact-us?product=ai-index-assessment">Contact us</a></p>
-      <p><span class="p-heading--four">$40,000</span> one off fee</p>
-    </div>
-  </div>
+  {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
 </section>
 
 <section class="p-strip--light is-bordered">


### PR DESCRIPTION
## Done

- Removed hard-coded K8's add-ons table and replaced with include, which fixes the styling.

- **You won't be able to see the include until #3478 is merged**

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/ai](http://0.0.0.0:8001/ai)
- Check that the include shows up, and the price is at the top under the header, rather than at the bottom. 


## Issue / Card

Fixes: #3482 
