### PR TITLE
Fixed secondary and tertiary nav for mobile

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -58,14 +58,12 @@
       <ul class="breadcrumbs--secondary col-12">
         {% for child in breadcrumbs.children %}
         <li class="breadcrumbs__item">
-          {% if child.title != 'Overview' %}
           <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">
-            {{ child.title }}
+            {% if child.title == 'Overview' %}{{ breadcrumbs.section.title }}  <li class="breadcrumbs__item"><span class="u-show--small">&nbsp;</span></li>{% else %}{{ child.title }}{% endif %}
           </a>
         </li>
-        {% endif %}
         {% if breadcrumbs.grandchildren %}
-        <li class="breadcrumbs__item"><span class="breadcrumbs__chevron">&rsaquo;</span></li>
+        <li class="breadcrumbs__item"><span class="breadcrumbs__chevron u-hide--small">&rsaquo;</span><span class="u-show--small">&nbsp;</span></li>
         {% for grandchild in breadcrumbs.grandchildren %}
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if grandchild.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ grandchild.path }}">


### PR DESCRIPTION
## Done

- for 2nd level, show the section breadcrumb title on its own line
- for 3rd level, remove the chevron

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [2nd level page](http://0.0.0.0:8001/download) see that it looks ok
- [3rd level page](http://0.0.0.0:8001/download/server) and see that this looks ok


## Issue / Card

Fixes #3510 and github.com/ubuntudesign/web-squad/issues/692

## Screenshots

[if relevant, include a screenshot]
