### PR TITLE
Update ai/install contextual footer

### DIFF
--- a/templates/ai/install.html
+++ b/templates/ai/install.html
@@ -108,7 +108,7 @@
   </div>
 </div>
 
-{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_cloud_bootstack" second_item="_download_cloud_buy_landscape" third_item="_download_documentation" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
 
 
 {% endblock content %}


### PR DESCRIPTION
## Done

Update contextual footer on `/ai/install`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/ai/install>
- See that the contextual footer matches the [copy doc](https://docs.google.com/document/d/1KVyyvZsDyrfoi5tK2m5SLWs9YuHg9hgqVz0c8cWHsf8/edit#)


## Issue / Card

Fixes [#715](https://github.com/ubuntudesign/web-squad/issues/715)