### PR TITLE
Copy updates on plans and pricing page

### DIFF
--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -23,10 +23,13 @@
       </tr>
 
       <tr>
-        <td>Per region per year</td>
+        <td>
+          Per region per year<br>
+          (unlimited machines)
+        </td>
         <td class="u-align--center">-</td>
         <td class="p-table__cell--highlight u-align--center">-</td>
-        <td class="p-table__cell--highlight u-align--center">Unlimited machines $75,000</td>
+        <td class="p-table__cell--highlight u-align--center">$75,000</td>
       </tr>
 
       <tr>
@@ -82,7 +85,7 @@
 
       <tr>
         <td>&nbsp;</td>
-        <td class="u-align--center"><a href="/download/server/provisioning" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Install MAAS', 'eventLabel' : 'Install MAAS - MAAS support table' : undefined });">Install MAAS&nbsp;&rsaquo;</a></td>
+        <td class="u-align--center"><a class="p-link--external" href="https://maas.io/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Install MAAS', 'eventLabel' : 'Install MAAS - MAAS support table' : undefined });">Install MAAS</a></td>
         <td class="p-table__cell--highlight u-align--center"><a href="/server/contact-us?product=server-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - standard - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
         <td class="p-table__cell--highlight u-align--center"><a href="/server/contact-us?product=server-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - advanced - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
       </tr>

--- a/templates/shared/pricing/_ua-server-support-add-ons.html
+++ b/templates/shared/pricing/_ua-server-support-add-ons.html
@@ -29,7 +29,7 @@
   </div>
   <div class="col-4 p-card">
     <h4>Dedicated engineers</h4>
-    <p>Canonical can write code to support your organisation; for example, get Canonical to write custom drivers for your hardware.</p>
+    <p>Canonical engineers dedicated to your Ubuntu operations for server, cloud and kubernetes.</p>
   </div>
 </div>
 

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -10,7 +10,6 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <h1>Plans and pricing</h1>
-    <p>Ubuntu is always free to download, install, run, and upgrade. Free community support is available from <a href="https://usn.ubuntu.com/usn/">Ubuntu Security Notices</a>, <a href="http://askubuntu.com">AskUbuntu</a>, <a href="http://ubuntuforums.org">UbuntuForums</a>, <a href="http://launchpad.net/ubuntu">Launchpad</a>, <a href="http://planet.ubuntu.com">PlanetUbuntu</a>, <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC</a> and through <a href="https://lists.ubuntu.com">Mailing Lists</a>.</p>
     <p>For enterprises with production workloads Canonical offers the following suite of Ubuntu Advantage tools, services and support packages.</p>
     <p><a href="/support/contact-us?product=support-pricing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Learn more', 'eventLabel' : 'Get in touch - Top CTA' : undefined });" class="p-button--positive">Get in touch</a></p>
   </div>
@@ -109,7 +108,7 @@
 <section class="p-strip--light is-shallow">
   <div class="row" style="overflow-x: auto;">
     <div class="col-12">
-      <h2>For servers</h2>
+      <h2 id="server">For servers</h2>
       {% include "shared/pricing/_ua-server-support.html" %}
     </div>
   </div>
@@ -118,7 +117,7 @@
 <section class="p-strip--light is-shallow u-no-padding--bottom">
   <div class="row" style="overflow-x: auto;">
     <div class="col-12">
-      <h2>For desktops</h2>
+      <h2 id="desktop">For desktops</h2>
       {% include "shared/pricing/_ua-desktop-support.html" %}
     </div>
   </div>
@@ -132,7 +131,7 @@
   <div class="row">
     <div class="col-12">
       <h2>MAAS</h2>
-      <p>MAAS is freely available, open source software from Canonical. Many enterprises depend on MAAS to automate and optimize provisioning for production hardware.  Canonical offers Standard and Advanced support plans priced per-machine-per-month or, for large volume and public clouds with dynamic scale, we offer per-region pricing with flexible node ranges.</p>
+      <p>MAAS is open source data center automation provisioning, DNS, DHCP and IPAM software from Canonical. Many enterprises depend on MAAS to automate and optimize provisioning for server clusters. Canonical offers Standard and Advanced support plans priced per-machine-per-month or, for large volume and public clouds with dynamic scale, we offer per-region pricing with flexible node ranges.</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Done

Update copy on `/support/plans-and-pricing` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/support/plans-and-pricing>
- See that page matches the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)
- Please mark comments as done once verified they are correct

## Issue / Card

Fixes #3759 