### PR TITLE
Update contact links on k8s partners page

### DIFF
--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -57,7 +57,7 @@
     <div class="col-8">
       <h2>Become a cloud partner</h2>
       <p>To learn more about becoming a Canonical Kubernetes partner, please contact us today.</p>
-      <p><a class="p-button--positive" href="/partners/contact-us">Get in touch</a> or <a href="https://partners.ubuntu.com/contact-us">learn more about partnering with us&nbsp;&rsaquo;</a></p>
+      <p><a class="p-button--positive" href="https://partners.ubuntu.com/contact-us">Get in touch</a> or <a href="https://partners.ubuntu.com/partnering-with-us">learn more about partnering with us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Update contact links on k8s partners page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/kubernetes/partners>
- See that contact links in last section match the [copy doc](https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit)


## Issue / Card

Fixes #3545 