### PR TITLE
Plans and pricing update

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -1,8 +1,11 @@
+<div class="row">
+  <h2 class="p-heading--four">AI/ML Add-on</h2>
+  <p><span class="p-heading--two">$40,000</span> one off fee</p>
+</div>
 <div class="row u-equal-height">
   <div class="col-6 p-card">
     <div class="p-card__header">
       <h2 class="p-heading--four">Workshop</h2>
-      <p><span class="p-heading--two">$40,000</span> one off fee</p>
     </div>
     <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>
     <ul class="p-list">
@@ -11,12 +14,10 @@
       <li class="p-list__item is-ticked">Full pipeline view</li>
       <li class="p-list__item is-ticked">ML / Data science assessment</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
       <h2 class="p-heading--four">ML / Data Science Assessment</h2>
-      <p><span class="p-heading--two">$40,000</span> one off fee</p>
     </div>
     <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
     <ul class="p-list">
@@ -26,6 +27,8 @@
       <li class="p-list__item is-ticked">Deploy and operate analysis</li>
       <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
   </div>
+</div>
+<div class="row">
+  <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -4,7 +4,7 @@
       <h2 class="p-heading--four">AI/ML Add-on</h2>
       <p><span class="p-heading--two">$40,000</span> one off fee</p>
     </div>
-    <div class="row u-equal-height p-divided">
+    <div class="row u-equal-height">
       <div class="col-6 p-divider__block">
         <h2 class="p-heading--four">Workshop</h2>
         <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -4,8 +4,8 @@
       <h2 class="p-heading--four">AI/ML Add-on</h2>
       <p><span class="p-heading--two">$40,000</span> one off fee</p>
     </div>
-    <div class="row u-equal-height">
-      <div class="col-6 p-divider__block">
+    <div class="row">
+      <div class="col-6">
         <h2 class="p-heading--four">Workshop</h2>
         <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>
         <ul class="p-list">
@@ -15,7 +15,7 @@
           <li class="p-list__item is-ticked">ML / Data science assessment</li>
         </ul>
       </div>
-      <div class="col-6 p-divider__block">
+      <div class="col-6">
         <h2 class="p-heading--four">ML / Data Science Assessment</h2>
         <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
         <ul class="p-list">

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -1,34 +1,32 @@
 <div class="row">
-  <h2 class="p-heading--four">AI/ML Add-on</h2>
-  <p><span class="p-heading--two">$40,000</span> one off fee</p>
-</div>
-<div class="row u-equal-height">
-  <div class="col-6 p-card">
-    <div class="p-card__header">
-      <h2 class="p-heading--four">Workshop</h2>
+  <div class="p-card">
+    <div class="col-12 p-card__header">
+      <h2 class="p-heading--four">AI/ML Add-on</h2>
+      <p><span class="p-heading--two">$40,000</span> one off fee</p>
     </div>
-    <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>
-    <ul class="p-list">
-      <li class="p-list__item is-ticked">On site or remote options</li>
-      <li class="p-list__item is-ticked">Hands-on K8s and Kubeflow</li>
-      <li class="p-list__item is-ticked">Full pipeline view</li>
-      <li class="p-list__item is-ticked">ML / Data science assessment</li>
-    </ul>
-  </div>
-  <div class="col-6 p-card">
-    <div class="p-card__header">
-      <h2 class="p-heading--four">ML / Data Science Assessment</h2>
+    <div class="row u-equal-height p-divided">
+      <div class="col-6 p-divider__block">
+        <h2 class="p-heading--four">Workshop</h2>
+        <p>One additional day on Kubeflow, including  Tensorflow and  JupyterHub, covering everything your business needs to know to have a full on-prem/off-prem AI/ML game plan.</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">On site or remote options</li>
+          <li class="p-list__item is-ticked">Hands-on K8s and Kubeflow</li>
+          <li class="p-list__item is-ticked">Full pipeline view</li>
+          <li class="p-list__item is-ticked">ML / Data science assessment</li>
+        </ul>
+      </div>
+      <div class="col-6 p-divider__block">
+        <h2 class="p-heading--four">ML / Data Science Assessment</h2>
+        <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Understand AI lifecycle</li>
+          <li class="p-list__item is-ticked">Preliminary AI discovery</li>
+          <li class="p-list__item is-ticked">Development assessment</li>
+          <li class="p-list__item is-ticked">Deploy and operate analysis</li>
+          <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
+        </ul>
+      </div>
     </div>
-    <p>Canonical will leverage its network of data science partners to deliver an AI assessment as part of the workshop with options for ongoing engagement post-deployment.</p>
-    <ul class="p-list">
-      <li class="p-list__item is-ticked">Understand AI lifecycle</li>
-      <li class="p-list__item is-ticked">Preliminary AI discovery</li>
-      <li class="p-list__item is-ticked">Development assessment</li>
-      <li class="p-list__item is-ticked">Deploy and operate analysis</li>
-      <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
-    </ul>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
   </div>
-</div>
-<div class="row">
-  <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

Update pricing on include

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/ai> and <http://0.0.0.0:8001/support/plans-and-pricing>
- See the 'AI add-on for Kubernetes Discoverer and Discoverer Plus' section matches the corresponding section in the [copy doc](https://docs.google.com/a/canonical.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit?disco=AAAACDy-B1I)


## Issue / Card

Fixes #3730 