### PR TITLE
Update Foundation Cloud Build datasheet

### DIFF
--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -10,7 +10,7 @@
       <div class="col-8">
         <h1>Foundation Cloud Build &mdash; your fast track to success</h1>
         <p>Building an OpenStack cloud requires domain expertise, cloud know-how, and detailed platform knowledge. After years of deploying, upgrading, and supporting OpenStack clouds, Canonical created Foundation Cloud Build, a fixed-price cloud with a proven reference architecture that Canonical will deploy for you on your premises.</p>
-        <p><a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Top CTA' : undefined });" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - Top CTA' : undefined });" class="p-button--neutral">Talk to us</a></p>
+        <p><a href="{{ ASSET_SERVER_URL }}6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf" class="p-button--neutral">Talk to us</a></p>
       </div>
     </div>
   </section>
@@ -42,8 +42,8 @@
         <h4 class="u-no-margin--bottom"><a href="/cloud/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
-        <a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" style="max-height: 58px; margin-bottom: 12px" /></a>
-        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - get started' : undefined });">Read the datasheet&nbsp;&rsaquo;</a></h4>
+        <a href="{{ ASSET_SERVER_URL }}6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf"><img src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" alt="Read the datasheet" style="max-height: 58px; margin-bottom: 12px" /></a>
+        <h4 class="u-no-margin--bottom"><a href="{{ ASSET_SERVER_URL }}6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
         <a href="{{ ASSET_SERVER_URL }}193373c7-canonical-foundation-cloud-requirements-2018-07-18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started' : undefined });"><img src="{{ ASSET_SERVER_URL }}4d7dbd0c-icon-settings.svg" alt="Hardware requirements" style="max-height: 58px; margin-bottom: 12px" /></a>
@@ -160,7 +160,7 @@
     <div class="row">
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
-        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}72fe0b54-canonical-foundation-cloud-build-datasheet-20180713.pdf" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Bottom CTA' : undefined });">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/cloud/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Updated datasheet links on /cloud/foundation-cloud

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/cloud/foundation-cloud
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the datasheet links have been updated with [this](https://assets.ubuntu.com/v1/6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf)
