### PR TITLE
3848: Add copydocs metadata to all pages

### DIFF
--- a/templates/about/base_about.html
+++ b/templates/about/base_about.html
@@ -1,4 +1,5 @@
 {% extends "templates/base.html" %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6c3hFbTVzdHB5SGs{% endblock meta_copydoc %}
 
 {% block outer_content %}

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -3,6 +3,7 @@
 {% block title %}About the Ubuntu project{% endblock %}
 {% block meta_description %}Learn about the Ubuntu project's history, release schedule, support, and governance.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1NvYOhOJzdY5ypifTPs73vH5Nb7rFABRWMzjXyDUQt_U/edit{% endblock meta_copydoc %}
+
 {% block content %}
 
 <section class="p-strip is-deep">

--- a/templates/ai/contact-us.html
+++ b/templates/ai/contact-us.html
@@ -1,4 +1,5 @@
 {% extends "ai/base_ai.html" %}
+
 {% block title %}Contact us | Artificial Intellegence {% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/185NqOTBSWuVIAppRIT0K7hcQzTHm6Rk7XyZXcjNTFQM/edit{% endblock meta_copydoc %}
 

--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -1,4 +1,5 @@
 {% extends "ai/base_ai.html" %}
+
 {% block title %}Canonical&rsquo;s AI and ML features{% endblock %}
 {% block meta_description %}Canonical Kubeflow on Ubuntu includes software-defined networking and storage options, architectural flexibility, and shared community-driven ops code independent of architecture.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1DT5nCRSJH-OkvDmlyKh6vVhofeHPHZJHTTBDNu44wCY/edit{% endblock meta_copydoc %}

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -1,4 +1,5 @@
 {% extends "ai/base_ai.html" %}
+
 {% block title %}AI and Machine Learning on Ubuntu{% endblock %}
 {% block meta_description %}The default platform for Tensorflow and other AI/ML frameworks, with automatic hardware GPGPU acceleration on Ubuntu. Canonical provides training and K8s-based ML expertise.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1mJq8PxH8FVRVF9i1Xzh0f6M73eyjqZE4NaKYHRcRAKM/edit{% endblock meta_copydoc %}

--- a/templates/ai/install.html
+++ b/templates/ai/install.html
@@ -1,4 +1,5 @@
 {% extends "ai/base_ai.html" %}
+
 {% block title %}Install Kubeflow yourself{% endblock %}
 {% block meta_description %}A step-by-step installation guide to Ubuntu OpenStack with Kubernetes and Kubeflow on bare metal servers.{% endblock %}
 

--- a/templates/community/_base_community.html
+++ b/templates/community/_base_community.html
@@ -1,4 +1,5 @@
 {% extends "templates/base.html" %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/10pxxjYNoTsQK8BbXPMEHRZuQQR8Kxv3O{% endblock meta_copydoc %}
 
 {% block outer_content %}

--- a/templates/contact-us/base_contact-us.html
+++ b/templates/contact-us/base_contact-us.html
@@ -1,6 +1,7 @@
 {% extends "templates/base.html" %}
 
 {% block meta_description %}Get in touch with Canonical sales and support on the phone or online for all your Ubuntu questions.{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0Bw_yUXzV8CSHYjJ6VkNuanVWQVE{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}

--- a/templates/contact-us/form/index.html
+++ b/templates/contact-us/form/index.html
@@ -1,8 +1,8 @@
 {% extends "contact-us/base_contact-us.html" %}
 
 {% block title %}Contact us{% endblock %}
-
 {% block meta_description %}Fast, easy and quick to deploy, switching to Ubuntu has never been easier{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1X1Qx5cimbU7D_xQKnm3se9gRDFcRDEaX5fkGR42b3yU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/contact-us/form/thank-you.html
+++ b/templates/contact-us/form/thank-you.html
@@ -1,7 +1,7 @@
 {% extends "contact-us/base_contact-us.html" %}
 
 {% block title %}Thank you{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1uNruzpoTYxhrCJDxB0q_FH8z8YFs8w_m02fckevjFrU/edit{% endblock meta_copydoc %}
 {% block canonical_url %}https://www.ubuntu.com/contact-us/form{% endblock %}
 
 {% block content %}

--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -1,6 +1,8 @@
 {% extends "contact-us/base_contact-us.html" %}
 
 {% block title %}Contact Canonical{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1LK7lJlhke8hKesVSglHxNSfUCDw0bfddzM4vezeXvBQ/edit{% endblock meta_copydoc %}
+
 {% block content %}
 
 <section class="p-strip is-bordered is-deep">

--- a/templates/containers/base_containers.html
+++ b/templates/containers/base_containers.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B7On4yuSCsiPbnJ2bWpQbzhSVWc{% endblock meta_copydoc %}
+
 {% block outer_content %}
   {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -1,6 +1,7 @@
 {% extends "containers/base_containers.html" %}
-{% block title %}Contact us | Containers {% endblock %}
 
+{% block title %}Contact us | Containers {% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1eTF2u8oOFGg-h-sQQwZtx3D6pOfqlJSXCuNo5-dh3Fg/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'containers-docker' %}

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -1,6 +1,8 @@
 {% extends "containers/base_containers.html" %}
+
 {% block title %}Containers{% endblock %}
 {% block meta_description %}Containers run best on Ubuntu because it has more modern Linux kernels and the latest tooling for the fast-moving Docker, K8s and LXD communities. Optimised on all major clouds.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1OtyfNeA--EJgpgvDzqcbJ8jqa6d9H5H9xyxHNxcKXvc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -1,7 +1,7 @@
 {% extends "containers/base_containers.html" %}
 
 {% block title %}Thank you | Containers{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/17WtTD1VsXnMlsI7qp67hkJhItU6XUcSmIYzGv06we7k/edit{% endblock meta_copydoc %}
 {% block canonical_url %}https://www.ubuntu.com/containers/contact-us{% endblock %}
 
 {% block content %}

--- a/templates/core/base_core.html
+++ b/templates/core/base_core.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3b3dHblpYdVlnSWM{% endblock meta_copydoc %}
+
 {% block outer_content %}
     {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/core/contact-us.html
+++ b/templates/core/contact-us.html
@@ -1,6 +1,6 @@
 {% extends "core/base_core.html" %}
-{% block title %}Contact us | Ubuntu Core{% endblock %}
 
+{% block title %}Contact us | Ubuntu Core{% endblock %}
 
 {% block content %}
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -2,9 +2,7 @@
 
 {% block title %}Ubuntu Core{% endblock %}
 {% block meta_description %}Introducing Ubuntu Core, the smallest Ubuntu ever, the perfect host operating system for IoT devices and large-scale cloud container deployments{% endblock meta_description %}
-
-
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip--light is-deep is-bordered">

--- a/templates/desktop/base_desktop.html
+++ b/templates/desktop/base_desktop.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3UThna3NsNzNZSEU{% endblock meta_copydoc %}
+
 {% block outer_content %}
     {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/desktop/contact-us.html
+++ b/templates/desktop/contact-us.html
@@ -2,6 +2,7 @@
 
 {% block title %}Contact us{% endblock %}
 {% block meta_description %}Fast, easy and quick to deploy, switching to Ubuntu has never been easier{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Z0UWLHT9AKRVfYOYQTXz27DefZ3BcQ7Sqg1kcmlIXtc/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'desktop-education' %}

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -1,7 +1,7 @@
   {% extends "desktop/base_desktop.html" %}
 
   {% block title %}Desktop for developers{% endblock %}
-
+  {% block meta_copydoc %}https://docs.google.com/document/d/1VJ3xT2ViC-CvL0UmsAUzpYFmvpuqUP4AbpnlPm8tqOA/edit{% endblock meta_copydoc %}
 
   {% block content %}
   <section class="p-strip u-image-position is-deep is-bordered">

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -29,6 +29,7 @@
 {% endblock %}
 {% block title %}Desktop features{% endblock %}
 {% block meta_description %}Learn about all the great features and default applications in the Ubuntu desktop operating system.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1nLHJlZ3igDwAAOUDP03wp4iKLxZts8110EA2ZOF5uaU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip u-image-position is-deep is-bordered">

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -2,8 +2,7 @@
 
 {% block title %}Ubuntu PC operating system{% endblock %}
 {% block meta_description %}Fast, secure and stylishly simple, the Ubuntu operating system is used by 50 million people worldwide every day.{% endblock %}
-
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1ZhMkLlkXcimHTIe1taXy24vbbR9pBkZd49H2sJqeQH0/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -1,9 +1,8 @@
 {% extends "desktop/base_desktop.html" %}
 
 {% block title %}Ubuntu in organisations{% endblock %}
-
 {% block meta_description %}Ubuntu is adopted by small and large teams alike because it is easy to use, highly secure, has a low cost of ownership and a huge range of apps.  You should use Ubuntu in your organisation.{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1q3_fQB3PUGbREsbCC4FnmHrpgn9nIWtMwyhDC6CXhNE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -2,7 +2,7 @@
 
 {% block title %}For partners{% endblock %}
 {% block meta_description %}Canonical partners offer Ubuntu certified pre-loaded hardware which integrates component drivers for optimal device performance. Service offerings by Canonical also available for partners include technical support, bespoke engineering, specialised training and consulting services.{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1b4pwQYVHm8-R5_Wqx5zj09Qn8QsrKt3JblteauspmKI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip is-deep is-bordered">

--- a/templates/desktop/thank-you.html
+++ b/templates/desktop/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "desktop/base_desktop.html" %}
 
 {% block title %}Thank you{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/14qdUa_Vpw6QQKnnwqxMV5vDIbovovVhUQN0UXw1w3kw/edit{% endblock meta_copydoc %}
 
 {% block canonical_url %}https://www.ubuntu.com/desktop/contact-us{% endblock %}
 

--- a/templates/download/_base_download.html
+++ b/templates/download/_base_download.html
@@ -1,5 +1,6 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3VE11eUc5LXNURS0yYjFyeU5FZDZHUQ{% endblock meta_copydoc %}
 
 {% block outer_content %}
     {% block content %}{% endblock %}

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -1,9 +1,8 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Alternative downloads{% endblock %}
-
 {% block meta_description %}Want to download via-bitTorrent links, get DVD images with more language packs, use the text-based alternate installer or find previous versions of Ubuntu?{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Use Ubuntu in public clouds | Download{% endblock %}
 {% block meta_description %}How to use Ubuntu in the public cloud and where to find our customised cloud images for development.{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL}}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Download Ubuntu Desktop | Download{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -1,9 +1,8 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Ubuntu flavours{% endblock %}
-
 {% block meta_description %}Ubuntu flavours offer a unique way to experience Ubuntu, each with their own choice of default applications and settings, backed by the full Ubuntu archive for packages and updates.{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep">

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Get Ubuntu | Download{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-shallow">

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Download Ubuntu for IoT boards | Download{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/download/iot/intel-joule-desktop.html
+++ b/templates/download/iot/intel-joule-desktop.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Desktop on the Intel Joule{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1uniGWQZokDNQIzdUEeq6WGs_x2jxa-vwA03TZ39kCWc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/intel-joule.html
+++ b/templates/download/iot/intel-joule.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on the Intel Joule{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1DeFj9aeZoGHm3tlTKGFnvdo3OgJwdHen5AI5hYe7geQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Desktop on the Intel&reg; NUC{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1hDkrBqpJXWaENYZMSxd8P-XLFQ2LQqS1wNe4o2MGLho/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered" id="core">

--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on the Intel&reg; NUC{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1e2aWvVEEXvxDWSbxDzs-_tqKbKbW9sapjCjIRiuAdMg/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/kvm.html
+++ b/templates/download/iot/kvm.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on KVM{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1FHIArLpuAyLe2gnDwymefvzc4Lg8dSGvN8QAl8wX18Q/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/orange-pi-zero.html
+++ b/templates/download/iot/orange-pi-zero.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on the Orange Pi Zero{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1vMQ9DesjpV3fA1iVpKxdHYANbf2Y-Mp5rIXGnV3HypY/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/qualcomm-dragonboard-410c.html
+++ b/templates/download/iot/qualcomm-dragonboard-410c.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on the DragonBoard 410c{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1nV3782gOD7q0RxWDUmQXJoGG_paRtIpFpa_eBbMwdJI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on a Raspberry Pi 2 or 3{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/raspberry-pi-compute-module-3.html
+++ b/templates/download/iot/raspberry-pi-compute-module-3.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on the Raspberry Pi Compute Module 3{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1BO8UI7BNDbyLhLcRSbxzhhaAj-dO6AbYPJUJ0A36vCQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/samsung-artik-5-10-server.html
+++ b/templates/download/iot/samsung-artik-5-10-server.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Server on the Samsung Artik 5 or 10{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1YZKKfrEk_RGqXQnfgGJ6dTs8hjcD6Tz88gEFwhWIiJk/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/samsung-artik-5-10.html
+++ b/templates/download/iot/samsung-artik-5-10.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on the Samsung Artik 5 or 10{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1PpFCRx06gny9WQ6IT7KrWj23AfCulobxx2pQPkxOQrE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/iot/up-squared-iot-grove-server.html
+++ b/templates/download/iot/up-squared-iot-grove-server.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Server on an UP Squared IoT Grove Development Kit{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1-q8NzhmqYvPCAT2AwSv7N9sr_TgJdCc8_gLT7RmaoNE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Ubuntu for ARM | Download{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -1,5 +1,7 @@
 {% extends "download/_base_download.html" %}
+
 {% block title %}Download Ubuntu Server | Download{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -1,9 +1,8 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Ubuntu for IBM LinuxONE and z&nbsp;Systems | Download{% endblock %}
-
 {% block meta_description %}Ubuntu for IBM LinuxONE brings the Ubuntu Server and Ubuntu Server for cloud with the OpenStack ecosystem to IBM LinuxONE.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1hDkrBqpJXWaENYZMSxd8P-XLFQ2LQqS1wNe4o2MGLho/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep">

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -1,7 +1,8 @@
 {% extends "download/_base_download.html" %}
+
 {% block title %}Ubuntu for POWER | Download{% endblock %}
 {% block meta_description %}Ubuntu for POWER brings the Ubuntu Server and Ubuntu ecosystem to POWER.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1e-vav_b54KlKsi92w3rDu9J14O0gpp8yAanEAIImlE8/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -1,8 +1,8 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Get MAAS to run your physical cloud | Download | Ubuntu{% endblock %}
-
 {% block meta_description %}{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/12GXYcP9WrOgoso6Sf3bQql6nALRUzpdlcRW3Gbu-npM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -1,9 +1,8 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Ubuntu Server for IBM LinuxONE and z Systems | Download{% endblock %}
-
 {% block meta_description %}Ubuntu for IBM Z and z Systems brings the Ubuntu Server and Ubuntu Server for cloud with the OpenStack, KVM and LXD ecosystem to IBM’s premium platform.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep">

--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -3,7 +3,7 @@
 {% block title %}
 Thanks for downloading Ubuntu Server for IBM Z and LinuxONE
 {% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1hDkrBqpJXWaENYZMSxd8P-XLFQ2LQqS1wNe4o2MGLho/edit{% endblock meta_copydoc %}
 {% block canonical_url %}https://www.ubuntu.com/download/server/s390x{% endblock %}
 
 {% block head_extra %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -4,7 +4,7 @@
 {% block title %}
 Thanks for downloading Ubuntu Server
 {% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit{% endblock meta_copydoc %}
 {% block canonical_url %}https://www.ubuntu.com/download/server{% endblock %}
 
 {% block content %}

--- a/templates/engage/base_engage.html
+++ b/templates/engage/base_engage.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1FyMcu6vqGnyQMdWLRjvxJVWm8gHgslk4{% endblock meta_copydoc %}
+
 {% block outer_content %}
   {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -1,8 +1,8 @@
-  {% extends "engage/base_engage.html" %}
-
-  {% block meta_description %}Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.{% endblock %}
+{% extends "engage/base_engage.html" %}
 
 {% block title %}Busting the myth of private cloud economics{% endblock %}
+{% block meta_description %}Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1NtRmAB4Pkphc8WTU8n4-b10knVqqFhMDc_FtGAwQ7nw/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip is-deep p-takeover--private-cloud-economics">

--- a/templates/engage/vmware-to-openstack.html
+++ b/templates/engage/vmware-to-openstack.html
@@ -1,8 +1,8 @@
-  {% extends "engage/base_engage.html" %}
-
-  {% block meta_description %}Ready to make the migration from proprietary virtualisation to OpenStack?{% endblock %}
+{% extends "engage/base_engage.html" %}
 
 {% block title %}From VMWare To Canonical OpenStack{% endblock %}
+{% block meta_description %}Ready to make the migration from proprietary virtualisation to OpenStack?{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Wt8fkmkTbWJowrujNwsMna8SwHr24VUnPB0GM7sxGco/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'); background-position: 77% 0%;">

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -1,8 +1,8 @@
 {% extends "templates/one-column.html" %}
 
-{% block meta_description %}With evolving regulations, growing security threats and increasing costs – plus the emergence of game-changing new technologies like AI and Blockchain – the finance world needs practical solutions, now more than ever.{% endblock %}
-
 {% block title %}Financial services{% endblock %}
+{% block meta_description %}With evolving regulations, growing security threats and increasing costs – plus the emergence of game-changing new technologies like AI and Blockchain – the finance world needs practical solutions, now more than ever.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1o9s_MFaiZZIS26tusRi0ALNrcqUihhTSZgxS55oHZj4/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -1,6 +1,8 @@
 {% extends "internet-of-things/base_things.html" %}
+
 {% block title %}White label app store for IOT | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}For cloud based and enterprise IoT app stores, control, manage and monetise software deployments on your connected Linux devices.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/internet-of-things/base_things.html
+++ b/templates/internet-of-things/base_things.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3fnUxRXBZMnhLd0NJUmFWT0dZSXNLR1Izb1MxeDB3WnRzV21CQ21rR20yTTQ{% endblock meta_copydoc %}
+
 {% block outer_content %}
     {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -1,6 +1,7 @@
 {% extends "internet-of-things/base_things.html" %}
-{% block title %}Contact us | Ubuntu for the Internet of Things{% endblock %}
 
+{% block title %}Contact us | Ubuntu for the Internet of Things{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Se-fD5hhb7EaR75jd_1D-JkADmg6aLjUs7_bScATvwE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -1,9 +1,8 @@
 {% extends "internet-of-things/base_things.html" %}
 
 {% block title %}Digital signage | Ubuntu for the Internet of Things {% endblock %}
-
 {% block meta_description %}With hundreds of thousands of devices deployed the world over, Ubuntu Core is the perfect robust, reliable and secure OS for the digital signage sector.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -1,7 +1,8 @@
 {% extends "internet-of-things/base_things.html" %}
+
 {% block title %}Gateways | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}Ubuntu Core is the perfect robust, reliable and secure OS host for the edge gateways and it&rsquo;s deployment.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1hQon1vuYPDg_GojABIwbp2gFBkE2WApZTZJGT3yUdLU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -1,9 +1,8 @@
 {% extends "internet-of-things/base_things.html" %}
 
 {% block title %}Ubuntu for the Internet of Things{% endblock %}
-
 {% block meta_description %}From home control to drones, robots and industrial systems, Ubuntu Core provides robust security, app stores and reliable updates for all your IoT devices.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -1,6 +1,8 @@
 {% extends "internet-of-things/base_things.html" %}
+
 {% block title %}Robotics | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}With hundreds of thousands of drones and robots deployed the world over, Ubuntu Core is the perfect robust, reliable and secure OS for the robotics sector. {% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1g8XpVzDkAdFETrfZvOf5Q6WlYwHCBYQ8Y6TgTlyTEYc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -1,7 +1,8 @@
 {% extends "internet-of-things/base_things.html" %}
-{% block title %}Thank you | Ubuntu for the Internet of Things{% endblock %}
 
+{% block title %}Thank you | Ubuntu for the Internet of Things{% endblock %}
 {% block canonical_url %}https://www.ubuntu.com/internet-of-things/contact-us{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1-WTp-Zf29CA5fiMV0A1rCyaNPF6xAYzZu6BThUXUSlk/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/kubernetes/base_kubernetes.html
+++ b/templates/kubernetes/base_kubernetes.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1x8qX79tshqmN6HxSLo8cbswRBSQi2MaT{% endblock meta_copydoc %}
+
 {% block outer_content %}
   {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -1,6 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
-{% block title %}Contact us | Kubernetes  {% endblock %}
 
+{% block title %}Contact us | Kubernetes  {% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Zf_xYK57S5T_T3HtKCPK7bf7vMVIMNuhJggSb-EdgAc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -1,6 +1,8 @@
 {% extends "kubernetes/base_kubernetes.html" %}
+
 {% block title %}Features of Canonical Kubernetes on Ubuntu{% endblock %}
 {% block meta_description %}Canonical OpenStack on Ubuntu includes software-defined networking and storage options, architectural flexibility, and shared community-driven ops code independent of architecture.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1mEOBW4pfsWJqTLm9Pn9myKtaslD-QB2RvUKcNQ52bXU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -1,7 +1,8 @@
 {% extends "kubernetes/base_kubernetes.html" %}
+
 {% block title %}Kubernetes{% endblock %}
 {% block meta_description %}The Canonical Distribution of Kubernetes delivers a ‘pure K8s’ experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.{% endblock meta_description %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -1,6 +1,8 @@
 {% extends "kubernetes/base_kubernetes.html" %}
+
 {% block title %}Install Canonical Kubernetes{% endblock %}
 {% block meta_description %}A step-by-step installation guide to Kubernetes on your software defined infrastructure.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1oiD6UUomf2daZitS3UOosujYBXPbiOMzPtXVZBq-ph0/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -1,6 +1,8 @@
 {% extends "kubernetes/base_kubernetes.html" %}
+
 {% block title %}Managed Kubernetes | Kubernetes{% endblock %}
 {% block meta_description %}Canonical is the leading managed private cloud provider. We will build, support and manage your Ubuntu Kubernetes private cloud for only $15 per server per day.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/15jzhasokjH5Ql9Za56ZxRknXNNhEXYdIFXXtLODGxns/edit#heading=h.q9m33avd7enn{% endblock meta_copydoc %}
 
 {% block content %}
   <section class="p-strip--accent is-deep">

--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -1,6 +1,8 @@
 {% extends "kubernetes/base_kubernetes.html" %}
+
 {% block title %}Canonical Kubernetes Partners{% endblock %}
 {% block meta_description %}Canonical Kubernetes partners provide regional consulting and operations, hosting, and third party technology for storage, networking, monitoring and chargeback to the Ubuntu Kubernetes and OpenStack ecosystem.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip is-deep is-bordered">

--- a/templates/kubernetes/thank-you.html
+++ b/templates/kubernetes/thank-you.html
@@ -1,7 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
 {% block title %}Thank you | Kubernetes{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1rkHUgJ4WqEL9Eu7GFgikr5dtIRVYNDjl8YV-tU4irLg/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'kubernetes' %}

--- a/templates/legal/_base_legal.html
+++ b/templates/legal/_base_legal.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
+
 {% block outer_content %}
     {% block content %}{% endblock %}
     {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_generic_download" third_item="_further_reading" %}

--- a/templates/legal/bootstack/index.html
+++ b/templates/legal/bootstack/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}BootStack{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/companies.html
+++ b/templates/legal/companies.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Canonical companies{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/contributors/index.html
+++ b/templates/legal/contributors/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Contributor licence agreement{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1O7n0CijJxO60eY8NLisra3BQw03SusqMUgop0PRPx6M/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/contributors/licence-agreement-faq.html
+++ b/templates/legal/contributors/licence-agreement-faq.html
@@ -1,8 +1,8 @@
 {% extends "legal/_base_legal.html" %}
 
-{% block meta_description %}Canonical Contribution Agreement for work to be included in selected open source software projects.{% endblock %}
-
 {% block title %}Contributor licence agreement FAQ | Contributors{% endblock %}
+{% block meta_description %}Canonical Contribution Agreement for work to be included in selected open source software projects.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1vluNwZuA2poLIA3o0O-5HFvyDEltrMxAenrnF-3A3-U/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/contributors/submit.html
+++ b/templates/legal/contributors/submit.html
@@ -93,6 +93,7 @@
 {% endblock %}
 
 {% block title %}Submit contributor agreement | Contributors{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1MfgTzlAxiFE6VUW1qAPmrks2ui1zzsX5T7d-DZJlOAw/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip">

--- a/templates/legal/contributors/thank-you.html
+++ b/templates/legal/contributors/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Thank you for submitting your contributor licence agreement | Ubuntu and Canonical legal{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1hF6GE5Ui-OzrubtSgjTE5-es2Nu10U999lddwgu2ROA/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/data-privacy-enquiry/index.html
+++ b/templates/legal/data-privacy-enquiry/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Contact Us | Ubuntu and Canonical Legal{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1_sM2dGQNd5FRda2gITWL1jD1oWsIekAw2jCxPTPD1Ss/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/dataprivacy/contact.html
+++ b/templates/legal/dataprivacy/contact.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy notice | Contact us &amp; enquiries{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1kQmhTCRSnx05oYEFcNr0Dq7UUFrznq-GvQlRxvNAZ9s/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Data privacy{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/dataprivacy/newsletter.html
+++ b/templates/legal/dataprivacy/newsletter.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy notice | Newsletter signup{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Et7uuP82vYgk-sXTOeLLlKi0NzwCdDHkSlfLS7IClzo/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/dataprivacy/online-purchase.html
+++ b/templates/legal/dataprivacy/online-purchase.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy notice | Online purchase{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1ZSNnMiLJl6SGSV0D_cr6MJAwpkf6xzbKYJdTL9MxLHc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/dataprivacy/snap-store.html
+++ b/templates/legal/dataprivacy/snap-store.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy notice | Snap store{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1rEyCOZWoKKJRPIg5jhANfWVibZJ9QVfqj4MkeNIJp4M/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/dataprivacy/sso.html
+++ b/templates/legal/dataprivacy/sso.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy notice | Single Sign On (SSO){% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1lNercxxavqCCaFkLbQ-uHa9Mq6iZDMOSBDIUa48zDcU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/dataprivacy/webinar.html
+++ b/templates/legal/dataprivacy/webinar.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy notice | Webinar signup{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1wMKqustrdcGK-yzGGe9we6nyHDvLUPukQaPpMA5T6wk/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -2,6 +2,7 @@
 
 {% block title %}Ubuntu legal terms and policies{% endblock %}
 {% block meta_description %}Ubuntu and Canonical Legal - legal terms and policies{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/19yTLYWu7rEErPrO0xDsqMeN8tcWKBjHuarw0tjxRlhY/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/managed-services/2015-07-01-service-description.html
+++ b/templates/legal/managed-services/2015-07-01-service-description.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}BootStack services description{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1nZEyfSUhGxC7ZEXTUApbQn_qVVOtttN3J2d3szpC4Q0/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/managed-services/2018-02-15-service-description.html
+++ b/templates/legal/managed-services/2018-02-15-service-description.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}BootStack services description{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip">

--- a/templates/legal/managed-services/index.html
+++ b/templates/legal/managed-services/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Managed Services{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1m1dEWFd24s33TJ8EPAdiMvEK8ApuKtDWJAKnQIGQW3s/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/managed-services/privacy.html
+++ b/templates/legal/managed-services/privacy.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}BootStack privacy information{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1jUpWZSL_60lcfyZTbnYqHjpLMUAOfK7fzjAg2W3rirs/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/managed-services/service-description.html
+++ b/templates/legal/managed-services/service-description.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Managed Services description{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip">

--- a/templates/legal/service-terms/2015-06-24.html
+++ b/templates/legal/service-terms/2015-06-24.html
@@ -1,8 +1,8 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Short form services agreement | 2015-06-24{% endblock %}
-
 {% block meta_description %}Ubuntu and Canonical Legal - Short form services agreement{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Hlto3k8FUPns9INEpPGJ90cK_Mtmn0ya5W6Cx88RAzM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/service-terms/2015-09-09.html
+++ b/templates/legal/service-terms/2015-09-09.html
@@ -1,8 +1,8 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Short Form Services Agreement | 2015-09-09{% endblock %}
-
 {% block meta_description %}Ubuntu and Canonical Legal - Short form services agreement{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/12UDLzKWVhXAeBsCFUvud4X4ACb5NsZ5lRcpOUrdlCqk/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/service-terms/2016-05-20.html
+++ b/templates/legal/service-terms/2016-05-20.html
@@ -1,8 +1,8 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Short Form Services Agreement | 2016-05-20{% endblock %}
-
 {% block meta_description %}Ubuntu and Canonical Legal - Short form services agreement{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1EK4AF_16oJOfRwu0_Kvw0R4p-4jd-y5B8LxcPjbuO7g/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/service-terms/2016-06-24.html
+++ b/templates/legal/service-terms/2016-06-24.html
@@ -1,8 +1,8 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Short Form Services Agreement | 2016-06-24{% endblock %}
-
 {% block meta_description %}Ubuntu and Canonical Legal - Short form services agreement{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/service-terms/index.html
+++ b/templates/legal/service-terms/index.html
@@ -1,8 +1,8 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Short form services agreement{% endblock %}
-
 {% block meta_description %}Ubuntu and Canonical Legal - Short form services agreement{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1W0WJrXaIvC54MDPgS62xfgPhqJaSE7RcZ2mjIqz1Y2o/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/service-terms/ja.html
+++ b/templates/legal/service-terms/ja.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}UA 簡易形式サービス契約書{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1rwGiNiXip5NtyDs1eMsdbUGmwTq_tEeSbwrNB5hlH4Y/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/confidentiality-agreement.html
+++ b/templates/legal/terms-and-policies/confidentiality-agreement.html
@@ -1,6 +1,8 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Confidentiality agreement{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
+
 {% block head_extra %}
 <script type="text/javascript" src="https://www.tfaforms.com/wForms/3.7/js/wforms.js"></script>
 <script type="text/javascript" src="https://www.tfaforms.com/wForms/3.7/js/localization-en_GB.js"></script>

--- a/templates/legal/terms-and-policies/contact-us.html
+++ b/templates/legal/terms-and-policies/contact-us.html
@@ -1,7 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Contact us | Intellectual property policy | Terms and policies{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1LU9eJrUSufbbcsvQQUecmrUcw316EfTYgFpFK9HRwJg/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/developer-terms-and-conditions/2016-04-06.html
+++ b/templates/legal/terms-and-policies/developer-terms-and-conditions/2016-04-06.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Developer terms and conditions{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1oeTdTqLcKzk-CSCYcVfQO_lhNCcEHeNK_tJjjgfdkAQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/developer-terms-and-conditions/2018-07-23.html
+++ b/templates/legal/terms-and-policies/developer-terms-and-conditions/2018-07-23.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Developer terms and conditions{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block second_level_nav_items %}
   {% include "templates/_nav_breadcrumb.html" with section_title="Legal" subsection_title="Terms and policies" page_title="Developer terms and conditions" %}

--- a/templates/legal/terms-and-policies/developer-terms-and-conditions/index.html
+++ b/templates/legal/terms-and-policies/developer-terms-and-conditions/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Developer terms and conditions{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1I0wumuzwywfKjiKC4YmQ-9h9O3ZvCaBTe2CIIyoEtJQ/edit{% endblock meta_copydoc %}
 
 {% block second_level_nav_items %}
   {% include "templates/_nav_breadcrumb.html" with section_title="Legal" subsection_title="Terms and policies" page_title="Developer terms and conditions" %}

--- a/templates/legal/terms-and-policies/font-licence/faq.html
+++ b/templates/legal/terms-and-policies/font-licence/faq.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
 
 {% block title %}Ubuntu font FAQs{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/font-licence/index.html
+++ b/templates/legal/terms-and-policies/font-licence/index.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
 
 {% block title %}Ubuntu font licence{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1X88aRJvR2dW8Cr0vy13gydyUPv-p-L13PHbFgTgyGdE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/font-licence/ofl-1.1-ufl-1.0.diff.html
+++ b/templates/legal/terms-and-policies/font-licence/ofl-1.1-ufl-1.0.diff.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
 
 {% block title %}Ubuntu font licence{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Terms and policies{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1p3ZWroZ3nkw8XJJdPvPxSlWGYcLZLT8UbUVuppBcyHk/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/intellectual-property-policy/2013-05-14/index.html
+++ b/templates/legal/terms-and-policies/intellectual-property-policy/2013-05-14/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Intellectual property rights policy | Terms and policies{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/intellectual-property-policy/index.html
+++ b/templates/legal/terms-and-policies/intellectual-property-policy/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Intellectual property rights policy | Terms and policies{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1SfGIFMDHfOwLprQvrJW70j1kP72qVtT73m3f1lRUjKw/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/jaas-beta-terms-of-service.html
+++ b/templates/legal/terms-and-policies/jaas-beta-terms-of-service.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}JAAS Beta Terms of Service{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1XybaOlJhaTjKUWwY07h7RNbQ_K5J6bAclGyJRtCwIDc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/launchpad-terms-of-service.html
+++ b/templates/legal/terms-and-policies/launchpad-terms-of-service.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Launchpad terms of service{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/livepatch-terms-of-service.html
+++ b/templates/legal/terms-and-policies/livepatch-terms-of-service.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Livepatch Terms of Service{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1b2TSeqGfBsmZMepXGEGkEWyTDo0M5aHmyqaQIzEZfPs/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/online-account-terms.html
+++ b/templates/legal/terms-and-policies/online-account-terms.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Online account tools{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1gDkiNJzLQQdGEWc5sOJ3onB5tCl-R27vzhW_8TNKnz4/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/privacy-policy/2013-03-25/index.html
+++ b/templates/legal/terms-and-policies/privacy-policy/2013-03-25/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy policy | Terms and policies{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1bDDY0NU8MybiMjso2mxVtoJl8Phgf98JtPa0b0pE2MI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/privacy-policy/2016-02-08/index.html
+++ b/templates/legal/terms-and-policies/privacy-policy/2016-02-08/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy policy | Terms and policies{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/privacy-policy/third-parties.html
+++ b/templates/legal/terms-and-policies/privacy-policy/third-parties.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Third parties | Privacy policy | Terms and policies{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1o4XTDcTr89_7-SalMR-tkcyusS51zDRAhAWC_A8g_pQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/systems-information-notice.html
+++ b/templates/legal/terms-and-policies/systems-information-notice.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Legal Notice – System Information{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/terms-of-service.html
+++ b/templates/legal/terms-and-policies/terms-of-service.html
@@ -1,7 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}U1 and Software Centre - Terms of Service{% endblock %}
-
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip">

--- a/templates/legal/terms-and-policies/terms.html
+++ b/templates/legal/terms-and-policies/terms.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Terms and conditions | Ubuntu and Canonical Legal{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1wlfspMWQ2ztlMC7vfk_CxKpekZ3U-HAoK_0OwpcFcfo/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/terms-and-policies/thank-you.html
+++ b/templates/legal/terms-and-policies/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Thank you | Intellectual property policy | Terms and policies{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1hscaZquDAIo0mcl6BjmZmxBdrNzd-S5Ft6hAul_gF5U/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/trademarks/index.html
+++ b/templates/legal/trademarks/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Trademarks | Ubuntu and Canonical Legal{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1o4P7HEIop3o4oibUH8rbj6mxIBmHakt-djZlpcpTW-I/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/ua-dell-tc/index.html
+++ b/templates/legal/ua-dell-tc/index.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
 
 {% block title %}Dell Ubuntu Advantage Reseller end user terms{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1MUA0idRzWvFHlus_GoAuIo62gr03V0d4X13p8A3thVU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/ua-miracle-tc-ja.html
+++ b/templates/legal/ua-miracle-tc-ja.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
 
 {% block title %}Miracle Linux - UA 略式サービス契約{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1cYyCuduaulluxCpYhTcaB8_0gEj-i1Hh7K6f_60aZvU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/ua-miracle-tc.html
+++ b/templates/legal/ua-miracle-tc.html
@@ -1,6 +1,7 @@
 {% extends "templates/one-column.html" %}
 
 {% block title %}Miracle Linux - UA Short Form Services Agreement{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1iEhWDqhUPoDazegSadjgVuyzWquNi3Ee6b8_3nnwbf4/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/ubuntu-advantage/assurance.html
+++ b/templates/legal/ubuntu-advantage/assurance.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Ubuntu Assurance | Ubuntu Advantage{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1h_lawMnIICZvxqzz5NsXfuXo-0t_uR0KwjnPogwUI-E/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/ubuntu-advantage/index.html
+++ b/templates/legal/ubuntu-advantage/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Ubuntu Advantage{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1p-xlkejIG5ZZhOfGrYnq6rmIpTpaX46yW4HArDtPX1s/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/ubuntu-advantage/service-description-ja/2017-02-09.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja/2017-02-09.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Ubuntu Advantage service description{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/ubuntu-advantage/service-description-ja/index.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja/index.html
@@ -1,7 +1,9 @@
 {% extends "legal/_base_legal.html" %}
-  {% block title %}Ubuntu Advantage service description{% endblock %}
-{% block content %}
 
+{% block title %}Ubuntu Advantage service description{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Tpf4FuP6SzvfyFw-nlR44uAIkofNdwzDaJFY36ZAk68/edit{% endblock meta_copydoc %}
+
+{% block content %}
 
 <div class="p-strip">
   <div class="row" id="service-description" lang="ja">

--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -1,4 +1,9 @@
-{% extends "legal/_base_legal.html" %} {% block title %}Ubuntu Advantage service description{% endblock %} {% block content %}
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Ubuntu Advantage service description{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1mrNrsC1WDf6QTg3nrVCEZS8vJzGz1fokvoFDVC4s_mI/edit{% endblock meta_copydoc %}
+
+{% block content %}
 <div class="p-strip is-deep">
   <div class="row" id="service-description">
     <div class="col-8">

--- a/templates/legal/ubuntu-advantage/ua-terms.html
+++ b/templates/legal/ubuntu-advantage/ua-terms.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Short Form Services Agreement{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Canonical websites{% endblock %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/licensing/index.html
+++ b/templates/licensing/index.html
@@ -2,6 +2,7 @@
 
 {% block title %}Licensing{% endblock %}
 {% block meta_description %}Ubuntu is a collection of thousands of computer programs and documents created by a range of individuals, teams and companies.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1cqzDlgJERp7BuNO-yWKz96hAQp8W4-8_5ETb_Il6x4I/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/openstack/_base_openstack.html
+++ b/templates/openstack/_base_openstack.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1mFxuTHCGqOdqzdT-0J2L6uVkMFQ7Cw5P{% endblock meta_copydoc %}
+
 {% block outer_content %}
   {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -1,8 +1,8 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Consulting | OpenStack{% endblock %}
-
 {% block meta_description %}Foundation Cloud Build is a service that builds, supports and manages your cloud for you.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit{% endblock meta_copydoc %}
 
 {% block content %}
   <section class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">

--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -1,5 +1,7 @@
 contextual-footer-openstack{% extends "openstack/_base_openstack.html" %}
+
 {% block title %}Contact us | OpenStack{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/10lo3O2TKiR-cc48CqhH3Ghak0xZQaP2n4YthDtdIXpo/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'openstack-training' %}

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -1,8 +1,8 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Features | OpenStack{% endblock %}
-
 {% block meta_description %}Canonical OpenStack on Ubuntu includes software-defined networking and storage options, architectural flexibility, and shared community-driven ops code independent of architecture.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1odFXuFtN1GjuZvgd8tW48HB4J9PjZJtP3w6wY0xlmog/edit{% endblock meta_copydoc %}
 
 {% block content %}
   <section class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -2,6 +2,7 @@
 
 {% block title %}OpenStack on Ubuntu is your scalable private cloud, by Canonical{% endblock %}
 {% block meta_description %}Ubuntu OpenStack is the most robust and economical way to build your private OpenStack cloud. Supported or fully managed by Canonical.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-deep is-bordered">

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -1,6 +1,8 @@
 {% extends "openstack/_base_openstack.html" %}
+
 {% block title %}Install | OpenStack | Ubuntu{% endblock %}
 {% block meta_description %}A step-by-step installation guide to Ubuntu OpenStack on bare metal servers.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1eQ16jzv6YRGzG_k_C-tUnhM06k6_Ic6fZM-x_ARMzuc/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip is-deep is-bordered">

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -1,7 +1,9 @@
 {% extends "openstack/_base_openstack.html" %}
 {% load versioned_static  %}
+
 {% block title %}BootStack - managed OpenStack on Ubuntu | OpenStack{% endblock %}
 {% block meta_description %}With BootStack, Canonical will build, support and manage your cloud for only $15 per host per day.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/openstack/partners.html
+++ b/templates/openstack/partners.html
@@ -1,8 +1,8 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Partners | OpenStack{% endblock %}
-
 {% block meta_description %}Canonical partners with a wide range of cloud vendors, offering engineering assistance, support and ongoing quality assurance to the ecosystem that is fast developing around Ubuntu and OpenStack.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1J2AxzOkFgkXyV7C7VO7ZJ0urzbEtrqRYCRt1SL64f3I/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -2,6 +2,7 @@
 
 {% block title %}Ubuntu Advantage Storage | OpenStack{% endblock %}
 {% block meta_description %}Canonical includes proven software-defined storage - Ceph, NexentaEdge, Swift and SwiftStack, in a 24x7 supported OpenStack with pay-for-what-you-use metered pricing options.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1iw2SWNmoj4GZ2pUh0yB8gbtVXK0oXfyEaXT44bQbPlI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/openstack/thank-you.html
+++ b/templates/openstack/thank-you.html
@@ -1,7 +1,8 @@
 {% extends "openstack/_base_openstack.html" %}
-{% block title %}Thank you{% endblock %}
 
+{% block title %}Thank you{% endblock %}
 {% block canonical_url %}https://www.ubuntu.com/cloud/contact-us{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1-dWhd0ydDWlYg16rEybPPmkQ6cdxsBmiFOuUz0ApCBM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -2,6 +2,7 @@
 
 {% block title %}Training | OpenStack{% endblock %}
 {% block meta_description %}Canonical run OpenStack and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit{% endblock meta_copydoc %}
 
 {% block outer_content %}
 {% block content %}

--- a/templates/public-cloud/_base_public-cloud.html
+++ b/templates/public-cloud/_base_public-cloud.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1Clp1XT2Mp6HNIX8Rklu0UXQpMpUoaym5{% endblock meta_copydoc %}
+
 {% block outer_content %}
     {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -1,6 +1,8 @@
 {% extends "public-cloud/_base_public-cloud.html" %}
+
 {% block title %}Public cloud{% endblock %}
 {% block meta_description %}Ubuntu is the most popular guest OS on both public and private clouds, thanks to its security, versatility and continually updated features.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-deep is-bordered">

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -1,8 +1,8 @@
 {% extends "templates/one-column.html" %}
 
-{% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
-
 {% block title %}Security{% endblock %}
+{% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/server/base_server.html
+++ b/templates/server/base_server.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B73pr1ianygAOTlOY1BrOHNrRTQ{% endblock meta_copydoc %}
+
 {% block outer_content %}
     {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/server/contact-us.html
+++ b/templates/server/contact-us.html
@@ -1,7 +1,8 @@
 {% extends "server/base_server.html" %}
+
 {% block title %}Contact us | Ubuntu Server{% endblock %}
 {% block meta_description %}Contact us about Ubuntu Server about Ubuntu Server{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1NsOLPLZLb3h49LIJCzMozjQBxKc041evAC1Dbx6U8_s/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'server-overview' %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -1,7 +1,8 @@
 {% extends "server/base_server.html" %}
+
 {% block title %}Ubuntu Server and hyperscale | Server{% endblock %}
 {% block meta_description %}Unlock the promise of new extreme low-energy server technology{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1f56CCzH519lIVa4KvxDt0QpxYFMK-bMdVlKo4TvPSIk/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -2,6 +2,7 @@
 
 {% block title %}Ubuntu Server - for scale out workloads{% endblock %}
 {% block meta_description %}Secure, fast and economically scalable, Ubuntu helps you make the most of your infrastructure. Whether you want to deploy a cloud or a web farm, Ubuntu Server supports the most popular hardware and software.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep is-bordered">

--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -1,7 +1,8 @@
 {% extends "server/base_server.html" %}
+
 {% block title %}Canonical Livepatch Service | Server{% endblock %}
 {% block meta_description %}The Canonical Livepatch Service for Ubuntu 16.04 servers reduces planned or unplanned downtime whilst keeping on top of compliance and security.{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip--image is-dark is-deep" style="background-position: center center; background-image:url('{{ ASSET_SERVER_URL }}2106addc-Cloud-081-final_hi-res_preview.jpg')">

--- a/templates/server/thank-you.html
+++ b/templates/server/thank-you.html
@@ -1,7 +1,8 @@
 {% extends "server/base_server.html" %}
-{% block title %}Thank you{% endblock %}
 
+{% block title %}Thank you{% endblock %}
 {% block canonical_url %}https://www.ubuntu.com/server/contact-us{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1XWmMQlhgqHeDrMepfxDzeDvXSwTMUbXW8s78bBOsfDw/edit{% endblock meta_copydoc %}
 
 {% block content %}
   {% if product == 'server-maas' %}

--- a/templates/support/base_support.html
+++ b/templates/support/base_support.html
@@ -1,5 +1,6 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/0B73pr1ianygAZDBnTEZnZURwcUE{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -1,9 +1,7 @@
 {% extends "support/base_support.html" %}
 
 {% block title %}Community support{% endblock %}
-
-
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1vrnljXUx71ZZhz3cQ6NupUNw6yNqW2OWkyY8Ozx2bqw/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-deep u-no-padding--bottom">

--- a/templates/support/contact-us.html
+++ b/templates/support/contact-us.html
@@ -1,7 +1,7 @@
 {% extends "support/base_support.html" %}
 
 {% block title %}Contact Canonical | Support{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1rWgWFGtal7ddDAkIOKtA6M3wXKd7gX-ABQtyhwbqjyk/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/support/esm.html
+++ b/templates/support/esm.html
@@ -1,7 +1,7 @@
 {% extends "support/base_support.html" %}
 
 {% block title %}Ubuntu 12.04 LTS Extended Security Maintenance{% endblock %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1BK-XXECYJJllG8jIe3WN3X8EMo_3wBBa03nlzYDP8xE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -1,10 +1,8 @@
 {% extends "support/base_support.html" %}
 
-{% block meta_description %}Landscape, the systems management tool provided with Ubuntu Advantage, Canonical's service programme, allows you to manage large-scale deployments of Ubuntu machines as easily as one, making it far more cost-effective to support large networks of desktops, servers and cloud instances.{% endblock %}
 {% block title %}Support and management{% endblock %}
-
-
-
+{% block meta_description %}Landscape, the systems management tool provided with Ubuntu Advantage, Canonical's service programme, allows you to manage large-scale deployments of Ubuntu machines as easily as one, making it far more cost-effective to support large networks of desktops, servers and cloud instances.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip has-background is-deep is-bordered">

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -1,9 +1,8 @@
 {% extends "support/base_support.html" %}
 
 {% block title %}Plans and pricing | Support{% endblock %}
-
-
 {% block meta_description %}A summary of all our support offerings. Ubuntu offers the best economics of any commercially supported Linux solution and the best community support.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "support/base_support.html" %}
 
 {% block title %}Thank you | Support{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Vya-1Uq7bqJ7SFQ36j9-REp1iDT3rFENjYyCzuY02r4/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -1,8 +1,8 @@
 {% extends "templates/one-column.html" %}
 
-{% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
-
 {% block title %}Ubuntu solutions for telecommunications{% endblock %}
+{% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--image is-dark is-deep" style="background-image: url('{{ ASSET_SERVER_URL }}ebdfffbf-Aubergine_suru_background.png'); background-position: 77% 0%;">


### PR DESCRIPTION
## Done

- Added copydocs metadata to almost every page on Ubuntu, just missing a few legal pages I think
- Tidied up the metadata in the templates a little bit, so it goes Title -> Description -> Copydoc link

## QA

- Check out this feature branch
- Download the Ubuntu Copydoc extension from [here](https://github.com/canonical-webteam/ubuntu-copy-docs) (thanks @bartaz!) for either Firefox or Chrome
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Navigate to as many pages as you can be bothered, and check that the copydoc link at the bottom of the page is correct

## Issue / Card

Fixes #3848 