### PR TITLE
3880: Update navigation dropdowns to latest copy

### DIFF
--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -20,7 +20,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip is-bordered" id="ai">
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title">Cloud Native Platform</h3>
@@ -54,7 +54,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light is-bordered" id="bare-metal">
   <div class="row">
     <h2>Kubernetes fits perfectly on top of OpenStack, and VMware and MAAS bare metal</h2>
     <p>There&rsquo;s no doubt that Kubernetes is the new standard operational layer for every multi-cloud business. Canonical enables K8s on demand for your devops teams &mdash; on OpenStack, on VMware, on public clouds, and on bare metal clusters with MAAS.</p>

--- a/templates/templates/_navigation-community-h.html
+++ b/templates/templates/_navigation-community-h.html
@@ -3,61 +3,83 @@
     <div class="p-strip is-x-shallow u-no-padding--bottom">
       <div class="row">
         <div class="col-4">
-          <h4 class="p-heading--four is-dense u-hide--small">Support</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Support</h4>
-          <p class="p-p--small u-hide--small">Ask Ubuntu is a question and answer site for Ubuntu users and developers.</p>
-          <a class="p-button--small p-button--positive u-align-text--left u-hide--small" href="https://askubuntu.com/">Ask Ubuntu</a>
+          <h4 class="p-heading--four is-dense u-hide--small">Learn</h4>
+          <h4 class="p-muted-heading u-hide--medium u-hide--large">Learn</h4>
+          <p class="p-p--small u-hide--small">Tutorials cover a wide range of topics. Learn or teach something new to Ubuntu users.</p>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-hide--medium u-hide--large"><a href="https://askubuntu.com/">Ask Ubuntu</a></li>
-            <li class="p-list__item"><a href="https://ubuntuforums.org/">Find help in the forums</a></li>
-            <li class="p-list__item"><a href="https://help.ubuntu.com/">Browse the official documentation</a></li>
-            <li class="p-list__item"><a href="https://tutorials.ubuntu.com/">Find step-by-step tutorials</a></li>
-            <li class="p-list__item"><a href="https://help.ubuntu.com/community/InternetRelayChat">Chat directly on Internet relay chat (IRC) channels</a></li>
-            <li class="p-list__item"><a href="/support">Support packages for enterprises from Canonical</a></li>
+            <li class="p-list__item"><a href="http://tutorials.ubuntu.com/">Ubuntu Tutorials</a></li>
+            <li class="p-list__item"><a href="https://help.ubuntu.com/">Ubuntu documentation</a></li>
+            <li class="p-list__item"><a href="https://www.youtube.com/user/celebrateubuntu">Ubuntu events on Youtube</a></li>
+            <li class="p-list__item"><a href="https://www.youtube.com/channel/UCSsoSZBAZ3Ivlbt_fxyjIkw">The Juju Cloud Operations Show</a></li>
           </ul>
         </div>
         <div class="col-4">
-          <h4 class="p-heading--four is-dense u-hide--small">Participate</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Participate</h4>
-          <p class="p-p--small u-hide--small">The Ubuntu Community Hub is the meeting point for contributors and the Ubuntu community.</p>
-          <a class="p-button--small p-button--positive u-align-text--left u-hide--small" href="https://community.ubuntu.com/">Ubuntu community hub</a>
+          <h4 class="p-heading--four is-dense u-hide--small">Contribute</h4>
+          <h4 class="p-muted-heading u-hide--medium u-hide--large">Contribute</h4>
+          <p class="p-p--small u-hide--small">Discourse is a meeting point for people who shape the direction of Ubuntu. We recommend you start there.</p>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-hide--medium u-hide--large"><a href="https://community.ubuntu.com/">Ubuntu community hub</a></li>
-            <li class="p-list__item"><a href="https://askubuntu.com/">Answer or ask questions on Ask Ubuntu</a></li>
-            <li class="p-list__item"><a href="https://ubuntuforums.org/">Join the forums</a></li>
-            <li class="p-list__item"><a href="https://community.ubuntu.com/t/translations/32">Translate apps into your first language</a></li>
-            <li class="p-list__item"><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation">Write documentation</a></li>
-            <li class="p-list__item"><a href="/download/desktop/thank-you">Ubuntu is free of charge, but you can donate</a></li>
+            <li class="p-list__item"><a href="https://community.ubuntu.com/">Ubuntu Discourse</a></li>
+            <li class="p-list__item"><a href="https://community.ubuntu.com/t/translations/32">Translate Ubuntu into your language</a></li>
+            <li class="p-list__item"><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation">Improve the documentation</a></li>
+            <li class="p-list__item"><a href="/download/desktop/thank-you">Donate to the project</a></li>
           </ul>
         </div>
         <div class="col-4">
           <h4 class="p-heading--four is-dense u-hide--small">Ethos</h4>
           <h4 class="p-muted-heading u-hide--medium u-hide--large">Ethos</h4>
           <p class="p-p--small u-hide--small">The mission of Ubuntu is to bring the benefits of free software to the widest possible audience.</p>
