### PR TITLE
Update  plans and pricing page with pricing and services updates

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -2,6 +2,7 @@
   <div class="col-6 p-card">
     <div class="p-card__header">
       <h2 class="p-heading--four">Workshop</h2>
+      <p><span class="p-heading--two">$40,000</span> one off fee</p>
     </div>
     <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>
     <ul class="p-list">
@@ -11,11 +12,11 @@
       <li class="p-list__item is-ticked">ML / Data science assessment</li>
     </ul>
     <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
-    <p><span class="p-heading--two">$40,000</span> one off fee</p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
       <h2 class="p-heading--four">ML / Data Science Assessment</h2>
+      <p><span class="p-heading--two">$40,000</span> one off fee</p>
     </div>
     <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
     <ul class="p-list">
@@ -26,6 +27,5 @@
       <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
     </ul>
     <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
-    <p><span class="p-heading--two">$40,000</span> one off fee</p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -11,7 +11,7 @@
       <li class="p-list__item is-ticked">Full pipeline view</li>
       <li class="p-list__item is-ticked">ML / Data science assessment</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
+    <p><a href="/containers/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
@@ -26,6 +26,6 @@
       <li class="p-list__item is-ticked">Deploy and operate analysis</li>
       <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
+    <p><a href="/containers/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -10,6 +10,8 @@
       <li class="p-list__item is-ticked">Full pipeline view</li>
       <li class="p-list__item is-ticked">ML / Data science assessment</li>
     </ul>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
+    <p><span class="p-heading--two">$40,000</span> one off fee</p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
@@ -23,19 +25,7 @@
       <li class="p-list__item is-ticked">Deploy and operate analysis</li>
       <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
     </ul>
-  </div>
-  <div class="col-6 p-card">
-    <div class="p-card__header">
-      <h2 class="p-heading--four">Full Remote Management</h2>
-    </div>
-    <p>Focus on your data pipelines and let Canonical handle all the operations from bare metal up to Kubeflow.</p>
-    <ul class="p-list">
-      <li class="p-list__item is-ticked">Fixed monnthly cost</li>
-      <li class="p-list__item is-ticked">On-prem / On-Cloud</li>
-      <li class="p-list__item is-ticked">Regulatory complaince</li>
-      <li class="p-list__item is-ticked">Hardware acceleration</li>
-      <li class="p-list__item is-ticked">Monitoring, management</li>
-      <li class="p-list__item is-ticked">Build, Operate, Transfer</li>
-    </ul>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
+    <p><span class="p-heading--two">$40,000</span> one off fee</p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -1,0 +1,41 @@
+<div class="row u-equal-height">
+  <div class="col-6 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">Workshop</h2>
+    </div>
+    <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">On site or remote options</li>
+      <li class="p-list__item is-ticked">Hands-on K8s and Kubeflow</li>
+      <li class="p-list__item is-ticked">Full pipeline view</li>
+      <li class="p-list__item is-ticked">ML / Data science assessment</li>
+    </ul>
+  </div>
+  <div class="col-6 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">ML / Data Science Assessment</h2>
+    </div>
+    <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">Understand AI lifecycle</li>
+      <li class="p-list__item is-ticked">Preliminary AI discovery</li>
+      <li class="p-list__item is-ticked">Development assessment</li>
+      <li class="p-list__item is-ticked">Deploy and operate analysis</li>
+      <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
+    </ul>
+  </div>
+  <div class="col-6 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">Full Remote Management</h2>
+    </div>
+    <p>Focus on your data pipelines and let Canonical handle all the operations from bare metal up to Kubeflow.</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">Fixed monnthly cost</li>
+      <li class="p-list__item is-ticked">On-prem / On-Cloud</li>
+      <li class="p-list__item is-ticked">Regulatory complaince</li>
+      <li class="p-list__item is-ticked">Hardware acceleration</li>
+      <li class="p-list__item is-ticked">Monitoring, management</li>
+      <li class="p-list__item is-ticked">Build, Operate, Transfer</li>
+    </ul>
+  </div>
+</div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -19,7 +19,7 @@
       <li class="p-list__item is-ticked">Lifecycle management</li>
       <li class="p-list__item is-ticked">Backup and recovery</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-explorer">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
