### PR TITLE
Updated the developer terms and conditions

### DIFF
--- a/templates/legal/terms-and-policies/developer-terms-and-conditions/2016-04-06.html
+++ b/templates/legal/terms-and-policies/developer-terms-and-conditions/2016-04-06.html
@@ -78,7 +78,8 @@
     <div class="col-4 p-card">
         <h3>Latest version</h3>
         <ul class="p-list">
-          <li class="p-list__item"><a href="/legal/terms-and-policies/developer-terms-and-conditions/">09 June 2017&nbsp;›</a></li>
+          <li class="p-list__item"><a href="/legal/terms-and-policies/developer-terms-and-conditions/">Latest&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="/legal/terms-and-policies/developer-terms-and-conditions/2018-07-23">23 July 2018&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
   </div>

--- a/templates/legal/terms-and-policies/developer-terms-and-conditions/2018-07-23.html
+++ b/templates/legal/terms-and-policies/developer-terms-and-conditions/2018-07-23.html
@@ -12,8 +12,8 @@
   <div class="row">
     <div class="col-8">
       <h1>Developer terms and conditions</h1>
-      <p>Valid since 10 July 2018</p>
-      <h2 id="dev-terms-canonical-terms-of-service">Canonical Terms of Service</h2>
+      <p>Valid since 09 June 2017</p>
+      <h2 id="dev-terms-canonical-terms-of-service"></h2>
       <p>This Agreement covers the provision of Services by Canonical Group Limited registered in England company number 6870835 (&quot;Canonical&quot;, &quot;us&quot;, &quot;we&quot; or &quot;our&quot;) through the Developer Site to you as an individual
         or an entity (&quot;you&quot; or &quot;your&quot;). Your use of the Services and distribution of your App(s) will be governed by this Agreement along with Canonical&apos;s Privacy Policy. Please read this Agreement carefully before you register
         for a Developer Account. If you register for a Developer Account and use the Services on behalf of a company or other entity, you represent that you have the full legal authority to bind the company to this Agreement and you are agreeing to this
@@ -23,7 +23,9 @@
       <ol type="a">
         <li class="p-list__item">App(s): one or more applications or content items owned by you which you submit through the Developer Site and any associated screen shots and marketing materials provided by you, these may be Snappy Ubuntu apps.</li>
         <li class="p-list__item">Client Software: any utilities provided by Canonical which enable end users to discover, install, and remove software including Apps.</li>
-        <li class="p-list__item">Developer Site: Canonical's websites for uploading and managing Apps, including <a href="https://dashboard.snapcraft.io/snaps/">https://dashboard.snapcraft.io/snaps/</a>.</li>
+        <li class="p-list__item">Developer Account: Your account on the Developer Site.</li>
+        <li class="p-list__item">Developer Site: Canonical&apos;s websites for uploading and managing Apps, including <a href="https://dashboard.snapcraft.io/snaps/">dashboard.snapcraft.io/snaps</a>.</li>
+        <li class="p-list__item">Publishing Policy: Canonical&apos;s policy for accepting Apps for publishing, as notified by Canonical from time to time.</li>
         <li class="p-list__item">Services: Canonical&apos;s services for distributing, publishing, discovery, installation, and removal of your Apps and payment collection.</li>
         <li class="p-list__item">Term: the term of this Agreement, as set out in Clause 10.</li>
         <li class="p-list__item">Ubuntu: any versions of the Linux-based operating system known as Ubuntu.</li>
@@ -33,7 +35,8 @@
         <li class="p-list__item">Once you are accepted for a Developer Account, you may submit Apps to the Developer Site.</li>
         <li class="p-list__item">Canonical or its partners may publish the Apps you submit through the Client Software, but is not obligated to do so.</li>
         <li class="p-list__item">You are the owner of the Apps and are solely and entirely responsible for your Apps and the distribution of your Apps through the Client Software.</li>
-        <li class="p-list__item">You agree that Apps you submit to the Developer Site do not infringe any intellectual property right of any third party or any applicable law or regulation, and will not contain any material from a third party, unless you have permission from the rightful owner of the material or you are otherwise legally entitled to distribute the material.</li>
+        <li class="p-list__item">You agree that Apps you submit to the Developer Site do not infringe any intellectual property right of any third party, the Publishing Policy or any applicable law or regulation, and will not contain any material from a third party, unless you
+          have permission from the rightful owner of the material or you are otherwise legally entitled to distribute the material.</li>
         <li class="p-list__item">Canonical expressly disclaims any and all liability in connection with your App. Except with respect to open source software, you will indemnify Canonical against any third party claim resulting from Canonical&apos;s publishing of your App through
           the Client Software.</li>
         <li class="p-list__item">Canonical may remove your App from the Client Software or Developer Site at any time and for any reason.</li>
@@ -43,7 +46,7 @@
       <h3 id="dev-terms-your-obligations">3. Your obligations</h3>
       <ol type="a">
         <li class="p-list__item">Prior to submitting an App, you must first test the App.</li>
-        <li class="p-list__item">Your Apps must comply with these terms and conditions and any additional terms and policies made known by Canonical from time to time.</li>
+        <li class="p-list__item">Your Apps must comply with the Publishing Policy.</li>
         <li class="p-list__item">You will set the price, if any, that end users will be charged for your Apps.</li>
         <li class="p-list__item">You are responsible for determining applicable taxes in connection with distributing your App, and you shall pay applicable taxes to the applicable tax authorities.</li>
         <li class="p-list__item">You will include the licence applicable to users of your App with your App. If you require an agreement to be displayed to the end user, you will configure your App to display it upon installation or first run of the App. Your App may include
@@ -113,7 +116,7 @@
     <div class="col-4 p-card">
       <h3>Older versions</h3>
       <ul class="p-list">
-        <li class="p-list__item"><a href="/legal/terms-and-policies/developer-terms-and-conditions/2018-07-23">23 July 2018&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/terms-and-policies/developer-terms-and-conditions/">Latest&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/terms-and-policies/developer-terms-and-conditions/2016-04-06">06 April 2016&nbsp;&rsaquo;</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Done
Updated the developer terms and conditions and version the previous one.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/terms-and-policies/developer-terms-and-conditions](http://0.0.0.0:8001/legal/terms-and-policies/developer-terms-and-conditions)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the [copy doc](https://docs.google.com/document/d/1PMmk3lcVGsHAOn8Nl0SRo4IW3yQCywqjw70fItT7DEk/edit) matches
- Check there are two edited versions and particularly a 23 July 2018 version.

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3779