-          <a class="p-button--small p-button--positive u-align-text--left u-hide--small" href="/community/mission">Our open source mission</a>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-hide--medium u-hide--large"><a href="/community/mission">Ubuntu community hub</a></li>
+            <li class="p-list__item"><a href="/community/mission">Our mission</a></li>
             <li class="p-list__item"><a href="/community/code-of-conduct">Ubuntu Code of Conduct</a></li>
-            <li class="p-list__item"><a href="/community/diversity">The Ubuntu project welcomes everyone</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="row"><hr></div>
+      <div class="row">
+        <div class="col-4">
+          <h4 class="p-heading--four is-dense u-hide--small">Meet</h4>
+          <h4 class="p-muted-heading u-hide--medium u-hide--large">Meet</h4>
+          <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu &mdash; our StackExchange</a></li>
+            <li class="p-list__item"><a href="https://loco.ubuntu.com/events/">Join your Local Community team</a></li>
+            <li class="p-list__item"><a href="https://ubuntuforums.org/">Meet up in the Ubuntu Forums</a></li>
+            <li class="p-list__item"><a href="https://help.ubuntu.com/community/InternetRelayChat">Chat on IRC</a></li>
+          </ul>
+        </div>
+        <div class="col-4">
+          <h4 class="p-heading--four is-dense u-hide--small">Follow</h4>
+          <h4 class="p-muted-heading u-hide--medium u-hide--large">Follow</h4>
+          <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item"><a href="https://twitter.com/ubuntu">Ubuntu on Twitter</a></li>
+            <li class="p-list__item"><a href="https://facebook.com/ubuntulinux">Facebook</a></li>
+            <li class="p-list__item"><a href="https://plus.google.com/+ubuntu">Google&plus;</a></li>
+          </ul>
+        </div>
+        <div class="col-4">
+          <h4 class="p-heading--four is-dense u-hide--small">Governance</h4>
+          <h4 class="p-muted-heading u-hide--medium u-hide--large">Governance</h4>
+          <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item"><a href="/community/governance/">Project Governance</a></li>
             <li class="p-list__item"><a href="https://community.ubuntu.com/t/what-is-the-ubuntu-community-council/706">Community Council</a></li>
-            <li class="p-list__item"><a href="https://www.canonical.com/">Canonical &mdash; the company behind Ubuntu</a></li>
+            <li class="p-list__item"><a href="/community/diversity">Diversity policy</a></li>
           </ul>
         </div>
       </div>
       <div class="row"><hr></div>
       <div class="u-sv3">
         <div class="row">
-          <div class="col-3">
+          <div class="col-2">
             <h4 class="p-muted-heading--small">Connect</h4>
           </div>
-          <div class="col-9">
+          <div class="col-10">
             <ul class="p-inline-list--middot is-x-dense">
