### PR TITLE
added new include for openstack packages

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -14,12 +14,7 @@
       <img src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png" alt="" />
     </div>
   </div>
-  <div class="row">
-    <div class="col-8">
-      <p>Choose your OpenStack package:</p>
-    </div>
-  </div>
-    {% include "shared/pricing/_openstack-consulting.html" %}
+  {% include "shared/pricing/_openstack-packages.html" %}
 </section>
 
 <section class="p-strip">

--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -1,0 +1,68 @@
+<div class="row">
+  <p>Choose your OpenStack package:</p>
+</div>
+
+<div class="row u-equal-height">
+  <div class="col-6 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">Cloud Build Servicer</h2>
+      <p><span class="p-heading--two">$75,000</span> with two week delivery</p>
+    </div>
+    <p>Design and deployment of OpenStack reference architecture.</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
+      <li class="p-list__item is-ticked">Fixed-price deployment</li>
+      <li class="p-list__item is-ticked">Reference architecture</li>
+      <li class="p-list__item is-ticked">Open source storage</li>
+      <li class="p-list__item is-ticked">Simplified networking</li>
+      <li class="p-list__item is-ticked">Hyper-converged</li>
+      <li class="p-list__item is-ticked">Containerised control plane</li>
+      <li class="p-list__item is-ticked">Log aggregation</li>
+      <li class="p-list__item is-ticked">Monitoring cluster</li>
+      <li class="p-list__item is-ticked">Upgrades on demand</li>
+      <li class="p-list__item is-ticked">High availability</li>
+    </ul>
+    <p>Two week delivery on certified hardware.</p>
+    <p><a href="/openstack/consulting">Get OpenStack&nbsp;&rsaquo;</a></p>
+  </div>
+  <div class="col-6 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">Cloud Build Plus</h2>
+      <p><span class="p-heading--two">$150,000</span> one-time fee</p>
+    </div>
+    <p>Additional OpenStack consulting packages for our Cloud Build Service.</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">Workload analysis</li>
+      <li class="p-list__item is-ticked">VMware migration plan</li>
+      <li class="p-list__item is-ticked">Customised architecture</li>
+      <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
+      <li class="p-list__item is-ticked">Storage and SDN integration</li>
+      <li class="p-list__item is-ticked">LDAP or Active Directory</li>
+      <li class="p-list__item is-ticked">Corporate monitoring</li>
+      <li class="p-list__item is-ticked">Telco VNF onboarding</li>
+      <li class="p-list__item is-ticked">GPGPU and FPGA passthrough</li>
+      <li class="p-list__item is-ticked">HPC optimisations</li>
+      <li class="p-list__item is-ticked">Regulatory compliance</li>
+    </ul>
+    <p>On site workshops determine the optimal architecture for your workloads and integration requirements.</p>
+    <p><a href="/openstack/consulting/">Migrate from VMware&nbsp;&rsaquo;</a></p>
+  </div>
+  <div class="col-6 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">Fully Managed Cloud</h2>
+      <p><span class="p-heading--two">$500</span> per server per month</p>
+    </div>
+    <p>Full remote operations of your Canonical OpenStack at half the price of VMware.</p>
+    <ul class="p-list">
+
+      <li class="p-list__item is-ticked">24/7 monitoring</li>
+      <li class="p-list__item is-ticked">Proactive management</li>
+      <li class="p-list__item is-ticked">EU and US regulatory compliance options</li>
+      <li class="p-list__item is-ticked">Telco NFV options</li>
+      <li class="p-list__item is-ticked">Finance sector options</li>
+      <li class="p-list__item is-ticked">SDN options</li>
+    </ul>
+    <p>$500 per server per month or $5,000 per server per year. The best way to start with OpenStack. <a href="engage/cloud-economics ">Recognised by cloud economists</a> as the best value private cloud.</p>
+    <p><a href="/openstack/managed">Fully Managed OpenStack&nbsp;&rsaquo;</a></p>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- updated the /openstack page with the packages in the [copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack](hhttp://0.0.0.0:8001/openstack)
- See that the table at the top is the same as in the copy doc

## Issue / Card

Fixes #3624

