### PR TITLE
3782: Make beta primary nav sticky

### DIFF
--- a/static/js/ga-events.js
+++ b/static/js/ga-events.js
@@ -1,0 +1,61 @@
+var origin = window.location.pathname;
+
+function addGANavEvents(target, category){
+  var t = document.querySelector(target);
+  if (t) {
+    t.querySelectorAll('a').forEach(function(a) {
+      var destination = a.href.replace('https://www.ubuntu.com', '').split("?")[0];
+      a.addEventListener('click', function() {
+        dataLayer.push({
+          'event' : 'GAEvent',
+          'eventCategory' : category,
+          'eventAction' : "from:" + origin + " to:" + destination,
+          'eventLabel' : a.text,
+          'eventValue' : undefined
+        });
+      });
+    });
+  }
+}
+
+function addGAContentEvents(target){
+  var t = document.querySelector(target);
+  if (t) {
+    t.querySelectorAll('a').forEach(function(a) {
+      var destination = a.href.replace('https://www.ubuntu.com', '').split("?")[0];
+      if (a.className.includes('p-button--positive')) {
+        var category = 'www.ubuntu.com-content-cta-0';
+      } else if (a.className.includes('p-button')) {
+        var category = 'www.ubuntu.com-content-cta-1';
+      } else {
+        var category = 'www.ubuntu.com-content-link';
+      }
+      if (!destination.startsWith("#")){
+        a.addEventListener('click', function() {
+          dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : category,
+            'eventAction' : "from:" + origin + " to:" + destination,
+            'eventLabel' : a.text,
+            'eventValue' : undefined
+          });
+        });
+      }
+    });
+  }
+}
+
+addGANavEvents('.global-nav__row', 'www.ubuntu.com-nav-0');
+addGANavEvents('#canonical-products', 'www.ubuntu.com-nav-0-products');
+addGANavEvents('#canonical-login', 'www.ubuntu.com-nav-0-login');
+addGANavEvents('#navigation', 'www.ubuntu.com-nav-1');
+addGANavEvents('#enterprise-content', 'www.ubuntu.com-nav-1-enterprise');
+addGANavEvents('#developer-content', 'www.ubuntu.com-nav-1-developer');
+addGANavEvents('#community-content', 'www.ubuntu.com-nav-1-community');
+addGANavEvents('#download-content', 'www.ubuntu.com-nav-1-download');
+addGANavEvents('.p-navigation--secondary', 'www.ubuntu.com-nav-2');
+addGANavEvents('.p-contextual-footer', 'www.ubuntu.com-footer-contextual');
+addGANavEvents('.p-footer__nav', 'www.ubuntu.com-nav-footer-0');
+addGANavEvents('.p-footer--secondary', 'www.ubuntu.com-nav-footer-1');
+
+addGAContentEvents('#main-content')

--- a/static/js/global-navigation.js
+++ b/static/js/global-navigation.js
@@ -1,7 +1,7 @@
 /* Constants */
 var NAV_BREAKPOINT = 900;
 
-/* Document elements */
+/* DOM elements */
 var globalNav = document.querySelector('.global-nav');
 var globalNavDropdowns = document.querySelectorAll('.global-nav__link--dropdown');
 var globalNavContent = document.querySelector('.global-nav__dropdown');

--- a/static/js/global-navigation.js
+++ b/static/js/global-navigation.js
@@ -65,13 +65,7 @@ globalNavDropdowns.forEach(function(dropdown) {
   });
 });
 
