### PR TITLE
3862: Remove global and primary navigation flyouts from print stylesheet

### DIFF
--- a/static/sass/print.scss
+++ b/static/sass/print.scss
@@ -77,7 +77,12 @@ footer,
 .p-top,
 .u-hide--small,
 .p-heading-icon__img,
-.p-contextual-footer {
+.p-contextual-footer,
+.p-navigation,
+.dropdown-window,
+.dropdown-window__overlay,
+.global-nav,
+.global-nav__dropdown-overlay {
   display: none;
 }
 


### PR DESCRIPTION
## Done

- Added global nav and primary nav divs to the `display: none` portion of print.scss

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Right click and hit `Print...`
- Check that the print preview does not show any global nav or primary nav content

## Issue / Card

Fixes #3862 