### PR TITLE
BETA: Make takeover alternate on every new session

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
     var secondaryTakeover = document.querySelector('.js-secondary-takeover');
 
     if (localStorage.getItem('TAKEOVER_SEEN')) {
+      localStorage.removeItem('TAKEOVER_SEEN');
       if (!sessionStorage.getItem('TAKEOVER_SEEN')) {
         secondaryTakeover.classList.remove('u-hide');
       } else {


### PR DESCRIPTION
## Done

- Made the takeover change on every new session as opposed to changing only once

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Open multiple new tabs at http://0.0.0.0:8001/ and see that the takeover changes every time