-globalNavOverlay.addEventListener('click', function() {
-  globalNavContent.classList.remove('show-global-nav-content');
-  globalNavOverlay.classList.remove('is-visible');
-  globalNavDropdowns.forEach(function(dropdown) {
-    dropdown.classList.remove('is-selected');
-  });
-});
+globalNavOverlay.addEventListener('click', closeGlobalNav);
 
 document.addEventListener('click', function(event) {
   globalNavDropdowns.forEach(function(globalNavDropdown) {
@@ -84,6 +78,14 @@ document.addEventListener('click', function(event) {
     }
   });
 });
+
+function closeGlobalNav() {
+  globalNavContent.classList.remove('show-global-nav-content');
+  globalNavOverlay.classList.remove('is-visible');
+  globalNavDropdowns.forEach(function(dropdown) {
+    dropdown.classList.remove('is-selected');
+  });
+}
 
 function closeMainMenu() {
   var navigationLinks = document.querySelectorAll('.p-navigation__dropdown-link');
@@ -98,6 +100,19 @@ function closeMainMenu() {
 
   if (!dropdownWindow.classList.contains('slide-animation')) {
     dropdownWindow.classList.add('slide-animation');
+  }
+}
+
+function controlGlobalNavPosition() {
+  var globalNavDropdown = document.querySelector('.global-nav__dropdown');
+
+  if (globalNavDropdown.classList.contains('show-global-nav-content')) {
+    var scrollPos = window.scrollY;
+    var globalNavHeight = globalNavDropdown.clientHeight;
+
+    if (scrollPos > globalNavHeight) {
+      closeGlobalNav();
+    }
   }
 }
 

--- a/static/js/global-navigation.js
+++ b/static/js/global-navigation.js
@@ -1,0 +1,112 @@
+/* Constants */
+var NAV_BREAKPOINT = 900;
+
+/* Document elements */
+var globalNav = document.querySelector('.global-nav');
+var globalNavDropdowns = document.querySelectorAll('.global-nav__link--dropdown');
+var globalNavContent = document.querySelector('.global-nav__dropdown');
+var globalNavOverlay = document.querySelector('.global-nav__dropdown-overlay');
+var globalNavDropdownMenus = document.querySelectorAll('.global-nav__dropdown-content');
+var footerTitlesA = document.querySelectorAll('.global-nav--mobile .p-footer__title');
+
+globalNavDropdowns.forEach(function(dropdown) {
+  dropdown.addEventListener('click', function(event) {
+    event.preventDefault();
+
+    var currentLink = this;
+
+    var targetMenuLink = dropdown.querySelector('.global-nav__link-anchor');
+    var targetMenuId = targetMenuLink.getAttribute('href');
+    var targetMenu = document.querySelector(targetMenuId);
+    var isMobile = window.innerWidth < NAV_BREAKPOINT;
+
+    function scrollGlobalNavToTop() {
+      window.scrollTo(0, globalNav.offsetTop);
+    }
+
+    if (globalNavContent.classList.contains('show-global-nav-content')) {
+      if (dropdown.classList.contains('is-selected')) {
+        dropdown.classList.remove('is-selected');
+        globalNavContent.classList.remove('show-global-nav-content');
+        globalNavOverlay.classList.remove('is-visible');
+      } else {
+        globalNavDropdowns.forEach(function(dropdown) {
+          dropdown.classList.remove('is-selected');
+        });
+        dropdown.classList.add('is-selected');
+        globalNavDropdownMenus.forEach(function(menu) {
+          if (menu !== targetMenu) {
+            menu.classList.add('u-hide');
+          }
+        });
+        targetMenu.classList.remove('u-hide');
+        closeMainMenu();
+
+        if (isMobile) {
+          scrollGlobalNavToTop();
+        }
+      }
+    } else {
+      currentLink.classList.add('is-selected');
+      globalNavContent.classList.add('show-global-nav-content');
+      globalNavOverlay.classList.add('is-visible');
+      globalNavDropdownMenus.forEach(function(menu) {
+        if (menu !== targetMenu) {
+          menu.classList.add('u-hide');
+        }
+      });
+      targetMenu.classList.remove('u-hide');
+      closeMainMenu();
+
+      if (isMobile) {
+        scrollGlobalNavToTop();
+      }
+    }
+  });
+});
+
+globalNavOverlay.addEventListener('click', function() {
+  globalNavContent.classList.remove('show-global-nav-content');
+  globalNavOverlay.classList.remove('is-visible');
+  globalNavDropdowns.forEach(function(dropdown) {
+    dropdown.classList.remove('is-selected');
+  });
+});
+
+document.addEventListener('click', function(event) {
+  globalNavDropdowns.forEach(function(globalNavDropdown) {
+    if (globalNavDropdown.classList.contains('is-selected')) {
+      var clickInsideGlobal = globalNav.contains(event.target);
+
+      if (!clickInsideGlobal) {
+        globalNavDropdown.classList.remove('is-selected');
+      }
+    }
+  });
+});
+
+function closeMainMenu() {
+  var navigationLinks = document.querySelectorAll('.p-navigation__dropdown-link');
+
+  navigationLinks.forEach(function(navLink) {
+    navLink.classList.remove('is-selected');
+  });
+
+  if (!dropdownWindowOverlay.classList.contains('fade-animation')) {
+    dropdownWindowOverlay.classList.add('fade-animation');
+  }
+
+  if (!dropdownWindow.classList.contains('slide-animation')) {
+    dropdownWindow.classList.add('slide-animation');
+  }
+}
+
+function mobileGlobalNav() {
+  footerTitlesA.forEach(function(node) {
+    node.addEventListener('click', function(e) {
+      e.target.classList.toggle('active');
+    });
+  });
+};
+
+mobileGlobalNav();

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -94,6 +94,7 @@ function controlNavPosition() {
 setInterval(function() {
   if (didScroll) {
     controlNavPosition();
+    controlGlobalNavPosition();
     didScroll = false;
   }
 }, SCROLL_LISTENER_INTERVAL);

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,61 +1,47 @@
-/* Document elements */
+/* DOM elements */
 var navDropdowns = document.querySelectorAll('.p-navigation__dropdown-link');
 var dropdownWindow = document.querySelector('.dropdown-window');
 var dropdownWindowOverlay = document.querySelector('.dropdown-window-overlay');
 var closeMenuLink = document.querySelector('.p-navigation__toggle--close');
 
-navDropdowns.forEach(function(dropdown) {
-  dropdown.addEventListener('click', function(event) {
-    event.preventDefault();
+var toggleDropdown = function(event) {
+  event.preventDefault();
 
-    var clickedDropdown = this;
+  var clickedDropdown = this;
 
-    dropdownWindow.classList.remove('slide-animation');
-    dropdownWindowOverlay.classList.remove('fade-animation');
+  dropdownWindow.classList.remove('slide-animation');
+  dropdownWindowOverlay.classList.remove('fade-animation');
 
-    navDropdowns.forEach(function(dropdown) {
-      var dropdownContent = document.getElementById(dropdown.id + "-content");
+  navDropdowns.forEach(function(dropdown) {
+    var dropdownContent = document.getElementById(dropdown.id + "-content");
 
-      if (dropdown === clickedDropdown) {
-        if (dropdown.classList.contains('is-selected')) {
-          closeMenu(dropdown, dropdownContent);
-        } else {
-          dropdown.classList.add('is-selected');
-          dropdownContent.classList.remove('u-hide');
-
-          if (window.history.pushState) {
-            window.history.pushState(null, null, '#' + dropdown.id);
-          }
-        }
+    if (dropdown === clickedDropdown) {
+      if (dropdown.classList.contains('is-selected')) {
+        closeDropdown(dropdown);
       } else {
-        dropdown.classList.remove('is-selected');
-        dropdownContent.classList.add('u-hide');
+        dropdown.classList.add('is-selected');
+        dropdownContent.classList.remove('u-hide');
+
+        if (window.history.pushState) {
+          window.history.pushState(null, null, '#' + dropdown.id);
+        }
       }
-    });
-  });
-});
-
-closeMenuLink.addEventListener('click', function() {
-  navDropdowns.forEach(function(dropdown) {
-    var dropdownContent = document.getElementById(dropdown.id + "-content");
-
-    if (dropdown.classList.contains('is-selected')) {
-      closeMenu(dropdown, dropdownContent);
+    } else {
+      dropdown.classList.remove('is-selected');
+      dropdownContent.classList.add('u-hide');
     }
   });
-});
+}
 
-dropdownWindowOverlay.addEventListener('click', function() {
+var closeNavigation = function() {
   navDropdowns.forEach(function(dropdown) {
-    var dropdownContent = document.getElementById(dropdown.id + "-content");
-
     if (dropdown.classList.contains('is-selected')) {
-      closeMenu(dropdown, dropdownContent);
+      closeDropdown(dropdown);
     }
   });
-});
+}
 
-function closeMenu(dropdown) {
+function closeDropdown(dropdown) {
   dropdown.classList.remove('is-selected');
   dropdownWindow.classList.add('slide-animation');
   dropdownWindowOverlay.classList.add('fade-animation');
@@ -64,6 +50,14 @@ function closeMenu(dropdown) {
   }
 }
 
+/* Apply event listeners to DOM elements */
+navDropdowns.forEach(function(dropdown) {
+  dropdown.addEventListener('click', toggleDropdown);
+});
+closeMenuLink.addEventListener('click', closeNavigation);
+dropdownWindowOverlay.addEventListener('click', closeNavigation);
+
+/* Open primary nav on relevant dropdown when browser back button pressed */
 if (window.location.hash) {
   var tabId = window.location.hash.split('#')[1];
   var tab = document.getElementById(tabId);

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,8 +1,25 @@
+/* Constants */
+var AUTO_CLOSE_BUFFER = 200;
+var GLOBAL_NAV_HEIGHT = 32;
+var NAV_BREAKPOINT = 900;
+var PRIMARY_NAV_HEIGHT = 48;
+var SCROLL_DELTA = 5;
+var SCROLL_LISTENER_INTERVAL = 250;
+var SLIDE_ANIM_TIME = 333;
+
 /* DOM elements */
-var navDropdowns = document.querySelectorAll('.p-navigation__dropdown-link');
+var body = document.body;
+var closeMenuLink = document.querySelector('.p-navigation__toggle--close');
 var dropdownWindow = document.querySelector('.dropdown-window');
 var dropdownWindowOverlay = document.querySelector('.dropdown-window-overlay');
-var closeMenuLink = document.querySelector('.p-navigation__toggle--close');
+var html = document.documentElement;
+var nav = document.querySelector('.p-navigation');
+var navDropdowns = document.querySelectorAll('.p-navigation__dropdown-link');
+
+/* Global variables */
+var didScroll;
+var lastScrollTop = 0;
+var slideAnimTimeout;
 
 var toggleDropdown = function(event) {
   event.preventDefault();
@@ -19,6 +36,14 @@ var toggleDropdown = function(event) {
       if (dropdown.classList.contains('is-selected')) {
         closeDropdown(dropdown);
       } else {
+        if (window.innerWidth > NAV_BREAKPOINT) {
+          clearTimeout(slideAnimTimeout);
+          var scrollPos = window.scrollY + PRIMARY_NAV_HEIGHT;
+          if (window.scrollY < GLOBAL_NAV_HEIGHT) {
+            scrollPos += GLOBAL_NAV_HEIGHT;
+          }
+          dropdownWindow.style.top = scrollPos + 'px';
+        }
         dropdown.classList.add('is-selected');
         dropdownContent.classList.remove('u-hide');
 
@@ -39,23 +64,74 @@ var closeNavigation = function() {
       closeDropdown(dropdown);
     }
   });
+  
 }
 
 function closeDropdown(dropdown) {
   dropdown.classList.remove('is-selected');
   dropdownWindow.classList.add('slide-animation');
   dropdownWindowOverlay.classList.add('fade-animation');
+  if (window.innerWidth > NAV_BREAKPOINT) {
+    dropdownWindow.style.top = window.scrollY - window.clientHeight;
+    slideAnimTimeout = setTimeout(function() {
+      dropdownWindow.style.top = null;
+    }, SLIDE_ANIM_TIME);
+  }
   if (window.history.pushState) {
     window.history.pushState(null, null, window.location.href.split('#')[0]);
   }
 }
 
+function controlNavPosition() {
+  var scrollPos = window.scrollY;
+  var dropdownHeight = dropdownWindow.clientHeight;
+  var dropdownPos = parseInt(dropdownWindow.style.top, 10);
+  var docHeight = Math.max(
+    body.offsetHeight,
+    body.scrollHeight,
+    html.clientHeight,
+    html.offsetHeight,
+    html.scrollHeight
+  );
+
+  if (Math.abs(lastScrollTop - scrollPos) <= SCROLL_DELTA) return;
+
+  if (scrollPos > lastScrollTop || scrollPos <= GLOBAL_NAV_HEIGHT) {
+    nav.classList.remove('is-down');
+    nav.classList.add('is-up');
+
+    if (scrollPos > dropdownPos + dropdownHeight) {
+      closeNavigation();
+    }
+  } else if (scrollPos + window.innerHeight < docHeight) {
+    nav.classList.remove('is-up');
+    nav.classList.add('is-down');
+
+    if (scrollPos + AUTO_CLOSE_BUFFER < dropdownPos) {
+      closeNavigation();
+    }
+  }
+
+  lastScrollTop = scrollPos;
+}
+
+/* Set interval on how often to run scroll function */
+setInterval(function() {
+  if (didScroll) {
+    controlNavPosition();
+    didScroll = false;
+  }
+}, SCROLL_LISTENER_INTERVAL);
+
 /* Apply event listeners to DOM elements */
+closeMenuLink.addEventListener('click', closeNavigation);
+dropdownWindowOverlay.addEventListener('click', closeNavigation);
 navDropdowns.forEach(function(dropdown) {
   dropdown.addEventListener('click', toggleDropdown);
 });
-closeMenuLink.addEventListener('click', closeNavigation);
-dropdownWindowOverlay.addEventListener('click', closeNavigation);
+window.addEventListener('scroll', function() {
+  didScroll = true;
+});
 
 /* Open primary nav on relevant dropdown when browser back button pressed */
 if (window.location.hash) {

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -3,7 +3,6 @@ var AUTO_CLOSE_BUFFER = 200;
 var GLOBAL_NAV_HEIGHT = 32;
 var NAV_BREAKPOINT = 900;
 var PRIMARY_NAV_HEIGHT = 48;
-var SCROLL_DELTA = 5;
 var SCROLL_LISTENER_INTERVAL = 250;
 var SLIDE_ANIM_TIME = 333;
 
@@ -18,7 +17,6 @@ var navDropdowns = document.querySelectorAll('.p-navigation__dropdown-link');
 
 /* Global variables */
 var didScroll;
-var lastScrollTop = 0;
 var slideAnimTimeout;
 
 var toggleDropdown = function(event) {
@@ -86,33 +84,10 @@ function controlNavPosition() {
   var scrollPos = window.scrollY;
   var dropdownHeight = dropdownWindow.clientHeight;
   var dropdownPos = parseInt(dropdownWindow.style.top, 10);
-  var docHeight = Math.max(
-    body.offsetHeight,
-    body.scrollHeight,
-    html.clientHeight,
-    html.offsetHeight,
-    html.scrollHeight
-  );
 
-  if (Math.abs(lastScrollTop - scrollPos) <= SCROLL_DELTA) return;
-
-  if (scrollPos > lastScrollTop || scrollPos <= GLOBAL_NAV_HEIGHT) {
-    nav.classList.remove('is-down');
-    nav.classList.add('is-up');
-
-    if (scrollPos > dropdownPos + dropdownHeight) {
-      closeNavigation();
-    }
-  } else if (scrollPos + window.innerHeight < docHeight) {
-    nav.classList.remove('is-up');
-    nav.classList.add('is-down');
-
-    if (scrollPos + AUTO_CLOSE_BUFFER < dropdownPos) {
-      closeNavigation();
-    }
+  if ((scrollPos + AUTO_CLOSE_BUFFER < dropdownPos) || (scrollPos > dropdownPos + dropdownHeight)) {
+    closeNavigation();
   }
-
-  lastScrollTop = scrollPos;
 }
 
 /* Set interval on how often to run scroll function */

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,8 +1,8 @@
+/* Document elements */
 var navDropdowns = document.querySelectorAll('.p-navigation__dropdown-link');
 var dropdownWindow = document.querySelector('.dropdown-window');
 var dropdownWindowOverlay = document.querySelector('.dropdown-window-overlay');
 var closeMenuLink = document.querySelector('.p-navigation__toggle--close');
-var navigationThresholdBreakpoint = 900;
 
 navDropdowns.forEach(function(dropdown) {
   dropdown.addEventListener('click', function(event) {
@@ -35,89 +35,7 @@ navDropdowns.forEach(function(dropdown) {
   });
 });
 
-var globalNav = document.querySelector('.global-nav');
-var globalNavDropdowns = document.querySelectorAll('.global-nav__link--dropdown');
-var globalNavContent = document.querySelector('.global-nav__dropdown');
-var globalNavOverlay = document.querySelector('.global-nav__dropdown-overlay');
-var globalNavDropdownMenus = document.querySelectorAll('.global-nav__dropdown-content');
-
-globalNavDropdowns.forEach(function(dropdown) {
-  dropdown.addEventListener('click', function(event) {
-    event.preventDefault();
-
-    var currentLink = this;
-
-    var targetMenuLink = dropdown.querySelector('.global-nav__link-anchor');
-    var targetMenuId = targetMenuLink.getAttribute('href');
-    var targetMenu = document.querySelector(targetMenuId);
-    var isMobile = window.innerWidth < navigationThresholdBreakpoint;
-
-    function scrollGlobalNavToTop() {
-      window.scrollTo(0, globalNav.offsetTop);
-    }
-
-    if (globalNavContent.classList.contains('show-global-nav-content')) {
-      if (dropdown.classList.contains('is-selected')) {
-        dropdown.classList.remove('is-selected');
-        globalNavContent.classList.remove('show-global-nav-content');
-        globalNavOverlay.classList.remove('is-visible');
-      } else {
-        globalNavDropdowns.forEach(function(dropdown) {
-          dropdown.classList.remove('is-selected');
-        });
-        dropdown.classList.add('is-selected');
-        globalNavDropdownMenus.forEach(function(menu) {
-          if (menu !== targetMenu) {
-            menu.classList.add('u-hide');
-          }
-        });
-        targetMenu.classList.remove('u-hide');
-        closeMainMenu();
-
-        if (isMobile) {
-          scrollGlobalNavToTop();
-        }
-      }
-    } else {
-      currentLink.classList.add('is-selected');
-      globalNavContent.classList.add('show-global-nav-content');
-      globalNavOverlay.classList.add('is-visible');
-      globalNavDropdownMenus.forEach(function(menu) {
-        if (menu !== targetMenu) {
-          menu.classList.add('u-hide');
-        }
-      });
-      targetMenu.classList.remove('u-hide');
-      closeMainMenu();
-
-      if (isMobile) {
-        scrollGlobalNavToTop();
-      }
-    }
-  });
-});
-
-globalNavOverlay.addEventListener('click', function() {
-  globalNavContent.classList.remove('show-global-nav-content');
-  globalNavOverlay.classList.remove('is-visible');
-  globalNavDropdowns.forEach(function(dropdown) {
-    dropdown.classList.remove('is-selected');
-  });
-});
-
-document.addEventListener('click', function(event) {
-  globalNavDropdowns.forEach(function(globalNavDropdown) {
-    if (globalNavDropdown.classList.contains('is-selected')) {
-      var clickInsideGlobal = globalNav.contains(event.target);
-
-      if (!clickInsideGlobal) {
-        globalNavDropdown.classList.remove('is-selected');
-      }
-    }
-  });
-});
-
-closeMenuLink.addEventListener('click', function(event) {
+closeMenuLink.addEventListener('click', function() {
   navDropdowns.forEach(function(dropdown) {
     var dropdownContent = document.getElementById(dropdown.id + "-content");
 
@@ -127,7 +45,7 @@ closeMenuLink.addEventListener('click', function(event) {
   });
 });
 
-dropdownWindowOverlay.addEventListener('click', function(event) {
+dropdownWindowOverlay.addEventListener('click', function() {
   navDropdowns.forEach(function(dropdown) {
     var dropdownContent = document.getElementById(dropdown.id + "-content");
 
@@ -137,7 +55,7 @@ dropdownWindowOverlay.addEventListener('click', function(event) {
   });
 });
 
-function closeMenu(dropdown, dropdownContent) {
+function closeMenu(dropdown) {
   dropdown.classList.remove('is-selected');
   dropdownWindow.classList.add('slide-animation');
   dropdownWindowOverlay.classList.add('fade-animation');
@@ -160,92 +78,3 @@ if (window.location.hash) {
     }, 0);
   }
 }
-
-function closeMainMenu() {
-  var navigationLinks = document.querySelectorAll('.p-navigation__dropdown-link');
-
-  navigationLinks.forEach(function(navLink) {
-    navLink.classList.remove('is-selected');
-  });
-
-  if (!dropdownWindowOverlay.classList.contains('fade-animation')) {
-    dropdownWindowOverlay.classList.add('fade-animation');
-  }
-
-  if (!dropdownWindow.classList.contains('slide-animation')) {
-    dropdownWindow.classList.add('slide-animation');
-  }
-}
-
-var origin = window.location.pathname;
-
-addGANavEvents('.global-nav__row', 'www.ubuntu.com-nav-0');
-addGANavEvents('#canonical-products', 'www.ubuntu.com-nav-0-products');
-addGANavEvents('#canonical-login', 'www.ubuntu.com-nav-0-login');
-addGANavEvents('#navigation', 'www.ubuntu.com-nav-1');
-addGANavEvents('#enterprise-content', 'www.ubuntu.com-nav-1-enterprise');
-addGANavEvents('#developer-content', 'www.ubuntu.com-nav-1-developer');
-addGANavEvents('#community-content', 'www.ubuntu.com-nav-1-community');
-addGANavEvents('#download-content', 'www.ubuntu.com-nav-1-download');
-addGANavEvents('.p-navigation--secondary', 'www.ubuntu.com-nav-2');
-addGANavEvents('.p-contextual-footer', 'www.ubuntu.com-footer-contextual');
-addGANavEvents('.p-footer__nav', 'www.ubuntu.com-nav-footer-0');
-addGANavEvents('.p-footer--secondary', 'www.ubuntu.com-nav-footer-1');
-
-function addGANavEvents(target, category){
-  var t = document.querySelector(target);
-  if (t) {
-    t.querySelectorAll('a').forEach(function(a) {
-      var destination = a.href.replace('https://www.ubuntu.com', '').split("?")[0];
-      a.addEventListener('click', function(event){
-        dataLayer.push({
-          'event' : 'GAEvent',
-          'eventCategory' : category,
-          'eventAction' : `from:${origin} to:${destination}`,
-          'eventLabel' : a.text,
-          'eventValue' : undefined
-        });
-      });
-    });
-  }
-}
-
-addGAContentEvents('#main-content')
-
-function addGAContentEvents(target){
-  var t = document.querySelector(target);
-  if (t) {
-    t.querySelectorAll('a').forEach(function(a) {
-      var destination = a.href.replace('https://www.ubuntu.com', '').split("?")[0];
-      if (a.className.includes('p-button--positive')) {
-        var category = 'www.ubuntu.com-content-cta-0';
-      } else if (a.className.includes('p-button')) {
-        var category = 'www.ubuntu.com-content-cta-1';
-      } else {
-        var category = 'www.ubuntu.com-content-link';
-      }
-      if (!destination.startsWith("#")){
-        a.addEventListener('click', function(event){
-          dataLayer.push({
-            'event' : 'GAEvent',
-            'eventCategory' : category,
-            'eventAction' : `from:${origin} to:${destination}`,
-            'eventLabel' : a.text,
-            'eventValue' : undefined
-          });
-        });
-      }
-    });
-  }
-}
-
-function mobileGlobalNav() {
-  var footerTitlesA = document.querySelectorAll('.global-nav--mobile .p-footer__title');
-  footerTitlesA.forEach(function(node) {
-    node.addEventListener('click', function(e) {
-      e.target.classList.toggle('active');
-    });
-  });
-};
-
-mobileGlobalNav();

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -16,8 +16,10 @@
   }
 
   .p-navigation {
+    @include vf-animation(top);
     background-color: $nav-bg-color;
     flex-direction: column;
+    position: sticky;
     z-index: 3;
 
     &::after { // disable rule under nav
@@ -361,6 +363,16 @@
       @media (max-width: $breakpoint-x-small - 1) {
         margin-left: $grid-margin-width / 1.5 !important;
         margin-right: $grid-margin-width / 1.5 !important;
+      }
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      &.is-down {
+        top: 0;
+      }
+  
+      &.is-up {
+        top: -3rem;
       }
     }
   }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -372,7 +372,9 @@
       }
   
       &.is-up {
-        top: -3rem;
+        @supports (position: sticky) {
+          top: -3rem; // Workaround for IE11 hiding nav completely
+        }
       }
     }
   }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -19,7 +19,6 @@
     @include vf-animation(top);
     background-color: $nav-bg-color;
     flex-direction: column;
-    position: sticky;
     z-index: 3;
 
     &::after { // disable rule under nav
@@ -367,15 +366,8 @@
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      &.is-down {
-        top: 0;
-      }
-  
-      &.is-up {
-        @supports (position: sticky) {
-          top: -3rem; // Workaround for IE11 hiding nav completely
-        }
-      }
+      position: sticky;
+      top: 0;
     }
   }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -378,10 +378,12 @@
   }
 
   .dropdown-window-overlay {
+    @include vf-animation(opacity, fast);
     width: 100%;
     height: 100%;
     top: 0;
     background-color: rgba(17,17,17, .4);
+    opacity: 1;
     position: fixed;
     z-index: 1;
   }
@@ -434,15 +436,19 @@
 
   .slide-animation {
     transform: translateY(-101%);
+
+    @media (min-width: $breakpoint-navigation-threshold ) {
+      opacity: .75;
+    }
   }
 
   .fade-animation {
-    visibility: hidden;
+    pointer-events: none;
+    opacity: 0;
 
     .u-visible-nav & {
       opacity: 1;
       transform: none;
-      visibility: visible;
     }
   }
 }

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -1,4 +1,4 @@
-<header id="navigation" class="p-navigation" role="banner">
+<header id="navigation" class="p-navigation is-up" role="banner">
   {% block header_banner %}
     <div class="p-navigation__row row">
       <div class="p-navigation__banner">

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -85,6 +85,8 @@
     {% include "templates/footer.html" %}
     {% include "shared/_polyfill.html" %}
     <script src="{% versioned_static 'js/navigation.js' %}"></script>
+    <script src="{% versioned_static 'js/global-navigation.js' %}"></script>
+    <script src="{% versioned_static 'js/ga-events.js' %}"></script>
     <script src="{% versioned_static 'js/core.js' %}"></script>
     <script src="{% versioned_static 'js/scratch.js' %}"></script>
     <script src="{{ ASSET_SERVER_URL }}f5bf3854-respond.min.js"></script>


### PR DESCRIPTION
## Done

- Separated the original `navigation.js` file into `navigation.js`, `global-navigation.js` and `ga-events.js`
- Refactored `navigation.js` slightly into discrete functions
- Made the beta primary nav stick to the top of the viewport on large screens
- Added slight fade transitions to the dropdowns and overlay

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the primary nav sticks to the top of the screen when you scroll down
- Check that clicking a dropdown will open the content at the right place
- Check that the dropdown closes automatically if you scroll up or down far enough
- Open the global nav and check that it closes if you scroll down too far

## Issue / Card

Fixes #3782 