+    <p><a href="/containers/contact-us?product=kubernetes-explorer">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
@@ -34,7 +34,7 @@
       <li class="p-list__item is-ticked">Calico, Canal, Flannel networking</li>
       <li class="p-list__item is-ticked">3 days on-site in-person Canonical Kubernetes training</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
+    <p><a href="/containers/contact-us?product=kubernetes-discoverer">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
@@ -54,6 +54,6 @@
       <li class="p-list__item is-ticked">Application Catalog</li>
       <li class="p-list__item is-ticked">2 days on-site in-person Knowledge Transfer to Kubernetes Operators</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer-plus">Contact us about Kubernetes Discoverer Plus&nbsp;&rsaquo;</a></p>
+    <p><a href="/containers/contact-us?product=kubernetes-discoverer-plus">Contact us about Kubernetes Discoverer Plus&nbsp;&rsaquo;</a></p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -1,89 +1,59 @@
 <div class="row">
-  <div class="col-8">
-    <p>Canonical has two Kubernetes offerings: Kubernetes Explorer and Kubernetes Discoverer. Every Kubernetes we build is future-proof with automated upgrades to newer versions on demand.</p>
-  </div>
+  <p>Canonical offers three service packages to help you launch your Kubernetes strategy.</p>
 </div>
+
 <div class="row u-equal-height">
-  <div class="p-card col-6">
+  <div class="col-6 p-card">
     <div class="p-card__header">
-      <h3 class="p-heading--five">Kubernetes Explorer</h3>
-      <p class="p-heading--two">$15,000 <span class="p-heading--six">one off fee</span></p>
+      <h2 class="p-heading--four">Kubernetes Explorer</h2>
+      <p><span class="p-heading--two">$19,500</span> one off fee</p>
     </div>
-    <p>Get up and running quickly with minimal setup, predefined architecture and web-based training.</p>
+    <p>Our three-day training on Canonical Kubernetes and tooling, helping you ramp up your Kubernetes skills and get you ready to deploy in your own environment.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
-      <li class="p-list__item is-ticked">High availability Kubernetes, deployed on public cloud</li>
+      <li class="p-list__item is-ticked">Kubernetes and Container basics</li>
       <li class="p-list__item is-ticked">Reference architecture</li>
-      <li class="p-list__item is-ticked">NodePort and Flannel networking</li>
-      <li class="p-list__item is-ticked">8 hours hands-on, web-based training</li>
-      <li class="p-list__item is-ticked">30 days of phone support included</li>
+      <li class="p-list__item is-ticked">Deployment on multiple substrates</li>
+      <li class="p-list__item is-ticked">Security and patching</li>
+      <li class="p-list__item is-ticked">Monitoring and logging</li>
+      <li class="p-list__item is-ticked">Lifecycle management</li>
+      <li class="p-list__item is-ticked">Backup and recovery</li>
     </ul>
-    <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us about Kubernetes Explorer', 'eventLabel' : 'Contact us about Kubernetes Explorer - consulting packages CTA' : undefined });">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-explorer">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
   </div>
-  <div class="p-card col-6">
+  <div class="col-6 p-card">
     <div class="p-card__header">
-      <h3 class="p-heading--five">Kubernetes Discoverer</h3>
-      <p class="p-heading--two">$35,000 <span class="p-heading--six">one off fee</span></p>
+      <h2 class="p-heading--four">Kubernetes Discoverer</h2>
+      <p><span class="p-heading--two">$45,000</span> one off fee</p>
     </div>
-    <p>Get a customised architecture to fit your requirements, including bare-metal environments or custom integrations and on-site training.</p>
+    <p>Get up and running in one week with a customised architecture to fit your requirements, including deploying on virtualised environments, private and public clouds.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
-      <li class="p-list__item is-ticked">High availability Kubernetes, deployed on Public Cloud, VMware, OpenStack, or Bare metal</li>
+      <li class="p-list__item is-ticked">High availability Kubernetes, deployed on Public Cloud, VMware, OpenStack</li>
       <li class="p-list__item is-ticked">Custom Kubernetes architecture optimised for your workloads</li>
-      <li class="p-list__item is-ticked">Any CNI-compatible network (Calico, Canal, Flannel, Weave)</li>
-      <li class="p-list__item is-ticked">4 days on-site  in-person training</li>
-      <li class="p-list__item is-ticked">30 days of phone support included</li>
+      <li class="p-list__item is-ticked">Calico, Canal, Flannel networking</li>
+      <li class="p-list__item is-ticked">3 days on-site in-person Canonical Kubernetes training</li>
     </ul>
