### PR TITLE
Prevent white line under nav when closing enterprise menu in Firefox

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -421,7 +421,7 @@
   }
 
   .slide-animation {
-    transform: translateY(-100%);
+    transform: translateY(-101%);
   }
 
   .fade-animation {


### PR DESCRIPTION
## Done

Prevent white line under nav when closing enterprise menu in Firefox

## QA

- Check out this feature branch
- Run the site using the command `./run serve` in Firefox
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Open and close the enterprise navigation
- See that there is no white line under the black navigation bar


## Issue / Card

Fixes #3751 