### PR TITLE
Make login nav two cols on tablet

### DIFF
--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -138,21 +138,41 @@ $color-rule--light: transparentize($color-mid-light, .5);
       z-index: 4;
       font-size: .875rem;
 
+      .p-matrix {
+        @media (max-width: $breakpoint-small - 1) {
+          display: block;
+        }
+
+        @media (min-width: $breakpoint-small) {
+          display: flex;
+        }
+      }
+
       .p-matrix__item {
         display: block;
+
+        @media (max-width: $breakpoint-small - 1) {
+          width: 100%;
+        }
+
+        @media (min-width: $breakpoint-small) and (max-width: $breakpoint-navigation-threshold) {
+          width: 50%;
+
+          &:nth-child(2n+1) {
+            padding-left: 0;
+          }
+        }
       }
 
       @media (max-width: $breakpoint-navigation-threshold - 1) {
         top: 3rem;
 
         .p-matrix {
-          display: block !important;
           margin-bottom: 0;
         }
 
         .p-matrix__item {
           position: relative;
-          width: 100%;
         }
 
         .p-matrix__img {

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -107,7 +107,7 @@
               <div class="p-matrix__content">
                 <h4 class="p-matrix__title">JAAS</h4>
                 <p class="p-matrix__desc u-sv1">Deploy, configure, scale and operate your software on public and private clouds</p>
-                <ul class="p-inline-list">
+                <ul class="p-inline-list u-no-margin--bottom">
                   <li class="p-inline-list__item">
                     <a class="p-link--inverted" href="https://jujucharms.com/login/">Login&nbsp;&rsaquo;</a>
                   </li>


### PR DESCRIPTION
## Done

Make login nav two cols on tablet

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- See that the login nav is two columns on tablet


## Issue / Card

Fixes #3716 