### PR TITLE
added the top section back to the enterprise menu on mobile, fixed links

### DIFF
--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -285,12 +285,12 @@ $color-rule--light: transparentize($color-mid-light, .5);
     & .p-list__item {
       margin-bottom: .25rem;
 
-      &:not(:first-child) {
-        padding-top: .25rem;
+      &:not(:last-child) {
+        padding-bottom: .25rem;
       }
 
-      &:not(:first-child) {
-        @extend %pseudo-border--top;
+      &:not(:last-child) {
+        @extend %pseudo-border--bottom;
 
         &::after {
           background-color: $color-rule--light;

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -1,21 +1,27 @@
 <div class="fade-animation u-hide" id="enterprise-content">
   <div class="dropdown-window__content u-no-padding--bottom u-no-padding--top">
-    <div class="p-strip is-x-shallow u-hide--small u-no-padding--bottom">
+    <div class="p-strip is-x-shallow u-no-padding--bottom">
       <div class="row u-equal-height">
         <!-- OpenStack solutions -->
         <div class="tablet-col-2 col-3 p-card--navigation">
-          <img class="p-logomark" src="{{ ASSET_SERVER_URL }}6a983826-Openstack+Logo.svg" alt="openstack logo"/>
-          <h4 class="p-heading-four is-dense">
+          <div class="u-hide--small">
+            <img class="p-logomark" src="{{ ASSET_SERVER_URL }}6a983826-Openstack+Logo.svg" alt="openstack logo"/>
+            <h4 class="p-heading-four is-dense">
+              <a href="/openstack">OpenStack solutions&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+              Canonical is the leading provider of managed OpenStack. We help design, build and operate your cloud, and train your team to take over.
+            </p>
+            <a href="/openstack" class="p-button--small p-button--positive u-align-text--left">
+              Get OpenStack
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
             <a href="/openstack">OpenStack solutions&nbsp;&rsaquo;</a>
           </h4>
-          <p class="p-p--small">
-            Canonical is the leading provider of managed OpenStack. We help design, build and operate your cloud, and train your team to take over.
-          </p>
-          <a href="/openstack" class="p-button--small p-button--positive u-align-text--left">
-            Get OpenStack
-          </a>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/openstack">Build private clouds</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/openstack">Get OpenStack</a></li>
+            <li class="p-list__item"><a href="/openstack/build">Build private clouds</a></li>
             <li class="p-list__item"><a href="/openstack/managed">Fully managed OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/training">Transfer and training</a></li>
             <li class="p-list__item"><a href="/openstack/consulting">Integration</a></li>
@@ -24,38 +30,50 @@
         </div>
         <!-- Kubernetes solutions -->
         <div class="tablet-col-2 col-3 p-card--navigation">
-          <img class="p-logomark" src="{{ ASSET_SERVER_URL }}dba11aee-kubernetes.svg" alt="kubernetes logo"/>
-          <h4 class="p-heading-four is-dense">
+          <div class="u-hide--small">
+            <img class="p-logomark" src="{{ ASSET_SERVER_URL }}dba11aee-kubernetes.svg" alt="kubernetes logo"/>
+            <h4 class="p-heading-four is-dense">
+              <a href="/kubernetes">Kubernetes solutions&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+              Canonical delivers the leading Kubernetes distribution and provides workshops, training, deployment and consulting services. On VMware, cloud, OpenStack and bare metal.
+            </p>
+            <a href="/kubernetes" class="p-button--small p-button--positive u-align-text--left">
+              Get Kubernetes
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
             <a href="/kubernetes">Kubernetes solutions&nbsp;&rsaquo;</a>
           </h4>
-          <p class="p-p--small">
-            Canonical delivers the leading Kubernetes distribution and provides workshops, training, deployment and consulting services. On VMware, cloud, OpenStack and bare metal.
-          </p>
-          <a href="/kubernetes" class="p-button--small p-button--positive u-align-text--left">
-            Get Kubernetes
-          </a>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/kubernetes">Bare metal, VMware, cloud</a></li>
-            <li class="p-list__item"><a href="/kubernetes">Upgrades, day 2 operations</a></li>
-            <li class="p-list__item"><a href="/kubernetes">GPGPU support for <abbr title="Machine learning">ML</abbr></a></li>
-            <li class="p-list__item"><a href="/kubernetes">CI/CD with Rancher &amp; Jenkins</a></li>
-            <li class="p-list__item"><a href="/kubernetes">AI and ML workflows</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/kubernetes">Get Kubernetes</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features">Bare metal, VMware, cloud</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features">Upgrades, day 2 operations</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features">GPGPU support for <abbr title="Machine learning">ML</abbr></a></li>
+            <li class="p-list__item"><a href="/kubernetes/partners">CI/CD with Rancher &amp; Jenkins</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features">AI and ML workflows</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed options</a></li>
           </ul>
         </div>
         <!-- AI and Machine learning -->
         <div class="tablet-col-2 col-3 p-card--navigation">
-          <img class="p-logomark" src="{{ ASSET_SERVER_URL }}6ff815e5-Kubeflow-Logo-RGB.svg" alt="Kubeflow logo">
-          <h4 class="p-heading-four is-dense">
+          <div class="u-hide--small">
+            <img class="p-logomark" src="{{ ASSET_SERVER_URL }}6ff815e5-Kubeflow-Logo-RGB.svg" alt="Kubeflow logo">
+            <h4 class="p-heading-four is-dense">
+              <a href="/ai">AI and ML&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+              Canonical provides perfect multi-cloud portability for your artificial intelligence and machine learning workloads.
+            </p>
+            <a href="/ai/consulting" class="p-button--small p-button--positive u-align-text--left">
+              Get started with Kubeflow
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
             <a href="/ai">AI and ML&nbsp;&rsaquo;</a>
           </h4>
-          <p class="p-p--small">
-            Canonical provides perfect multi-cloud portability for your artificial intelligence and machine learning workloads.
-          </p>
-          <a href="/ai/consulting" class="p-button--small p-button--positive u-align-text--left">
-            Get started with Kubeflow
-          </a>
           <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/ai/consulting">Get started with Kubeflow</a></li>
             <li class="p-list__item"><a href="/ai/kubeflow" title="Visit TensorFlow - external site">Google TensorFlow and Kubeflow</a></li>
             <li class="p-list__item"><a href="/ai/nvidia" title="Visit Nvidia developer - external site">Nvidia’s ML stack</a></li>
             <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML toolchain on Ubuntu</a></li>
@@ -64,17 +82,23 @@
         </div>
         <!-- Enterprise support -->
         <div class="tablet-col-2 col-3 p-card--navigation">
-          <img class="p-logomark" src="{{ ASSET_SERVER_URL }}3c1de878-canonical-logo.png" alt="canonical logo">
-          <h4 class="p-heading-four is-dense">
-            <a href="/support">Enterprise support&nbsp;&rsaquo;</a>
+          <div class="u-hide--small">
+            <img class="p-logomark" src="{{ ASSET_SERVER_URL }}3c1de878-canonical-logo.png" alt="canonical logo">
+            <h4 class="p-heading-four is-dense">
+              <a href="/support">Enterprise support&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+              Canonical provides 24/7 enterprise support, security, and break-fix engineering for Ubuntu, OpenStack, Docker and Kubernetes. Enterprise Linux done right.
+            </p>
+            <a href="/support" class="p-button--small p-button--positive u-align-text--left">
+              Get support
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
+            <a href="/support">Enterprise suppor&nbsp;&rsaquo;</a>
           </h4>
-          <p class="p-p--small">
-            Canonical provides 24/7 enterprise support, security, and break-fix engineering for Ubuntu, OpenStack, Docker and Kubernetes. Enterprise Linux done right.
-          </p>
-          <a href="/support" class="p-button--small p-button--positive u-align-text--left">
-            Get support
-          </a>
           <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
             <li class="p-list__item"><a href="/server/livepatch">Kernel Live Patch</a></li>
             <li class="p-list__item"><a href="/support/esm">Extended Ubuntu Security</a></li>
             <li class="p-list__item"><a href="/support">Optimised Windows VMs</a></li>
@@ -89,11 +113,11 @@
       <!-- Public cloud -->
       <div class="col-3">
         <h4 class="p-muted-heading">
-          <a href="/cloud/public-cloud">Public cloud&nbsp;&rsaquo;</a>
+          <a href="/public-cloud">Public cloud&nbsp;&rsaquo;</a>
         </h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="/download/cloud">Use Ubuntu on AWS, Azure, Google, Oracle and IBM clouds</a></li>
-          <li class="p-list__item"><a href="/cloud/public-cloud">Use Ubuntu on Google Kubernetes and Azure Kubernetes</a></li>
+          <li class="p-list__item"><a href="/download/cloud">Use Ubuntu on Google Kubernetes and Azure Kubernetes</a></li>
         </ul>
       </div>
       <!-- Containers -->
@@ -102,7 +126,6 @@
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="/kubernetes">Install and operate Kubernetes</a></li>
           <li class="p-list__item"><a href="https://linuxcontainers.org/" title="Visit the LXD website - external site">LXD for legacy apps in containers</a></li>
-          <li class="p-list__item"><a href="/containers/docker-ubuntu">Run the Docker Engine on Ubuntu</a></li>
         </ul>
       </div>
       <!-- data centre -->
@@ -167,12 +190,12 @@
           <li class="p-inline-list__item"><a href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
           <li class="p-inline-list__item"><a href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
           <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
-          <li class="p-inline-list__item"><a href="https://insights.ubuntu.com/category/case-studies" title="Visit the Case studies - external site">Case studies</a></li>
-          <li class="p-inline-list__item"><a href="https://insights.ubuntu.com/category/white-papers" title="Visit the White papers - external site">White papers</a></li>
+          <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
+          <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
           <li class="p-inline-list__item"><a href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
           <li class="p-inline-list__item"><a href="/cloud/training">Training</a></li>
           <li class="p-inline-list__item"><a href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
-          <li class="p-inline-list__item"><a href="https://insights.ubuntu.com/press-centre/" title="Visit the Press Centre - external site">Press centre</a></li>
+          <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/press-centre" title="Visit the Press Centre - external site">Press centre</a></li>
         </ul>
       </div>
     </div>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -21,7 +21,7 @@
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/openstack">Get OpenStack</a></li>
-            <li class="p-list__item"><a href="/openstack/build">Build private clouds</a></li>
+            <li class="p-list__item"><a href="/openstack/consulting">Build private clouds</a></li>
             <li class="p-list__item"><a href="/openstack/managed">Fully managed OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/training">Transfer and training</a></li>
             <li class="p-list__item"><a href="/openstack/consulting">Integration</a></li>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -78,7 +78,7 @@
               <a class="p-link--soft" href="http://www.canonical.com/careers"><small>Careers</small></a>
             </li>
             <li class="p-inline-list__item">
-              <a class="p-link--soft" href="https://insights.ubuntu.com/press-centre/"><small>Press centre</small></a>
+              <a class="p-link--soft" href="https://blog.ubuntu.com/press-centre"><small>Press centre</small></a>
             </li>
           </ul>
         </nav>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -152,8 +152,8 @@
             <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
             <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
             <li class="p-list__item"><a class="p-link" href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com/category/case-studies" title="Visit the Case studies - external site">Case studies</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com/category/white-papers" title="Visit the White papers - external site">White papers</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
             <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
             <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
             <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
@@ -288,8 +288,8 @@
               <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
               <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
               <li class="p-list__item"><a class="p-link" href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com/category/case-studies" title="Visit the Case studies - external site">Case studies</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com/category/white-papers" title="Visit the White papers - external site">White papers</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
               <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
               <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
               <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>


### PR DESCRIPTION
## Done

- added the top section back to the enterprise menu on mobile
- made the border on the p-list use last-child logic not first
- fixed up the links per the [copy doc](https://drive.google.com/open?id=1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ)
- generally fixed up links to insights over to blog


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/]
- See that the mobile version of the enterprise menu looks good and contains the top (openstack, k8s, ai and ml, and support sections)
- See that the links go as the copy doc says

## Issue / Card

Fixes [#695](https://github.com/ubuntudesign/web-squad/issues/695)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/42225047-880533d0-7ed3-11e8-888f-7c69d1397754.png)
