### PR TITLE
Update PR template with QA steps practices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
 - Check out this feature branch
 - Run the site using the command `./run serve`
 - View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
+- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
 - [List additional steps to QA the new features or prove the bug has been resolved]
 
 


### PR DESCRIPTION
## Done

Added a line to the PR template to include the [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md) page

## QA

- Check that the link is correct
