### PR TITLE
Update page Kubernetes features copy

### DIFF
--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -39,7 +39,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Keeping Kubernetes current</h3>
       <hr>
-      <p>Developers demand the latest features as Kubernetes evolves rapidly in the open source community. On Bare-Metal, VMs or as a service &mdash; CDK will keep your kubernetes cluster up to date</p>
+      <p>Developers demand the latest features as Kubernetes evolves rapidly in the open source community. On bare metal, VMs or as a service &mdash; CDK will keep your kubernetes cluster up to date</p>
       <p>Using Snaps, point releases of Kubernetes are automatically installed. And whenever there is a new major version, juju charms make upgrading CDK easy.</p>
       <p><a class="p-button--positive" href="/kubernetes/install">Install CDK now</a></p>
     </div>
@@ -54,7 +54,7 @@
 
 <section class="p-strip--light is-bordered">
   <div class="row">
-    <h2>Kubernetes fits perfectly on top of OpenStack, and VMware and MAAS Bare Metal</h2>
+    <h2>Kubernetes fits perfectly on top of OpenStack, and VMware and MAAS bare metal</h2>
     <p>There&rsquo;s no doubt that Kubernetes is the new standard operational layer for every multi-cloud business. Canonical enables K8s on demand for your devops teams &mdash; on OpenStack, on VMware, on public clouds, and on bare metal clusters with MAAS.</p>
   </div>
   <div class="row">
@@ -143,7 +143,7 @@
         <li class="p-list__item is-ticked">Make storage available to containers wherever they&rsquo;re scheduled.</li>
         <li class="p-list__item is-ticked">Automatically delete the storage when no longer needed.</li>
       </ul>
-      <p>To improve the extensibility of the storage feature set and plugin ecosystem, Kubernetes has announced a new initiative &mdash; the Container Storage Interface (CSI) &mdash; which is currently in Beta. CSI enables storage plugins to be developed independent from the Kubernetes github tree, containerized, deployed via standard Kubernetes primitives, and consumed through the Kubernetes storage primitives users know and love (PersistentVolumeClaims, PersistentVolumes, StorageClasses). The next dot release of CDK will provide early access to CSI.</p>
+      <p>To improve the extensibility of the storage feature set and plugin ecosystem, Kubernetes has announced a new initiative &mdash; the Container Storage Interface (CSI) &mdash; which is currently in Beta. CSI enables storage plugins to be developed independent from the Kubernetes github tree, containerized, deployed via standard Kubernetes primitives, and consumed through the Kubernetes storage primitives users know and love (<code>PersistentVolumeClaims</code>, <code>PersistentVolumes</code>, <code>StorageClasses</code>). The next dot release of CDK will provide early access to CSI.</p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}4bf27234-logo+%281%29.png" alt="">
@@ -156,7 +156,7 @@
     <h2>Logging and monitoring</h2>
     <p>Operations in highly coherent large-scale distributed clusters require a new level of operational monitoring and observability. Canonical delivers a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using Prometheus, the Elasticsearch and Kibana stack (ELK), and Nagios.</p>
     <div><img src="{{ ASSET_SERVER_URL }}9f6916dd-k8s-prometheus-light.png" alt=""></div>
-    <p class="p-heading--six">These dashboards can be customised or integrated into existing monitoring systems at your business.</p>
+    <cite>These dashboards can be customised or integrated into existing monitoring systems at your business.</cite>
   </div>
 </section>
 <section class="p-strip--light">

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -161,8 +161,10 @@
 </section>
 <section class="p-strip--light">
   <div class="row">
+    <h2>Get started with Canonical&rsquo;s Distribution of Kubernetes<sup>&reg;</sup></h2>
     <p>Find out how the Canonical Distribution of Kubernetes can give you the flexibility to share operational code with a large community whilst placing your services exactly where you want them.</p>
     <p><a href="/kubernetes/contact-us" class="p-button--positive">Contact Canonical about Kubernetes</a></p>
+    <p><small>* Kubernetes<sup>&reg;</sup> is a registered trademark of The Linux Foundation in the United States and other countries, and is used pursuant to a license from The Linux Foundation</small></p>
   </div>
 </section>
 

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -37,7 +37,7 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Keeping Kubernetes Current</h3>
+      <h3 class="p-card__title">Keeping Kubernetes current</h3>
       <hr>
       <p>Developers demand the latest features as Kubernetes evolves rapidly in the open source community. On Bare-Metal, VMs or as a service &mdash; CDK will keep your kubernetes cluster up to date</p>
       <p>Using Snaps, point releases of Kubernetes are automatically installed. And whenever there is a new major version, juju charms make upgrading CDK easy.</p>
@@ -46,7 +46,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Managed Kubernetes</h3>
       <hr>
