### PR TITLE
Remove duplicated copy

### DIFF
--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -71,16 +71,17 @@
 </section>
 
 <section class="p-strip--light is-bordered">
-  <div class="row u-equal-height u-vertically-center">
+  <div class="row">
+    <h2>Tensorflow&trade;</h2>
+  </div>
+  <div class="row u-equal-height">
     <div class="col-8">
-      <h2>Tensorflow&trade;</h2>
       <p>TensorFlow is an open source software library for high performance numerical computation. Its flexible architecture allows easy deployment of computation across a variety of platforms (CPUs, GPUs, TPUs), and from desktops to clusters of servers to mobile and edge devices. Originally developed by researchers and engineers from the Google Brain team within Google&rsquo;s AI organization, it comes with strong support for machine learning and deep learning and the flexible numerical computation core is used across many other scientific domains.</p>
       <p>TensorFlow comes with visualisation technology &mdash; TensorBoard. It features graphs, histograms, and helps with visualising learning.</p>
       <p><a href="https://www.tensorflow.org/" class="p-link--external">Learn more about Tensorflow</a>
     </div>
-    <div class="col-4 u-hide--small">
+    <div class="col-4 u-hide--small u-vertically-center">
       <p><img src="{{ ASSET_SERVER_URL }}710ddd41-mnist_tensorboard.png" class="p-image--shadowed" alt="" /></p>
-      <p class="p-heading--six">TensorFlow comes with visualisation technology &mdash; TensorBoard. It features graphs, histograms, and helps with visualising learning.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Remove duplicated copy on ai featurespage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/ai/features>
- See that the caption under the tensorflow image has been removed


## Issue / Card

Fixes #3659 