### PR TITLE
Livepatch page pictogram removal and card styling

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -78,10 +78,14 @@
         </ol>
       </div>
       <div class="col-4">
-        <div class="p-card--highlighted  u-float--right">
-          <h2 class="p-card__title"><a href="{{ ASSET_SERVER_URL }}ac3aa269-DS_Canonical_Livepatch_Service_screen-AW_08.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/server/livepatch', 'eventValue' : undefined });">Livepatch overview&nbsp;&rsaquo;</a></h2>
-          <p class="p-card__content">Download the datasheet for more technical details and FAQs on the Canonical Livepatch Service.</p>
-          <p class="p-card__category">Datasheet</p>
+        <div class="p-card--highlighted">
+          <div class="p-card__header">
+            <p class="p-muted-heading">Datasheet</p>
+          </div>
+          <div class="p-card__content u-no-margin--top">
+            <h3 class="p-card__title p-heading--four"><a href="{{ ASSET_SERVER_URL }}ac3aa269-DS_Canonical_Livepatch_Service_screen-AW_08.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/server/livepatch', 'eventValue' : undefined });">Livepatch overview&nbsp;&rsaquo;</a></h3>
+            <p>Download the datasheet for more technical details and FAQs on the Canonical Livepatch Service.</p>
+          </div>
         </div>
       </div>
     </div>

--- a/templates/shared/_case-study-itstrategen.html
+++ b/templates/shared/_case-study-itstrategen.html
@@ -5,8 +5,4 @@
       <p>The security of customer data is of the utmost importance to ITstrategen, which is why Ubuntu is their server operating system of choice.</p>
       <a class="p-button--neutral" href="https://pages.ubuntu.com/Cloud_CS_ITstrategen.html"><span class="p-link--external">Read the case study</span></a>
     </div>
-    <div class="col-4 u-hide--small u-align--center u-vertically-center">
-      <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}16e21217-pictogram-safety-orange.svg" width="150" alt="" />
-    </div>
-  </div>
 </section>


### PR DESCRIPTION
## Done

- Removed picto
- Fixed card styling

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/server/livepatch](http://0.0.0.0:8001/server/livepatch)
- Check that the pictogram has been removed
- Check the card styling is the new one (as seen on /openstack/storage)


## Issue / Card

Fixes: #3555 #3556 

