### PR TITLE
Update image on openstack training page

### DIFF
--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -12,7 +12,9 @@
       <h1>Train with Ubuntu</h1>
       <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack. All classes and materials are provided in English.</p>
     </div>
-    <img class="u-image-position--top u-image-position--right u-hide--small u-no-margin--top" alt="" src="{{ ASSET_SERVER_URL }}c45cabb5-ubuntu-openstack-medals.svg" style="width: 360px; right: 150px;" />
+    <div class="col-6 u-hide--small" style="position: relative; margin-top: -6rem;">
+      <img class="u-image-position--top u-image-position--right u-hide--small u-no-margin--top" alt="" src="{{ ASSET_SERVER_URL }}c45cabb5-ubuntu-openstack-medals.svg" style="width: 360px;" />
+    </div>
   </div>
 </section>
 

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -12,7 +12,7 @@
       <h1>Train with Ubuntu</h1>
       <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack. All classes and materials are provided in English.</p>
     </div>
-    <img class="u-image-position--top u-image-position--right u-hide--small u-no-margin--top" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" style="right: 150px;" />
+    <img class="u-image-position--top u-image-position--right u-hide--small u-no-margin--top" alt="" src="{{ ASSET_SERVER_URL }}c45cabb5-ubuntu-openstack-medals.svg" style="width: 360px; right: 150px;" />
   </div>
 </section>
 


### PR DESCRIPTION
## Done

Update image on openstack training page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/openstack/training>
- See image in hero has been updated


## Issue / Card

Fixes #3625 