### PR TITLE
Change install media instructions link on the nuc desktop install page

### DIFF
--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -61,7 +61,7 @@
             Flash the USB drive
           </h3>
           <div class="p-list-step__content">
-            <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
+            <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">installation media instructions</a>.</p>
           </div>
         </li>
         <li class="p-list-step__item">


### PR DESCRIPTION
## Done

- As requested by partner, update Intel NUC desktop installation media instructions link to point to the USB tutorial

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/iot/intel-nuc-desktop](http://0.0.0.0:8001/download/iot/intel-nuc-desktop)
- Ensure the installation media instructions link points to a flash-to-USB creation guide