### PR TITLE
3473 fix flavours menu

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -9,8 +9,6 @@ openstack:
       path: /openstack/features
     - title: Managed
       path: /openstack/managed
-    - title: Install
-      path: /openstack/install
     - title: Consulting
       path: /openstack/consulting
     - title: Training

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -9,6 +9,8 @@ openstack:
       path: /openstack/features
     - title: Managed
       path: /openstack/managed
+    - title: Install
+      path: /openstack/install
     - title: Consulting
       path: /openstack/consulting
     - title: Training
@@ -304,7 +306,7 @@ download:
     - title: Alternative downloads
       path: /download/alternative-downloads
     - title: Ubuntu flavours
-      path: /download/ubuntu-flavours
+      path: /download/flavours
 
 contact-us:
   title: Contact Canonical


### PR DESCRIPTION
## Done

- fixed url of flavours in the navigation.yaml so menu appears

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/flavours](http://0.0.0.0:8001/download/flavours)
- see that there is a secondary meny

## Issue / Card

Fixes #3473