### PR TITLE
Remove pictogram

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -80,9 +80,6 @@
         <p>Canonical is also a pioneer with ARM Servers, building the first commercial general-purpose ARM Linux OS in 2007 and the first ARM-based Server OS in 2009. We founded Linaro along with Arm in 2010.</p>
         <p>Ubuntu now runs on every significant ARM platform deployed in the datacentre, including the recently-announced Baidu storage cluster.</p>
       </div>
-      <div class="col-5 u-align--center u-vertically-center">
-        <img src="{{ ASSET_SERVER_URL }}c74f59b7-picto-reducecosts-warmgrey.svg" width="199" height="199" class="u-hide--small" alt="" />
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Removed pictogram next to "canonical's long-term commitment" heading

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/server/hyperscale](http://0.0.0.0:8001/server/hyperscale)
- Check that the picto has been removed

## Issue / Card

Fixes: #3554 


