### PR TITLE
Update links

### DIFF
--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -125,14 +125,14 @@
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Products</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://maas.io/">MAAS</a></li>
             <li class="p-list__item"><a class="p-link" href="https://landscape.canonical.com/">Landscape</a></li>
             <li class="p-list__item"><a class="p-link" href="https://jujucharms.com/">Juju</a></li>
             <li class="p-list__item"><a class="p-link" href="https://linuxcontainers.org/">LXD</a></li>
             <li class="p-list__item"><a class="p-link" href="https://snapcraft.io/">Snaps</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/openstack">OpenStack</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/kubernetes">Kubernetes</a></li>
           </ul>
         </div>
         <div class="row">
@@ -156,21 +156,21 @@
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
             <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
             <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
             <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download/cloud">Install</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download">Download</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">About</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com/press-centre">Press centre</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
             <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
             <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/about/contact-us">Contact</a></li>
           </ul>
         </div>
       </div>
@@ -180,11 +180,11 @@
         <div class="row u-hide--small">
           <ul class="p-matrix u-no-margin--bottom">
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com">
+              <a href="https://mongoose.ubuntu.com">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://mongoose.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s most popular Linux for servers, desktops and things, with enterprise support and enhanced security by Canonical</p>
               </div>
             </li>
@@ -234,20 +234,20 @@
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com/openstack">
+              <a href="https://mongoose.ubuntu.com/openstack">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}a7916513-picto-openstack.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://mongoose.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s first choice for OpenStack - the leader in density and cost per VM</p>
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com/kubernetes">
+              <a href="https://mongoose.ubuntu.com/kubernetes">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}b81a45e4-kubernetes.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://mongoose.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">Canonical works with Google GKE and Azure AKS for app portability between private and public infra</p>
               </div>
             </li>
@@ -292,19 +292,19 @@
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
               <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
               <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
               <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download/cloud">Install</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download">Download</a></li>
             </ul>
             <h5 class="p-muted-heading">About</h5>
             <ul class="p-list is-split u-no-margin--bottom">
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com">Ubuntu</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com">Ubuntu</a></li>
               <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://insights.ubuntu.com/press-centre">Press centre</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
               <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
               <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/about/contact-us">Contact</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Done

Make sure links in global nav for ubuntu.com go to mongoose.ubuntu.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the ubuntu links in the global nav all go to mongoose


## Issue / Card

Fixes #3670 