### PR TITLE
Update link on server page

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -150,7 +150,7 @@
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}64493bba-logo-openbravo.png" alt="Openbravo" />
         </li>
       </ul>
-      <p class="u-align--center u-vertically-spaced"><a href="/partners/certified-software">View all certified software&nbsp;&rsaquo;</a></p>
+      <p class="u-align--center u-vertically-spaced"><a href="https://partners.ubuntu.com/programmes/software">View all certified software&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Update link on server page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/server>
- See that 'View all certified software' link goes to the same place as in the [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#)


## Issue / Card

Fixes #3548 