### PR TITLE
Remove autofocus on search field

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -137,9 +137,11 @@ core.siteSearch = function(){
 
   siteSearchToggle = document.querySelector('.search-toggle__link');
   siteSearchForm  = document.querySelector('.p-site-search__form');
+  siteSearchInput  = document.querySelector('.p-site-search__input');
 
   siteSearchToggle.addEventListener('click', function(e) {
     siteSearchForm.classList.toggle('u-visible');
+    siteSearchInput.focus();
     e.preventDefault();
   });
 };

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -108,7 +108,7 @@
 
         <form action="/search" class="p-site-search__form u-hide--small u-hide--medium u-visible--large" id="google-appliance-search-form">
           <label for="edit-keys" class="u-off-screen">Search</label>
-          <input type="search" maxlength="255" name="q" id="edit-keys" class="p-site-search__input" placeholder="Search" value="{{ query }}" autofocus />
+          <input type="search" maxlength="255" name="q" id="edit-keys" class="p-site-search__input" placeholder="Search" value="{{ query }}" />
           <button type="submit" class="p-site-search__button">
             <svg class="u-hide--small u-hide--medium" xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 90 90'><g color='#fff'><path fill='none' stroke-width='4' d='M0 0h90v90H0z'/><path d='M69 36.5a33 33.5 0 1 1-66 0 33 33.5 0 1 1 66 0z' transform='matrix(.636 0 0 .627 16.114 16.12)' fill='none' stroke='#fff' stroke-width='9.5'/><path d='M55.77 52.92L52.94 55.75l14 14 2.83-2.83-14-14z' fill='#fff' stroke-width='6' class='s0'/></g></svg>
           </button>


### PR DESCRIPTION
## Done
Removed the autofocus from the search field and added the focus with JS on the mobile search button.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Check that the search box is not focused
- Scale to small screens
- Click the search button and see the search field is focused

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3246
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3688