### PR TITLE
Fix caption styling on ai/features page

### DIFF
--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -84,8 +84,10 @@
       <p><a href="https://www.tensorflow.org/" class="p-link--external">Learn more about Tensorflow</a>
     </div>
     <div class="col-4 u-hide--small u-vertically-center">
-      <p><img src="{{ ASSET_SERVER_URL }}710ddd41-mnist_tensorboard.png" class="p-image--shadowed" alt="" /></p>
-      <p class="p-heading--six">Tensorflow from Google is officially published for Ubuntu</p>
+      <div>
+        <p><img src="{{ ASSET_SERVER_URL }}710ddd41-mnist_tensorboard.png" class="p-image--shadowed" alt="" /></p>
+        <cite>Tensorflow from Google is officially published for Ubuntu</cite>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -84,10 +84,10 @@
       <p><a href="https://www.tensorflow.org/" class="p-link--external">Learn more about Tensorflow</a>
     </div>
     <div class="col-4 u-hide--small u-vertically-center">
-      <div>
-        <p><img src="{{ ASSET_SERVER_URL }}710ddd41-mnist_tensorboard.png" class="p-image--shadowed" alt="" /></p>
-        <cite>Tensorflow from Google is officially published for Ubuntu</cite>
-      </div>
+      <figure class="u-no-margin">
+        <img src="{{ ASSET_SERVER_URL }}710ddd41-mnist_tensorboard.png" class="p-image--shadowed" alt="" />
+        <figcaption>Tensorflow from Google is officially published for Ubuntu</figcaption>
+      </figure>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Fix image and caption styles on `/ai/features`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/ai/features>
- See that the image and caption styles are as expected in the tensorflow section of the page


## Issue / Card

Fixes [#714](https://github.com/ubuntudesign/web-squad/issues/714)