### PR TITLE
Fix max-width issue on homepage heading

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
 <section class="p-strip--light is-bordered">
   <div class="row u-align--center">
     <div class="col-12">
-      <h2 class="p-heading--three">
+      <h2 class="p-heading--three u-no-max-width">
         Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things
       </h2>
     </div>


### PR DESCRIPTION
## Done

Fix max-width of heading on homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the 'Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things' h2 is centered and not offset to the left


## Issue / Card

Fixes #3771 

## Screenshots

![screenshot-2018-7-19 the leading operating system for pcs iot devices servers and the cloud ubuntu](https://user-images.githubusercontent.com/1413534/42973651-d48a3b76-8bab-11e8-8399-79deed41dee9.png)
