### PR TITLE
Updated rancher webinar

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -42,7 +42,7 @@
     <div class="col-6">
       <h2>Cloud Native Platform</h3>
       <p>The Cloud Native Platform is a turn-key application delivery platform, built on Ubuntu, Kubernetes, and Rancher. Maximise developer velocity, integrate CI/CD, and ease the path from development into production with enterprise-calibre container management. Canonical delivers the Cloud Native Platform in partnership with Rancher Labs.</p>
-      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });"><span class="p-link--external">Watch webinar</span></a></p>
+      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/308889" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch webinar', 'eventLabel' : 'Watch webinar' : undefined });"><span class="p-link--external">Watch webinar</span></a></p>
     </div>
     <div class="col-6 prefix-1 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}85700cb3-rancher_cloud_partnerships_visual.svg" alt="Rancher Labs logo" />


### PR DESCRIPTION
## Done

- updated the rancher webinar to <https://www.brighttalk.com/webcast/6793/308889>

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the webinar has changed


## Issue / Card

Fixes #3113

