### PR TITLE
Add more nav events, introduce content events

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -175,18 +175,20 @@ function closeMainMenu() {
 
 var origin = window.location.pathname;
 
-addGAEvents('#canonical-products', 'www.ubuntu.com-nav-0-products');
-addGAEvents('#canonical-login', 'www.ubuntu.com-nav-0-login');
-addGAEvents('#enterprise-content', 'www.ubuntu.com-nav-1-enterprise');
-addGAEvents('#developer-content', 'www.ubuntu.com-nav-1-developer');
-addGAEvents('#community-content', 'www.ubuntu.com-nav-1-community');
-addGAEvents('#download-content', 'www.ubuntu.com-nav-1-download');
-addGAEvents('.p-navigation--secondary', 'www.ubuntu.com-nav-2');
-addGAEvents('.p-footer__nav', 'www.ubuntu.com-nav-footer');
-addGAEvents('.p-footer--secondary', 'www.ubuntu.com-nav-footer-2');
-addGAEvents('.p-contextual-footer', 'www.ubuntu.com-nav-contextual-footer');
+addGANavEvents('.global-nav__row', 'www.ubuntu.com-nav-0');
+addGANavEvents('#canonical-products', 'www.ubuntu.com-nav-0-products');
+addGANavEvents('#canonical-login', 'www.ubuntu.com-nav-0-login');
+addGANavEvents('#navigation', 'www.ubuntu.com-nav-1');
+addGANavEvents('#enterprise-content', 'www.ubuntu.com-nav-1-enterprise');
+addGANavEvents('#developer-content', 'www.ubuntu.com-nav-1-developer');
+addGANavEvents('#community-content', 'www.ubuntu.com-nav-1-community');
+addGANavEvents('#download-content', 'www.ubuntu.com-nav-1-download');
+addGANavEvents('.p-navigation--secondary', 'www.ubuntu.com-nav-2');
+addGANavEvents('.p-contextual-footer', 'www.ubuntu.com-footer-contextual');
+addGANavEvents('.p-footer__nav', 'www.ubuntu.com-nav-footer-0');
+addGANavEvents('.p-footer--secondary', 'www.ubuntu.com-nav-footer-1');
 
-function addGAEvents(target, category){
+function addGANavEvents(target, category){
   var t = document.querySelector(target);
   if (t) {
     t.querySelectorAll('a').forEach(function(a) {
@@ -200,6 +202,35 @@ function addGAEvents(target, category){
           'eventValue' : undefined
         });
       });
+    });
+  }
+}
+
+addGAContentEvents('#main-content')
+
+function addGAContentEvents(target){
+  var t = document.querySelector(target);
+  if (t) {
+    t.querySelectorAll('a').forEach(function(a) {
+      var destination = a.href.replace('https://www.ubuntu.com', '').split("?")[0];
+      if (a.className.includes('p-button--positive')) {
+        var category = 'www.ubuntu.com-content-cta-0';
+      } else if (a.className.includes('p-button')) {
+        var category = 'www.ubuntu.com-content-cta-1';
+      } else {
+        var category = 'www.ubuntu.com-content-link';
+      }
+      if (!destination.startsWith("#")){
+        a.addEventListener('click', function(event){
+          dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : category,
+            'eventAction' : `from:${origin} to:${destination}`,
+            'eventLabel' : a.text,
+            'eventValue' : undefined
+          });
+        });
+      }
     });
   }
 }


### PR DESCRIPTION
## Done

* Add new nav events for menu openings and logo clicks, rename contextual-footer to footer-contextual
* Add content events for primary and secondary CTAs, links in content

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Ensure events appear in GA (combo tracker) real-time events view when filtered on "www.ubuntu.com"