-    <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us about Kubernetes Discoverer', 'eventLabel' : 'Contact us about Kubernetes Discoverer - consulting packages CTA' : undefined });">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
   </div>
-</div>
-<div class="row">
-  <div class="col-10">
-    <h3>Optional add-ons</h3>
-    <table>
-      <tr>
-        <td>Workload analysis (Artificial Intelligence, Machine Learning, <br />Blockchain, CI/CD, Serverless, Transcoding)</td>
-        <td class="p-table__cell--highlight u-align--center">+$9,000 <sup><a href="#fn-kc-1">*</a></sup></td>
-      </tr>
-      <tr>
-        <td>CI/CD Workload</td>
-        <td class="p-table__cell--highlight u-align--center">+$13,000 <sup><a href="#fn-kc-1">*</a></sup></td>
-      </tr>
-      <tr>
-        <td>Architecture design</td>
-        <td class="p-table__cell--highlight u-align--center">+$20,000 <sup><a href="#fn-kc-1">*</a></sup></td>
-      </tr>
-      <tr>
-        <td>Custom monitoring</td>
-        <td class="p-table__cell--highlight u-align--center">+$7,000</td>
-      </tr>
-      <tr>
-        <td>Disaster recovery</td>
-        <td class="p-table__cell--highlight u-align--center">+$10,000</td>
-      </tr>
-      <tr>
-        <td>Alternate runtime</td>
-        <td class="p-table__cell--highlight u-align--center">+$5,000</td>
-      </tr>
-      <tr>
-        <td>Additional customisation</td>
-        <td class="p-table__cell--highlight u-align--center">+$1,500/day</td>
-      </tr>
-    </table>
-  </div>
-</div>
-<div class="row" id="fn-kc-1">
-  <div class="col-12">
-    <p>
-      <small><sup>*</sup> included in Kubernetes Discoverer</small>
-    </p>
-  </div>
-</div>
-<div class="row">
-  <div class="col-12">
-    <div>
-      <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - consulting packages CTA' : undefined });">Contact us</a></p>
-      <p><a href="https://assets.ubuntu.com/v1/Enterprise-Canonical-Kubernetes.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - consulting packages CTA' : undefined });">Download the datasheet</a></p>
+  <div class="col-6 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">Kubernetes Discoverer Plus</h2>
+      <p><span class="p-heading--two">$95,000</span> one off fee</p>
     </div>
+    <p>Be up and running in three weeks with a production-grade Kubernetes cluster with a modular ecosystem to fit your requirements. Deploy virtualised or bare metal.</p>
+    <p>What&rsquo;s included:</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">High availability production-grade Kubernetes, deployed on Public Cloud, VMware, OpenStack, or Bare metal</li>
+      <li class="p-list__item is-ticked">GPU acceleration</li>
+      <li class="p-list__item is-ticked">Storage for persistent volumes</li>
+      <li class="p-list__item is-ticked">Custom Networking options</li>
+      <li class="p-list__item is-ticked">Management platform</li>
+      <li class="p-list__item is-ticked">Private Registry</li>
+      <li class="p-list__item is-ticked">Load balancers</li>
+      <li class="p-list__item is-ticked">Application Catalog</li>
+      <li class="p-list__item is-ticked">2 days on-site in-person Knowledge Transfer to Kubernetes Operators</li>
+    </ul>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer-plus">Contact us about Kubernetes Discoverer Plus&nbsp;&rsaquo;</a></p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -1,103 +1,107 @@
 <div class="row">
   <div class="col-12" style="overflow-x: auto;">
