### PR TITLE
Change PR template URL syntax to avoid duplication

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 - Check out this feature branch
 - Run the site using the command `./run serve`
-- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
+- View the site locally in your web browser at: <http://0.0.0.0:8001/>
 - [List additional steps to QA the new features or prove the bug has been resolved]
 
 


### PR DESCRIPTION
## Done

Change URL markdown syntax of PR template to avoid having to type/paste the URL twice