### PR TITLE
Move table on server page

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -255,8 +255,10 @@
 
 <div class="p-strip is-bordered">
   <div class="row">
+    <h2 id="the-fast-track-to-virtualisation">The fast track to virtualisation and containers</h2>
+  </div>
+  <div class="row">
     <div class="col-6">
-      <h2 id="the-fast-track-to-virtualisation">The fast track to virtualisation and containers</h2>
       <p>Ready to boost efficiencies and reduce costs? Virtualise your servers with Ubuntu Server, KVM and LXD. When you use a secure, lean version of Ubuntu as a guest operating system for your application, you can create virtual machines and machine containers in seconds. KVM, LXD, Xen, VMware, Vagrant, VirtualBox, and Docker are all first class experiences with Ubuntu Server. Ubuntu Server now supports KVM on ARM and IBM POWER8 architectures.</p>
       <p>Canonical believes in choice &mdash; that's why we support an open ecosystem of operating system intercompatibility. By providing choice, users of Ubuntu for both servers and clouds are empowered to succeed with any workload. We encourage others to do the same and offer support for all (currently supported) versions of Ubuntu Server running on other virtualisation platforms, including KVM on other commercially available Linux distributions, VMware vSphere, and Microsoft Hyper&#8209;V.</p>
     </div>


### PR DESCRIPTION
## Done

Move table on `/server` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/server>
- See that table is aligned with copy


## Issue / Card

Fixes #3550 