### PR TITLE
update the path to the thank-you pages for /openstack/contact-us

### DIFF
--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -4,39 +4,39 @@ contextual-footer-openstack{% extends "openstack/_base_openstack.html" %}
 {% block content %}
   {% if product == 'openstack-training' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/cloud/thank-you?product=openstack-training" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" %}
 
   {% elif product == 'openstack-training-classroom' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Register for Ubuntu OpenStack Training" intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we’ll get back to you with available dates and locations." formid="1261" lpId="2161" returnURL="https://www.ubuntu.com/cloud/thank-you?product=openstack-training-classroom" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Register for Ubuntu OpenStack Training" intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we’ll get back to you with available dates and locations." formid="1261" lpId="2161" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-classroom" %}
 
   {% elif product == 'openstack-training-onsite' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1223" lpId="1973" returnURL="https://www.ubuntu.com/cloud/thank-you?product=openstack-training-onsite" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1223" lpId="1973" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-onsite" %}
 
   {% elif product == 'openstack-training-server-admin' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/cloud/thank-you?product=openstack-training-server-admin" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-server-admin" %}
 
   {% elif product == 'ubuntu-advantage-storage' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/cloud/thank-you?product=ubuntu-advantage-storage" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" %}
 
   {% elif product == 'openstack-managed-cloud' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about an OpenStack managed cloud" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/cloud/thank-you?product=openstack-managed-cloud" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about an OpenStack managed cloud" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
 
     {% elif product == 'openstack-managed-cloud-demo' %}
 
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/cloud/thank-you?product=openstack-managed-cloud" %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
 
   {% elif product == 'foundation-cloud' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Talk to us about building your cloud" intro_text="Fill in your details below and a member of our Foundation Cloud Build team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/cloud/thank-you?product=foundation-cloud' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Talk to us about building your cloud" intro_text="Fill in your details below and a member of our Foundation Cloud Build team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' %}
 
   {% else %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about OpenStack" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/cloud/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about OpenStack" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' %}
 
   {% endif %}
 {% endblock content %}


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Test the following
  - http://0.0.0.0:8001/openstack/thank-you?product=openstack-training
  - http://0.0.0.0:8001/openstack/thank-you?product=openstack-training-classroom
  - http://0.0.0.0:8001/openstack/thank-you?product=openstack-training-onsite
  - http://0.0.0.0:8001/openstack/thank-you?product=openstack-training-server-admin
  - http://0.0.0.0:8001/openstack/thank-you?product=ubuntu-advantage-storage
  - http://0.0.0.0:8001/openstack/thank-you?product=openstack-managed-cloud
  - http://0.0.0.0:8001/openstack/thank-you?product=foundation-cloud
  - http://0.0.0.0:8001/openstack/thank-you

## Issue / Card

Fixes #3658
