### PR TITLE
Add SSO data privacy notice

### DIFF
--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -38,6 +38,7 @@
         <li class="p-list__item"><a href="/legal/dataprivacy/online-purchase">Online purchase privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/dataprivacy/snap-store">Snap Store privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/dataprivacy/contact">Contact us and enquiries privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/dataprivacy/sso">Single Sign On Privacy Notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">

--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -36,9 +36,9 @@
         <li class="p-list__item"><a href="/legal/dataprivacy/newsletter">Newsletter privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/dataprivacy/webinar">Webinar privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/dataprivacy/online-purchase">Online purchase privacy notice&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="/legal/dataprivacy/snap-store">Snap Store privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/dataprivacy/snap-store">Snap store privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/dataprivacy/contact">Contact us and enquiries privacy notice&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="/legal/dataprivacy/sso">Single Sign On Privacy Notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/dataprivacy/sso">Single sign on privacy notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">

--- a/templates/legal/dataprivacy/sso.html
+++ b/templates/legal/dataprivacy/sso.html
@@ -1,0 +1,41 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Privacy notice | Single Sign On (SSO){% endblock %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Privacy notice - Single Sign On (SSO)</h1>
+      <p>Version - June 2018</p>
+      <p>This privacy notice tells you about the information collected from you when you register for a Single Sign On (SSO) account. SSO is an identity provider service that creates, maintains and manages user identity information, providing authentication services for Canonical and other third party applications. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.</p>
+      <h2 id="who-are-we">Who are we?</h2>
+      <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of &ldquo;Legal&rdquo;.</p>
+      <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
+      <h2 id="what-personal-data-do-we-collect">What personal data do we collect?</h2>
+      <p>When you register an SSO account, we ask you for your name and your email address and related information.</p>
+      <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
+      <p>Your information will be used by us for the provision of services in the creation of an SSO account. The SSO account is then used to verify your identity to access certain Canonical and third party services.</p>
+      <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
+      <p>Your information is stored in our database and may be processed outside of the European Economic Area. It is shared with the third parties only as reasonably required for Canonical to process and store your data in accordance with this notice.</p>
+      <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>
+      <p>We keep your information for as long as you retain an SSO account and thereafter for so long as reasonably required in accordance with our record retention policy.</p>
+      <h2 id="your-rights-over-your-information">Your rights over your information</h2>
+      <p>By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.</p>
+      <p>You can also ask for it to be erased and you can ask for us to give you a copy of the information. If you ask us to remove your SSO account you will no longer be able to access certain Canonical and third party services.</p>
+      <h2 id="your-right-to-complain">Your right to complain</h2>
+      <p>If you have a complaint about our use of your information, you can contact the Information Commissioner&rsquo;s Office via their website at <a href="https://ico.org.uk/concerns/">ico.org.uk/concerns/</a> or write to them at:</p>
+      <ul class="p-list">
+        <li class="p-list__item">Information Commissioner&rsquo;s Office</li>
+        <li class="p-list__item">Wycliffe House</li>
+        <li class="p-list__item">Water Lane</li>
+        <li class="p-list__item">Wilmslow</li>
+        <li class="p-list__item">Cheshire</li>
+        <li class="p-list__item">SK9 5AF</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

Add SSO data privacy notice

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/dataprivacy>
- See that there is a link to the single sign on privacy notice under the heading 'Privacy notices'
- See that the SSO privacy notice matches the [copy doc](https://docs.google.com/document/d/1lNercxxavqCCaFkLbQ-uHa9Mq6iZDMOSBDIUa48zDcU/edit?ts=5b2cf77a#)


## Issue / Card

Fixes #3498 