### PR TITLE
Removed extra header block from s390x thank you page

### DIFF
--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -4,9 +4,8 @@
 Thanks for downloading Ubuntu Server for IBM Z and LinuxONE
 {% endblock %}
 
-{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
-
 {% block head_extra %}
+  <meta name="robots" content="noindex" />
   <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release_with_point}}-server-s390x.iso">
 {% endblock %}
 


### PR DESCRIPTION
## Done

- Page was 500ing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:<http://0.0.0.0:8001/download/server/thank-you-s390x>
- see that it doesn't give you a 500