-              <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/">Ubuntu blog</a></li>
-              <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/UbuntuWeeklyNewsletter">Ubuntu weekly newsletter</a></li>
-              <li class="p-inline-list__item"><a href="http://planet.ubuntu.com/">Ubuntu planet</a></li>
-              <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/Teams">Ubuntu teams</a></li>
-              <li class="p-inline-list__item"><a href="http://loco.ubuntu.com/teams/">LoCo teams</a></li>
-              <li class="p-inline-list__item"><a href="https://lists.ubuntu.com/">Mailing lists</a></li>
+              <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/">Blog</a></li>
+              <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/UbuntuWeeklyNewsletter">Weekly Newsletter</a></li>
+              <li class="p-inline-list__item"><a href="http://community.ubuntu.com/">Discourse</a></li>
+              <li class="p-inline-list__item"><a href="http://planet.ubuntu.com/">Planet</a></li>
+              <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/Teams">Teams</a></li>
+              <li class="p-inline-list__item"><a href="http://loco.ubuntu.com/teams/">LoCos</a></li>
+              <li class="p-inline-list__item"><a href="https://lists.ubuntu.com/">Lists</a></li>
               <li class="p-inline-list__item"><a href="https://help.ubuntu.com/community/InternetRelayChat">IRC</a></li>
             </ul>
           </div>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -6,8 +6,7 @@
           <h4 class="is-dense">
             <a href="/desktop/developers">Develop on Ubuntu&nbsp;&rsaquo;</a>
           </h4>
-          <p class="p-p--small">Ubuntu is the primary Linux platform for modern cloud and IoT development.  Whether you code in Python, Javascript, Atom, Android Studio, for x86, POWER, ARM or Z, or whether you deploy to AWS or to Heroku, you’ll find the latest versions of thousands of tools and libraries.</p>
-          <p class="u-no-margin--bottom"><a class="p-button--positive p-button--small" href="/desktop/developers">Develop with Ubuntu</a></p>
+          <p class="p-p--small">The best Linux platform for modern cloud and IoT development.</p>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item">GCC, CLANG</li>
             <li class="p-list__item">Go</li>
@@ -15,121 +14,93 @@
             <li class="p-list__item">Deb, snap, and charm packages</li>
             <li class="p-list__item">Android development</li>
             <li class="p-list__item">Architectures and ISAs</li>
+            <li class="p-list__item">Kernel selection &amp; lifecycle</li>
+            <li class="p-list__item">Multipass</li>
           </ul>
+          <p><a class="p-button--positive p-button--small" href="/desktop/developers">Develop with Ubuntu</a></p>
         </div>
         <div class="tablet-col-2 col-3 p-card--navigation">
           <h4 class="is-dense">
-            <a href="https://snapcraft.io/">Publish apps for Ubuntu&nbsp;&rsaquo;</a>
+            <a href="https://snapcraft.io/">Publish apps&nbsp;&rsaquo;</a>
           </h4>
