### PR TITLE
3514 footer link bug

### DIFF
--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -103,7 +103,7 @@
       <div class="col-6 p-card">
         <h3>Systems information notice</h3>
         <p>Find out about the information we may collect during installation of Ubuntu.</p>
-        <p><a href="/legal/terms-and-policies/systems-information-notice">View systems information notice&nbsp;&rsaquo;</p>
+        <p><a href="/legal/terms-and-policies/systems-information-notice">View systems information notice&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fix unclosed link tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/terms-and-policies>

## Issue / Card

Fixes #3514