### PR TITLE
Add landing page for the Fingbox case study

### DIFF
--- a/templates/engage/fingbox-case-study.html
+++ b/templates/engage/fingbox-case-study.html
@@ -1,6 +1,6 @@
 {% extends "engage/base_engage.html" %}
 
-{% block meta_description %}Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.{% endblock %}
+{% block meta_description %}Using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades.{% endblock %}
 
 {% block title %}Fing serves 30,000 customers with a secure, future-proof IoT device{% endblock %}
 

--- a/templates/engage/fingbox-case-study.html
+++ b/templates/engage/fingbox-case-study.html
@@ -1,0 +1,124 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.{% endblock %}
+
+{% block title %}Fing serves 30,000 customers with a secure, future-proof IoT device{% endblock %}
+
+{% block content %}
+<section class="p-strip u-no-margin--bottom u-no-padding--bottom">
+  <div class="row">
+    <div class="col-9">
+      <h1>Fing serves 30,000 customers with a secure, future-proof IoT device</h1>
+      </div>
+      <div class="col-3 prefix-1">
+          <img src="{{ ASSET_SERVER_URL }}f527ae57-Screenshot+from+2018-06-22+12-16-43.png" onclick="document.getElementById('FirstName').focus();">
+          </div>
+      </div>
+      </section>
+      <section class="p-strip is-shallow">
+
+      <div class="row">
+          <div class="col-7">
+        <p >The estimated number of IoT devices set to be in use worldwide is due to explode depending on the source over the next couple of years. According to Gartner, the figure is as much as 20.4 bn devices by 2020 with consumer devices representing 63% of this figure.</p>
+        
+        <p>Many of these will be low-cost devices rushed out by manufacturers to jump on this opportunity. However, low-cost isn't always a positive especially if little thought has been given to the long-term lifecycle and software strategy of the product.</p>
+        <p>Fing, a company known for its network security app, considered these factors and more when developing their consumer-facing security toolkit hardware, Fingbox. One of Fing's main priorities from the outset was to be able to future-proof their device so that their customers could benefit from the latest features and have seamless security patches. Fing also wanted to ensure they could build a sustainable business that wasn't reliant on shipping new hardware and opened up a new revenue stream throughout its lifecycle. </p><p>To address all these requirements, Fing adopted Ubuntu Core, snaps and Canonical's IoT app store to facilitate their product.</p>
+        <h3>Case study highlights</h3>
+        <ul class="p-list">
+            <li class="p-list__item is-ticked">Using Ubuntu Core and snaps enabled Fing to bring their device to market in less than a year while saving 4 man months of development time, or the equivalent of €100k.</li>
+            <li class="p-list__item is-ticked">Due to the use of snaps, Fingbox can update their 30,000 devices in consumer homes within a matter of hours if needed in case of an urgent security patch.</li>
+            <li class="p-list__item is-ticked">Adopting Canonical's IoT app store enables Fing to control and release new features out to their consumer base proving their customers with new functionality on an ongoing basis.</li>
+          </ul>
+        <p>Download the case study to find out more.</p>
+    </div>
+
+
+
+  <div class="col-5">
+
+      <!-- MARKETO FORM -->
+   <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
+   <script  src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+   <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>‌​
+   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3216" style="margin-top:-1em;">
+     <fieldset class="u-no-padding--top">
+       <ul class="p-list">
+         <li  class="mktFormReq mktField p-list__item">
+           <label for="FirstName" class="mktoLabel " >First Name:</label>
+           <input required  id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="First Name">
+         </li>
+         <li  class="mktFormReq mktField">
+           <label for="LastName" class="mktoLabel " >Last Name:</label>
+           <input required  id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Last Name">
+         </li>
+         <li  class="mktFormReq mktField">
+           <label for="Email" class="mktoLabel " >Work email:</label>
+           <input required  id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired"  type="email" aria-label="Email">
+         </li>
+         <li  class="mktFormReq mktField">
+           <label for="Company" class="mktoLabel " >Company Name:</label>
+           <input required  id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Company Name">
+         </li>
+         <li  class="mktFormReq mktField">
+           <label for="Title" class="mktoLabel " >Job Title:</label>
+           <input required  id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired"  type="text" aria-label="Job Title">
+         </li>
+         <li  class="mktFormReq mktField">
+           <label for="Phone" class="mktoLabel " >Phone Number:</label>
+           <input required  id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired"  type="tel" aria-label="Phone Number">
+         </li>
+         <li  class="mktField">
+           <input name="utm_campaign" class="mktoField  mktoFormCol"  value="{{utm_campaign}}" type="hidden">
+         </li>
+         <li  class="mktField">
+           <input name="utm_medium" class="mktoField  mktoFormCol"  value="{{utm_medium}}" type="hidden">
+         </li>
+         <li  class="mktField">
+           <input name="utm_source" class="mktoField  mktoFormCol"  value="{{utm_source}}" type="hidden">
+         </li>
+         <li  class="mktField">
+           <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" aria-label="I agree to receive information about Canonical’s products and services."></label>
+           <label for="canonicalUpdatesOptIn" class="mktoLabel " >I agree to receive information about Canonical’s products and services.</label>
+         </li>
+         <li  class="mktField">
+           In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank" class="mchNoDecorate">Canonical's Privacy Policy</a><input name="RichText" type="hidden">
+         </li>
+         <li  class="mktField">
+           <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol"  value="Yes" type="hidden">
+         </li>
+         <li  class="mktField">
+           <button type="submit" class="mktoButton">Download the case study</button><input name="formid" class="mktoField" value="3216" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
+         </li>
+       </ul>
+     </fieldset>
+     <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/CloudEconomics_TY.html" />
+     <input type="hidden" name="retURL" value="https://pages.ubuntu.com/CloudEconomics_TY.html" />
+   </form>
+   <script>
+   $("#mktoForm_3216").validate({
+       errorElement: "span",
+       errorClass: "mktFormMsg mktError",
+       onkeyup: false,
+       onclick: false,
+       onblur: false
+   });
+
+     $(function(){$("#comments").hide()});
+
+     $('#Ubuntu_User__c').on('change',function(){
+
+      var selection = $(this).val();
+      if(selection == 'Commercially only') {
+         $('#comments').show();
+      } else {
+         $('#comments').hide();
+      }
+     });
+   </script>
+   <script  src="//assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
+<!-- /MARKETO FORM -->
+   </div>
+
+</div>
+</section>
+{% endblock content %}

