### PR TITLE
Add spacing under graph image

### DIFF
--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -3,7 +3,9 @@
     <div class="u-equal-height">
       <div class="col-7">
         <h3>Ubuntu release cycle</h3>
-        <img src="{{ ASSET_SERVER_URL }}cf53cf6c-release-ubuntu-end-of-life.png" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
+        <div class="u-sv3">
+          <img src="{{ ASSET_SERVER_URL }}cf53cf6c-release-ubuntu-end-of-life.png" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
+        </div>
       </div>
       <div class="col-5">
         <h2 id="a-release-schedule-you-can-depend-on">A release schedule you can depend on</h2>


### PR DESCRIPTION
## Done

Add spacing under graph image on `/server`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/server>
- See that there is sufficient spacing under graph image


## Issue / Card

Fixes #3561 