### PR TITLE
Keep URL parameters in link events

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -182,7 +182,7 @@ function addGANavEvents(target, category){
   var t = document.querySelector(target);
   if (t) {
     t.querySelectorAll('a').forEach(function(a) {
-      var destination = a.href.replace('https://www.ubuntu.com', '').split("?")[0];
+      var destination = a.href.replace('https://www.ubuntu.com', '');
       a.addEventListener('click', function(event){
         dataLayer.push({
           'event' : 'GAEvent',
@@ -202,7 +202,7 @@ function addGAContentEvents(target){
   var t = document.querySelector(target);
   if (t) {
     t.querySelectorAll('a').forEach(function(a) {
-      var destination = a.href.replace('https://www.ubuntu.com', '').split("?")[0];
+      var destination = a.href.replace('https://www.ubuntu.com', '');
       if (a.className.includes('p-button--positive')) {
         var category = 'www.ubuntu.com-content-cta-0';
       } else if (a.className.includes('p-button')) {


### PR DESCRIPTION
## Done

* Keep URL parameters in automatically generated events that contain URLs, as it's currently discarding some useful data

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Trust me :)