### PR TITLE
Make absolute url relative

### DIFF
--- a/templates/legal/terms-and-policies/livepatch-terms-of-service.html
+++ b/templates/legal/terms-and-policies/livepatch-terms-of-service.html
@@ -16,7 +16,7 @@
       <p>Canonical may update these Terms of Service from time to time in its discretion.</p>
       <section>
         <h2 id="service">2. Service</h2>
-        <p>Details about the Service can be found here: <a href="https://www.ubuntu.com/server/livepatch">www.ubuntu.com/server/livepatch</a></p>
+        <p>Details about the Service can be found here: <a href="/server/livepatch">www.ubuntu.com/server/livepatch</a></p>
         <p>The Service provides users of Ubuntu with a subscription to use the Software on up to three physical or virtual Ubuntu systems and to make a reasonable number of copies of this software for backup and installation purposes.</p>
       </section>
       <section>


### PR DESCRIPTION
## Done

Make absolute URL relative

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/terms-and-policies/livepatch-terms-of-service>
- See that 'www.ubuntu.com/server/livepatch' keeps you on the same domain


## Issue / Card

Fixes #3525 