### PR TITLE
Kubernetes enterprise datasheet

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -77,8 +77,8 @@
       <h4><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?backURL=%2F#0"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Installation tutorial', 'eventLabel' : 'Installation tutorial - get started' : undefined });" class="p-link--external">Installation tutorial</a></h4>
     </div>
     <div class="col-4 p-card u-align--center">
-      <p><a href="{{ ASSET_SERVER_URL }}894857eb-DS_Enterprise-Kubernetes_screen-AW_11.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet icon - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" style="max-height: 47px;" /></a></p>
-      <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}894857eb-DS_Enterprise-Kubernetes_screen-AW_11.17.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet - get started' : undefined });">Download datasheet</a></h4>
+      <p><a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet icon - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" style="max-height: 47px;" /></a></p>
+      <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet - get started' : undefined });">Download datasheet</a></h4>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -77,8 +77,8 @@
       <h4><a href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up?backURL=%2F#0"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Installation tutorial', 'eventLabel' : 'Installation tutorial - get started' : undefined });" class="p-link--external">Installation tutorial</a></h4>
     </div>
     <div class="col-4 p-card u-align--center">
-      <p><a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet icon - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" style="max-height: 47px;" /></a></p>
-      <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download datasheet', 'eventLabel' : 'Download datasheet - get started' : undefined });">Download datasheet</a></h4>
+      <p><a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"><img src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" alt="" style="max-height: 47px;" /></a></p>
+      <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" class="p-link--external">Download datasheet</a></h4>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -119,7 +119,7 @@
               <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Datasheet</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf">Kubernetes for the enterprise</a></h3>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -119,7 +119,7 @@
               <h4 class="p-heading-icon__title p-heading-icon__title--muted p-muted-heading">Datasheet</h4>
             </div>
           </div>
-          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b35eca50-Enterprise-Kubernetes-datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
+          <h3 class="p-heading--four u-no-margin--top"><a class="p-link--external" href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes for the enterprise', 'eventLabel' : 'Resources - Kubernetes for the enterprise', 'eventValue' : undefined });">Kubernetes for the enterprise</a></h3>
         </div>
         <div class="col-4 p-divider__block">
           <div class="p-heading-icon u-no-margin--bottom">


### PR DESCRIPTION
## Done

- remove onclick from datasheet link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/kubernetes> and  <http://0.0.0.0:8001/kubernetes/managed>
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]


