### PR TITLE
Update how large size secondary nav deals with mobile spacing

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -275,6 +275,14 @@
           padding: 0.55rem 0 0.2rem 0;
         }
 
+        &__space {
+          display: none;
+
+          @media (max-width: $breakpoint-small - 1) {
+            display: block;
+          }
+        }
+
         &__link {
           font-size: 1rem / pow($ms-ratio, 1); //XXX: move font-sizes to map in vanilla so it can be changed globally
           // line-height: map-get($line-heights, small);

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -59,7 +59,7 @@
         {% for child in breadcrumbs.children %}
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">
-            {% if child.title == 'Overview' %}{{ breadcrumbs.section.title }}  <li class="breadcrumbs__item"><span class="u-show--small">&nbsp;</span></li>{% else %}{{ child.title }}{% endif %}
+            {% if child.title == 'Overview' %}{{ breadcrumbs.section.title }}  </a><li class="breadcrumbs__item breadcrumbs__space"><a href="#">&nbsp;</li>{% else %}{{ child.title }}{% endif %}
           </a>
         </li>
         {% if breadcrumbs.grandchildren %}


### PR DESCRIPTION
## Done

- I have hidden the empty list item better from large screens in the secondary nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download](http://0.0.0.0:8001/download)
- see that the nav has no gap on large screens, but looks fine in mobile too

## Screenshots

before
![image](https://user-images.githubusercontent.com/441217/42264830-ae0555e2-7f69-11e8-94dc-6b5a159d2d08.png)

after
![image](https://user-images.githubusercontent.com/441217/42264814-a58ece3e-7f69-11e8-9919-0b8ff2cec062.png)
