### PR TITLE
Remove sticky header for mobile

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -20,11 +20,6 @@
     flex-direction: column;
     z-index: 3;
 
-    @media (max-width: $breakpoint-navigation-threshold - 1) {
-      position: sticky;
-      top: 0;
-    }
-
     &::after { // disable rule under nav
       background-color: none;
       height: 0;


### PR DESCRIPTION
## Done

Remove sticky header from mobile view to avoid scrolling/ux issues

There are a number of usability issues with such long menus and a fixed header that will be addressed as part of: https://github.com/canonical-websites/www.ubuntu.com/issues/3272

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the header is not fixed on mobile and therefore opening a menu opens in the right position


## Issue / Card

Fixes #3668 