### PR TITLE
3838: Keep primary nav open on mobile screens

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,7 +1,6 @@
 var navDropdowns = document.querySelectorAll('.p-navigation__dropdown-link');
 var dropdownWindow = document.querySelector('.dropdown-window');
 var dropdownWindowOverlay = document.querySelector('.dropdown-window-overlay');
-var closeMenuLink = document.querySelector('.p-navigation__toggle--close');
 var navigationThresholdBreakpoint = 900;
 
 navDropdowns.forEach(function(dropdown) {
@@ -117,16 +116,6 @@ document.addEventListener('click', function(event) {
   });
 });
 
-closeMenuLink.addEventListener('click', function(event) {
-  navDropdowns.forEach(function(dropdown) {
-    var dropdownContent = document.getElementById(dropdown.id + "-content");
-
-    if (dropdown.classList.contains('is-selected')) {
-      closeMenu(dropdown, dropdownContent);
-    }
-  });
-});
-
 dropdownWindowOverlay.addEventListener('click', function(event) {
   navDropdowns.forEach(function(dropdown) {
     var dropdownContent = document.getElementById(dropdown.id + "-content");
@@ -150,11 +139,8 @@ if (window.location.hash) {
   var tabId = window.location.hash.split('#')[1];
   var tab = document.getElementById(tabId);
   var tabContent = document.getElementById(tabId + '-content');
-  var navButton = document.querySelector('.p-navigation__toggle--open');
 
   if (tab) {
-    navButton.click();
-    // Hack so this fires at the end of the event loop after previous click
     setTimeout(function() {
       document.getElementById(tabId).click();
     }, 0);

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -107,6 +107,7 @@
 
     & &__nav {
       border-bottom: 0;
+      display: flex;
       width: 100%;
     }
 

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -15,8 +15,6 @@
           </h5>
           {% endif %}
         </div>
-        <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-        <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
       </div>
       <nav class="p-navigation__nav">
         <span class="u-off-screen">


### PR DESCRIPTION
## Done

- Made the primary nav open by default on mobile screens, and removed the Menu button

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Resize your browser to mobile size
- Check that the primary nav is open by default and the "Menu" toggle is gone


## Issue / Card

Fixes #3838