### PR TITLE
Fix typo in enterprise menu

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -95,7 +95,7 @@
             </a>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
-            <a href="/support">Enterprise suppor&nbsp;&rsaquo;</a>
+            <a href="/support">Enterprise support&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>


### PR DESCRIPTION
## Done

Fix typo in enterprise menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the typo has been fixed in the code

## Issue / Card

Fixes #3675 