### PR TITLE
Add padding on mobile cards

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -167,6 +167,7 @@
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
           <img src="{{ ASSET_SERVER_URL }}f38c9ed1-hpe_pri_grn_pos_rgb.svg"  width="200" alt="Hewlett Packard Enterprise logo" />
         </div>
+        <div class="u-sv2 u-hide--medium u-hide--large"></div>
         <p class="p-card__content">Canonical has been involved in the development of Moonshot, Hewlett Packard Enterprise&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
         <p class="p-card__content"><a href="http://partners.ubuntu.com/hewlett-packard-enterprise" class="p-link--external">Learn more</a></p>
       </div>
@@ -174,6 +175,7 @@
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
           <img src="{{ ASSET_SERVER_URL }}4efbd291-Arm_logo_blue_cropped.svg" width="150" height="45" alt="Arm logo" />
         </div>
+        <div class="u-sv2 u-hide--medium u-hide--large"></div>
         <p class="p-card__content">Arm and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
         <p class="p-card__content"><a href="http://partners.ubuntu.com/arm" class="p-link--external">Learn more</a></p>
       </div>
@@ -185,6 +187,7 @@
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
           <img src="{{ ASSET_SERVER_URL }}d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium logo" />
         </div>
+        <div class="u-sv2 u-hide--medium u-hide--large"></div>
         <p class="p-card__content">Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
         <p class="p-card__content"><a class="p-link--external" href="http://www.cavium.com">Learn more</a></p>
       </div>
@@ -192,6 +195,7 @@
         <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
           <img src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation logo" />
         </div>
+        <div class="u-sv2 u-hide--medium u-hide--large"></div>
         <p class="p-card__content">Applied Micro Circuits Corporation is a global leader in computing and connectivity solutions for next-generation cloud infrastructure and data centers. AppliedMicro delivers silicon solutions that dramatically lower total cost of ownership.</p>
         <p class="p-card__content"><a class="p-link--external" href="https://www.apm.com/products/data-center/x-gene-family/">Learn more</a></p>
       </div>


### PR DESCRIPTION
## Done

Add padding to cards with no header on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/server/hyperscale>
- See that the cards under the heading 'Hyperscale partners' have sufficient padding on top


## Issue / Card

Fixes #3562 