### PR TITLE
Fix spacing on ai hero

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -12,7 +12,6 @@
       <p>Canonical&rsquo;s Kubeflow supports the most popular tools for machine learning &mdash; starting with JupyterHub and Tensorflow &mdash; in a standardised workflow running on Kubernetes.</p>
       <p>
         <a class="p-button--positive" href="/ai/install">Get started by installing Kubeflow</a>
-        &#8195;
         <a class="p-button--neutral" href="/ai/contact-us?product=ai-index">Call the experts</a>
       </p>
     </div>


### PR DESCRIPTION
## Done

Fix spacing in ai hero

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/ai>
- See that button spacing in hero is correct

## Issue / Card

Fixes #3657 