### PR TITLE
Update for the 18.04.1 release

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04" latest_release_eol='April 2023' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04" lts_release_full_with_point='18.04 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Queens" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.4" previous_lts_release_full_with_point='16.04.4 <abbr title="Long-term support">LTS</abbr>' %}
+{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04.1" latest_release_eol='April 2023' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.1" lts_release_full_with_point='18.04.1 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Queens" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.4" previous_lts_release_full_with_point='16.04.4 <abbr title="Long-term support">LTS</abbr>' %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done
Updated the point release to `18.04.1` which will be released shortly.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/desktop](http://0.0.0.0:8001/download/desktop)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check references to `18.04` have `.1` and that the download is correct but will fail until the files are in place.