-          <p class="p-p--small">Deliver your app to millions of Ubuntu users, servers and devices. Snaps are containerised software packages that auto-update and are safe to run on most Linux distributions.</p>
-          <p class="u-no-margin--bottom"><a class="p-button--positive p-button--small" href="https://snapcraft.io/">Publish with Snapcraft</a></p>
+          <p class="p-p--small">Deliver your app to millions of Ubuntu users, servers and devices.</p>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item">
-              <a href="https://snapcraft.io/store">
-                Browse the snap store&nbsp;&rsaquo;
-              </a>
+              <a href="https://snapcraft.io/store">Browse the snap store&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://docs.snapcraft.io/core/usage">
-                The snap command line interface&nbsp;&rsaquo;
-              </a>
+              <a href="https://docs.snapcraft.io/core/usage">The snap command line interface&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://build.snapcraft.io/">
-                Auto-build service for snaps&nbsp;&rsaquo;
-              </a>
+              <a href="https://build.snapcraft.io/">Auto-build service for snaps&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://docs.snapcraft.io/">
-                Snap documentation&nbsp;&rsaquo;
-              </a>
+              <a href="https://docs.snapcraft.io/">Snap documentation&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://docs.snapcraft.io/reference/channels">
-                Snap channels (tracks/risks/branches)&nbsp;&rsaquo;
-              </a>
+              <a href="https://docs.snapcraft.io/reference/channels">Snap channels - track/risk/branch&nbsp;&rsaquo;</a>
+            </li>
+            <li class="p-list__item">Cross-distro testing of snaps</li>
+            <li class="p-list__item">Rigorous snap security model</li>
+            <li class="p-list__item">Integration between snaps</li>
+          </ul>
+          <p><a class="p-button--positive p-button--small" href="https://snapcraft.io/">Publish with Snapcraft</a></p>
+        </div>
+        <div class="tablet-col-2 col-3 p-card--navigation">
+          <h4 class="is-dense">Devops</h4>
+          <p class="p-p--small">Automate everything from dev to production.</p>
+          <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item">
+              <a href="/public-cloud">Ubuntu images on public clouds&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              Cross-distro testing of snaps
+              <a href="https://blog.ubuntu.com/2018/07/09/minimal-ubuntu-released">Minimal Ubuntu for containers&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              Rigorous snap security model
+              <a href="https://cloud-init.io/">Cloud-init - customise cloud instances&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              Integration between snaps
+              <a href="https://jujucharms.com/">Juju for standardised operations&nbsp;&rsaquo;</a>
+            </li>
+            <li class="p-list__item">
+              <a href="/kubernetes">Canonical Distribution of Kubernetes&nbsp;&rsaquo;</a>
+            </li>
+            <li class="p-list__item">
+              <a href="https://microk8s.io/">MicroK8s - single node k8s for devs&nbsp;&rsaquo;</a>
+            </li>
+            <li class="p-list__item">
+              <a href="https://maas.io/">MAAS - fast server provisioning&nbsp;&rsaquo;</a>
+            </li>
+            <li class="p-list__item">
+              <a href="https://github.com/CanonicalLtd/multipass">Multipass - Ubuntu on MacOS&nbsp;&rsaquo;</a>
             </li>
           </ul>
+          <p><a class="p-button--positive p-button--small" href="/public-cloud">Learn more</a></p>
         </div>
         <div class="tablet-col-2 col-3 p-card--navigation">
           <h4 class="is-dense">
-            <a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a>
+            <a href="/internet-of-things">Make devices&nbsp;&rsaquo;</a>
           </h4>
-          <p class="p-p--small">Create smart connected devices with Ubuntu on a wide range of boards and SoC&rsquo;s. Build app ecosystems for your appliance or robot.</p>
-          <p class="p-p--small">Use Ubuntu Classic for a friendly micro-server, or the new Ubuntu Core for next-gen appliance security and transactional updates.</p>
-          <p class="u-no-margin--bottom"><a class="p-button--positive p-button--small" href="/internet-of-things/contact-us">Accelerate your time to market</a></p>
+          <p class="p-p--small">Use headless Ubuntu Server, or Ubuntu Core for embedded appliance security.</p>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item">
-              <a href="/core">
-                The tiny, transactional Ubuntu Core&nbsp;&rsaquo;
-              </a>
+              <a href="/core">Secure, embedded Ubuntu Core&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="/internet-of-things/robotics">
-                Secure robots with app stores&nbsp;&rsaquo;
-              </a>
+              <a href="/internet-of-things/robotics">Make robots with app stores&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="/internet-of-things/gateways">
-                Industrial gateways and controllers&nbsp;&rsaquo;
-              </a>
+              <a href="/internet-of-things/gateways">Industrial gateways and controllers&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="/internet-of-things/digital-signage">
-                The leading OS for digital signage&nbsp;&rsaquo;
-              </a>
+              <a href="https://tutorials.ubuntu.com/tutorial/graphical-snaps">Build a secure Ubuntu based kiosk&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              Build a secure Ubuntu based kiosk
+              <a href="/internet-of-things/digital-signage">The leading OS for digital signage&nbsp;&rsaquo;</a>
             </li>
-            <li class="p-list__item">
-              Drones and autopilots
-            </li>
+            <li class="p-list__item">Drones and autopilots</li>
           </ul>
