### PR TITLE
Fix mobile menu state

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -151,9 +151,11 @@ if (window.location.hash) {
   var tabId = window.location.hash.split('#')[1];
   var tab = document.getElementById(tabId);
   var tabContent = document.getElementById(tabId + '-content');
+  var navButton = document.querySelector('.p-navigation__toggle--open');
 
   if (tab) {
     document.getElementById(tabId).click();
+    navButton.click();
   }
 }
 


### PR DESCRIPTION
## Done

Fix navigation on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Open one of the navigation menus
- Click through to another page
- Hit the back button
- See that the previous menu tab is open as is the main navigation

## Issue / Card

Fixes #3669 