### PR TITLE
Fix typo on about page

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -30,7 +30,7 @@
       <p>The first official Ubuntu release &mdash; Version 4.10, codenamed the ‘Warty Warthog’ &mdash; was launched in October 2004, and sparked dramatic global interest as thousands of free software enthusiasts and experts joined the Ubuntu community.</p>
       <p>Ubuntu today has <a class="p-link--external" href="https://wiki.ubuntu.com/UbuntuFlavors">many flavours</a> and <a href="https://wiki.ubuntu.com/DerivativeTeam/Derivatives" class="p-link--external">dozens of specialised derivatives</a>. There are also special editions for servers, OpenStack clouds, and connected devices. All editions share common infrastructure and software, making Ubuntu a unique single platform that scales from consumer electronics to the desktop and up into the cloud for enterprise computing.</p>
       <p>The Ubuntu desktop is by far the world’s most widely used Linux workstation platform, powering the work of engineers across the globe. Ubuntu Core sets the standard for tiny, transactional operating systems for highly secure connected devices. Ubuntu Server is the reference operating system for the OpenStack project, and a hugely popular guest OS on AWS, Azure and Google Cloud. Ubuntu is pre-installed on computers from Dell, HP, Asus, Lenovo and other global vendors.</p>
-      <p>We hope Ubuntu will bring something wonderful your computing &mdash; and we hope that you’ll join us in helping to shape and build the future of free software together.</p>
+      <p>We hope Ubuntu will bring something wonderful to your computing &mdash; and we hope that you’ll join us in helping to shape and build the future of free software together.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Fix typo on about page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/about>
- See that typo addressed in issue has been fixed


## Issue / Card

Fixes #3400 