### PR TITLE
Fix search error: Handle missing 'searchInformation'

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -12,7 +12,13 @@
       <div class="col-6 u-vertically-center">
         <div>
           <h1>500: Server error</h1>
-          <p class="p-heading--four">Something&rsquo;s gone wrong, try reloading.</p>
+          <p class="p-heading--four">Something&rsquo;s gone wrong.</p>
+          {% if message %}<p><blockquote><code>{{ message }}</code></blockquote></p>{% endif %}
+          <p>
+            Try reloading the page.
+            If the error persists, please it may be a <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues">known issue</a>.
+            If not, please <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new">file a new issue</a>.
+          </p>
         </div>
       </div>
     </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -9,10 +9,10 @@
     <div class="row">
       <div class="col-12">
         {% if query %}
-          {% if estimatedTotal > 0 %}
-            <h1 class="p-heading--two">Search results for "{{ query }}"</h1>
+          {% if estimatedTotal == 0 %}
+            <h1 class="p-heading--two">Sorry we couldn't find "{{ query }}"</h1>
           {% else %}
-             <h1 class="p-heading--two">Sorry we couldn't find "{{ query }}"</h1>
+            <h1 class="p-heading--two">Search results for "{{ query }}"</h1>
           {% endif %}
         {% else %}
           <h1>Search Ubuntu and Canonical sites</h1>
@@ -39,44 +39,43 @@
   </div>
 
   {# no results page #}
-  {% if results and estimatedTotal == 0 %}
-    <div class="p-strip">
-      <div class="row">
-        <div class="col-6">
-          <h3>Why not try widening your search?</h3>
-          <p>You can do this by:</p>
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
-            <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
-            <li class="p-list__item is-ticked">Trying a different spelling</li>
-          </ul>
-        </div>
-        <div class="col-6">
-          <h3>Still no luck?</h3>
-          <ul class="p-list">
-            <li class="p-list__item is-ticked"><a href="/">Visit the Ubuntu homepage</a></li>
-            <li class="p-list__item is-ticked"><a href="/desktop/contact-us?product=search-page">Contact us</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  {% endif %}
-
-  {# search results #}
-  {% if results and estimatedTotal > 0 %}
-    {% for item in results.items %}
-      <div class="p-strip is-shallow">
+  {% if results %}
+    {% if estimatedTotal == 0 %}
+      <div class="p-strip">
         <div class="row">
-          <div class="col-12">
-            <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
-            <p>
-              {{ item.htmlSnippet | safe }}
-            </p>
-            <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
-	  </div>
-	</div>
+          <div class="col-6">
+            <h3>Why not try widening your search?</h3>
+            <p>You can do this by:</p>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
+              <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
+              <li class="p-list__item is-ticked">Trying a different spelling</li>
+            </ul>
+          </div>
+          <div class="col-6">
+            <h3>Still no luck?</h3>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked"><a href="/">Visit the Ubuntu homepage</a></li>
+              <li class="p-list__item is-ticked"><a href="/desktop/contact-us?product=search-page">Contact us</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-    {% endfor %}
+    {% else %}
+      {% for item in results.items %}
+        <div class="p-strip is-shallow">
+          <div class="row">
+            <div class="col-12">
+              <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
+              <p>
+                {{ item.htmlSnippet | safe }}
+              </p>
+              <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
   {% endif %}
 
   {# pagination #}


### PR DESCRIPTION
Fixes #3879

Handle missing 'searchInformation'
---

pretty sure the error was this:

> Internal Server Error: /search
> Traceback (most recent call last):
>   File
"/usr/local/lib/python2.7/dist-packages/django/core/handlers/exception.py",
line 41, in inner
>     response = get_response(request)
>   File
"/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line
249, in _legacy_get_response
>     response = self._get_response(request)
>   File
"/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line
187, in _get_response
>     response = self.process_exception_by_middleware(e, request)
>   File
"/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line
185, in _get_response
>     response = wrapped_callback(request, *callback_args,
**callback_kwargs)
>   File "/srv/webapp-12/code/c920db4/webapp/views.py", line 66, in search
>     results['searchInformation']['totalResults']
> KeyError: 'searchInformation'

It appears that occasionally, the API payload returned from Google Custom
Search API was simply missing the searchInformation key. There doesn't seem
to be any obvious pattern to when this key is missing
(it doesn't correlate with there being no results), and it isn't mentioned
in the API docs:

https://developers.google.com/custom-search/json-api/v1/reference/cse/list

Here I'm trying my best to continue even if this key is missing:

- If the key is missing, set "estimatedTotal" to None
- Only show the "Sorry we couldn't find" message if the estimatedTotal is
*explicitly* zero, because otherwise there *may* be results

This should mean the search results page will work as normal most of the
time - the only slightly odd behaviour will be when there are no search
results and "searchInformation" is missing - in this case the user will see
an empty results set instead of the "Sorry we couldn't find" message.

Expose the error message in search results
--

Since the Google Custom Search API is clearly a bit unreliable in what it
returns (see 339639a and 3879), when it causes search to break it would be
helpful to know what went wrong without digging through logs.

To that end, here I am exposing the error message on the error page, for
search retrieval errors.

QA
--

To simulate missing data coming back from the API, on line 49 of `webapp/views.py`, add:

``` bash
del results['searchInformation']
```

Now `./run` the site and try searching for something that returns results and something that doesn't. Check there aren't errors in either case.

Now try mangling the returned data in another way, change the above line to:

``` bash
del results['items'][0]['htmlSnippet']
```

Now search for something and check you see an error with the error message printed out.