### PR TITLE
Add animation to AI/ML takeover

### DIFF
--- a/static/sass/takeovers/_ai-webinar.scss
+++ b/static/sass/takeovers/_ai-webinar.scss
@@ -1,4 +1,27 @@
 @mixin p-takeover-ai-webinar {
+  @keyframes dotted-circle {
+    0% {opacity: 0; transform: rotate(45deg)}
+    100% {opacity: 1; transform: rotate(0deg)}
+  }
+
+  @keyframes ubuntu-logo {
+    0% {opacity: 0; transform: rotate(90deg)}
+    100% {opacity: 1; transform: rotate(0deg)}
+  }
+
+  @keyframes pop-in {
+    0% {opacity: 0; transform: scale(0);}
+    40% {opacity: 1; transform: scale(1.1);}
+    100% {opacity: 1; transform: scale(1);}
+  }
+
+  %takeover-logo {
+    animation: pop-in .35s cubic-bezier(0.215, 0.61, 0.355, 1) 1 forwards;
+    opacity: 0;
+    position: absolute;
+    transform: scale(0);
+  }
+
   .p-takeover--ai-webinar {
     background-image: linear-gradient(45deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
     background-color: #171717;
@@ -14,11 +37,63 @@
       margin-bottom: 1.7rem;
     }
 
-    .p-takeover__image {
+    .p-takeover__image-container {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      position: relative;
+
       @media (max-width: $breakpoint-medium) {
         margin-bottom: 1.5rem;
-        width: 300px;
+        max-width: 300px;
       }
+    }
+
+    .dotted-circle {
+      animation: dotted-circle 1.5s cubic-bezier(0.215, 0.61, 0.355, 1) .5s 1 forwards;
+      opacity: 0;
+      transform: rotate(45deg);
+    }
+
+    .ubuntu-logo {
+      align-self: center;
+      animation: ubuntu-logo 2s cubic-bezier(0.215, 0.61, 0.355, 1) .5s 1 forwards;
+      opacity: 0;
+      position: absolute;
+      transform: rotate(90deg);
+      width: 32%;
+    }
+
+    .cloud-picto {
+      @extend %takeover-logo;
+      animation-delay: 2.25s;
+      height: 15.5%;
+      left: 15%;
+      top: 82%;
+    }
+
+    .desktop-picto {
+      @extend %takeover-logo;
+      animation-delay: 1.5s;
+      height: 16%;
+      left: -5%;
+      top: 23%;
+    }
+
+    .iot-picto {
+      @extend %takeover-logo;
+      animation-delay: 2s;
+      height: 19%;
+      left: 86%;
+      top: 56%;
+    }
+
+    .server-picto {
+      @extend %takeover-logo;
+      animation-delay: 1.75s;
+      height: 16%;
+      left: 65%;
+      top: 0;
     }
   }
 }

--- a/templates/takeovers/_ai_webinar.html
+++ b/templates/takeovers/_ai_webinar.html
@@ -8,7 +8,14 @@
       </div>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
-      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}ef777f66-AI_ML_illustration.svg" alt="AI/ML illustration">
+      <div class="p-takeover__image-container u-align-text--center">
+        <img class="dotted-circle" src="{{ ASSET_SERVER_URL }}9f3f2b68-dotted-circle.svg" alt="">
+        <img class="ubuntu-logo" src="{{ ASSET_SERVER_URL }}54e24b4c-ubuntu-logo.svg" alt="">
+        <img class="desktop-picto" src="{{ ASSET_SERVER_URL }}5e8d3f1a-desktop-icon.svg" alt="">
+        <img class="iot-picto" src="{{ ASSET_SERVER_URL }}c2715a27-iot-icon.svg" alt="">
+        <img class="cloud-picto" src="{{ ASSET_SERVER_URL }}82c26ccc-cloud-icon.svg" alt="">
+        <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
+      </div>
       <div class="u-hide--medium u-hide--large">
         <a href="https://www.brighttalk.com/webcast/6793/330440?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning, and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
       </div>


### PR DESCRIPTION
## Done

- Added a short animation to the AI/ML takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the AI/ML takeover is shown (not Rigado), otherwise open again in another tab.
- Check that the animation works and looks good