### PR TITLE
[HACKDAY] BETA: Add copy docs links to metadata

### DIFF
--- a/templates/about/base_about.html
+++ b/templates/about/base_about.html
@@ -1,4 +1,5 @@
 {% extends "templates/base.html" %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6c3hFbTVzdHB5SGs{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}About the Ubuntu project{% endblock %}
 {% block meta_description %}Learn about the Ubuntu project's history, release schedule, support, and governance.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1NvYOhOJzdY5ypifTPs73vH5Nb7rFABRWMzjXyDUQt_U/edit{% endblock meta_copydoc %}
 {% block content %}
 
 <section class="p-strip is-deep">

--- a/templates/ai/base_ai.html
+++ b/templates/ai/base_ai.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1ktGxpcrrvlpJktHGtTEG1xI_UIhVg-Jo{% endblock meta_copydoc %}
+
 {% block outer_content %}
   {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/ai/contact-us.html
+++ b/templates/ai/contact-us.html
@@ -1,6 +1,6 @@
 {% extends "ai/base_ai.html" %}
 {% block title %}Contact us | Artificial Intellegence {% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/185NqOTBSWuVIAppRIT0K7hcQzTHm6Rk7XyZXcjNTFQM/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'ai-index-workshop' %}

--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -1,6 +1,7 @@
 {% extends "ai/base_ai.html" %}
 {% block title %}Canonical&rsquo;s AI and ML features{% endblock %}
 {% block meta_description %}Canonical Kubeflow on Ubuntu includes software-defined networking and storage options, architectural flexibility, and shared community-driven ops code independent of architecture.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1DT5nCRSJH-OkvDmlyKh6vVhofeHPHZJHTTBDNu44wCY/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -1,7 +1,7 @@
 {% extends "ai/base_ai.html" %}
 {% block title %}AI and Machine Learning on Ubuntu{% endblock %}
 {% block meta_description %}The default platform for Tensorflow and other AI/ML frameworks, with automatic hardware GPGPU acceleration on Ubuntu. Canonical provides training and K8s-based ML expertise.{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1mJq8PxH8FVRVF9i1Xzh0f6M73eyjqZE4NaKYHRcRAKM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip is-deep is-bordered">

--- a/templates/ai/thank-you.html
+++ b/templates/ai/thank-you.html
@@ -1,7 +1,7 @@
 {% extends "ai/base_ai.html" %}
 
 {% block title %}Thank you | Artificial Intellegence{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1fLjt6qfj8p03d0wTZdN_yWbBcoi4umT2lGeiFT_c6NQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'ai-index-workshop' %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -3,6 +3,8 @@
 {% block title %}The leading operating system for PCs, IoT devices, servers and the cloud{% endblock %}
 {% block extra_body_class %}homepage {% block takeover_body_class %}{% endblock takeover_body_class %}{% endblock extra_body_class %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit{% endblock %}
+
 {% block outer_content %}
   {% block content %}
     {% block takeover_content %}

--- a/templates/community/_base_community.html
+++ b/templates/community/_base_community.html
@@ -1,4 +1,5 @@
 {% extends "templates/base.html" %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/10pxxjYNoTsQK8BbXPMEHRZuQQR8Kxv3O{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}

--- a/templates/community/canonical.html
+++ b/templates/community/canonical.html
@@ -2,6 +2,7 @@
 
 {% block title %}Canonical and Ubuntu{% endblock %}
 {% block meta_description %}As the company behind the Ubuntu Project, Canonical knows Ubuntu inside out.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1kup0vH-dschLdqhjp7CuktEa8CNoLPSm5Fo24y4y1lc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/community/code-of-conduct.html
+++ b/templates/community/code-of-conduct.html
@@ -2,6 +2,7 @@
 
 {% block title %}Ubuntu Code of Conduct v2.0{% endblock %}
 {% block meta_description %}Ubuntu is about showing humanity to one another: the word itself captures the spirit of being human.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1SWBQmBvpVvJnSZVB7aEDWLOo8rBhHgTkYii1Wvgjx20/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/community/debian.html
+++ b/templates/community/debian.html
@@ -2,6 +2,7 @@
 
 {% block title %}Debian{% endblock %}
 {% block meta_description %}Debian is the rock on which Ubuntu is built.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/16wyBJyzmRJMkz677QFkfXWapie22SyGrjXHduo8GibA/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/community/diversity.html
+++ b/templates/community/diversity.html
@@ -2,6 +2,7 @@
 
 {% block title %}Diversity | About Ubuntu{% endblock %}
 {% block meta_description %}The Ubuntu project welcomes and encourages participation by everyone.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1e85ec2AgQgLau5rrGx69cUqtCUPcD4yrrKjKHvLNM5w/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/community/governance.html
+++ b/templates/community/governance.html
@@ -2,6 +2,7 @@
 
 {% block title %}Governance{% endblock %}
 {% block meta_description %}We make Ubuntu a wonderful place to participate.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/11obb5eQNVwAD8auz2SLFqiZeTVpqbj8uph0jShsZvVA/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/community/index.html
+++ b/templates/community/index.html
@@ -2,6 +2,7 @@
 
 {% block title %}Community{% endblock %}
 {% block meta_description %}The Ubuntu operating system brings the spirit of Ubuntu to the world of computers.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/18sNzCqHj8Nf1w-JKRfnM9bvMaz2uZPPDgj_DISgJ30A/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/community/mission.html
+++ b/templates/community/mission.html
@@ -2,6 +2,7 @@
 
 {% block title %}Our mission{% endblock %}
 {% block meta_description %}Ubuntu’s mission is to bring free software to the widest audience.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1KREEL0iRsg7G1Sol4J5v7EraNljDTiIYMem5_rQLtKE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -23,6 +23,8 @@
     <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
     <meta name="theme-color" content="#E95420" />
 
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
+
     <!--[if IE]>
     <meta http-equiv="X-UA-Compatible" content="IE=8">
     <![endif]-->


### PR DESCRIPTION
## Done

Adds meta data with copy docs links (to be used with https://github.com/bartaz/ubuntu-copy-docs)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Install browser extension from https://github.com/bartaz/ubuntu-copy-docs
- Check if you see a link to copydocs in the bottom of the page


## Screenshots

<img width="1388" alt="screen shot 2018-07-25 at 16 54 49" src="https://user-images.githubusercontent.com/83575/43212299-824c58a6-902b-11e8-8f13-7d1cf44fe66f.png">

