### PR TITLE
Upgrade vanilla to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "LGPL v3",
   "devDependencies": {
     "postcss-cli": "^4.1.0",
-    "vanilla-framework": "1.7.0-beta-2.1"
+    "vanilla-framework": "1.7.1"
   },
   "dependencies": {
     "autoprefixer": "^6.3.1",

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -290,7 +290,7 @@ $color-rule--light: transparentize($color-mid-light, .5);
       }
 
       &:not(:last-child) {
-        @extend %pseudo-border--bottom;
+        @extend %vf-pseudo-border--bottom;
 
         &::after {
           background-color: $color-rule--light;

--- a/static/sass/_pattern_matrix.scss
+++ b/static/sass/_pattern_matrix.scss
@@ -67,15 +67,4 @@
       margin-top: 0;
     }
   }
-
-  // XXX Steve: 04.06.18 - fixes layout issue when matrix images have a link
-  // Issue: https://github.com/vanilla-framework/vanilla-framework/issues/1908
-  .p-matrix__img--link {
-    @extend .p-matrix__img;
-    z-index: 1;
-
-    img {
-      display: block;
-    }
-  }
 }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -228,7 +228,7 @@
 
         &::after {
           // white separator inside lockup
-          @extend %pseudo-border--top;
+          @extend %vf-pseudo-border--top;
           display: none;
 
           @media only screen and (min-width: $breakpoint-navigation-threshold) {
@@ -457,7 +457,7 @@ h2,
 }
 
 .p-card--navigation {
-  @extend %p-card;
+  @include vf-p-card;
   display: flex;
   flex-direction: column;
   margin-bottom: 0;
@@ -465,9 +465,9 @@ h2,
 }
 
 .p-card--light {
-  @extend %has-round-corners;
+  @extend %vf-has-round-corners;
   @extend %bg--light;
-  @extend %p-card;
+  @include vf-p-card;
   flex-direction: column;
   margin-bottom: $spv-inter--condensed-scaleable;
   padding: $spv-intra--scaleable - $px;

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -56,8 +56,8 @@
     <div class="col-12">
       <ul class="p-matrix is-trisected">
         <li class="p-matrix__item">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/spotify">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2017/12/spotify-linux-256.png" alt="Spotify icon" />
+          <a href="https://snapcraft.io/spotify">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/12/spotify-linux-256.png" alt="Spotify icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/spotify">Spotify</a></h3>
@@ -65,8 +65,8 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/skype">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2017/11/Skype.png" alt="Skype icon" />
+          <a href="https://snapcraft.io/skype">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/11/Skype.png" alt="Skype icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/skype">Skype</a></h3>
@@ -74,8 +74,8 @@
           </div>
         </li>
         <li class="p-matrix__item last-row">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/vlc">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2016/07/vlc.png" alt="VLC icon" />
+          <a href="https://snapcraft.io/vlc">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2016/07/vlc.png" alt="VLC icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/vlc">VLC player</a></h3>
@@ -83,8 +83,8 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/firefox">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2018/02/firefox256.png" alt="Firefox icon" />
+          <a href="https://snapcraft.io/firefox">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/02/firefox256.png" alt="Firefox icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/firefox">Firefox</a></h3>
@@ -92,8 +92,8 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/slack">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2017/12/slack.png" alt="Slack icon" />
+          <a href="https://snapcraft.io/slack">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/12/slack.png" alt="Slack icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/slack">Slack</a></h3>
@@ -101,8 +101,8 @@
           </div>
         </li>
         <li class="p-matrix__item last-row">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/atom">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2017/04/atom-256px.png" alt="Atom icon" />
+          <a href="https://snapcraft.io/atom">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/04/atom-256px.png" alt="Atom icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/atom">Atom</a></h3>
@@ -110,8 +110,8 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/chromium">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2017/08/chromium-browser.svg.png" alt="Chromium icon" />
+          <a href="https://snapcraft.io/chromium">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/08/chromium-browser.svg.png" alt="Chromium icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/chromium">Chromium</a></h3>
@@ -119,8 +119,8 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/pycharm-community">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png" alt="PyCharm" />
+          <a href="https://snapcraft.io/pycharm-community">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2017/11/PyCharmCore256.png" alt="PyCharm" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/pycharm-community">PyCharm</a></h3>
@@ -128,8 +128,8 @@
           </div>
         </li>
         <li class="p-matrix__item last-row">
-          <a class="p-matrix__img--link" href="https://snapcraft.io/telegram-desktop">
-            <img src="https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon256.png" alt="Telegram icon" />
+          <a href="https://snapcraft.io/telegram-desktop">
+            <img class="p-matrix__img" src="https://dashboard.snapcraft.io/site_media/appmedia/2018/02/icon256.png" alt="Telegram icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/telegram-desktop">Telegram</a></h3>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,9 +2971,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@1.7.0-beta-2.1:
-  version "1.7.0-beta-2.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0-beta-2.1.tgz#36ffb4461b7431d2aa245ff3c43010469751a231"
+vanilla-framework@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.1.tgz#3649e693a57cdd9b457d9589e98aecd32218b9be"
 
 vendors@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
## Done

Update Vanilla to latest version
Reverted changes made in https://github.com/canonical-websites/www.ubuntu.com/pull/3557 as fixed by Vanilla

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that Vanilla has been updated


## Issue / Card

Fixes #3616 