### PR TITLE
eol d3 charts

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -193,7 +193,7 @@ function formatKeyLabel(key) {
  */
 function createChart(chartSelector, taskTypes, taskStatus, tasks) {
   var margin = {
-    top: 20,
+    top: 0,
     right: 40,
     bottom: 20,
     left: 150

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -1,0 +1,252 @@
+/**
+ *
+ * @param {Array} tasks
+ *
+ * Sorts tasks by date
+ */
+function sortTasks(tasks) {
+  tasks.sort(function(a, b) {
+    return a.endDate - b.endDate;
+  });
+
+  tasks.sort(function(a, b) {
+    return a.startDate - b.startDate;
+  });
+
+  return tasks;
+}
+
+
+/**
+ *
+ * @param {*} svg
+ * @param {Array} tasks
+ * @param {Object} taskStatus
+ * @param {*} x
+ * @param {*} y
+ *
+ * Add bars to chart using supplied data
+ */
+function addBarsToChart(svg, tasks, taskStatus, x, y) {
+  svg.selectAll(".chart")
+    .data(tasks, function(d) {
+      return d.startDate + d.taskName + d.endDate;
+    })
+    .enter()
+    .append("rect")
+    .attr("class", function(d) {
+      if (taskStatus[d.status] == null) {
+        return "bar";
+      }
+      return taskStatus[d.status];
+    })
+    .attr("y", 0)
+    .attr("transform", function(d) {
+      return "translate(" + x(d.startDate) + "," + y(d.taskName) + ")";
+    })
+    .attr("height", function(d) {
+      return y.rangeBand();
+    })
+    .attr("width", function(d) {
+      return x(d.endDate) - x(d.startDate);
+    });
+}
+
+
+/**
+ *
+ * @param {*} svg
+ * @param {Int} height
+ * @param {Object} margin
+ * @param {*} xAxis
+ *
+ * Add x axis to chart
+ */
+function addXAxis(svg, height, margin, xAxis) {
+  svg.append("g")
+    .attr("class", "x axis")
+    .attr(
+      "transform",
+      "translate(0, " + (height - margin.top - margin.bottom) + ")"
+    )
+    .transition()
+    .call(xAxis);
+}
+
+
+/**
+ *
+ * @param {*} svg
+ * @param {*} yAxis
+ *
+ * Add y axis to chart
+ */
+function addYAxis(svg, yAxis) {
+  svg.append("g")
+    .attr("class", "y axis")
+    .transition()
+    .call(yAxis);
+}
+
+
+/**
+ *
+ * @param {*} svg
+ *
+ * Clean up unwanted elements on chart put in by d3.js
+ */
+function cleanUpChart(svg) {
+  svg.select(".domain").remove();
+}
+
+
+/**
+ *
+ * @param {*} svg
+ *
+ * Embolden LTS labels on y axis
+ */
+function emboldenLTSLabels(svg) {
+  svg.selectAll(".tick text").select(function() {
+    var text = this.textContent;
+
+    if (text.includes("LTS")) {
+      this.classList.add("chart__label--bold");
+    }
+  });
+}
+
+
+/**
+ *
+ * @param {*} svg
+ * @param {Int} height
+ *
+ * Adds vertical lines to the x axis
+ */
+function addXAxisVerticalLines(svg, height) {
+  svg.selectAll(".x.axis .tick line").attr("y1", -height);
+}
+
+
+/**
+ *
+ * @param {String} chartSelector
+ * @param {Object} taskStatus
+ *
+ * Builds key for supplied chart based on task status
+ */
+function buildChartKey(chartSelector, taskStatus) {
+  var taskStatusKeys = Object.keys(taskStatus);
+
+  var chartKey = d3.select(chartSelector)
+    .append("svg")
+    .attr("class", "chart-key")
+    .attr("width", "400")
+    .attr("height", 24 * taskStatusKeys.length);
+
+  taskStatusKeys.forEach(function(key, i) {
+    var keyRow = chartKey.append('g')
+      .attr('class', 'chart-key__row')
+      .attr('transform', 'translate(0, ' + 21 * i + ')')
+      .attr('height', 24);
+
+    keyRow
+      .append('rect')
+      .attr('class', taskStatus[key])
+      .attr('width', 18)
+      .attr('height', 14)
+      .attr('y', 0);
+
+    keyRow
+      .append('text')
+      .text(formatKeyLabel(key))
+      .attr('class', 'chart-key__label')
+      .attr('x', 24)
+      .attr('y', 13);
+  });
+}
+
+
+/**
+ *
+ * @param {String} key
+ *
+ * Formats key into readable string
+ */
+function formatKeyLabel(key) {
+  var keyLowerCase = key.toLowerCase().replace(/_/g, ' ');
+  var formattedKey = keyLowerCase.charAt(0).toUpperCase() + keyLowerCase.substr(1);
+
+  return formattedKey;
+}
+
+
+/**
+ *
+ * @param {String} chartSelector
+ * @param {Array} taskTypes
+ * @param {Object} taskStatus
+ * @param {Array} tasks
+ *
+ * Builds chart using supplied selector and data
+ */
+function createChart(chartSelector, taskTypes, taskStatus, tasks) {
+  var margin = {
+    top: 20,
+    right: 40,
+    bottom: 20,
+    left: 180
+  };
+  var rowHeight = 32;
+  var timeDomainStart = d3.time.year.offset(tasks[0].startDate, -1);
+  var timeDomainEnd = d3.time.year.offset(tasks[tasks.length - 1].endDate, +1);
+  var height = taskTypes.length * rowHeight;
+  var width = document.querySelector(chartSelector).clientWidth - margin.right - margin.left;
+
+  var x = d3.time
+    .scale()
+    .domain([timeDomainStart, timeDomainEnd])
+    .range([0, width])
+    .clamp(true);
+
+  var y = d3.scale
+    .ordinal()
+    .domain(taskTypes)
+    .rangeRoundBands([0, height - margin.top - margin.bottom], 0.1);
+
+  var xAxis = d3.svg
+    .axis()
+    .scale(x)
+    .orient("bottom")
+    .ticks(d3.time.years, 1);;
+
+  var yAxis = d3.svg
+    .axis()
+    .scale(y)
+    .orient("left")
+    .tickSize(0);
+
+  sortTasks(tasks);
+
+  // Build initial chart body
+  var svg = d3
+    .select(chartSelector)
+    .append("svg")
+    .attr("class", "chart")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .append("g")
+    .attr("class", "gantt-chart")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .attr("transform", "translate(" + margin.left + ", " + margin.top + ")");
+
+  addBarsToChart(svg, tasks, taskStatus, x, y);
+  addXAxis(svg, height, margin, xAxis);
+  addYAxis(svg, yAxis);
+  cleanUpChart(svg);
+  emboldenLTSLabels(svg);
+  addXAxisVerticalLines(svg, height);
+  buildChartKey(chartSelector, taskStatus);
+};

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -196,7 +196,7 @@ function createChart(chartSelector, taskTypes, taskStatus, tasks) {
     top: 20,
     right: 40,
     bottom: 20,
-    left: 180
+    left: 150
   };
   var rowHeight = 32;
   var timeDomainStart = d3.time.year.offset(tasks[0].startDate, -1);
@@ -219,12 +219,13 @@ function createChart(chartSelector, taskTypes, taskStatus, tasks) {
     .axis()
     .scale(x)
     .orient("bottom")
-    .ticks(d3.time.years, 1);;
+    .ticks(d3.time.years, 1);
 
   var yAxis = d3.svg
     .axis()
     .scale(y)
-    .orient("left")
+    .orient("right")
+    .tickPadding(-margin.left)
     .tickSize(0);
 
   sortTasks(tasks);

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -1,0 +1,402 @@
+var serverAndDesktopReleases = [
+  {
+    startDate: new Date('2010-04-01T00:00:00'),
+    endDate: new Date('2012-07-01T00:00:00'),
+    taskName: 'Ubuntu 10.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2012-07-01T00:00:00'),
+    endDate: new Date('2015-04-01T00:00:00'),
+    taskName: 'Ubuntu 10.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2012-04-01T00:00:00'),
+    endDate: new Date('2014-10-01T00:00:00'),
+    taskName: 'Ubuntu 12.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2014-10-01T00:00:00'),
+    endDate: new Date('2017-04-01T00:00:00'),
+    taskName: 'Ubuntu 12.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2017-04-01T00:00:00'),
+    endDate: new Date('2019-04-01T00:00:00'),
+    taskName: 'Ubuntu 12.04 LTS',
+    status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2014-04-01T00:00:00'),
+    endDate: new Date('2016-10-01T00:00:00'),
+    taskName: 'Ubuntu 14.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2016-10-01T00:00:00'),
+    endDate: new Date('2019-04-01T00:00:00'),
+    taskName: 'Ubuntu 14.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2016-04-01T00:00:00'),
+    endDate: new Date('2018-10-01T00:00:00'),
+    taskName: 'Ubuntu 16.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2018-10-01T00:00:00'),
+    endDate: new Date('2021-04-01T00:00:00'),
+    taskName: 'Ubuntu 16.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2017-10-01T00:00:00'),
+    endDate: new Date('2018-07-01T00:00:00'),
+    taskName: 'Ubuntu 17.10',
+    status: 'STANDARD_RELEASE'
+  },
+  {
+    startDate: new Date('2018-04-01T00:00:00'),
+    endDate: new Date('2020-10-01T00:00:00'),
+    taskName: 'Ubuntu 18.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2020-10-01T00:00:00'),
+    endDate: new Date('2023-04-01T00:00:00'),
+    taskName: 'Ubuntu 18.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2018-10-01T00:00:00'),
+    endDate: new Date('2019-07-01T00:00:00'),
+    taskName: 'Ubuntu 18.10',
+    status: 'STANDARD_RELEASE'
+  },
+  {
+    startDate: new Date('2019-04-01T00:00:00'),
+    endDate: new Date('2019-12-31T00:00:00'),
+    taskName: 'Ubuntu 19.04',
+    status: 'STANDARD_RELEASE'
+  },
+  {
+    startDate: new Date('2019-10-01T00:00:00'),
+    endDate: new Date('2020-07-01T00:00:00'),
+    taskName: 'Ubuntu 19.10',
+    status: 'STANDARD_RELEASE'
+  },
+  {
+    startDate: new Date('2020-04-01T00:00:00'),
+    endDate: new Date('2022-10-01T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2022-10-01T00:00:00'),
+    endDate: new Date('2025-04-01T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  }
+];
+
+var kernelReleases = [
+  {
+    startDate: new Date('2012-04-01T00:00:00'),
+    endDate: new Date('2017-04-01T00:00:00'),
+    taskName: 'Ubuntu 12.01.0 LTS (v3.2)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-04-01T00:00:00'),
+    endDate: new Date('2019-07-01T00:00:00'),
+    taskName: 'Ubuntu 12.01.0 LTS (v3.2)',
+    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2012-07-01T00:00:00'),
+    endDate: new Date('2017-04-01T00:00:00'),
+    taskName: 'Ubuntu 12.04.1 LTS (v3.2)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-04-01T00:00:00'),
+    endDate: new Date('2019-07-01T00:00:00'),
+    taskName: 'Ubuntu 12.04.1 LTS (v3.2)',
+    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2014-04-01T00:00:00'),
+    endDate: new Date('2018-07-01T00:00:00'),
+    taskName: 'Ubuntu 14.04.0 LTS (v3.13)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2014-07-01T00:00:00'),
+    endDate: new Date('2017-04-01T00:00:00'),
+    taskName: 'Ubuntu 12.04.5 LTS (v3.13)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-04-01T00:00:00'),
+    endDate: new Date('2019-07-01T00:00:00'),
+    taskName: 'Ubuntu 12.04.5 LTS (v3.13)',
+    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2014-07-01T00:00:00'),
+    endDate: new Date('2018-07-01T00:00:00'),
+    taskName: 'Ubuntu 14.04.1 LTS (v3.13)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2016-04-01T00:00:00'),
+    endDate: new Date('2021-07-01T00:00:00'),
+    taskName: 'Ubuntu 16.04.0 LTS (v4.4)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2016-07-01T00:00:00'),
+    endDate: new Date('2018-07-01T00:00:00'),
+    taskName: 'Ubuntu 14.04.5 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2016-04-01T00:00:00'),
+    endDate: new Date('2021-07-01T00:00:00'),
+    taskName: 'Ubuntu 16.04.1 LTS (v4.4)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-10-01T00:00:00'),
+    endDate: new Date('2018-10-01T00:00:00'),
+    taskName: 'Ubuntu 17.10 (v4.13)',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-01-01T00:00:00'),
+    endDate: new Date('2018-10-01T00:00:00'),
+    taskName: 'Ubuntu 16.04.4 LTS (v4.13)',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-04-01T00:00:00'),
+    endDate: new Date('2023-07-01T00:00:00'),
+    taskName: 'Ubuntu 18.04.0 LTS (v4.15)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-07-01T00:00:00'),
+    endDate: new Date('2021-07-01T00:00:00'),
+    taskName: 'Ubuntu 16.04.5 LTS (v4.15)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-07-01T00:00:00'),
+    endDate: new Date('2023-07-01T00:00:00'),
+    taskName: 'Ubuntu 18.04.1 LTS (v4.15)',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-10-01T00:00:00'),
+    endDate: new Date('2019-10-01T00:00:00'),
+    taskName: 'Ubuntu 18.10',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2019-01-01T00:00:00'),
+    endDate: new Date('2019-10-01T00:00:00'),
+    taskName: 'Ubuntu 18.04.2 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2019-04-01T00:00:00'),
+    endDate: new Date('2020-04-01T00:00:00'),
+    taskName: 'Ubuntu 19.04',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2019-07-01T00:00:00'),
+    endDate: new Date('2020-04-01T00:00:00'),
+    taskName: 'Ubuntu 18.04.3 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2019-10-01T00:00:00'),
+    endDate: new Date('2020-10-01T00:00:00'),
+    taskName: 'Ubuntu 19.10',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2020-01-01T00:00:00'),
+    endDate: new Date('2020-10-01T00:00:00'),
+    taskName: 'Ubuntu 18.04.4 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2020-04-01T00:00:00'),
+    endDate: new Date('2025-07-01T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2020-07-01T00:00:00'),
+    endDate: new Date('2023-07-01T00:00:00'),
+    taskName: 'Ubuntu 18.04.5 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  }
+];
+
+var openStackReleases = [
+  {
+    startDate: new Date('2014-04-01T00:00:00'),
+    endDate: new Date('2019-04-01T00:00:00'),
+    taskName: 'Ubuntu 14.04 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2014-04-01T00:00:00'),
+    endDate: new Date('2019-04-01T00:00:00'),
+    taskName: 'OpenStack Icehouse',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2015-04-01T00:00:00'),
+    endDate: new Date('2016-10-01T00:00:00'),
+    taskName: 'OpenStack Kilo',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2016-10-01T00:00:00'),
+    endDate: new Date('2018-04-01T00:00:00'),
+    taskName: 'OpenStack Kilo',
+    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2016-04-01T00:00:00'),
+    endDate: new Date('2019-04-01T00:00:00'),
+    taskName: 'OpenStack Mitaka',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2016-04-01T00:00:00'),
+    endDate: new Date('2021-04-01T00:00:00'),
+    taskName: 'Ubuntu 16.04 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2016-10-01T00:00:00'),
+    endDate: new Date('2018-04-01T00:00:00'),
+    taskName: 'OpenStack Newton',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-04-01T00:00:00'),
+    endDate: new Date('2018-10-01T00:00:00'),
+    taskName: 'OpenStack Ocata',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-10-01T00:00:00'),
+    endDate: new Date('2020-04-01T00:00:00'),
+    taskName: 'OpenStack Ocata',
+    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2017-10-01T00:00:00'),
+    endDate: new Date('2019-04-01T00:00:00'),
+    taskName: 'OpenStack Pike',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-04-01T00:00:00'),
+    endDate: new Date('2021-04-01T00:00:00'),
+    taskName: 'OpenStack Queens',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-04-01T00:00:00'),
+    endDate: new Date('2023-07-01T00:00:00'),
+    taskName: 'Ubuntu 18.04 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-10-01T00:00:00'),
+    endDate: new Date('2020-04-01T00:00:00'),
+    taskName: 'OpenStack Rocky',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  }
+];
+
+var desktopServerStatus = {
+  HARDWARE_AND_MAINTENANCE_UPDATES: 'chart__bar--orange',
+  MAINTENANCE_UPDATES: 'chart__bar--orange-light',
+  STANDARD_RELEASE: 'chart__bar--grey',
+  EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS: 'chart__bar--aubergine'
+};
+
+var kernelStatus = {
+  UBUNTU_LTS_RELEASE_SUPPORT: 'chart__bar--orange',
+  MATCHING_OPENSTACK_RELEASE_SUPPORT: 'chart__bar--grey',
+  EXTENDED_SUPPORT_FOR_CUSTOMERS: 'chart__bar--aubergine'
+};
+
+var openStackStatus = {
+  UBUNTU_LTS_RELEASE_SUPPORT: 'chart__bar--orange',
+  MATCHING_OPENSTACK_RELEASE_SUPPORT: 'chart__bar--grey',
+  EXTENDED_SUPPORT_FOR_CUSTOMERS: 'chart__bar--aubergine'
+};
+
+var desktopServerReleaseNames = [
+  'Ubuntu 20.04 LTS',
+  'Ubuntu 19.10',
+  'Ubuntu 19.04',
+  'Ubuntu 18.10',
+  'Ubuntu 18.04 LTS',
+  'Ubuntu 17.10',
+  'Ubuntu 16.04 LTS',
+  'Ubuntu 14.04 LTS',
+  'Ubuntu 12.04 LTS',
+  'Ubuntu 10.04 LTS'
+];
+
+var kernelReleaseNames = [
+  'Ubuntu 18.04.5 LTS',
+  'Ubuntu 20.04 LTS',
+  'Ubuntu 18.04.4 LTS',
+  'Ubuntu 19.10',
+  'Ubuntu 18.04.3 LTS',
+  'Ubuntu 19.04',
+  'Ubuntu 18.04.2 LTS',
+  'Ubuntu 18.10',
+  'Ubuntu 18.04.1 LTS (v4.15)',
+  'Ubuntu 16.04.5 LTS (v4.15)',
+  'Ubuntu 18.04.0 LTS (v4.15)',
+  'Ubuntu 16.04.4 LTS (v4.13)',
+  'Ubuntu 17.10 (v4.13)',
+  'Ubuntu 16.04.1 LTS (v4.4)',
+  'Ubuntu 14.04.5 LTS',
+  'Ubuntu 16.04.0 LTS (v4.4)',
+  'Ubuntu 14.04.1 LTS (v3.13)',
+  'Ubuntu 12.04.5 LTS (v3.13)',
+  'Ubuntu 14.04.0 LTS (v3.13)',
+  'Ubuntu 12.04.1 LTS (v3.2)',
+  'Ubuntu 12.01.0 LTS (v3.2)'
+];
+
+var openStackReleaseNames = [
+  'OpenStack Rocky',
+  'Ubuntu 18.04 LTS',
+  'OpenStack Queens',
+  'OpenStack Pike',
+  'OpenStack Ocata',
+  'OpenStack Newton',
+  'Ubuntu 16.04 LTS',
+  'OpenStack Mitaka',
+  'OpenStack Kilo',
+  'OpenStack Icehouse',
+  'Ubuntu 14.04 LTS'
+];

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -1,0 +1,56 @@
+.chart__bar--orange {
+  fill: #e95420;
+  stroke: #e95420;
+  stroke-width: 1px;
+}
+
+.chart__bar--orange-light {
+  fill: #fbddd2;
+  stroke: #e95420;
+  stroke-width: 1px;
+}
+
+.chart__bar--grey {
+  fill: #aea79f;
+  stroke: #aea79f;
+  stroke-width: 1px;
+}
+
+.chart__bar--aubergine {
+  fill: #772953;
+  stroke: #772953;
+  stroke-width: 1px;
+}
+
+.chart__label--bold {
+  font-weight: bold;
+}
+
+.x.axis line {
+  stroke: #d6d3cf;
+  shape-rendering: crispEdges;
+  stroke-dasharray: 3 2;
+}
+
+.tick text {
+  font-size: 12px;
+}
+
+.x.axis text {
+  text-anchor: start !important;
+  font-size: 11px;
+}
+
+.chart-key {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.chart-key__row {
+  display: block;
+}
+
+.chart-key text {
+  font-size: 14px;
+}

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -1,3 +1,7 @@
+.chart {
+  margin-top: $sp-unit * 3;
+}
+
 .chart__bar--orange {
   fill: #e95420;
   stroke: #e95420;

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -33,18 +33,16 @@
 }
 
 .tick text {
-  font-size: 12px;
+  font-size: 14px;
 }
 
 .x.axis text {
   text-anchor: start !important;
-  font-size: 11px;
+  font-size: 12px;
 }
 
 .chart-key {
   display: block;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .chart-key__row {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -38,6 +38,7 @@
 @import 'pattern_feedback';
 @import 'takeovers/rigado-webinar';
 @import 'utility-animations';
+@import 'pattern_chart';
 
 @include ubuntu-p-buttons;
 @include ubuntu-p-navigation;

--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -1,4 +1,5 @@
 {% extends "templates/one-column.html" %}
+{% load versioned_static  %}
 
 {% block meta_description %}When an Ubuntu release reaches its end of life it receives no further maintenance updates, including critical security upgrades. It is highly recommended that you upgrade to a recent version of Ubuntu at this point.{% endblock %}
 
@@ -36,9 +37,7 @@
   </div>
   <div class="row">
     <div class="col-10">
-      <div>
-        <img src="{{ ASSET_SERVER_URL }}f02f0a4b-r-eol-ubuntu-full-2018-02-28.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long-term support" class="u-hide--small" />
-      </div>
+      <div class="u-hide--small" id="server-desktop-eol"></div>
       <table class="u-hide--medium u-hide--large">
         <thead>
           <tr>
@@ -148,9 +147,7 @@
   </div>
   <div class="row">
     <div class="col-10">
-      <div>
-        <img src="{{ ASSET_SERVER_URL }}3a8a15fc-2018-04-10_kernel-end-of-life.jpg" alt="" class="u-hide--small " />
-      </div>
+      <div class="u-hide--small" id="kernel-eol"></div>
       <table class="u-hide--medium u-hide--large ">
         <thead>
           <tr>
@@ -307,9 +304,7 @@
   </div>
   <div class="row">
     <div class="col-10">
-      <div>
-        <img src="{{ ASSET_SERVER_URL }}21318ad0-r-eol-openstack-2018-03-02.png" alt=" " class="u-hide--small " />
-      </div>
+      <div class="u-hide--small" id="openstack-eol"></div>
       <table class="u-hide--medium u-hide--large ">
         <thead>
           <tr>
@@ -456,5 +451,48 @@
     </div>
   </div>
 </section>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+<script src="{% versioned_static 'js/chartData.js' %}"></script>
+<script src="{% versioned_static 'js/chart.js' %}"></script>
+<script>
+function debounce(func, wait, immediate) {
+	var timeout;
+	return function() {
+		var context = this, args = arguments;
+		clearTimeout(timeout);
+		timeout = setTimeout(function() {
+			timeout = null;
+			if (!immediate) func.apply(context, args);
+		}, wait);
+		if (immediate && !timeout) func.apply(context, args);
+	};
+}
+
+function buildCharts() {
+  createChart('#server-desktop-eol', desktopServerReleaseNames, desktopServerStatus, serverAndDesktopReleases);
+  createChart('#kernel-eol', kernelReleaseNames, kernelStatus, kernelReleases);
+  createChart('#openstack-eol', openStackReleaseNames, openStackStatus, openStackReleases);
+}
+
+function clearCharts() {
+  document.querySelector('#server-desktop-eol').innerHTML = '';
+  document.querySelector('#kernel-eol').innerHTML = '';
+  document.querySelector('#openstack-eol').innerHTML = '';
+}
+
+var mediumBreakpoint = 768;
+
+if (window.innerWidth >= mediumBreakpoint) {
+  buildCharts();
+}
+
+window.addEventListener('resize', debounce(function() {
+  if (window.innerWidth >= mediumBreakpoint) {
+    clearCharts();
+    buildCharts();
+  }
+}, 250));
+</script>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

Make release end of life charts with d3 rather than static images

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/info/release-end-of-life>
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the charts are good


## Issue / Card

Fixes #2922 
