### PR TITLE
Fix incorrect link

### DIFF
--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -9,7 +9,7 @@
     <div class="col-7">
       <h1>Canonical&rsquo;s AI and ML solutions feature&hellip;</h1>
       <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical&rsquo;s AI solutions such as <a href="/kubeflow">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
+      <p>Canonical&rsquo;s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
       <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
       <p><a href="/ai/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI consulting&nbsp;&rsaquo;</a></p>
     </div>

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -99,8 +99,8 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-4 p-card u-align--center">
-        <a href="/openstack/contactus?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" alt="Talk to us" /></a>
-        <h4 class="u-no-margin--bottom"><a href="/openstack/contactus?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
+        <a href="/openstack/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" alt="Talk to us" /></a>
+        <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
         <a href="{{ ASSET_SERVER_URL }}8cf6fe4f-Foundation-Cloud-Build-Openstack-data-sheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" /></a>


### PR DESCRIPTION
## Done

Fix incorrect openstack contact link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/openstack/consulting)
- See that contact us links don't 404


## Issue / Card

Fixes #3686