### PR TITLE
Hide image on mobile

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -113,13 +113,13 @@
   {% include "openstack/shared/_openstack_clients.html" %}
 </section>
 
-<section class="p-strip">
+<section class="p-strip u-no-padding--bottom">
   <div class="row u-equal-height">
     <div class="col-7 suffix-1">
       <h2>Real architectural flexibility, no snowflakes allowed</h2>
       <p>Every business is different, and every sector faces unique constraints. That creates real reasons to have your own OpenStack architecture. At the same time, reinventing all of the operations for a large open source codebase makes no sense. Canonical encodes operations in a way that is shared across all our customers, while retaining the ability to craft the architecture that’s right for a particular deployment. This is why Canonical can consistently and repeatedly beat the competition on delivery and flexibility for OpenStack, and why Canonical leads on day-2 operations such as upgrades and scaling for the private cloud.</p>
     </div>
-    <div class="col-5 u-vertically-center">
+    <div class="col-5 u-vertically-center u-hide--small">
         <object wmode="transparent" class="bundle-card__bundle-image" type="image/svg+xml" data="https://api.jujucharms.com/charmstore/v5/bundle/openstack-base-55/diagram.svg" width="100%"></object>
     </div>
   </div>


### PR DESCRIPTION
## Done

Hide image on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/openstack>
- See that on mobile the 'Real architectural flexibility, no snowflakes allowed' image is hidden


## Issue / Card

Fixes #3630 