### PR TITLE
Change spacing in footer links

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -248,4 +248,10 @@
       margin-top: $sp-x-small;
     }
   }
+
+  .p-footer__item--spaced {
+    @media only screen and (min-width: $breakpoint-medium) {
+      margin-bottom: $sp-large;
+    }
+  }
 }

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -35,7 +35,7 @@
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom last-col">
         <ul class="p-footer__links">
-          <li class="p-footer__item">
+          <li class="p-footer__item p-footer__item--spaced">
             <h2 class="p-footer__title">
               <a href="#" class="p-link--soft">Sectors</a>
             </h2>
@@ -48,7 +48,6 @@
               <li><a href="/desktop/organisations">Organisations</a></li>
             </ul>
           </li>
-          <li>&nbsp;</li>
           {% include 'templates/_footer_item.html' with section=nav_sections.security %}
           {% include 'templates/_footer_item.html' with section=nav_sections.publiccloud %}
           {% include 'templates/_footer_item.html' with section=nav_sections.containers %}


### PR DESCRIPTION
## Done

Fix spacing in the footer links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/resources>
- See that in the footer, on mobile the sectors nav item is the same height as the others


## Issue / Card

Fixes #3518 