### PR TITLE
Fix margins on mobile cards on desktop developers page

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -127,7 +127,7 @@
       </div>
     </div>
     <div class="row u-equal-height">
-      <div class="col-4 p-card u-align--center u-no-margin--bottom">
+      <div class="col-4 p-card u-align--center">
         <svg class="p-card__icon" viewBox="0 0 46 54">
           <g id="02-Product-page" fill-rule="evenodd" fill="none">
             <g id="MAAS-page" transform="translate(-361 -1205)">
@@ -144,7 +144,7 @@
         </svg>
         <h3 class="p-card__title p-heading--four"><a href="https://docs.snapcraft.io/core/install">Installation instructions&nbsp;&rsaquo;</a></h3>
       </div>
-      <div class="col-4 p-card u-align--center u-no-margin--bottom">
+      <div class="col-4 p-card u-align--center">
         <svg class="p-card__icon" viewBox="0 0 37 32">
           <g id="Page-1" fill-rule="evenodd" fill="none">
             <g id="Developers-page" fill-rule="nonzero" fill="#666" transform="translate(-822 -3750)">
@@ -161,7 +161,7 @@
         </svg>
         <h3 class="p-card__title p-heading--four"><a href="https://docs.snapcraft.io/core/usage">Use snap commands&nbsp;&rsaquo;</a></h3>
       </div>
-      <div class="col-4 p-card u-align--center u-no-margin--bottom">
+      <div class="col-4 p-card u-align--center ">
         <svg class="p-card__icon" viewBox="0 0 32 28">
           <g id="Page-1" fill-rule="evenodd" fill="none">
             <g id="009_Features" fill-rule="nonzero" fill="#666" transform="translate(-553 -653)">


### PR DESCRIPTION
## Done

Fix margins under cards on desktop developers page for mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/desktop/developers>
- See that spacing between cards is sufficient


## Issue / Card

Fixes #3704 