-        </div>
-        <div class="tablet-col-2 col-3 p-card--navigation">
-          <h4 class="is-dense">
-            <a href="/ai">AI &amp; Machine Learning&nbsp;&rsaquo;</a>
-          </h4>
-          <p class="p-p--small">Ubuntu is the tested platform for Tensorflow, Caffe2, PyTorch, and other ML frameworks. Hardware acceleration on Nvidia for all clouds and bare metal.</p>
-          <p class="u-no-margin--bottom"><a class="p-button--positive p-button--small" href="/ai">Develop and test with AI</a></p>
-          <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item">
-              <a href="/ai/features">
-                Kubeflow on Ubuntu&nbsp;&rsaquo;
-              </a>
-            </li>
-            <li class="p-list__item">
-              <a href="/ai">
-                AI/ML dev, test and production&nbsp;&rsaquo;
-              </a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://www.tensorflow.org/install/install_linux">
-                Tensorflow upstream, on Ubuntu&nbsp;&rsaquo;
-              </a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://www.nvidia.com/en-us/data-center/gpu-accelerated-applications/tensorflow/">
-                Benchmark your Nvidia on Ubuntu
-              </a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://mxnet.incubator.apache.org/install/index.html">MXNet on Ubuntu</a> with <a href="https://www.nvidia.com/en-us/data-center/gpu-accelerated-applications/mxnet/">Nvidia</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://pytorch.org/">Pytorch</a> &middot; <a href="http://www.paddlepaddle.org/">PaddPaddle</a> &middot; <a href="https://chainer.org/">Chainer</a>
-            </li>
-          </ul>
+          <p><a class="p-button--positive p-button--small" href="/internet-of-things/contact-us">Accelerate to market</a></p>
         </div>
       </div>
     </div>
@@ -139,28 +110,41 @@
     <div class="p-strip is-x-shallow u-no-padding--bottom">
       <div class="row">
         <div class="col-3">
-          <h4 class="p-muted-heading">Ubuntu desktop</h4>
+          <h4 class="p-muted-heading">
+            <a href="">AI &amp; Machine Learning</a>
+          </h4>
           <div>
+            <p class="p-p--small">Ubuntu delivers hardware acceleration on Nvidia for all clouds and bare metal.</p>
             <ul class="p-text-list--small is-bordered">
               <li class="p-list__item">
-                <a href="/desktop">The developer&rsquo;s favourite desktop&nbsp;&rsaquo;</a>
+                <a href="/ai/features">Kubeflow on Ubuntu&nbsp;&rsaquo;</a>
               </li>
               <li class="p-list__item">
-                <a href="/server">Built on, and includes, Ubuntu server&nbsp;&rsaquo;</a>
+                <a href="/ai">AI/ML dev, test and production&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://www.tensorflow.org/install/install_linux">Tensorflow upstream, on Ubuntu&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://www.nvidia.com/en-us/data-center/gpu-accelerated-applications/tensorflow/">Benchmark your Nvidia on Ubuntu</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://mxnet.incubator.apache.org/install/index.html">MXNet on Ubuntu</a> with <a href="https://www.nvidia.com/en-us/data-center/gpu-accelerated-applications/mxnet/">Nvidia</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://pytorch.org/">Pytorch</a> &middot; <a href="http://www.paddlepaddle.org/">PaddPaddle</a> &middot; <a href="https://chainer.org/">Chainer</a>
               </li>
             </ul>
+            <p><a class="p-button--positive p-button--small" href="https://jujucharms.com/">Develop for AI/ML</a></p>
           </div>
         </div>
         <div class="col-3">
           <h4 class="p-muted-heading">
-            <a href="https://jujucharms.com/">
-              Cloud app operators
-            </a>
+            <a href="https://jujucharms.com/">Cloud packages</a>
           </h4>
           <div>
-            <p class="p-p--small">Simplify your operations of Hadoop, Spark, OpenStack and Kubernetes with Juju, the open source model-driven operations tool.</p>
-            <p class="p-p--small">Standard multicloud operations across all major public clouds, VMware, OpenStack, LXD, and bare metal.</p>
-            <p><a class="p-button--positive p-button--small" href="https://jujucharms.com/">Discover Juju</a></p>
+            <p class="p-p--small">Standard ways to deploy and operate cloud software like Hadoop, Spark, OpenStack and Kubernetes.</p>
+            <p><a class="p-button--positive p-button--small" href="https://jujucharms.com/">Discover Charm Packages</a></p>
           </div>
         </div>
         <div class="col-3">
