### PR TITLE
Hide picto on mobile /kubernetes/partners

### DIFF
--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -10,7 +10,7 @@
       <p>It takes an open ecosystem to solve the diverse challenges of private cloud infrastructure across every sector and in every region. Our partners ensure that you have the widest range of capabilities available for automated integration in your Kubernetes on OpenStack cloud, and that you can get insight and support locally.</p>
       <p><a href="/openstack/partners">See our private cloud partner page&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-4 u-vertically-center">
+    <div class="col-4 u-vertically-center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}1c786630-image-cloud.svg" alt="">
     </div>
   </div>


### PR DESCRIPTION
## Done

- Hide pictogram on mobile on /kubernetes/partners

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/partners](http://0.0.0.0:8001/kubernetes/partners)
- Check that the pictogram is hidden on mobile


## Issue / Card

Fixes: #3566 

