### PR TITLE
Fix /download/cloud/ card images on mobile

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -33,7 +33,7 @@
       </header>
       <div class="p-card__content">
         <a class="p-card__image-container u-vertically-center" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-          <img src="{{ ASSET_SERVER_URL }}410984a3-Google-cloud-platform-stacked.svg" alt="" style="max-height: 10rem;">
+          <img src="{{ ASSET_SERVER_URL }}410984a3-Google-cloud-platform-stacked.svg" alt="" style="max-height: 10rem; align-self: center;">
         </a>
         <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>
       </div>
@@ -48,7 +48,7 @@
       </header>
       <div class="p-card__content">
         <a class="p-card__image-container u-vertically-center" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-          <img src="{{ ASSET_SERVER_URL }}39002345-AmazonWebservices_Logo.svg" alt="" style="max-height: 10rem; max-width:10rem;">
+          <img src="{{ ASSET_SERVER_URL }}39002345-AmazonWebservices_Logo.svg" alt="" style="max-height: 10rem; max-width:10rem; align-self: center;">
         </a>
         <p>Amazon Web Services offers reliable, scalable, and inexpensive cloud computing services.</p>
       </div>
@@ -63,7 +63,7 @@
       </header>
       <div class="p-card__content">
         <a class="p-card__image-container u-vertically-center" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-          <img src="{{ ASSET_SERVER_URL }}208cd3a7-azure-logo-blue-on-white.svg" alt="" style="max-height: 10rem; max-width:12rem;">
+          <img src="{{ ASSET_SERVER_URL }}208cd3a7-azure-logo-blue-on-white.svg" alt="" style="max-height: 10rem; max-width:12rem; align-self: center;">
         </a>
         <p>Microsoft Azure is an open, flexible, enterprise-grade cloud computing platform.</p>
       </div>
@@ -80,7 +80,7 @@
       </header>
       <div class="p-card__content">
         <a class="p-card__image-container u-vertically-center" href="https://www.ibm.com/cloud/">
-          <img src="{{ ASSET_SERVER_URL }}5e91ff73-ibm-cloud-logo.svg" alt="" style="max-height: 10rem; max-width:12rem;">
+          <img src="{{ ASSET_SERVER_URL }}5e91ff73-ibm-cloud-logo.svg" alt="" style="max-height: 10rem; max-width:12rem; align-self: center;">
         </a>
       </div>
       <ul class="p-list">
@@ -93,7 +93,7 @@
       </header>
       <div class="p-card__content">
         <a class="p-card__image-container u-vertically-center" href="https://www.rackspace.com/managed-hosting">
-          <img src="{{ ASSET_SERVER_URL }}ff936628-rackspace.svg" alt="" style="max-height: 10rem; max-width:12rem;">
+          <img src="{{ ASSET_SERVER_URL }}ff936628-rackspace.svg" alt="" style="max-height: 10rem; max-width:12rem; align-self: center;">
         </a>
       </div>
       <ul class="p-list">
@@ -106,7 +106,7 @@
       </header>
       <div class="p-card__content">
         <a class="p-card__image-container u-vertically-center" href="https://docs.oracle.com/en/cloud/get-started/index.html">
-          <img src="{{ ASSET_SERVER_URL }}08646a72-logo-oracle.svg" alt="" style="max-height: 10rem; max-width:12rem;">
+          <img src="{{ ASSET_SERVER_URL }}08646a72-logo-oracle.svg" alt="" style="max-height: 10rem; max-width:12rem; align-self: center;">
         </a>
       </div>
       <ul class="p-list">


### PR DESCRIPTION
## Done

Fix `/download/cloud` card images on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/download/cloud>
- See that card images are aligned properly on mobile


## Issue / Card

Fixes #3697 