-    <table style="width: 100%;">
-      <tr>
-        <td width="35%">&nbsp;</td>
-        <th width="15%" class="u-align--center">Ubuntu</th>
-        <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for Kubernetes</th>
-        <th class="p-table__cell--highlight u-align--center">BootStack</th>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
-        <td>&nbsp;</td>
-        <th class="p-table__cell--highlight u-align--center">Standard</th>
-        <th class="p-table__cell--highlight u-align--center">Advanced</th>
-        <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
-      </tr>
-      <tr>
-        <th>Price per node (physical) <sup><a href="#fn-kes-1">*</a></sup></th>
-        <td class="u-align--center">$0</td>
-        <td class="p-table__cell--highlight u-align--center">$600/year</td>
-        <td class="p-table__cell--highlight u-align--center">$1,200/year</td>
-        <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
-      </tr>
-      <tr>
-        <th>Price per node (virtual) <sup><a href="#fn-kes-1">*</a></sup></th>
-        <td class="u-align--center">$0</td>
-        <td class="p-table__cell--highlight u-align--center">$200/year</td>
-        <td class="p-table__cell--highlight u-align--center">$400/year</td>
-        <td class="p-table__cell--highlight u-align--center">$1,460/year</td>
-      </tr>
-      <tr>
-        <th>Phone and web ticket support</th>
-        <td class="u-align--center">None</td>
-        <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
-        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
-        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
-      </tr>
-      <tr>
-        <th>Industry-leading cloud operations tooling <br />(Ubuntu, MAAS, Juju, LXD)</th>
-        <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>Deploy, run, scale, upgrade K8s</th>
-        <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>Monitoring and logging</th>
-        <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>Landscape management</th>
-        <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>Livepatch</th>
-        <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>Knowledge Base</th>
-        <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>High availability support</th>
-        <td>&nbsp;</td>
-        <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>24x7 remote operations, smart alerts and proactive monitoring by Canonical’s cloud experts</th>
-        <td>&nbsp;</td>
-        <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
-      <tr>
-        <th>Disaster recovery</th>
-        <td>&nbsp;</td>
-        <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-      </tr>
+    <table class="p-table">
+      <thead>
+        <tr>
+          <th>&nbsp;</th>
+          <th class="u-align--center">Ubuntu</th>
+          <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for Kubernetes</th>
+          <th class="p-table__cell--highlight u-align--center">Managed Kubernetes</th>
+        </tr>
+        <tr>
+          <th>&nbsp;</th>
+          <th class="u-align--center">Without support</th>
+          <th class="p-table__cell--highlight u-align--center">Standard</th>
+          <th class="p-table__cell--highlight u-align--center">Advanced</th>
+          <th class="p-table__cell--highlight u-align--center">Managed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Price per node (physical) <sup><a href="#fn-ks">*</a></sup></td>
+          <td class="u-align--center">$0</td>
+          <td class="p-table__cell--highlight u-align--center">$600/year</td>
+          <td class="p-table__cell--highlight u-align--center">$1,200/year</td>
+          <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
+        </tr>
+        <tr>
+          <td>Price per node (virtual) <sup><a href="#fn-ks">*</a></sup></td>
+          <td class="u-align--center">$0</td>
+          <td class="p-table__cell--highlight u-align--center">$200/year</td>
+          <td class="p-table__cell--highlight u-align--center">$400/year</td>
+          <td class="p-table__cell--highlight u-align--center">$1,460/year</td>
+        </tr>
+        <tr>
+          <td>Phone and web ticket support</td>
+          <td class="u-align--center">None</td>
+          <td class="p-table__cell--highlight u-align--center">8am &ndash; 6pm on weekdays</td>
+          <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+          <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+        </tr>
+        <tr>
+          <td>Industry-leading cloud operations tooling (Ubuntu, MAAS, Juju, LXD)</td>
+          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>Deploy, run, scale, upgrade K8s</td>
+          <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>Monitoring and logging</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>Landscape Management</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>Livepatch</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>Knowledge Base</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>High availability support</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>24x7 remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td>Disaster recovery</td>
+          <td>&nbsp;</td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+      </tbody>
     </table>
   </div>
   <div class="row" id="fn-ks">
@@ -105,13 +109,5 @@
       <p><small><sup>*</sup> Minimums apply</small></p>
       <p><a href="/containers/contact-us?product=containers-kubernetes-support">For more information about Kubernetes support, contact us&nbsp;&rsaquo;</a></p>
     </div>
-  </div>
-</div>
-
-<div class="row" id="fn-kes-1">
-  <div class="col-12">
-    <p>
-      <small><sup>*</sup> Minimums apply</small>
-    </p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -100,6 +100,12 @@
       </tr>
     </table>
   </div>
