### PR TITLE
Update marketo download forms to mongoose

### DIFF
--- a/templates/download/iot/intel-joule.html
+++ b/templates/download/iot/intel-joule.html
@@ -65,7 +65,7 @@
           </h3>
           <div class="p-list-step__content">
             <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="http://www.ubuntu.com/download/desktop">Ubuntu {{lts_release_full_with_point}}</a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+              <li>Download and copy the <a href="/download/desktop">Ubuntu {{lts_release_full_with_point}}</a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
               <li>Download the Ubuntu Core image for Intel Joule and copy the file on the second USB drive.</li>
             </ol>
           </div>

--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -66,7 +66,7 @@
           </h3>
           <div class="p-list-step__content">
             <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="http://www.ubuntu.com/download/desktop">Ubuntu Desktop {{ lts_release_full_with_point }}</a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+              <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ lts_release_full_with_point }}</a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
               <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
             </ol>
           </div>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -83,7 +83,7 @@
               <li class="mktField p-list__item">
                 <input name="Optin_cloud_nuture" id="Optin_cloud_nuture" type="checkbox" value="yes" class="mktoField"> <label for="Optin_cloud_nuture" class="mktoLabel">I would like to receive eBooks and White Papers by Canonical.</label>
               </li>
-              <li><p>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
+              <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
               <li class="mktField p-list__item">
                 <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide">Accept terms and download</button>
                 <input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
@@ -93,8 +93,8 @@
               </li>
             </ul>
           </fieldset>
-          <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
-          <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
+          <input type="hidden" name="returnURL" value="https://mongoose.ubuntu.com/download/server/thank-you-s390x" />
+          <input type="hidden" name="retURL" value="https://mongoose.ubuntu.com/download/server/thank-you-s390x" />
         </form>
         <script>
           $("#mktoForm_1400").validate({

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -17,7 +17,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
       <p>Thank you for downloading Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems. Your ISO download should start automatically.</p>
       <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/xenial/release">visit the download page</a>.</p>
       <p>Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
-      <p>Your use of Ubuntu on z Systems and LinuxONE in production constitutes <a href="https://www.ubuntu.com/legal/service-terms">acceptance of these terms</a>.</p>
+      <p>Your use of Ubuntu on z Systems and LinuxONE in production constitutes <a href="/legal/service-terms">acceptance of these terms</a>.</p>
       <p>For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us +44 (0) 203 656 5291 or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
     </div>
     <div class="col-6 p-card">
@@ -92,8 +92,8 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
             </li>
           </ul>
         </fieldset>
-        <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
-        <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+        <input type="hidden" name="returnURL" value="https://mongoose.ubuntu.com/download/server/linuxone-signup-thank-you" />
+        <input type="hidden" name="retURL" value="https://mongoose.ubuntu.com/download/server/linuxone-signup-thank-you" />
       </form>
       <script>
         $("#mktoForm_1400").validate({

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -35,7 +35,7 @@ Thanks for downloading Ubuntu Server
   </div>
 </div>
 
-{% include "download/shared/_get_ebook.html"%}
+{% include "download/shared/_get_ebook.html"  with return_url="https://mongoose.ubuntu.com/server/thank-you" %}
 
 <div class="p-strip is-shallow">
   <div class="row">

--- a/templates/download/shared/_get_ebook.html
+++ b/templates/download/shared/_get_ebook.html
@@ -59,8 +59,8 @@
           </ul>
         </fieldset>
 
-        <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/cloud#instructions" />
-        <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/cloud#instructions" />
+        <input type="hidden" name="returnURL" value="{{ return_url }}" />
+        <input type="hidden" name="retURL" value="{{ return_url }}" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
       </form>
       <!-- /MARKETO FORM -->

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -84,8 +84,8 @@
           </ul>
         </fieldset>
 
-        <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/provisioning#instructions">
-        <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/provisioning#instructions">
+        <input type="hidden" name="returnURL" value="https://mongoose.ubuntu.com/download/server/provisioning#instructions">
+        <input type="hidden" name="retURL" value="https://mongoose.ubuntu.com/download/server/provisioning#instructions">
       </form>
       <!-- /MARKETO FORM -->
     </div>


### PR DESCRIPTION
## Done

- updated from www. to mongoose. for download pages
- made links to download/desktop relative for intel pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
  - http://0.0.0.0:8001/download/iot/intel-joule.html
  - http://0.0.0.0:8001/download/iot/intel-nuc.html
  - http://0.0.0.0:8001/download/server/s390x.html
  - http://0.0.0.0:8001/download/server/thank-you-linuxone.html
  - http://0.0.0.0:8001/download/server/thank-you.html
  - http://0.0.0.0:8001/download/shared/_get_ebook.html
  - http://0.0.0.0:8001/download/shared/_get_ebook_maas.html


## Issue / Card

Fixes #3672
