### PR TITLE
Fix margins for takeunders

### DIFF
--- a/static/sass/_pattern_takeunders.scss
+++ b/static/sass/_pattern_takeunders.scss
@@ -3,10 +3,11 @@
   .p-takeunder {
     border-radius: .125rem;
     color: $color-x-light;
-    margin-right: -1 rem;
+    margin-bottom: $sp-large;
     padding: $sp-x-large;
 
     @media only screen and (min-width: $breakpoint-medium) {
+      margin-bottom: 0;
       padding: $sp-x-large $sp-medium;
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -94,11 +94,9 @@
 
 {# strip takeunders #}
 <section class="p-strip">
-  <div class="row">
-    <div class="u-equal-height">
-      {% include "takeovers/takeunders/_ubuntu-product-month.html" %}
-      {% include "takeovers/takeunders/_openstack-ebook.html" %}
-    </div>
+  <div class="row u-equal-height">
+    {% include "takeovers/takeunders/_ubuntu-product-month.html" %}
+    {% include "takeovers/takeunders/_openstack-ebook.html" %}
   </div>
 </section>
 


### PR DESCRIPTION
## Done

Add padding between takeunders

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that takeunders have sufficient margins on small screens


## Issue / Card

Fixes #3515 