### PR TITLE
Update FCB datasheet on beta

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -13,7 +13,7 @@
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>
           <a href="/openstack/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Engage Canonical exports', 'eventLabel' : 'Engage Canonical exports - Top CTA', 'eventValue' : undefined });" class="p-button--positive">Engage Canonical experts</a>
-          <a href="{{ ASSET_SERVER_URL }}8cf6fe4f-Foundation-Cloud-Build-Openstack-data-sheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read our consulting datasheet', 'eventLabel' : 'Read our consulting datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Read our consulting datasheet</a>
+          <a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read our consulting datasheet', 'eventLabel' : 'Read our consulting datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Read our consulting datasheet</a>
         </p>
       </div>
     </div>
@@ -103,8 +103,8 @@
         <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
-        <a href="{{ ASSET_SERVER_URL }}8cf6fe4f-Foundation-Cloud-Build-Openstack-data-sheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" /></a>
-        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}8cf6fe4f-Foundation-Cloud-Build-Openstack-data-sheet.pdf"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });">Read the datasheet&nbsp;&rsaquo;</a></h4>
+        <a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" /></a>
+        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
         <a href="{{ ASSET_SERVER_URL }}8c0ed26d-FCB_Hardware_requirements.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}4d7dbd0c-icon-settings.svg" alt="Hardware requirements" /></a>
@@ -226,7 +226,7 @@
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
         <p><a href="/openstack/features">Find out how</a> Canonical delivers the worlds favourite enterprise OpenStack. The choice of the largest operators in telco, finance, media, pharma, retail and government sectors, Canonical’s OpenStack on Ubuntu offers a flexible architecture and enables integration of GPGPUs, FPGAs and cloud network accelerators.</p>
-        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}8cf6fe4f-Foundation-Cloud-Build-Openstack-data-sheet.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA', 'eventValue' : undefined });">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA', 'eventValue' : undefined });">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -13,7 +13,7 @@
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>
           <a href="/openstack/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Engage Canonical exports', 'eventLabel' : 'Engage Canonical exports - Top CTA', 'eventValue' : undefined });" class="p-button--positive">Engage Canonical experts</a>
-          <a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read our consulting datasheet', 'eventLabel' : 'Read our consulting datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Read our consulting datasheet</a>
+          <a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read our consulting datasheet', 'eventLabel' : 'Read our consulting datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Read our consulting datasheet</a>
         </p>
       </div>
     </div>
@@ -103,8 +103,8 @@
         <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
-        <a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" /></a>
-        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });">Read the datasheet&nbsp;&rsaquo;</a></h4>
+        <a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" /></a>
+        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
         <a href="{{ ASSET_SERVER_URL }}8c0ed26d-FCB_Hardware_requirements.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}4d7dbd0c-icon-settings.svg" alt="Hardware requirements" /></a>
@@ -226,7 +226,7 @@
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
         <p><a href="/openstack/features">Find out how</a> Canonical delivers the worlds favourite enterprise OpenStack. The choice of the largest operators in telco, finance, media, pharma, retail and government sectors, Canonical’s OpenStack on Ubuntu offers a flexible architecture and enables integration of GPGPUs, FPGAs and cloud network accelerators.</p>
-        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}72fe0b54-EN_Foundation-Cloud-Build_screen-AW_10.18.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA', 'eventValue' : undefined });">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA', 'eventValue' : undefined });">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -13,7 +13,7 @@
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>
           <a href="/openstack/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Engage Canonical exports', 'eventLabel' : 'Engage Canonical exports - Top CTA', 'eventValue' : undefined });" class="p-button--positive">Engage Canonical experts</a>
-          <a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read our consulting datasheet', 'eventLabel' : 'Read our consulting datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Read our consulting datasheet</a>
+          <a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read our consulting datasheet', 'eventLabel' : 'Read our consulting datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Read our consulting datasheet</a>
         </p>
       </div>
     </div>
@@ -103,8 +103,8 @@
         <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
-        <a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" /></a>
-        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });">Read the datasheet&nbsp;&rsaquo;</a></h4>
+        <a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" /></a>
+        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started', 'eventValue' : undefined });">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
         <a href="{{ ASSET_SERVER_URL }}8c0ed26d-FCB_Hardware_requirements.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}4d7dbd0c-icon-settings.svg" alt="Hardware requirements" /></a>
@@ -226,7 +226,7 @@
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
         <p><a href="/openstack/features">Find out how</a> Canonical delivers the worlds favourite enterprise OpenStack. The choice of the largest operators in telco, finance, media, pharma, retail and government sectors, Canonical’s OpenStack on Ubuntu offers a flexible architecture and enables integration of GPGPUs, FPGAs and cloud network accelerators.</p>
-        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}72fe0b54-Foundation-Cloud-Build-EN-2018.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA', 'eventValue' : undefined });">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA', 'eventValue' : undefined });">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

Updated the link of FCB datasheet on openstack consulting page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/openstack/consulting](http://0.0.0.0:8001/openstack/consulting)
- Check that the links to go the updated datasheet


## Issue / Card

Fixes: #3743 
