### PR TITLE
Update image for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,14 @@ ENV LANG C.UTF-8
 
 # Set git commit ID
 ARG COMMIT_ID
-RUN echo $COMMIT_ID > /srv/version-info.txt
 RUN test -n "${COMMIT_ID}"
+RUN echo "${COMMIT_ID}" > version-info.txt
 
 # Import code, install code dependencies
 ADD . .
 RUN pip3 install -r requirements.txt
 
 # Setup commands to run server
-ENTRYPOINT ["talisker.gunicorn", "webapp.wsgi", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
+ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+set -e
+
+talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind $1
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css' && rm -rf static/global-nav && cp -r node_modules/global-nav static/global-nav",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'node_modules/vanilla-framework/scss/*.scss' -c 'yarn run build'",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/global-nav",
-    "serve": "./manage.py runserver 0.0.0.0:$PORT"
+    "serve": "./entrypoint 0.0.0.0:${PORT}"
   },
   "keywords": [
     "website",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ canonicalwebteam.get-feeds==0.2.4
 canonicalwebteam.http==0.1.6
 whitenoise==3.3.0
 talisker==0.9.13
+gunicorn[gevent]
 django-yaml-redirects==0.5.3
 django-asset-server-url==0.1
 django-template-finder-view==0.3


### PR DESCRIPTION
Basically exactly the same as #3868.

- Use gevent workers in Talisker
- Use talisker in local development as well
- Base image off bionic
- Use system version of pip3
- Copy global-nav in place, rather than symlink

Fixes https://github.com/ubuntudesign/base-squad/issues/96

QA
--

``` bash
./run build
docker build --tag beta --build-arg COMMIT_ID=`git rev-parse HEAD` .
docker run -ti -p 8099:80 beta
```

Now go to http://localhost:8099 and check it looks kosha.

Also try just `./run` and check that still serves the site as expected.