### PR TITLE
Update for 16.04.5 release

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -50,12 +50,12 @@
       </ul>
     </div>
     <div class="col-4">
-      <h3 class="p-link--external"><span>Ubuntu 16.04 LTS</span></h3>
+      <h3 class="p-link--external"><span>Ubuntu {{previous_lts_release_full_with_point}}</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-desktop-amd64.iso.torrent">Ubuntu 16.04 Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-desktop-i386.iso.torrent">Ubuntu 16.04 Desktop (32-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-amd64.iso.torrent">Ubuntu 16.04 Server (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-i386.iso.torrent">Ubuntu 16.04 Server (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-desktop-amd64.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-desktop-i386.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Desktop (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-server-amd64.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-server-i386.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Server (32-bit)</a></li>
       </ul>
     </div>
     <div class="col-4">

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04.1" latest_release_eol='April 2023' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.1" lts_release_full_with_point='18.04.1 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Queens" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.4" previous_lts_release_full_with_point='16.04.4 <abbr title="Long-term support">LTS</abbr>' %}
+{% with latest_release_name="BionicBeaver" latest_release='18.04' latest_release_with_point="18.04.1" latest_release_eol='April 2023' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.1" lts_release_full_with_point='18.04.1 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Queens" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

- Updated the last release variables to 16.04.5
- Updated the torrents in /download/alternative-downloads to use these variables

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001 /download/alternative-downloads
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the links for 16.04.5 work


## Issue / Card

Fixes #3846 
