### PR TITLE
Fix breadcrumb - section title duplicated on large screens

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -57,7 +57,7 @@
       {% if breadcrumbs.children %}
       <ul class="breadcrumbs--secondary col-12">
         {% for child in breadcrumbs.children %}
-        <li class="breadcrumbs__item">
+        <li class="breadcrumbs__item  {% if child.title == 'Overview' %}u-hide--nav-threshold-up{% endif %}">
           <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">
             {% if child.title == 'Overview' %}{{ breadcrumbs.section.title }}  </a><li class="breadcrumbs__item breadcrumbs__space"><a href="#">&nbsp;</li>{% else %}{{ child.title }}{% endif %}
           </a>


### PR DESCRIPTION
## Done

Remove duplicated link in breadcrumb for desktop

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/openstack>
- See that the section title only appears once in the breadcrumb


## Issue / Card

Fixes #3576 