@@ -171,26 +155,25 @@
                 <a href="/kubernetes">Kubernetes on Ubuntu&nbsp;&rsaquo;</a>
               </li>
               <li class="p-list__item">
-                <a href="/kubernetes/install">Install K8s &ndash; workstation or cluster&nbsp;&rsaquo;</a>
+                <a href="/kubernetes/install">Install K8s &ndash; workstations&nbsp;&rsaquo;</a>
               </li>
               <li class="p-list__item">
-                <a href="https://linuxcontainers.org/">Run legacy apps in LXD containers&nbsp;&rsaquo;</a>
+                <a href="/kubernetes/install">Install K8s &ndash; clouds and clusters&nbsp;&rsaquo;</a>
               </li>
+              <li class="p-list__item">
+                  <a href="https://linuxcontainers.org/">Run pre-K8s apps in LXD containers&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">Test CentOS apps on Ubuntu with LXD</li>
             </ul>
           </div>
         </div>
         <div class="col-3">
-          <h4 class="p-muted-heading">Cloud</h4>
+          <h4 class="p-muted-heading">Tutorials</h4>
+          <p class="p-p--small">Fun <a href="http://tutorials.ubuntu.com/">guides and HOWTOs</a> covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">
               <li class="p-list__item">
-                <a href="/download/cloud">Ubuntu is the leading cloud guest OS&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                <a href="/public-cloud">Optimised on all major public clouds&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                <a href="/openstack/install">Building your own OpenStack cloud&nbsp;&rsaquo;</a>
+                <a href="https://tutorials.ubuntu.com/tutorial/tutorial-guidelines">How to write a tutorial&nbsp;&rsaquo;</a>
               </li>
             </ul>
           </div>
@@ -264,9 +247,6 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item">
-            <a href="/support/community-support">Community support</a>
-          </li>
-          <li class="p-inline-list__item">
             <a href="https://docs.ubuntu.com/">Read the docs</a>
           </li>
           <li class="p-inline-list__item">
@@ -277,6 +257,9 @@
           </li>
           <li class="p-inline-list__item">
             <a href="https://help.ubuntu.com/community/CommunityHelpWiki">Help</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/support">Commercial Support</a>
           </li>
         </ul>
       </div>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -47,12 +47,13 @@
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/kubernetes">Get Kubernetes</a></li>
-            <li class="p-list__item"><a href="/kubernetes/features">Bare metal, VMware, cloud</a></li>
-            <li class="p-list__item"><a href="/kubernetes/features">Upgrades, day 2 operations</a></li>
-            <li class="p-list__item"><a href="/kubernetes/features">GPGPU support for <abbr title="Machine learning">ML</abbr></a></li>
+            <li class="p-list__item"><a href="/kubernetes/features#bare-metal">Bare metal, VMware, cloud</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features#ai">Upgrades and automation included</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features#ai">GPGPU support for <abbr title="Artificial intelligence">AI</abbr>/<abbr title="Machine learning">ML</abbr></a></li>
             <li class="p-list__item"><a href="/kubernetes/partners">CI/CD with Rancher &amp; Jenkins</a></li>
-            <li class="p-list__item"><a href="/kubernetes/features">AI and ML workflows</a></li>
-            <li class="p-list__item"><a href="/kubernetes/managed">Fully managed options</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features#ai">AI and ML workflows</a></li>
+            <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
+            <li class="p-list__item"><a href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">GKE with Ubuntu on Google Cloud</a></li>
           </ul>
         </div>
         <!-- AI and Machine learning -->
@@ -63,17 +64,17 @@
               <a href="/ai">AI and ML&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
-              Canonical provides perfect multi-cloud portability for your artificial intelligence and machine learning workloads.
+              Ubuntu and Kubernetes from Canonical provide perfect multi cloud portability for your artificial intelligence and machine learning workloads.
             </p>
             <a href="/ai/install" class="p-button--small p-button--positive u-align-text--left">
