### PR TITLE
Make hardcoded link relative

### DIFF
--- a/templates/legal/data-privacy-enquiry/index.html
+++ b/templates/legal/data-privacy-enquiry/index.html
@@ -187,7 +187,7 @@
         </fieldset>
 
         <fieldset>
-          <p>Data collected from this survey will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">privacy policy</a>.</p>
+          <p>Data collected from this survey will be handled in accordance with the Canonical <a href="/legal/terms-and-policies/privacy-policy">privacy policy</a>.</p>
           <ul class="p-list">
             <li>
               <label for="tfa_55">


### PR DESCRIPTION
## Done

Make absolute URL link relative

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/data-privacy-enquiry
- See that the 'privacy policy' link at the bottom of the form links to the current domain


## Issue / Card

Fixes #3530