--- a/templates/engage/fingbox-case-study.html
+++ b/templates/engage/fingbox-case-study.html
@@ -40,7 +40,7 @@
    <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
    <script  src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
    <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>‌​
-   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3216" style="margin-top:-1em;">
+   <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3232" style="margin-top:-1em;">
      <fieldset class="u-no-padding--top">
        <ul class="p-list">
          <li  class="mktFormReq mktField p-list__item">
@@ -87,15 +87,15 @@
            <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol"  value="Yes" type="hidden">
          </li>
          <li  class="mktField">
-           <button type="submit" class="mktoButton">Download the case study</button><input name="formid" class="mktoField" value="3216" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
+           <button type="submit" class="mktoButton">Download the case study</button><input name="formid" class="mktoField" value="3232" type="hidden"><input name="lpId" class="mktoField " value="" type="hidden"><input name="subId" class="mktoField " value="" type="hidden"><input name="munchkinId" class="mktoField " value="" type="hidden"><input name="lpurl" class="mktoField " value="" type="hidden"><input name="cr" class="mktoField " value="" type="hidden"><input name="kw" class="mktoField " value="" type="hidden"><input name="q" class="mktoField " value="" type="hidden">
          </li>
        </ul>
      </fieldset>
-     <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/CloudEconomics_TY.html" />
-     <input type="hidden" name="retURL" value="https://pages.ubuntu.com/CloudEconomics_TY.html" />
+     <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/CS_Fingbox_TY.html" />
+     <input type="hidden" name="retURL" value="https://pages.ubuntu.com/CS_Fingbox_TY.html" />
    </form>
    <script>
-   $("#mktoForm_3216").validate({
+   $("#mktoForm_3232").validate({
        errorElement: "span",
        errorClass: "mktFormMsg mktError",
        onkeyup: false,


### PR DESCRIPTION
## Done

* New Fingbox case study landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/engage/fingbox-case-study](http://0.0.0.0:8001/engage/fingbox-case-study)
- Ensure the landing page matches the [copy doc](https://docs.google.com/document/d/1gbdgX7y1s22YBcm4N1dzuqgDwQwhJRMaNreHObZ8SdA/edit#)

## Screenshots

* https://screenshotscdn.firefoxusercontent.com/images/afa2c768-aaf8-4609-9ade-c97bcc858a86.png
