### PR TITLE
Force all canonical tags as https

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -29,7 +29,7 @@
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
-    <link rel="canonical" href="https://www.ubuntu.com{{ request.get_full_path }}" />
+    <link rel="canonical" href="https://ubuntu.com{{ request.get_full_path }}" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -29,7 +29,7 @@
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
-    <link rel="canonical" href="https://ubuntu.com{{ request.get_full_path }}" />
+    <link rel="canonical" href="https://www.ubuntu.com{{ request.get_full_path }}" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -29,7 +29,7 @@
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
-    <link rel="canonical" href="{{ request.build_absolute_uri }}" />
+    <link rel="canonical" href="https://www.ubuntu.com{{ request.get_full_path }}" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />
 


### PR DESCRIPTION
## Done

Moving from Django request.build_absolute_uri to request.get_full_path to force https in canonical tags.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Look at the source of any page and ensure the following line `<link rel="canonical" href="URL">` is using "https".