+  <div class="row" id="fn-ks">
+    <div class="col-12">
+      <p><small><sup>*</sup> Minimums apply</small></p>
+      <p><a href="/containers/contact-us?product=containers-kubernetes-support">For more information about Kubernetes support, contact us&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
 </div>
 
 <div class="row" id="fn-kes-1">

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th style="width: 40%;">&nbsp;</th>
-      <th class="u-align--center" style="width: 20%;">Ubuntu</th>
+      <th class="u-align--center" style="width: 20%;">MAAS</th>
       <th class="p-table__cell--highlight u-align--center" colspan="2">Ubuntu Advantage for MAAS</th>
     </tr>
     <tr>
@@ -15,7 +15,7 @@
 
   <tbody>
     <tr>
-      <td>Price per machine</td>
+      <td>Per machine enlisted in a MAAS plan</td>
       <td class="u-align--center">$0</td>
       <td class="p-table__cell--highlight u-align--center">$5 per month</td>
       <td class="p-table__cell--highlight u-align--center">$10 per month</td>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -25,7 +25,7 @@
       <td>Per region per year</td>
       <td class="u-align--center">-</td>
       <td class="p-table__cell--highlight u-align--center">-</td>
-      <td class="p-table__cell--highlight u-align--center"><small>Unlimited machines $75,000</small></td>
+      <td class="p-table__cell--highlight u-align--center">Unlimited machines $75,000</td>
     </tr>
 
     <tr>

--- a/templates/shared/pricing/_openstack-consulting.html
+++ b/templates/shared/pricing/_openstack-consulting.html
@@ -1,53 +1,57 @@
-<table>
-  <thead>
-    <tr>
-      <td>&nbsp;</td>
-      <th class="p-table__cell--highlight u-align--center">Foundation Cloud</th>
-      <th class="p-table__cell--highlight u-align--center">Foundation Cloud Plus</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>One-time price</td>
-      <td class="p-table__cell--highlight u-align--center">$75,000</td>
-      <td class="p-table__cell--highlight u-align--center">$150,000</td>
-    </tr>
-    <tr>
-      <td>Expert delivery of an Ubuntu OpenStack&nbsp;cloud</td>
-      <td class="p-table__cell--highlight u-align--center">Reference architecture</td>
-      <td class="p-table__cell--highlight u-align--center">Custom architecture</td>
-    </tr>
-    <tr>
-      <td>On-site workshop and training</td>
-      <td class="p-table__cell--highlight u-align--center">2-days</td>
-      <td class="p-table__cell--highlight u-align--center">4-days</td>
-    </tr>
-    <tr>
-      <td>Hypervisor options</td>
-      <td class="p-table__cell--highlight u-align--center">KVM and LXD</td>
-      <td class="p-table__cell--highlight u-align--center">KVM, LXD, and Hyper-V</td>
-    </tr>
-    <tr>
-      <td>Software Defined Networking options</td>
-      <td class="p-table__cell--highlight u-align--center">OVS (GRE and/or VXLAN)</td>
-      <td class="p-table__cell--highlight u-align--center">OVS with Provider Networks,<br />BGP, DVR <sup><a href="#fn-oc-1">*</a></sup></td>
-    </tr>
-    <tr>
-      <td>Software Defined Storage options</td>
-      <td class="p-table__cell--highlight u-align--center">Ceph</td>
-      <td class="p-table__cell--highlight u-align--center">Ceph, Swift <sup><a href="#fn-oc-2">**</a></sup></td>
-    </tr>
-    <tr>
-      <td>Encryption</td>
-      <td class="p-table__cell--highlight">&nbsp;</td>
-      <td class="p-table__cell--highlight u-align--center">Control plane and storage</td>
-    </tr>
-  </tbody>
-</table>
+<div class="row">
+  <div class="col-12">
+    <table>
+      <thead>
+        <tr>
+          <td>&nbsp;</td>
+          <th class="p-table__cell--highlight u-align--center">Foundation Cloud</th>
+          <th class="p-table__cell--highlight u-align--center">Foundation Cloud Plus</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>One-time price</td>
+          <td class="p-table__cell--highlight u-align--center">$75,000</td>
+          <td class="p-table__cell--highlight u-align--center">$150,000</td>
+        </tr>
+        <tr>
+          <td>Expert delivery of an Ubuntu OpenStack&nbsp;cloud</td>
+          <td class="p-table__cell--highlight u-align--center">Reference architecture</td>
+          <td class="p-table__cell--highlight u-align--center">Custom architecture</td>
+        </tr>
+        <tr>
+          <td>On-site workshop and training</td>
+          <td class="p-table__cell--highlight u-align--center">2-days</td>
+          <td class="p-table__cell--highlight u-align--center">4-days</td>
+        </tr>
+        <tr>
+          <td>Hypervisor options</td>
+          <td class="p-table__cell--highlight u-align--center">KVM and LXD</td>
+          <td class="p-table__cell--highlight u-align--center">KVM, LXD, and Hyper-V</td>
+        </tr>
+        <tr>
+          <td>Software Defined Networking options</td>
+          <td class="p-table__cell--highlight u-align--center">OVS (GRE and/or VXLAN)</td>
+          <td class="p-table__cell--highlight u-align--center">OVS with Provider Networks,<br />BGP, DVR <sup><a href="#fn-oc-1">*</a></sup></td>
+        </tr>
+        <tr>
+          <td>Software Defined Storage options</td>
+          <td class="p-table__cell--highlight u-align--center">Ceph</td>
+          <td class="p-table__cell--highlight u-align--center">Ceph, Swift <sup><a href="#fn-oc-2">**</a></sup></td>
+        </tr>
+        <tr>
+          <td>Encryption</td>
+          <td class="p-table__cell--highlight">&nbsp;</td>
+          <td class="p-table__cell--highlight u-align--center">Control plane and storage</td>
+        </tr>
+      </tbody>
+    </table>
 