-              Get started with Kubeflow
+              Get started with AI
             </a>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
             <a href="/ai">AI and ML&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/ai/install">Get started with Kubeflow</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/ai/install">Get started with AI</a></li>
             <li class="p-list__item"><a href="/ai/features">Google TensorFlow and Kubeflow</a></li>
             <li class="p-list__item"><a href="https://developer.nvidia.com/deep-learning" title="Visit Nvidia developer - external site">Nvidia’s ML stack</a></li>
             <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML toolchain on Ubuntu</a></li>
@@ -117,7 +118,6 @@
         </h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="/download/cloud">Use Ubuntu on AWS, Azure, Google, Oracle and IBM clouds</a></li>
-          <li class="p-list__item"><a href="/download/cloud">Use Ubuntu on Google Kubernetes and Azure Kubernetes</a></li>
         </ul>
       </div>
       <!-- Containers -->
@@ -125,26 +125,27 @@
         <h4 class="p-muted-heading"><a href="/containers" title="Visit the containers pages">Containers&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="/kubernetes">Install and operate Kubernetes</a></li>
-          <li class="p-list__item"><a href="https://linuxcontainers.org/" title="Visit the LXD website - external site">LXD for legacy apps in containers</a></li>
+          <li class="p-list__item"><a href="https://linuxcontainers.org/" title="Visit the LXD website - external site">Run legacy apps in LXD containers</a></li>
         </ul>
       </div>
-      <!-- data centre -->
+      <!-- Data centre -->
       <div class="col-3">
         <h4 class="p-muted-heading"><a href="/server">Data centre&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">Provision servers with Metal as a Service (MAAS)</a></li>
-          <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">MAAS edge and micro-clouds</a></li>
-          <li class="p-list__item"><a href="https://jujucharms.com" title="Visit jujucharms.com - external site">Multi-cloud operations</a></li>
+          <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">Metal as a Service provisioning</a></li>
+          <li class="p-list__item"><a href="https://jujucharms.com" title="Visit jujucharms.com - external site">Multi cloud operations</a></li>
         </ul>
       </div>
       <!-- Internet of Things -->
       <div class="col-3">
         <h4 class="p-muted-heading"><a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="/core">Ubuntu Core - tiny and highly secure</a></li>
+          <li class="p-list__item"><a href="/core">Ubuntu Core - embedded, secure Ubuntu</a></li>
+          <li class="p-list__item"><a href="/internet-of-things/digital-signage">Digital signage and smart displays</a></li>
+          <li class="p-list__item"><a href="/internet-of-things/robotics">Robots and drones with Ubuntu</a></li>
+          <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
           <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>
           <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure app packages</a></li>
-          <li class="p-list__item"><a href="/internet-of-things">Robots, drones, gateways, and smart displays</a></li>
         </ul>
       </div>
     </div>
@@ -187,11 +188,11 @@
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
-          <li class="p-inline-list__item"><a href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
+          <li class="p-inline-list__item"><a href="/resources?content=webinars">Webinars</a></li>
           <li class="p-inline-list__item"><a href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
           <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
-          <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
-          <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
+          <li class="p-inline-list__item"><a href="/resources?content=case-studies">Case studies</a></li>
+          <li class="p-inline-list__item"><a href="/resources?content=whitepapers">White papers</a></li>
           <li class="p-inline-list__item"><a href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
           <li class="p-inline-list__item"><a href="/cloud/training">Training</a></li>
           <li class="p-inline-list__item"><a href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>


### PR DESCRIPTION
## Done

- Updated the Enterprise tab according to the [copydoc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit)
- Updated the Developer tab according to the [copydoc](https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit)
  - **Note that the Devops section is missing a header link, and CTA copy**
- Updated the Community tab according to the [copydoc](https://docs.google.com/document/d/1TgsBJdGgsP4KrGiz5kU5QYkdGSlKqhAVnZGnCJgshYY/edit)
- Added anchor tags to /kubernetes/features

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that each navigation dropdown matches the respective copydoc

## Issue / Card

Fixes #3880 