### PR TITLE
Hide logos on small screens

### DIFF
--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -119,7 +119,7 @@
         <li class="p-list__item is-ticked">Production  scale</li>
       </ul>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}a6fdc787-logo.png" alt="">
     </div>
   </div>
@@ -145,7 +145,7 @@
       </ul>
       <p>To improve the extensibility of the storage feature set and plugin ecosystem, Kubernetes has announced a new initiative &mdash; the Container Storage Interface (CSI) &mdash; which is currently in Beta. CSI enables storage plugins to be developed independent from the kubernetes github tree, containerized, deployed via standard Kubernetes primitives, and consumed through the Kubernetes storage primitives users know and love (PersistentVolumeClaims, PersistentVolumes, StorageClasses). The next dot release of CDK will provide early access to CSI.</p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}4bf27234-logo+%281%29.png" alt="">
     </div>
   </div>


### PR DESCRIPTION
## Done

Hide CSI and CNI logos on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/kubernetes/features>
- See that CSI and CNI logos are hidden on small screens


## Issue / Card

Fixes #3567 