### PR TITLE
Hide kubeflow logo on mobile

### DIFF
--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -57,7 +57,7 @@
 
 <section class="p-strip is-bordered">
   <div class="row u-equal-height">
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}da5a7c9e-Kubeflow-Logo.svg" alt="">
     </div>
     <div class="col-8">


### PR DESCRIPTION
## Done

Hide kubeflow logo on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/ai/features>
- See that kubeflow logo is hidden on mobile


## Issue / Card

Fixes #3660 