### PR TITLE
Update kubernetes managed copy

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -13,7 +13,7 @@
           <li>Fully managed Kubernetes on your bare metal, VMWare, OpenStack or any public cloud</li>
           <li>Built in two weeks using a proven reference architecture with our <a class="p-link--inverted" href="/kubernetes">Kubernetes consulting packages</a></li>
           <li>Customise the architecture in iterations based on workloads</li>
-          <li>Enterprise class SLA for the infrastructure, upgrades included</li>
+          <li>Enterprise class <abbr title="Service level agreement">SLA</abbr> for the infrastructure, upgrades included</li>
           <li>Monitoring and log management integration</li>
         </ul>
         <div>
@@ -87,7 +87,7 @@
   <section class="p-strip strip-light is-bordered">
     <div class="row">
       <div class="col-12">
-        <h2>Build, Operate, Transfer and Support</h2>
+        <h2>Build, operate, transfer and support</h2>
         <p class="u-sv3">The best way to keep costs down and ensure a high quality cloud is to use a repeatable, standardised methodology for workload analysis, requirements gathering, deployment and operations.</p>
       </div>
     </div>
@@ -406,7 +406,7 @@
   <section class="p-strip--light is-bordered">
     <div class="row">
       <div class="col-8">
-        <p>Talk to Canonical&rsquo;s remote operations team about building and operating your Kubernetes cluster today.</p>
+        <h3>Talk to Canonical&rsquo;s remote operations team about building and operating your Kubernetes cluster today.</h3>
         <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Schedule a Kubernetes demo', 'eventLabel' : 'Schedule a Kubernetes demo - Bottom CTA' : undefined });">Schedule a Kubernetes demo</a></p>
       </div>
     </div>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -180,7 +180,7 @@
         <h3>Fully Managed OpenStack</h3>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Controlled density and performance</li>
-          <li class="p-list__item is-ticked">Containers for bare-metal speed</li>
+          <li class="p-list__item is-ticked">Containers for bare metal speed</li>
           <li class="p-list__item is-ticked">CAPEX for long term workloads</li>
           <li class="p-list__item is-ticked">Regulatory compliance</li>
           <li class="p-list__item is-ticked">Data sovereignty</li>
@@ -269,7 +269,7 @@
             <li class="p-matrix__item">
               <div class="p-matrix__content">
                 <h3 class="p-matrix__title p-heading--four">Cloud native storage</h3>
-                <p class="p-matrix__desc">Use proven software‐defined storage like Ceph, Nexenta Edge, and Swift in your BootStack, or integrate your existing SAN.</p>
+                <p class="p-matrix__desc">Use proven software‐defined storage like Ceph, NexentaEdge, and Swift in your BootStack, or integrate your existing SAN.</p>
               </div>
             </li>
             <li class="p-matrix__item">
@@ -403,18 +403,12 @@
     </div>
   </section>
 
-  <section class="p-strip--light is-bordered">
+  <section class="p-strip--light">
     <div class="row">
       <div class="col-8">
         <h3>Talk to Canonical&rsquo;s remote operations team about building and operating your Kubernetes cluster today.</h3>
         <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Schedule a Kubernetes demo', 'eventLabel' : 'Schedule a Kubernetes demo - Bottom CTA' : undefined });">Schedule a Kubernetes demo</a></p>
       </div>
-    </div>
-  </section>
-
-  <section class="p-strip">
-    <div class="row">
-      <p id="fn1" class="note"><a href="#r1">*</a> Kubernetes&reg; is a registered trademark of The Linux Foundation in the United States and other countries, and is used pursuant to a license from The Linux Foundation</p>
     </div>
   </section>
 

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -397,7 +397,7 @@
   <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-8">
-        <h2>Pricing</h2>
+        <h2>Managed Kubernetes pricing</h2>
         {% include "shared/pricing/_kubernetes-managed.html" %}
       </div>
     </div>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -6,11 +6,11 @@
   </thead>
   <tbody>
     <tr>
-      <th>Price per node (physical)</th>
+      <th>Price per node (physical) *</th>
       <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
     </tr>
     <tr>
-      <th>Price per node (virtual)</th>
+      <th>Price per node (virtual) *</th>
       <td class="p-table__cell--highlight u-align--center">$1,460/year</td>
     </tr>
     <tr>
@@ -56,3 +56,5 @@
     </tr>
   </tbody>
 </table>
+
+<p><small>* Minimums apply</small></p>


### PR DESCRIPTION
## Done

Update 'Managed Kubernetes pricing' section of `/kubernetes/managed`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/kubernetes/managed>
- See that 'Managed Kubernetes pricing' section matches the [copy doc](https://docs.google.com/document/d/15jzhasokjH5Ql9Za56ZxRknXNNhEXYdIFXXtLODGxns/edit#)


## Issue / Card

Fixes [#708](https://github.com/ubuntudesign/web-squad/issues/708)