### PR TITLE
Fix spacing on openstack features

### DIFF
--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -71,7 +71,9 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-8">
-        <p class="p-heading--four">Migrate your existing VMs to Canonical OpenStack &mdash; quickly and cost-effectively.</p>
+        <div>
+          <p class="p-heading--four">Migrate your existing VMs to Canonical OpenStack &mdash; quickly and cost-effectively.</p>
+        </div>
         <p>Canonical provides workload analysis and migration services. Not every workload is best run on a cloud, but 80-90% of enterprise workloads can move to OpenStack easily, and are much more cost-effective to run there.</p>
         <p>The main driver for most OpenStack cloud deployments is the cost benefit of a leaner and more open IAAS. Canonical OpenStack also offers a range of cloud services, and compatibility with multi-cloud operations tools. While legacy virtualisation continues to be important, the future is cloud APIs and container-based operations, which Canonical OpenStack delivers.</p>
       </div>


### PR DESCRIPTION
## Done

Fix spacing on openstack features page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/openstack/features>
- See that spacing around 'VMware migration' section is sufficient on mobile


## Issue / Card

Fixes #3640 