### PR TITLE
Fix telecominfraproject logo size

### DIFF
--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -159,7 +159,7 @@
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}9635c8f7-opencompute-logo-green.png" alt="Open Compute" />
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eeae998a-telecominfraproject-logo.svg" alt="Telecom Infra Project" />
+          <img style="width: 300px;" class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eeae998a-telecominfraproject-logo.svg" alt="Telecom Infra Project" />
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}061ffe4a-onf-logo.jpg" alt="ONF" />


### PR DESCRIPTION
## Done

Fix size of telecominfraproject logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/telecommunications>
- See that telecominfraproject logo size is correct


## Issue / Card

Fixes #3654 