### PR TITLE
Fix position of livechat button

### DIFF
--- a/static/sass/_pattern_feedback.scss
+++ b/static/sass/_pattern_feedback.scss
@@ -50,7 +50,7 @@
 
   .p-feedback__button {
     position: fixed;
-    bottom: 3rem;
+    bottom: 4rem;
     right: 0;
     width: auto;
     margin: 0;

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -94,21 +94,9 @@
 
     <!-- Overrides for livechat button -->
     <style>
-      #livechat-compact-container {
-        right: 0 !important;
-        height: 2.3rem !important;
-        background: #e95420 !important;
-      }
-
-      #livechat-compact-container iframe {
-        top: .25rem !important;
-      }
-
       @media (min-width: 620px) {
-        #livechat-compact-container {
+        #chat-widget-container {
           right: 160px !important;
-          border-top-left-radius: .125rem;
-          border-top-right-radius: .125rem;
         }
       }
     </style>


### PR DESCRIPTION
## Done

Fix livechat button position so it doesn't overlap feedback button

## QA

- This can only be seen on the live site
- Best way to test it is to paste the following snippet into the document using the web inspector

```
<style>
      @media (min-width: 620px) {
        #chat-widget-container {
          right: 160px !important;
        }
      } 
</style>
```


## Issue / Card

Fixes #3750 

## Screenshots

![screenshot from 2018-07-18 14-43-39](https://user-images.githubusercontent.com/501889/42885542-29d64a3e-8a99-11e8-9988-38b7d4eb4079.png)
