### PR TITLE
Fix spacing in hero

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -13,7 +13,6 @@
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>
           <a href="/openstack/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Engage Canonical exports', 'eventLabel' : 'Engage Canonical exports - Top CTA', 'eventValue' : undefined });" class="p-button--positive">Engage Canonical experts</a>
-          &#8195;
           <a href="{{ ASSET_SERVER_URL }}8cf6fe4f-Foundation-Cloud-Build-Openstack-data-sheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read our consulting datasheet', 'eventLabel' : 'Read our consulting datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Read our consulting datasheet</a>
         </p>
       </div>


### PR DESCRIPTION
## Done

Fix spacing on openstack consulting hero buttons

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/openstack/consulting>
- See button spacing is correct


## Issue / Card

Fixes #3647 