### PR TITLE
Replace the install K8s bit.ly links with asset ones

### DIFF
--- a/templates/ai/install.html
+++ b/templates/ai/install.html
@@ -34,7 +34,7 @@
           <div class="p-list-step__content">
             <p>Get the bash script that will install mircok8s</p>
             <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="wget https://bit.ly/2tp2aOo -O install-kubeflow-pre-micro.sh" readonly="readonly">
+              <input class="p-code-snippet__input" value="wget https://assets.ubuntu.com/v1/b783a95d-install-kubeflow-pre-micro.sh -O install-kubeflow-pre-micro.sh" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
             </div>
             <p>Set permissions so the script can run</p>
@@ -69,7 +69,7 @@
           <div class="p-list-step__content">
             <p>Get the bash script that will install mircok8s</p>
             <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="wget https://bit.ly/2tndL0g -O install-kubeflow.sh" readonly="readonly">
+              <input class="p-code-snippet__input" value="wget https://assets.ubuntu.com/v1/58a9e137-install-kubeflow.sh -O install-kubeflow.sh" readonly="readonly">
               <button class="p-code-snippet__action">Copy to clipboard</button>
             </div>
             <p>Set permissions so the script can run</p>


### PR DESCRIPTION
## Done
Replace the install K8s bit.ly links with asset links

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/ai/install](http://0.0.0.0:8001/ai/install)
- Check that the links in the steps are assets links