-<p id="fn-oc-1">
-  <small><sup>*</sup> Juniper Contrail, Cisco ACI, Nokia Nuage and more available as add-ons</small>
-</p>
-<p class="u-no-margin--top" id="fn-oc-2">
-  <small><sup>**</sup> Nexenta, Solidfire, Quobyte, ScaleIO and more available as add-ons</small>
-</p>
+    <p id="fn-oc-1">
+      <small><sup>*</sup> Juniper Contrail, Cisco ACI, Nokia Nuage and more available as add-ons</small>
+    </p>
+    <p class="u-no-margin--top" id="fn-oc-2">
+      <small><sup>**</sup> Nexenta, Solidfire, Quobyte, ScaleIO and more available as add-ons</small>
+    </p>
+  </div>
+</div>

--- a/templates/shared/pricing/_openstack-consulting.html
+++ b/templates/shared/pricing/_openstack-consulting.html
@@ -20,7 +20,7 @@
           <td class="p-table__cell--highlight u-align--center">Custom architecture</td>
         </tr>
         <tr>
-          <td>On-site workshop and training</td>
+          <td>Workshop and training</td>
           <td class="p-table__cell--highlight u-align--center">2-days</td>
           <td class="p-table__cell--highlight u-align--center">4-days</td>
         </tr>

--- a/templates/shared/pricing/_openstack-support.html
+++ b/templates/shared/pricing/_openstack-support.html
@@ -12,7 +12,7 @@
           <td>&nbsp;</td>
           <th class="u-align--center" width="15%">Without support</th>
           <th class="p-table__cell--highlight u-align--center">Advanced</th>
-          <th class="p-table__cell--highlight u-align--center">Fully Managed</th>
+          <th class="p-table__cell--highlight u-align--center">Managed</th>
         </tr>
       </thead>
       <tbody>
@@ -21,12 +21,6 @@
           <td class="u-align--center">$0</td>
           <td class="p-table__cell--highlight u-align--center">$1,500/year</td>
           <td class="p-table__cell--highlight u-align--center">$5,450/year</td>
-        </tr>
-        <tr>
-          <td>Or, price per region per year <sup><a href="#fn-os-2">**</a></sup></td>
-          <td class="u-align--center">-</td>
-          <td class="p-table__cell--highlight u-align--center"><small>Small: $95,000<br />Medium: $225,000<br />Large: $420,000</small></td>
-          <td class="p-table__cell--highlight u-align--center">-</td>
         </tr>
         <tr>
           <td>Industry-leading cloud operations tooling<br />(Ubuntu, MAAS, Juju, LXD)</td>
@@ -99,9 +93,6 @@
 
     <p id="fn-os-1">
       <small><sup>*</sup> Minimum of 12 supported nodes</small>
-    </p>
-    <p class="u-no-margin--top" id="fn-os-2">
-      <small><sup>**</sup> Small region: Up to 99 nodes, Medium region: 100-499 nodes; Large region: 500+ nodes</small>
     </p>
   </div>
 </div>

