### PR TITLE
Remove dead nvidia link

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -183,7 +183,6 @@
         <li class="p-list__item is-ticked">NVIDIA Kubernetes extensions for hardware acceleration are enabled in the Canonical Distribution of Kubernetes</li>
         <li class="p-list__item is-ticked">NVIDIA Tegra and Drive PX2 ship with Ubuntu for Edge AI</li>
       </ul>
-      <p><a class="p-button--positive" href="/ai/nvidia">Learn more</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Removed a dead link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/ai](http://0.0.0.0:8001/ai)
- Check that the link under the header "NVIDIA and Canonical accelerate AI everywhere" has been removed.


## Issue / Card

Fixed: #3635 


