### PR TITLE
Update K8s page copy

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -23,56 +23,22 @@
 </section>
 
 <section class="p-strip is-bordered">
+  <div class="row">
+    <h2>Kubernetes services</h2>
+  </div>
   {% include 'shared/pricing/_kubernetes-consulting.html' %}
 </section>
 
 <section class="p-strip--light is-bordered">
   <div class="row">
-    <h2>AI/ML Add-on for Discoverer and Pioneer</h2>
-    <h3>$40,000 <small>one off fee</small></h3>
-    <p>Turn on the taps with a workshop to understand the full stack of machine learning. Build a full pipeline from developer stations to your data center, to the public cloud. Canonical works with the leading companies to ensure you have the widest range of choices.</p>
-  </div>
-  <div class="row">
-    <div class="u-equal-height">
-      <div class="col-4 p-card">
-        <h3 class="p-card__title">Workshop</h3>
-        <div class="p-card__content">
-          <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">On site or remote options</li>
-            <li class="p-list__item is-ticked">Hands-on K8s and Kubeflow</li>
-            <li class="p-list__item is-ticked">Full pipeline view</li>
-            <li class="p-list__item is-ticked">ML / Data science assessment</li>
-          </ul>
-        </div>
-      </div>
-      <div class="col-4 p-card">
-        <h3 class="p-card__title">ML / Data Science Assessment</h3>
-        <div class="p-card__content">
-          <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">Understand AI Lifecycle</li>
-            <li class="p-list__item is-ticked">Preliminary AI Discovery</li>
-            <li class="p-list__item is-ticked">Development Assessment</li>
-            <li class="p-list__item is-ticked">Deploy and Operate Analysis</li>
-            <li class="p-list__item is-ticked">Finalize Initial AI Strategy</li>
-          </ul>
-        </div>
-      </div>
-      <div class="col-4 p-card">
-        <h3 class="p-card__title">Full Remote Management</h3>
-        <p>Focus on your data pipelines and let Canonical handle all the operations from bare metal up to Kubeflow.</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Fixed monthly cost</li>
-          <li class="p-list__item is-ticked">On-Prem / On-Cloud</li>
-          <li class="p-list__item is-ticked">Regulatory compliance</li>
-          <li class="p-list__item is-ticked">Hardware acceleration</li>
-          <li class="p-list__item is-ticked">Monitoring, management</li>
-          <li class="p-list__item is-ticked">Build, Operate, Transfer</li>
-        </ul>
-      </div>
+    <div class="col-12">
+      <h3>AI/ML Add-on for Discoverer and Discoverer Plus</h3>
+      <p>Turn on the taps with a workshop to understand the full stack of machine learning. Build a full pipeline from developer stations to your data center, to the public cloud. Canonical works with the leading companies to ensure you have the widest range of choices.</p>
     </div>
   </div>
+    
+  {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
+  
   <div class="row">
     <p><a class="p-button--positive" href="/kubernetes/contact-us?product=kubernetes-add-on">Contact us</a></p>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -24,7 +24,7 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <h2>Kubernetes services</h2>
+    <h2>Kubernetes services packages</h2>
   </div>
   {% include 'shared/pricing/_kubernetes-consulting.html' %}
 </section>
@@ -38,10 +38,7 @@
   </div>
     
   {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
-  
-  <div class="row">
-    <p><a class="p-button--positive" href="/kubernetes/contact-us?product=kubernetes-add-on">Contact us</a></p>
-  </div>
+
 </section>
 
 <section class="p-strip is-bordered">


### PR DESCRIPTION
## Done

- Removed hard-coded prices table in K8's page and added an include
- Updated some copy 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Check that the copy matches the [copydoc](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#)


## Issue / Card

Fixes: #3483 

