### PR TITLE
BETA: Update snap store screenshot on /iot

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -52,7 +52,7 @@
   </div>
   <div class="row">
     <div class="col-12 u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}313be7a3-snapcraft.io_store.png" alt="Snap store screenshot" />
+      <img src="{{ ASSET_SERVER_URL }}30a4ee8e-branded+store+snaps.jpg" alt="Snap store screenshot" />
       <p><a href="http://snapcraft.io/store" class="p-link--external">Visit the Snap Store</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Replaced the snap store screenshot on the /internet-of-things page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the screenshot matches the [design issue](https://github.com/ubuntudesign/web-squad/issues/736)