-      <p>Predictable OpEx for organizations looking to disaggregate Kubernetes adoption from operational readiness. Canonical provides managed service for Kubernetes at great economics.</p>
+      <p>Predictable OpEx for organisations looking to disaggregate Kubernetes adoption from operational readiness. Canonical provides managed service for Kubernetes at great economics.</p>
       <p><a class="p-button--positive" href="/kubernetes/managed">Learn more</a></p>
     </div>
   </div>
@@ -143,7 +143,7 @@
         <li class="p-list__item is-ticked">Make storage available to containers wherever they&rsquo;re scheduled.</li>
         <li class="p-list__item is-ticked">Automatically delete the storage when no longer needed.</li>
       </ul>
-      <p>To improve the extensibility of the storage feature set and plugin ecosystem, Kubernetes has announced a new initiative &mdash; the Container Storage Interface (CSI) &mdash; which is currently in Beta. CSI enables storage plugins to be developed independent from the kubernetes github tree, containerized, deployed via standard Kubernetes primitives, and consumed through the Kubernetes storage primitives users know and love (PersistentVolumeClaims, PersistentVolumes, StorageClasses). The next dot release of CDK will provide early access to CSI.</p>
+      <p>To improve the extensibility of the storage feature set and plugin ecosystem, Kubernetes has announced a new initiative &mdash; the Container Storage Interface (CSI) &mdash; which is currently in Beta. CSI enables storage plugins to be developed independent from the Kubernetes github tree, containerized, deployed via standard Kubernetes primitives, and consumed through the Kubernetes storage primitives users know and love (PersistentVolumeClaims, PersistentVolumes, StorageClasses). The next dot release of CDK will provide early access to CSI.</p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}4bf27234-logo+%281%29.png" alt="">
@@ -153,16 +153,16 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <h2>Logging and Monitoring</h2>
-    <p>Operations in highly coherent large-scale distributed clusters require a new level of operational monitoring and observability. Canonical delivers a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using Prometheus, the Elastic Search and Kibana stack (ELK), and Nagios.</p>
+    <h2>Logging and monitoring</h2>
+    <p>Operations in highly coherent large-scale distributed clusters require a new level of operational monitoring and observability. Canonical delivers a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using Prometheus, the Elasticsearch and Kibana stack (ELK), and Nagios.</p>
     <div><img src="{{ ASSET_SERVER_URL }}9f6916dd-k8s-prometheus-light.png" alt=""></div>
     <p class="p-heading--six">These dashboards can be customised or integrated into existing monitoring systems at your business.</p>
   </div>
 </section>
 <section class="p-strip--light">
   <div class="row">
-    <h2>Get started with Canonical&rsquo;s Distribution of Kubernetes<sup>&reg;</sup></h2>
-    <p>Find out how the Canonical Distribution of Kubernetes can give you the flexibility to share operational code with a large community whilst placing your services exactly where you want them.</p>
+    <h2>Get started with Canonical&rsquo;s Distribution of Kubernetes<sup>&reg;</sup> *</h2>
+    <p>Find out how Canonical can enable Kubernetes on demand for your devops teams &mdash; on OpenStack, on VMware, on public clouds, and on bare metal clusters.</p>
     <p><a href="/kubernetes/contact-us" class="p-button--positive">Contact Canonical about Kubernetes</a></p>
     <p><small>* Kubernetes<sup>&reg;</sup> is a registered trademark of The Linux Foundation in the United States and other countries, and is used pursuant to a license from The Linux Foundation</small></p>
   </div>

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -161,7 +161,7 @@
 </section>
 <section class="p-strip--light">
   <div class="row">
-    <h2>Get started with Canonical&rsquo;s Distribution of Kubernetes<sup>&reg;</sup> *</h2>
+    <h2>Get started with Canonical&rsquo;s Distribution of Kubernetes<sup>&reg;</sup> <sup>*</sup></h2>
     <p>Find out how Canonical can enable Kubernetes on demand for your devops teams &mdash; on OpenStack, on VMware, on public clouds, and on bare metal clusters.</p>
     <p><a href="/kubernetes/contact-us" class="p-button--positive">Contact Canonical about Kubernetes</a></p>
     <p><small>* Kubernetes<sup>&reg;</sup> is a registered trademark of The Linux Foundation in the United States and other countries, and is used pursuant to a license from The Linux Foundation</small></p>


### PR DESCRIPTION
## Done

Update copy of Kubernetes features page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/kubernetes/features>
- See that the last section of the page matches the [copy doc](https://docs.google.com/document/d/1mEOBW4pfsWJqTLm9Pn9myKtaslD-QB2RvUKcNQ52bXU/edit#heading=h.b3bz7op7xuz2)


## Issue / Card

Fixes [#707](https://github.com/ubuntudesign/web-squad/issues/707)