### PR TITLE
Fix typo on page

### DIFF
--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -124,7 +124,7 @@
           <li class="p-list__item is-ticked">HP, Dell, Supermicro, Quanta, Lenovo and others</li>
           <li class="p-list__item is-ticked">Cisco UCS, Open Compute Foundation, Intel RSD</li>
           <li class="p-list__item is-ticked">PXE, DNS, DHCP, NTP, IPv4 and IPv6</li>
-          <li class="p-list__item is-ticked">Window, CentOS / RHEL, Ubuntu deployment</li>
+          <li class="p-list__item is-ticked">Windows, CentOS / RHEL, Ubuntu deployment</li>
           <li class="p-list__item is-ticked">Hardware inventory and asset management</li>
           <li class="p-list__item is-ticked">IP Address Management (IPAM) built in</li>
           <li class="p-list__item is-ticked">Automated testing of NICs, disks, CPU and RAM</li>


### PR DESCRIPTION
## Done

Fix a typo on `/openstack/features`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/openstack/features>
- See that page matches [copy doc](https://docs.google.com/document/d/1odFXuFtN1GjuZvgd8tW48HB4J9PjZJtP3w6wY0xlmog/edit)


## Issue / Card

Fixes #3529 