### PR TITLE
Remove pictogram and move text

### DIFF
--- a/templates/openstack/partners.html
+++ b/templates/openstack/partners.html
@@ -60,9 +60,6 @@
 
 <section class="p-strip--light">
   <div class="row">
-    <div class="col-4 u-align--center">
-      <img src="{{ ASSET_SERVER_URL }}2cc56cf9-picto-partner-midaubergine.svg" width="160" height="160" alt="" />
-    </div>
     <div class="col-8">
       <h2>Become a cloud partner</h2>
       <p>To learn more about becoming a charm, Ubuntu certified public cloud or Ubuntu OpenStack partner, please contact us today.</p>


### PR DESCRIPTION
## Done

Remove pictogram on openstack partners page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/openstack/partners>
- See that the pictogram from the last section of the page has been removed


## Issue / Card

Fixes #3629 