### PR TITLE
Update developer menu

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -37,6 +37,9 @@
       <div class="col-3">
         <h4 class="p-muted-heading">Desktop</h4>
         <ul class="p-text-list--small is-bordered">
+          <li class="p-list__item u-hide--medium u-hide--large">
+            <a href="/desktop/developer">Develop with Ubuntu</a>
+           </li>
           <li class="p-list__item">
             <a href="/desktop">The developer&rsquo;s favourite OS</a>
           </li>
@@ -57,6 +60,9 @@
       <div class="col-3">
         <h4 class="p-muted-heading">Internet of Things</h4>
         <ul class="p-text-list--small is-bordered">
+          <li class="p-list__item u-hide--medium u-hide--large">
+            <a href="https://snapcraft.io/">Publish with Snapcraft</a>
+          </li>
           <li class="p-list__item">
             <a href="/core">Ubuntu Core, the tiny transactional edition of Ubuntu</a>
           </li>
@@ -74,6 +80,9 @@
       <div class="col-3">
         <h4 class="p-muted-heading">Containers</h4>
         <ul class="p-text-list--small is-bordered">
+          <li class="p-list__item u-hide--medium u-hide--large">
+            <a href="/ai">Develop and test with AI</a>
+          </li>
           <li class="p-list__item">
             <a href="/kubernetes">Canonical Distribution of Kubernetes</a>
           </li>
@@ -88,6 +97,9 @@
       <div class="col-3">
         <h4 class="p-muted-heading">Cloud</h4>
         <ul class="p-text-list--small is-bordered">
+          <li class="p-list__item u-hide--medium u-hide--large">
+            <a href="https://jujucharms.com/r">Get started with Juju</a>
+          </li>
           <li class="p-list__item">
             <a href="/download/cloud">Ubuntu is the leading cloud guest OS</a>
           </li>


### PR DESCRIPTION
## Done

Update developer menu as suggested in issue

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that developer menu has been updated as per issue
- Please ignore top padding issue as that is fixed in https://github.com/canonical-websites/www.ubuntu.com/pull/3608

## Issue / Card

Fixes [#690](https://github.com/ubuntudesign/web-squad/issues/690)