### PR TITLE
Add hover state to breadcrumb title

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -198,7 +198,8 @@
         font-weight: 300;
 
         &:hover {
-          text-decoration: none;
+          text-decoration: underline;
+          color: $color-x-light;
         }
       }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -198,7 +198,6 @@
         font-weight: 300;
 
         &:hover {
-          text-decoration: underline;
           color: $color-x-light;
         }
       }


### PR DESCRIPTION
## Done

Add hover state to breadcrumb title

@frankiegranato If by selected state you mean when you are on that specific page, if we highlight in that case then it will be highlight when you're on one of the sub pages too, e.g.

If on /openstack it is highlighted
If on /openstack/features it is highlight as you are still within the openstack section

Here is what it would look like:
![screenshot from 2018-07-04 11-04-17](https://user-images.githubusercontent.com/501889/42271165-8daa723a-7f7a-11e8-9c49-1c8dbb34ae5d.png)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/openstack](http://0.0.0.0:8001/openstack)
- See that the breadcrumb title (orange box) has a hover state


## Issue / Card

Fixes #3532 