### PR TITLE
fix typo on openstack index

### DIFF
--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -5,7 +5,7 @@
 <div class="row u-equal-height">
   <div class="col-6 p-card">
     <div class="p-card__header">
-      <h2 class="p-heading--four">Cloud Build Servicer</h2>
+      <h2 class="p-heading--four">Cloud Build Service</h2>
       <p><span class="p-heading--two">$75,000</span> with two week delivery</p>
     </div>
     <p>Design and deployment of OpenStack reference architecture.</p>


### PR DESCRIPTION
## Done

* fix typo on Cloud Build Service(r)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/openstack](http://0.0.0.0:8001/openstack)
- see that the typo was fixed

