### PR TITLE
Fix mobile list and image styling

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -58,7 +58,6 @@
       <div class="col-8">
         <h2>Landscape: Server management</h2>
         <p>Landscape allows you to manage thousands of Ubuntu machines as easily as one, making the administration of Ubuntu desktops, servers and cloud instances more cost-effective. It&rsquo;s easy to set up, easy to use and it requires no special hardware.</p>
-        <div class="p-list">
           <ul class="p-list is-split">
             <li class="p-list__item is-ticked">Management at scale</li>
             <li class="p-list__item is-ticked">Deploy security updates</li>
@@ -66,7 +65,6 @@
             <li class="p-list__item is-ticked">Role-based access</li>
             <li class="p-list__item is-ticked">Informative monitoring</li>
           </ul>
-        </div>
         <p><a href="https://landscape.canonical.com/" class="p-button--neutral"><span class="p-link--external">Learn more about Landscape</span></a></p>
       </div>
     </div>
@@ -81,7 +79,7 @@
         <p>In addition to x86 and ARM servers, Ubuntu is supported on the Power architecture. For the enterprise datacentre, this means you can now build your infrastructure on any hardware you choose.</p>
       </div>
       <div class="col-4 u-vertically-center u-align--center">
-        <img src="{{ ASSET_SERVER_URL }}683950fd-logo-ibm.svg" alt="IBM logo" width="200" />
+        <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}683950fd-logo-ibm.svg" alt="IBM logo" width="200" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Fixed list styling on mobile by removing unnecessary div
- Fixed image hide on mobile by adding hide class on img


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/server](http://0.0.0.0:8001/server)
- Check that on mobile the list does not show 2 bullet points (only the ticked vanilla ones)
- Check that on mobile the IBM image is hidden


## Issue / Card

Fixes: #3559 & #3558 

