### PR TITLE
Add new legal page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -348,6 +348,8 @@ legal:
           path: /legal/dataprivacy
         - title: Trademarks
           path: /legal/trademarks
+        - title: GPL Enforcement
+          path: /legal/gpl-enforcement
 
     - title: Ubuntu Advantage
       path: /legal/ubuntu-advantage

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -356,3 +356,11 @@ p + pre {
     background-position: left 70% top;
   }
 }
+
+.u-indent {
+  padding-left: 1rem;
+
+  @media (min-width: $breakpoint-medium) {
+    padding-left: 2rem;
+  }
+}

--- a/templates/legal/gpl-enforcement.html
+++ b/templates/legal/gpl-enforcement.html
@@ -1,0 +1,25 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}GPL Enforcement{% endblock %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>GPL Enforcement</h1>
+      <h2 id="our-commitment">Our commitment</h2>
+      <p>Before filing or continuing to prosecute any legal proceeding or claim (other than a Defensive Action) arising from termination of a Covered License, Canonical commits to extend to the person or entity (&ldquo;<strong>you</strong>&rdquo;) accused of violating the Covered License the following provisions regarding cure and reinstatement, taken from GPL version 3. As used here, the term ‘this License’ refers to the specific Covered License being enforced.</p>
+      <p class="u-indent">However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.</p>
+      <p class="u-indent">Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.</p>
+      <p>Canonical intends this Commitment to be irrevocable, and binding and enforceable against Canonical and assignees of or successors to Canonical&rsquo;s copyrights.</p>
+      <p>Canonical may modify this Commitment by publishing a new edition on this page or a successor location.</p>
+      <h2 id="definitions">Definitions</h2>
+      <p>&ldquo;<strong>Canonical</strong>&rdquo; means Canonical Limited and its affiliates.</p>
+      <p>&ldquo;<strong>Covered License</strong>&rdquo; means the GNU General Public License, version 2 (GPLv2), the GNU Lesser General Public License, version 2.1 (LGPLv2.1), or the GNU Library General Public License, version 2 (LGPLv2), all as published by the Free Software Foundation.</p>
+      <p>&ldquo;<strong>Defensive Action</strong>&rdquo; means a legal proceeding or claim that Canonical brings against you in response to a prior proceeding or claim initiated by you or your affiliate.</p>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -103,8 +103,16 @@
       <div class="col-6 p-card">
         <h3>Systems information notice</h3>
         <p>Find out about the information we may collect during installation of Ubuntu.</p>
-        <p><a href="/legal/terms-and-policies/systems-information-notice">View systems information notice&nbsp;&rsaquo;</p>
+        <p><a href="/legal/terms-and-policies/systems-information-notice">View systems information notice&nbsp;&rsaquo;</a></p>
       </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 p-card">
+      <h3>GPL Enforcement</h3>
+      <p>Canonical&rsquo;s commit to applying the cure provisions of GPLv3 to all software Canonical licences under GPLv2.</p>
+      <p><a href="/legal/gpl-enforcement">View the commitment&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -111,7 +111,7 @@
   <div class="row">
     <div class="col-12 p-card">
       <h3>GPL Enforcement</h3>
-      <p>Canonical&rsquo;s commit to applying the cure provisions of GPLv3 to all software Canonical licences under GPLv2.</p>
+      <p>Canonical&rsquo;s commitment to applying the cure provisions of GPLv3 to all software Canonical licences under GPLv2.</p>
       <p><a href="/legal/gpl-enforcement">View the commitment&nbsp;&rsaquo;</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Add new legal page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/gpl-enforcement>
- See that page matches the [copy doc](https://docs.google.com/document/d/1knhlbP0tsoxjfX4SpDrP8_OdTuqKNRBL_zNDB70cXfs/edit#)
- Go to <http://0.0.0.0:8001/legal/terms-and-policies>
- See that previous page is linked to


## Issue / Card

Fixes #3591 
Fixes #3592