### PR TITLE
Updated k8s datasheet on plans-and-pricing page

### DIFF
--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -208,7 +208,7 @@
   <div class="row">
     <div class="col-12">
       <div>
-        <p><a href="https://assets.ubuntu.com/v1/Enterprise-Canonical-Kubernetes.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - cloud storage CTA' : undefined });">Download the datasheet</a></p>
+        <p><a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - cloud storage CTA' : undefined });">Download the datasheet</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Updated k8s datasheet on plans-and-pricing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/pricing](http://0.0.0.0:8001/pricing)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- see that it now points to 223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf


## Issue / Card

Fixes #3823
