### PR TITLE
Added Overview menu item back to secondary nav

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -57,10 +57,8 @@
       {% if breadcrumbs.children %}
       <ul class="breadcrumbs--secondary col-12">
         {% for child in breadcrumbs.children %}
-        <li class="breadcrumbs__item  {% if child.title == 'Overview' %}u-hide--nav-threshold-up{% endif %}">
-          <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">
-            {% if child.title == 'Overview' %}{{ breadcrumbs.section.title }}  </a><li class="breadcrumbs__item breadcrumbs__space"><a href="#">&nbsp;</li>{% else %}{{ child.title }}{% endif %}
-          </a>
+        <li class="breadcrumbs__item">
+          <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">{{ child.title }}</a>
         </li>
         {% if breadcrumbs.grandchildren %}
         <li class="breadcrumbs__item"><span class="breadcrumbs__chevron u-hide--small">&rsaquo;</span><span class="u-show--small">&nbsp;</span></li>


### PR DESCRIPTION
## Done

- Added 'Overview' menu to the secondary nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that 'Overview' is on the secondary nav
- See that it is NOT in the footer
- See that the orange section is still linked (we think it is better)

## Issue / Card

Fixes #3812

