### PR TITLE
Update enterprise links

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -50,7 +50,7 @@
             <li class="p-list__item"><a href="/kubernetes/features">Bare metal, VMware, cloud</a></li>
             <li class="p-list__item"><a href="/kubernetes/features">Upgrades, day 2 operations</a></li>
             <li class="p-list__item"><a href="/kubernetes/features">GPGPU support for <abbr title="Machine learning">ML</abbr></a></li>
-            <li class="p-list__item"><a href="/kubernetes/partners">CI/CD with Rancher &amp; Jenkins</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features">CI/CD with Rancher &amp; Jenkins</a></li>
             <li class="p-list__item"><a href="/kubernetes/features">AI and ML workflows</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed options</a></li>
           </ul>


### PR DESCRIPTION
## Done

Update link that has changed in the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that enterprise menu links match the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit#)


## Issue / Card

Fixes #3563 