### PR TITLE
Re-add deleted datasheet button

### DIFF
--- a/templates/cloud/foundation-cloud/index.html
+++ b/templates/cloud/foundation-cloud/index.html
@@ -10,7 +10,7 @@
       <div class="col-8">
         <h1>Foundation Cloud Build &mdash; your fast track to success</h1>
         <p>Building an OpenStack cloud requires domain expertise, cloud know-how, and detailed platform knowledge. After years of deploying, upgrading, and supporting OpenStack clouds, Canonical created Foundation Cloud Build, a fixed-price cloud with a proven reference architecture that Canonical will deploy for you on your premises.</p>
-        <p><a href="{{ ASSET_SERVER_URL }}6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf" class="p-button--neutral">Talk to us</a></p>
+        <p><a href="{{ ASSET_SERVER_URL }}6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Read the datasheet - Top CTA' , undefined });" class="p-button--positive">Read the datasheet</a>&emsp;<a href="/cloud/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - Top CTA' , undefined });" class="p-button--neutral">Talk to us</a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Added back the 'Read the datasheet' button, which Peter should have caught in the previous PR

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/cloud/foundation-cloud
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that there is a `p-button--positive` button on the hero strip that leads to [here](https://assets.ubuntu.com/v1/6a031fb9-EN_Foundation-Cloud-Build_screen-AW_19.07.18.pdf?_ga=2.42953125.1244333005.1532594036-549686022.1524126781)
