### PR TITLE
Update cookie notification markup

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -11,7 +11,7 @@ core.cookiePolicy = function() {
     switch(stateChange) {
       case 'open':
         var range = document.createRange();
-        var cookieNode = range.createContextualFragment('<div class="p-notification p-notification--floating cookie-policy"><p class="p-notification--floating__content">We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself. To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>. <a href="?cp=close" class="p-notification--floating__close js-close">Close</a></p></div>');
+        var cookieNode = range.createContextualFragment('<div class="p-notification p-notification--floating cookie-policy"><p class="p-notification__response">We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself. To change your settings please <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>.</p><button class="p-icon--close js-close">Close</button></div>');
         document.body.insertBefore(cookieNode, document.body.lastChild);
         document.querySelector('footer.p-footer').classList.add('has-cookie');
         window.setTimeout(function() {


### PR DESCRIPTION
## Done

Update markup for cookie notification so it looks as it should

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See the cookie notification matches the [Vanilla pattern](https://docs.vanillaframework.io/en/patterns/notification)


## Issue / Card

Fixes #3707 