### PR TITLE
3875: Remove reference to global-nav module in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
-    "build": "node-sass --include-path node_modules static/sass --source-map true --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css' && rm -rf static/global-nav && cp -r node_modules/global-nav static/global-nav",
+    "build": "node-sass --include-path node_modules static/sass --source-map true --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css'",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'node_modules/vanilla-framework/scss/*.scss' -c 'yarn run build'",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "serve": "./entrypoint 0.0.0.0:${PORT}"


### PR DESCRIPTION
## Done

- Removed reference to global-nav node module in build script, because the beta version of the global-nav is built within the site

## QA

- Check out the upstream `beta` branch
- Run `./run` and confirm there is an error
- Check out this feature branch
- Run `./run` and confirm there is no longer an error

## Issues

Fixes #3875