--- a/templates/shared/pricing/_ua-server-support-add-ons.html
+++ b/templates/shared/pricing/_ua-server-support-add-ons.html
@@ -24,7 +24,7 @@
     <p>If you need more than the included 3TB. </p>
   </div>
   <div class="col-4 p-card">
-    <h4>Technical account manager</h4>
+    <h4>Technical Account Manager</h4>
     <p>Get a dedicated support person for your account.</p>
   </div>
   <div class="col-4 p-card">

--- a/templates/shared/pricing/_ua-server-support-add-ons.html
+++ b/templates/shared/pricing/_ua-server-support-add-ons.html
@@ -6,15 +6,15 @@
 
 <div class="row u-equal-height">
   <div class="col-4 p-card">
-    <h4>Feature Sponsorships <sup><a href="#fn-fs">*</a></sup></h4>
+    <h4>Feature sponsorships<sup><a href="#fn-fs">*</a></sup></h4>
     <p>Enterprises can support the quicker development of certain features, packages, or changes to Ubuntu for everyone’s benefit.</p>
   </div>
   <div class="col-4 p-card">
-    <h4>Custom Hardware Certification&nbsp;<sup><a href="#fn-fs">*</a></sup></h4>
+    <h4>Custom hardware certification<sup><a href="#fn-fs">*</a></sup></h4>
     <p>Get Canonical to certify specific hardware you are running that isn’t officially supported on Ubuntu.</p>
   </div>
   <div class="col-4 p-card">
-    <h4>Custom OS Images <sup><a href="#fn-fs">*</a></sup></h4>
+    <h4>Custom OS images<sup><a href="#fn-fs">*</a></sup></h4>
     <p>Have Canonical create and maintain images that have the customisations your company requires.</p>
   </div>
 </div>
@@ -24,7 +24,7 @@
     <p>If you need more than the included 3TB. </p>
   </div>
   <div class="col-4 p-card">
-    <h4>Technical Account Manager</h4>
+    <h4>Technical account manager</h4>
     <p>Get a dedicated support person for your account.</p>
   </div>
   <div class="col-4 p-card">

--- a/templates/shared/pricing/_ua-server-support-add-ons.html
+++ b/templates/shared/pricing/_ua-server-support-add-ons.html
@@ -10,7 +10,7 @@
     <p>Enterprises can support the quicker development of certain features, packages, or changes to Ubuntu for everyone’s benefit.</p>
   </div>
   <div class="col-4 p-card">
-    <h4>Custom Hardware Certification <sup><a href="#fn-fs">*</a></sup></h4>
+    <h4>Custom Hardware Certification&nbsp;<sup><a href="#fn-fs">*</a></sup></h4>
     <p>Get Canonical to certify specific hardware you are running that isn’t officially supported on Ubuntu.</p>
   </div>
   <div class="col-4 p-card">

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -167,6 +167,7 @@
       <p>Canonical delivers turnkey OpenStack software solutions, on-site, through its field consulting team. Two plans are offered: the Foundation Cloud, which is based on our award-winning reference architecture, and Foundation Plus, which packs in a complete set of enterprise features and  architectural flexibility.</p>
     </div>
   </div>
+    {% include "shared/pricing/_openstack-consulting.html" %}
   <div class="row">
     <div class="col-10">
       {% include "shared/pricing/_openstack-consulting.html" %}
@@ -202,7 +203,7 @@
 
   <div class="row">
     <div class="col-12">
-      <h3>AI/ML Add-on for Discover and Discoverer Plus</h3>
+      <h3>AI/ML Add-on for Discoverer and Discoverer Plus</h3>
       <p>Turn on the taps with a workshop to understand the full stack of machine learning. Build a full pipeline from developer stations to your data center, to the public cloud. Canonical works with the leading companies to ensure you have the widest range of choices.</p>
     </div>
   </div>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -155,7 +155,7 @@
   {% include "shared/pricing/_openstack-support.html" %}
   <div class="row">
     <div class="col-8">
-      <p><a href="https://buy.ubuntu.com/" class="p-link--external">Buy Ubuntu Advantage</a></p>
+      <p><a href="/cloud/contact-us" class="p-link--external">Get in touch&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -163,16 +163,11 @@
 <section class="p-strip--light is-deep is-bordered" id="consulting">
   <div class="row">
     <div class="col-8">
