### PR TITLE
3792: Remove word "physical" from desktop support

### DIFF
--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -16,7 +16,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>Price per node (physical) *</td>
+          <td>Price per node *</td>
           <td class="u-align--center">$0</td>
           <td class="p-table__cell--highlight u-align--center">$150/year</td>
           <td class="p-table__cell--highlight u-align--center">$300/year</td>


### PR DESCRIPTION
## Done

- Removed a single word, and that word was "physical". I didn't remove any other words.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support/plans-and-pricing#desktop
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- You better make damn sure the word "physical" doesn't appear in the desktop support section, after price per node

## Issue / Card

Fixes #3792 

## Screenshots

![screenshot_1](https://user-images.githubusercontent.com/25733845/43408971-8076700a-941a-11e8-8f92-2c8b8aefc0ac.png)
