### PR TITLE
BETA: Add AI/ML webinar takeover

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -34,9 +34,9 @@
 @import 'pattern_ubuntu_intro';
 @import 'pattern_takeunders';
 @import 'pattern_table';
-@import 'takeovers/private_cloud_economics';
 @import 'pattern_feedback';
 @import 'takeovers/rigado-webinar';
+@import 'takeovers/ai-webinar';
 @import 'utility-animations';
 
 @include ubuntu-p-buttons;
@@ -56,9 +56,9 @@
 @include ubuntu-p-ubuntu-intro;
 @include ubuntu-p-takeunders;
 @include ubuntu-p-tables;
-@include p-takeover-private-cloud-economics;
 @include ubuntu-p-feedback;
 @include p-takeover-rigado-webinar;
+@include p-takeover-ai-webinar;
 @include u-animations;
 
 // Bug fixes

--- a/static/sass/takeovers/_ai-webinar.scss
+++ b/static/sass/takeovers/_ai-webinar.scss
@@ -1,0 +1,24 @@
+@mixin p-takeover-ai-webinar {
+  .p-takeover--ai-webinar {
+    background-image: linear-gradient(45deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    background-color: #171717;
+
+    .p-takeover__title {
+      font-weight: 100;
+      color: $color-x-light;
+    }
+
+    .p-takeover__text {
+      @extend %vf-heading-4;
+      color: $color-x-light;
+      margin-bottom: 1.7rem;
+    }
+
+    .p-takeover__image {
+      @media (max-width: $breakpoint-medium) {
+        margin-bottom: 1.5rem;
+        width: 300px;
+      }
+    }
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,8 @@
 
 {% block takeover_content %}
 
+{% include "takeovers/_ai_webinar.html" %}
 {% include "takeovers/_rigado_webinar.html" %}
-{% include "takeovers/_private_cloud_economics.html" %}
 
 <script>
   if (window.localStorage && window.sessionStorage) {

--- a/templates/takeovers/_ai_webinar.html
+++ b/templates/takeovers/_ai_webinar.html
@@ -1,0 +1,17 @@
+<section class="p-strip is-deep p-takeover--ai-webinar u-hide js-primary-takeover">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
+      <p class="p-takeover__text">Find out how you can use Ubuntu to power your AI and ML ambitions from developer workstations to the cloud.</p>
+      <div class="u-hide--small">
+        <a href="https://www.brighttalk.com/webcast/6793/330440?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+      </div>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center">
+      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}ef777f66-AI_ML_illustration.svg" alt="AI/ML illustration">
+      <div class="u-hide--medium u-hide--large">
+        <a href="https://www.brighttalk.com/webcast/6793/330440?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning, and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/templates/takeovers/_rigado_webinar.html
+++ b/templates/takeovers/_rigado_webinar.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--rigado-webinar u-hide js-primary-takeover">
+<section class="p-strip is-deep p-takeover--rigado-webinar u-hide js-secondary-takeover">
   <div class="row u-equal-height">
     <div class="col-8 u-fade-left--medium">
       <h1 class="p-takeover__title">Managing IoT security at scale</h1>


### PR DESCRIPTION
## Done

- Added AI/ML webinar takeover
- Changed Rigado webinar takeover to be secondary instead of primary
- Removed Private Cloud Economics takeover from rotation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the takeover matches the design in the original [issue](#3805)


## Issue / Card

Fixes #3805 

## Screenshots

![0 0 0 0_8001_](https://user-images.githubusercontent.com/25733845/43257041-901a8fb6-90c6-11e8-8129-4ac3afd7960f.png)

