### PR TITLE
Update Enterprise kubernetes datasheet on beta

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -17,7 +17,7 @@
           <li>Monitoring and log management integration</li>
         </ul>
         <div>
-          <a href="{{ ASSET_SERVER_URL }}894857eb-DS_Enterprise-Kubernetes_screen-AW_11.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Top CTA' : undefined });" class="p-button--positive">Read the datasheet</a>
+          <a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Top CTA' : undefined });" class="p-button--positive">Read the datasheet</a>
 
           <a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--neutral">Talk to us</a>
         </div>
@@ -59,7 +59,7 @@
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" />
               <h4 class="p-heading-icon__title">Datasheet</h4>
             </div>
-            <h3 class="p-heading--four"><a class="p-link--external" href="{{ ASSET_SERVER_URL }}b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
+            <h3 class="p-heading--four"><a class="p-link--external" href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
           </div>
         </div>
         <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

Updated the links to the enterprise k8's datasheet on beta

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/managed](http://0.0.0.0:8001/kubernetes/managed)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the links match the links in the[ copydoc
](https://docs.google.com/document/d/15jzhasokjH5Ql9Za56ZxRknXNNhEXYdIFXXtLODGxns/edit)

## Issue / Card

Fixes #3796 