-      <h2>OpenStack consulting packages</h2>
+      <h2>OpenStack services packages</h2>
       <p>Canonical delivers turnkey OpenStack software solutions, on-site, through its field consulting team. Two plans are offered: the Foundation Cloud, which is based on our award-winning reference architecture, and Foundation Plus, which packs in a complete set of enterprise features and  architectural flexibility.</p>
     </div>
   </div>
     {% include "shared/pricing/_openstack-consulting.html" %}
-  <div class="row">
-    <div class="col-10">
-      {% include "shared/pricing/_openstack-consulting.html" %}
-    </div>
-  </div>
   <div class="row">
     <div class="col-8">
       <p>For more information about Foundation Cloud Build or if you are not sure which one is right for you, <a href="/cloud/contact-us?product=foundation-cloud">contact us&nbsp;&rsaquo;</a></p>
@@ -196,7 +191,7 @@
 <section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2 class="u-no-margin--bottom">Kubernetes consulting packages</h2>
+      <h2 class="u-no-margin--bottom">Kubernetes services packages</h2>
     </div>
   </div>
   {% include "shared/pricing/_kubernetes-consulting.html" %}

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -212,7 +212,6 @@
   <div class="row">
     <div class="col-12">
       <div>
-        <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - Kubernetes add ons CTA' : undefined });">Contact us</a></p>
         <p><a href="https://assets.ubuntu.com/v1/Enterprise-Canonical-Kubernetes.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - cloud storage CTA' : undefined });">Download the datasheet</a></p>
       </div>
     </div>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -126,7 +126,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-deep">
+<section class="p-strip--light is-deep u-no-padding--bottom">
   {% include "shared/pricing/_ua-server-support-add-ons.html" %}
 </section>
 
@@ -203,13 +203,20 @@
   <div class="row">
     <div class="col-12">
       <h3>AI/ML Add-on for Discover and Discoverer Plus</h3>
-      <p><span class="p-heading--two">$40,000</span> one off fee</p>
       <p>Turn on the taps with a workshop to understand the full stack of machine learning. Build a full pipeline from developer stations to your data center, to the public cloud. Canonical works with the leading companies to ensure you have the widest range of choices.</p>
     </div>
   </div>
 
   {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
 
+  <div class="row">
+    <div class="col-12">
+      <div>
+        <p><a href="/containers/contact-us?product=containers-kubernetes-foundation" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - Kubernetes add ons CTA' : undefined });">Contact us</a></p>
+        <p><a href="https://assets.ubuntu.com/v1/Enterprise-Canonical-Kubernetes.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - cloud storage CTA' : undefined });">Download the datasheet</a></p>
+      </div>
+    </div>
+  </div>
 </section>
 
 <section class="p-strip--light is-deep is-bordered" id="storage">

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -149,7 +149,7 @@
   <div class="row">
     <div class="col-8">
       <h2>OpenStack</h2>
-      <p>Canonical provides support services, management tools, and the Cloud Archive which keeps thousands of businesses productive with their own local OpenStack clouds.  For large volume and public clouds with dynamic scale, we&rsquo;re pleased to offer per-region pricing with flexible node ranges.</p>
+      <p>Canonical provides support services, management tools, and the Cloud Archive which keeps thousands of businesses productive with their own local OpenStack clouds.</p>
     </div>
   </div>
   {% include "shared/pricing/_openstack-support.html" %}
@@ -199,6 +199,17 @@
     </div>
   </div>
   {% include "shared/pricing/_kubernetes-consulting.html" %}
+
+  <div class="row">
+    <div class="col-12">
+      <h3>AI/ML Add-on for Discover and Discoverer Plus</h3>
+      <p><span class="p-heading--two">$40,000</span> one off fee</p>
+      <p>Turn on the taps with a workshop to understand the full stack of machine learning. Build a full pipeline from developer stations to your data center, to the public cloud. Canonical works with the leading companies to ensure you have the widest range of choices.</p>
+    </div>
+  </div>
+
+  {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
+
 </section>
 
 <section class="p-strip--light is-deep is-bordered" id="storage">


### PR DESCRIPTION
## Done

- Updated the plans and pricing page per the recent beta updates

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/support/plans-and-pricing](http://0.0.0.0:8001/support/plans-and-pricing)
- compare to the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)

## Issue / Card

Fixes #3492

