### PR TITLE
Create basic template for User Report page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -145,6 +145,8 @@ desktop:
       path: /desktop/developers
     - title: Partners
       path: /desktop/partners
+    - title: User report
+      path: /desktop/user-report
 
     - title: Contact us
       path: /desktop/contact-us

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -145,8 +145,8 @@ desktop:
       path: /desktop/developers
     - title: Partners
       path: /desktop/partners
-    - title: User report
-      path: /desktop/user-report
+    - title: Statistics
+      path: /desktop/statistics
 
     - title: Contact us
       path: /desktop/contact-us

--- a/static/js/desktop-statistics.js
+++ b/static/js/desktop-statistics.js
@@ -1,0 +1,51 @@
+var SCROLL_LISTENER_INTERVAL = 150;
+var stickyNav = document.querySelector('.p-sticky-nav');
+var userReportTab = document.querySelector('.js-user-report-tab');
+var specsTab = document.querySelector('.js-specs-tab');
+var configTab = document.querySelector('.js-config-tab');
+var didScroll;
+
+function getSectionPos(tab) {
+  var sectionId = tab.href.split('#')[1];
+  var section = document.getElementById(sectionId);
+  var rect = section.getBoundingClientRect();
+  var stickyNavHeight = stickyNav.clientHeight;
+  return rect.top + window.scrollY - stickyNavHeight;
+}
+
+function controlActiveTab() {
+  var scrollPos = window.scrollY;
+  var userReportPos = getSectionPos(userReportTab);
+  var specsPos = getSectionPos(specsTab);
+  var configPos = getSectionPos(configTab);
+
+  if (scrollPos > configPos) {
+    userReportTab.classList.remove('is-selected');
+    specsTab.classList.remove('is-selected');
+    configTab.classList.add('is-selected');
+  } else if (scrollPos > specsPos) {
+    userReportTab.classList.remove('is-selected');
+    specsTab.classList.add('is-selected');
+    configTab.classList.remove('is-selected');
+  } else if (scrollPos > userReportPos) {
+    userReportTab.classList.add('is-selected');
+    specsTab.classList.remove('is-selected');
+    configTab.classList.remove('is-selected');
+  } else {
+    userReportTab.classList.remove('is-selected');
+    specsTab.classList.remove('is-selected');
+    configTab.classList.remove('is-selected');
+  }
+}
+
+/* Set interval on how often to run scroll function */
+setInterval(function() {
+  if (didScroll) {
+    controlActiveTab();
+    didScroll = false;
+  }
+}, SCROLL_LISTENER_INTERVAL);
+
+window.addEventListener('scroll', function() {
+  didScroll = true;
+});

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -15,4 +15,19 @@
     @extend %p-card--highlighted;
     @include vf-highlight-bar(#ff8936);
   }
+
+  .p-card--flex {
+    @extend %p-card--highlighted;
+    display: flex;
+    flex-direction: column;
+
+    .p-card__center-content {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      flex-grow: 10;
+      margin: 1rem 0;
+    }
+  }
 }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -373,7 +373,7 @@
     background-color: rgba(17,17,17, .4);
     opacity: 1;
     position: fixed;
-    z-index: 1;
+    z-index: 2;
     transition: opacity .5s ease-in-out;
   }
 

--- a/static/sass/_pattern_sticky-nav.scss
+++ b/static/sass/_pattern_sticky-nav.scss
@@ -4,7 +4,7 @@
     border-bottom: 1px solid $color-mid-light;
     position: sticky;
     top: 0;
-    z-index: 5;
+    z-index: 1;
   
     .p-tabs__list {
       margin-bottom: 0;

--- a/static/sass/_pattern_sticky-nav.scss
+++ b/static/sass/_pattern_sticky-nav.scss
@@ -8,6 +8,7 @@
   
     .p-tabs__list {
       margin-bottom: 0;
+      overflow: auto;
   
       &::after {
         display: none;

--- a/static/sass/_pattern_sticky-nav.scss
+++ b/static/sass/_pattern_sticky-nav.scss
@@ -2,6 +2,7 @@
   .p-sticky-nav {
     background-color: $color-light;
     border-bottom: 1px solid $color-mid-light;
+    box-shadow: 0 3px 5px -1px rgba(17, 17, 17, 0.2);
     position: sticky;
     top: 0;
     z-index: 1;

--- a/static/sass/_pattern_sticky-nav.scss
+++ b/static/sass/_pattern_sticky-nav.scss
@@ -1,0 +1,17 @@
+@mixin ubuntu-p-sticky-nav {
+  .p-sticky-nav {
+    background-color: $color-light;
+    border-bottom: 1px solid $color-mid-light;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+  
+    .p-tabs__list {
+      margin-bottom: 0;
+  
+      &::after {
+        display: none;
+      }
+    }
+  }
+}

--- a/static/sass/_pattern_sticky-nav.scss
+++ b/static/sass/_pattern_sticky-nav.scss
@@ -5,6 +5,14 @@
     position: sticky;
     top: 0;
     z-index: 1;
+
+    .p-tabs__link:hover::before {
+      background-color: $color-brand;
+    }
+
+    .p-tabs__link.is-selected {
+      @include vf-highlight-bar($color-brand, bottom, true);
+    }
   
     .p-tabs__list {
       margin-bottom: 0;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -39,6 +39,7 @@
 @import 'takeovers/ai-webinar';
 @import 'utility-animations';
 @import 'pattern_chart';
+@import 'pattern_sticky-nav';
 
 @include ubuntu-p-buttons;
 @include ubuntu-p-navigation;
@@ -57,6 +58,7 @@
 @include ubuntu-p-ubuntu-intro;
 @include ubuntu-p-takeunders;
 @include ubuntu-p-tables;
+@include ubuntu-p-sticky-nav;
 @include ubuntu-p-feedback;
 @include p-takeover-rigado-webinar;
 @include p-takeover-ai-webinar;

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -1,6 +1,6 @@
 {% extends "desktop/base_desktop.html" %}
 
-{% block title %}User report{% endblock %}
+{% block title %}User statistics{% endblock %}
 {% block meta_description %}The Ubuntu user report showcases the data collected from users installing or upgrading to Ubuntu 18.04 LTS.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/153OkfZHM_eTfAoUZF3f38VMtiFzaa2txB9B2lvs8xXA/edit{% endblock meta_copydoc %}
 
@@ -9,7 +9,7 @@
 <section id="user-report" class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
   <div class="row">
     <div class="col-6">
-      <h1>Ubuntu user report</h1>
+      <h1>Ubuntu user statistics</h1>
       <p>This report is generated from basic, non-identifiable system data that was asked of users to provide when installing Ubuntu 18.04 LTS.</p>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small">

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -1,4 +1,5 @@
 {% extends "desktop/base_desktop.html" %}
+{% load versioned_static  %}
 
 {% block title %}User statistics{% endblock %}
 {% block meta_description %}The Ubuntu user report showcases the data collected from users installing or upgrading to Ubuntu 18.04 LTS.{% endblock %}
@@ -6,7 +7,7 @@
 
 {% block content %}
 
-<section id="user-report" class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
+<section class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu user statistics</h1>
@@ -20,18 +21,18 @@
 <nav class="p-tabs p-sticky-nav">
   <ul class="p-tabs__list" role="tablist">
     <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link" href="#user-report">User report</a>
+      <a class="p-tabs__link js-user-report-tab" href="#user-report">User report</a>
     </li>
     <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link" href="#desktop-specs">Desktop specs</a>
+      <a class="p-tabs__link js-specs-tab" href="#desktop-specs">Desktop specs</a>
     </li>
     <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link" href="#configuration">Configuration</a>
+      <a class="p-tabs__link js-config-tab" href="#configuration">Configuration</a>
     </li>
   </ul>
 </nav>
 
-<section class="p-strip is-shallow is-bordered">
+<section id="user-report" class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
       <h2 class="p-heading--four">How many users opted in?</h2>
@@ -393,5 +394,7 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
+
+<script src="{% versioned_static 'js/desktop-statistics.js' %}"></script>
 
 {% endblock content %}

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu user statistics</h1>
-      <p>This report is generated from basic, non-identifiable system data that was asked of users to provide when installing Ubuntu 18.04 LTS.</p>
+      <p>This report is generated from basic, non-identifiable system data that was provided by users when installing Ubuntu 18.04 LTS.</p>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}ed348358-logo-cof.svg" width="200" alt="ubuntu logo">
@@ -80,7 +80,7 @@
     </div>
     <div class="col-6">
       <h2 class="p-heading--four">Where are Ubuntu users?</h2>
-      <p>Location is derived from a users setting the timezone and location in the installer and not from an identifiable IP address.</p>
+      <p>Location is derived from the user setting the timezone and location in the installer and not from an identifiable IP address.</p>
     </div>
   </div>
 </section>
@@ -112,10 +112,8 @@
 <section id="desktop-specs" class="p-strip--image u-no-background--small is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
   <div class="row">
     <h2>Desktop specs</h2>
-    <p>Data was collected from users’ machines. This is viewable for either real or virtual hardware.</p>
+    <p>This data was collected from user’s machines.</p>
   </div>
-</section>
-<section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height">
     <div class="col-4 p-card--flex">
       <header class="p-card__header">
@@ -150,7 +148,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip--light is-shallow is-bordered">
+<section class="p-strip is-shallow is-bordered">
   <div class="row">
     <h3>What graphics setup do users have?</h2>
   </div>
@@ -175,10 +173,10 @@
     </div>
   </div>
 </section>
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row">
     <h3>Popular screen sizes</h2>
-    <p>This data set show the 15 most popular screen sizes.</p>
+    <p>This data set shows the 15 most popular screen sizes.</p>
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
@@ -193,7 +191,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered u-no-padding--top">
+<section class="p-strip--light is-bordered u-no-padding--top">
   <div class="row u-equal-height">
     <div class="col-6">
       <h4>Pixel density</h4>
@@ -209,7 +207,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <h3>What CPU and memory do users have?</h3>
   </div>
@@ -223,11 +221,11 @@
       </div>
     </div>
     <div class="col-6">
-      <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output functions required by the user and software. A computer may have multiple to be able to perform more complex tasks in parallel.</p>
+      <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output functions. Having multiple CPUs allows a computer to perform more tasks in parallel.</p>
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <h4>Size of RAM (GB)</h4>
   </div>
@@ -242,7 +240,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip--light is-bordered">
+<section class="p-strip">
   <div class="row">
     <h3>What physical disks do people have?</h3>
   </div>
@@ -260,9 +258,9 @@
     </div>
   </div>
 </section>
-<section class="p-strip">
+<section class="p-strip is-bordered u-no-padding--top">
   <div class="row">
-    <h3>Partition type</h3>
+    <h4>Partition type</h4>
   </div>
   <div class="row">
     <p>There are a number of ways to partition a disk when installing Ubuntu depending on what the user wants to do.</p>
@@ -273,7 +271,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered u-no-padding--top">
+<section class="p-strip--light is-bordered">
   <div class="row u-equal-height">
     <div class="col-6">
       <h4>Size of partitions</h4>
@@ -299,7 +297,7 @@
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who installed Ubuntu using all the default settings.</h3>
+      <h3 class="p-heading--four">Users who installed Ubuntu ‘out the box’.</h3>
     </div>
     <div class="col-6 u-align--center">
       <div id="default-settings">
@@ -316,14 +314,14 @@
       </div>
     </div>
     <div class="col-6">
-      <h3 class="p-heading--four">Users who restricted at least one add-on when installing.</h3>
+      <h3 class="p-heading--four">Users who restricted at least one add-on.</h3>
     </div>
   </div>
 </section>
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who use auto-login, which lets users automatically log in when they start up their computer.</h3>
+      <h3 class="p-heading--four">Users who auto-login, which automatically logs a user in on start-up.</h3>
     </div>
     <div class="col-6 u-align--center">
       <div id="auto-login">
@@ -340,14 +338,14 @@
       </div>
     </div>
     <div class="col-6">
-      <h3 class="p-heading--four">Users who used Minimal Install; a stripped down Ubuntu that contains a web browser and other basic applications.</h3>
+      <h3 class="p-heading--four">Users who used the Minimal Install; a stripped down Ubuntu that contains a web browser and other basic applications.</h3>
     </div>
   </div>
 </section>
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who choose to download and update the software Ubuntu would be using at install time.</h3>
+      <h3 class="p-heading--four">Users who chose to download and update software whilst installing Ubuntu.</h3>
     </div>
     <div class="col-6 u-align--center">
       <div id="update-install-time">
@@ -370,7 +368,7 @@
   <div class="row">
     <div class="col-6">
       <h3>Want to know more?</h3>
-      <p>Read what Will Cooke, Head of the desktop team for Ubuntu 18.04 LTS release had to say about the methodology behind these metrics.</p>
+      <p>Find out what Will Cooke, Engineering Director for Desktop, had to say about the methodology behind these metrics.</p>
       <a class="p-link--external" href="https://blog.ubuntu.com/2018/06/22/a-first-look-at-desktop-metrics">Read on</a>
     </div>
     <div class="col-5 prefix-1">
@@ -382,12 +380,12 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3>The Ubuntu Report tool</h3>
-      <p>Head to GitHub to see the full list of data points collected and how to run the tool from your terminal.</p>
-      <p><a class="p-link--external" href="https://github.com/ubuntu/ubuntu-report">The Ubuntu Report tool</a></p>
+      <p>The full list of collected data points is viewable on GitHub as well as information about how to run the tool from your terminal.</p>
+      <p><a class="p-link--external" href="https://github.com/ubuntu/ubuntu-report">Learn more about the Ubuntu Report tool on GitHub</a></p>
     </div>
     <div class="col-6 p-divider__block">
       <h3>Don't have Ubuntu desktop?</h3>
-      <p>Enjoy the simplicity of Ubuntu’s intuitive interface. It’s easy to install on Windows or Mac OS, or, run Ubuntu alongside it.</p>
+      <p>Ubuntu desktop can replace your current operating system or it can be run alongside it.</p>
       <p><a href="/download/desktop">Download Ubuntu desktop&nbsp;&rsaquo;</a></p>
     </div>
   </div>

--- a/templates/desktop/user-report.html
+++ b/templates/desktop/user-report.html
@@ -1,0 +1,310 @@
+{% extends "desktop/base_desktop.html" %}
+
+{% block title %}User report{% endblock %}
+{% block meta_description %}The Ubuntu user report showcases the data collected from users installing or upgrading to Ubuntu 18.04 LTS.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/153OkfZHM_eTfAoUZF3f38VMtiFzaa2txB9B2lvs8xXA/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section id="user-report" class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h1>Ubuntu user report</h1>
+      <p>This report is generated from basic, non-identifiable system data that was asked of users to provide when installing Ubuntu 18.04 LTS.</p>
+    </div>
+    <div class="col-6 u-vertically-center u-align--center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}ed348358-logo-cof.svg" width="200" alt="ubuntu logo">
+    </div>
+  </div>
+</section>
+<nav class="p-tabs p-sticky-nav">
+  <ul class="p-tabs__list" role="tablist">
+    <li class="p-tabs__item" role="presentation">
+      <a class="p-tabs__link" href="#user-report">User report</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a class="p-tabs__link" href="#desktop-specs">Desktop specs</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a class="p-tabs__link" href="#configuration">Configuration</a>
+    </li>
+  </ul>
+</nav>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-heading--three">How many users opted in?</h2>
+      <p>We appreciate the trust that has been given to us with handling this data and we aim to use the results to focus our development efforts on where it matters most to users.</p>
+    </div>
+    <div class="col-6 u-vertically-center u-hide--small">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-6 u-vertically-center u-hide--small">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <h2 class="p-heading--three">Real or virtual machines?</h2>
+      <p>Some machines could not be determined as either real or virtual, that data is not included in this report.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-heading--three">Clean install or upgrade?</h2>
+      <p>Users setting up a virtual machine are much more likely to perform a clean install rather than upgrading Ubuntu.</p>
+    </div>
+    <div class="col-6 u-vertically-center u-hide--small">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-6 u-vertically-center u-align--center u-hide--small">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <h2 class="p-heading--three">Where are Ubuntu users?</h2>
+      <p>Location is derived from a users setting the timezone and location in the installer and not from an identifiable IP address.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-heading--three">What language do they use?</h2>
+      <ol>
+        <li>American English</li>
+        <li>English</li>
+        <li>German</li>
+        <li>Brazilian Portuguese</li>
+        <li>French</li>
+        <li>Chinese</li>
+        <li>Russian</li>
+        <li>Italian</li>
+        <li>Canadian English</li>
+        <li>Australian English</li>
+      </ol>
+    </div>
+    <div class="col-6 u-vertically-center u-align--center u-hide--small">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section id="desktop-specs" class="p-strip">
+  <div class="row">
+    <h2>Desktop specs</h2>
+    <p>Data was collected from users’ machines. This is viewable for either real or virtual hardware.</p>
+  </div>
+</section>
+<section class="p-strip is-bordered u-no-padding--top">
+  <div class="row u-equal-height">
+    <div class="p-card--highlighted col-4">
+      <header class="p-card__header">
+        <h4>OS architecture</h4>
+      </header>
+      <div class="p-card__content">
+        <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+        <p class="u-no-margin--bottom">OS architecture is responsible for running programs and providing secure access to the machine's hardware.</p>
+      </div>
+    </div>
+    <div class="p-card--highlighted col-4">
+      <header class="p-card__header">
+        <h4>Firmware</h4>
+      </header>
+      <div class="p-card__content">
+        <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+        <p class="u-no-margin--bottom">Firmware initialises hardware components and the operating system at start up.</p>
+      </div>
+    </div>
+    <div class="p-card--highlighted col-4">
+      <header class="p-card__header">
+        <h4>Display server</h4>
+      </header>
+      <div class="p-card__content">
+        <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+        <p class="u-no-margin--bottom">The display server controls the input and output of its clients to and from the rest of the operating system and the hardware.</p>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <h2>What graphics setup do users have?</h2>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h2 class="u-align-text--center u-no-margin--bottom">99%</h2>
+      <h4 class="u-align-text--center">Have one screen</h4>
+      <p>This was detected on install so many users may have connected screens after the installing Ubuntu.</p>
+    </div>
+    <div class="col-6">
+      <h2 class="u-align-text--center u-no-margin--bottom">87%</h2>
+      <h4 class="u-align-text--center">Have one GPU</h4>
+      <p>Graphical Processing Unit (GPU) is used to generate videos and images for displaying on screen.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <h2 class="p-heading--three">Popular screen sizes</h2>
+    <p>This data set show the 15 most popular screen sizes.</p>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered u-no-padding--top">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h4>Pixel density</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <h4>Relative pixel size</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <h2>What CPU and memory do users have?</h2>
+  </div>
+  <div class="row">
+    <h3>Number of CPUs</h3>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output functions required by the user and software. A computer may have multiple to be able to perform more complex tasks in parallel.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h3>Size of RAM (GB)</h3>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>The more memory, the more power the computer has to carry out functions. Some users reported having RAM upwards of 96GB!</p>
+    </div>
+    <div class="col-6">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <h2>What physical disks do people have?</h2>
+  </div>
+  <div class="row">
+    <h3>Physical disk</h3>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <p>Physical disks denote how much data can be stored on a computer. For this report the total disk size is inferred from the number and size of partitions of a disk.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <h3>Partition type</h3>
+  </div>
+  <div class="row">
+    <p>There are a number of ways to partition a disk when installing Ubuntu depending on what the user wants to do.</p>
+    <div class="u-align--center">
+      <img src="https://via.placeholder.com/1040x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered u-no-padding--top">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h4>Size of partitions</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <h4>Number of partitions</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section id="configuration" class="p-strip--light">
+  <div class="row">
+    <h2>Configuring Ubuntu</h2>
+    <p>Users configure Ubuntu in many different ways, we recorded some key points and this will help inform the design of future releases.</p>
+  </div>
+</section>
+<section class="p-strip--light is-shallow u-no-padding--top">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h4>Users who installed Ubuntu using all the default settings</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <h4>Users who restricted at least one add-on when installing</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h4>Users who use auto-login, which lets users automatically log in when they start up their computer.</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+    <div class="col-6">
+      <h4>Users who used Minimal Install; a stripped down Ubuntu that contains a web browser and other basic applications.</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-shallow is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h4>Users who chose to download and update the software Ubuntu would be using at install time.</h4>
+      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h3>How long to get Ubuntu running?</h3>
+  </div>
+  <div class="row">
+    <img src="https://via.placeholder.com/1040x320?text=Chart" alt="">
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row p-divider">
+    <div class="col-6 p-divider__block">
+      <h3>The Ubuntu Report tool</h3>
+      <p>Head to GitHub to see the full list of data points collected and how to run the tool from your terminal.</p>
+      <p><a class="p-link--external" href="https://github.com/ubuntu/ubuntu-report">The Ubuntu Report tool</a></p>
+    </div>
+    <div class="col-6 p-divider__block">
+      <h3>Don't have Ubuntu desktop?</h3>
+      <p>Enjoy the simplicity of Ubuntu’s intuitive interface. It’s easy to install on Windows or Mac OS, or, run Ubuntu alongside it.</p>
+      <p><a href="/download/desktop">Download Ubuntu desktop&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
+
+{% endblock content %}

--- a/templates/desktop/user-report.html
+++ b/templates/desktop/user-report.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<section id="user-report" class="p-strip is-deep is-bordered">
+<section id="user-report" class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu user report</h1>
@@ -30,55 +30,64 @@
     </li>
   </ul>
 </nav>
-<section class="p-strip--light is-bordered">
-  <div class="row">
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h2 class="p-heading--three">How many users opted in?</h2>
+      <h2 class="p-heading--four">How many users opted in?</h2>
       <p>We appreciate the trust that has been given to us with handling this data and we aim to use the results to focus our development efforts on where it matters most to users.</p>
     </div>
-    <div class="col-6 u-vertically-center u-hide--small">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    <div class="col-6 u-align--center">
+      <div id="opt-in">
+        <img src="https://via.placeholder.com/250x250?text=Pie chart" alt="">
+      </div>
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-6 u-vertically-center u-hide--small">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+<section class="p-strip--light is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center">
+      <div id="real-or-virtual">
+        <img src="https://via.placeholder.com/250x250?text=Pie chart" alt="">
+      </div>
     </div>
     <div class="col-6">
-      <h2 class="p-heading--three">Real or virtual machines?</h2>
+      <h2 class="p-heading--four">Real or virtual machines?</h2>
       <p>Some machines could not be determined as either real or virtual, that data is not included in this report.</p>
     </div>
   </div>
 </section>
-<section class="p-strip--light is-bordered">
-  <div class="row">
+<section class="p-strip is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h2 class="p-heading--three">Clean install or upgrade?</h2>
+      <h2 class="p-heading--four">Clean install or upgrade?</h2>
       <p>Users setting up a virtual machine are much more likely to perform a clean install rather than upgrading Ubuntu.</p>
     </div>
-    <div class="col-6 u-vertically-center u-hide--small">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    <div class="col-6 u-align--center">
+      <div id="install-or-upgrade">
+        <img src="https://via.placeholder.com/400x250?text=Bar chart" alt="">
+      </div>
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-6 u-vertically-center u-align--center u-hide--small">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+<section class="p-strip--light is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center">
+      <div id="where-are-users">
+        <img src="https://via.placeholder.com/500x320?text=Map" alt="">
+      </div>
     </div>
     <div class="col-6">
-      <h2 class="p-heading--three">Where are Ubuntu users?</h2>
+      <h2 class="p-heading--four">Where are Ubuntu users?</h2>
       <p>Location is derived from a users setting the timezone and location in the installer and not from an identifiable IP address.</p>
     </div>
   </div>
 </section>
-<section class="p-strip--light is-bordered">
-  <div class="row">
+<section class="p-strip is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h2 class="p-heading--three">What language do they use?</h2>
-      <ol>
+      <h2 class="p-heading--four">What language do they use?</h2>
+      <ol id="language-list">
         <li>American English</li>
         <li>English</li>
         <li>German</li>
@@ -91,76 +100,95 @@
         <li>Australian English</li>
       </ol>
     </div>
-    <div class="col-6 u-vertically-center u-align--center u-hide--small">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    <div class="col-6 u-align--center">
+      <div id="language-map">
+        <img src="https://via.placeholder.com/500x320?text=Tree map" alt="">
+      </div>
     </div>
   </div>
 </section>
-<section id="desktop-specs" class="p-strip">
+
+<section id="desktop-specs" class="p-strip--image u-no-background--small is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
   <div class="row">
     <h2>Desktop specs</h2>
     <p>Data was collected from users’ machines. This is viewable for either real or virtual hardware.</p>
   </div>
 </section>
-<section class="p-strip is-bordered u-no-padding--top">
+<section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height">
-    <div class="p-card--highlighted col-4">
+    <div class="col-4 p-card--flex">
       <header class="p-card__header">
-        <h4>OS architecture</h4>
+        <h3 class="p-heading--four">OS architecture</h3>
       </header>
-      <div class="p-card__content">
-        <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
-        <p class="u-no-margin--bottom">OS architecture is responsible for running programs and providing secure access to the machine's hardware.</p>
+      <div class="p-card__center-content">
+        <h3 id="os-architecture" class="u-no-margin--bottom">99%</h3>
+        <h4>amd64</h4>
       </div>
+      <p class="u-no-margin--bottom">OS architecture is responsible for running programs and providing secure access to the machine's hardware.</p>
     </div>
-    <div class="p-card--highlighted col-4">
+    <div class="col-4 p-card--flex">
       <header class="p-card__header">
-        <h4>Firmware</h4>
+        <h3 class="p-heading--four">Firmware</h3>
       </header>
-      <div class="p-card__content">
-        <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
-        <p class="u-no-margin--bottom">Firmware initialises hardware components and the operating system at start up.</p>
+      <div class="p-card__center-content">
+        <div id="firmware">
+          <img src="https://via.placeholder.com/200x200?text=Pie chart" alt="">
+        </div>
       </div>
+      <p class="u-no-margin--bottom">Firmware initialises hardware components and the operating system at start up.</p>
     </div>
-    <div class="p-card--highlighted col-4">
+    <div class="col-4 p-card--flex">
       <header class="p-card__header">
-        <h4>Display server</h4>
+        <h3 class="p-heading--four">Display server</h3>
       </header>
-      <div class="p-card__content">
-        <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
-        <p class="u-no-margin--bottom">The display server controls the input and output of its clients to and from the rest of the operating system and the hardware.</p>
+      <div class="p-card__center-content">
+        <h3 id="display-server" class="u-no-margin--bottom">99%</h3>
+        <h4>X11</h4>
       </div>
+      <p class="u-no-margin--bottom">The display server controls the input and output of its clients to and from the rest of the operating system and the hardware.</p>
     </div>
   </div>
 </section>
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light is-shallow is-bordered">
   <div class="row">
-    <h2>What graphics setup do users have?</h2>
+    <h3>What graphics setup do users have?</h2>
   </div>
   <div class="row u-equal-height">
-    <div class="col-6">
-      <h2 class="u-align-text--center u-no-margin--bottom">99%</h2>
-      <h4 class="u-align-text--center">Have one screen</h4>
-      <p>This was detected on install so many users may have connected screens after the installing Ubuntu.</p>
+    <div class="col-6 prefix-2">
+      <div class="p-card--flex">
+        <div class="p-card__center-content">
+          <h3 id="one-screen" class="u-no-margin--bottom">99%</h3>
+          <h4>Have one screen</h4>
+        </div>
+        <p class="u-no-margin--bottom">This was detected on install so many users may have connected screens after the installing Ubuntu.</p>
+      </div>
     </div>
-    <div class="col-6">
-      <h2 class="u-align-text--center u-no-margin--bottom">87%</h2>
-      <h4 class="u-align-text--center">Have one GPU</h4>
-      <p>Graphical Processing Unit (GPU) is used to generate videos and images for displaying on screen.</p>
+    <div class="col-6 suffix-2">
+      <div class="p-card--flex">
+        <div class="p-card__center-content">
+          <h3 id="one-gpu" class="u-no-margin--bottom">87%</h3>
+          <h4>Have one GPU</h4>
+        </div>
+        <p class="u-no-margin--bottom">Graphical Processing Unit (GPU) is used to generate videos and images for displaying on screen.</p>
+      </div>
     </div>
   </div>
 </section>
 <section class="p-strip">
   <div class="row">
-    <h2 class="p-heading--three">Popular screen sizes</h2>
+    <h3>Popular screen sizes</h2>
     <p>This data set show the 15 most popular screen sizes.</p>
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <div id="popular-screen-sizes">
+        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
+      </div>
     </div>
     <div class="col-6">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <div id="screen-size-comparison">
+        <img src="https://via.placeholder.com/500x320?text=Graphic" alt="">
+      </div>
     </div>
   </div>
 </section>
@@ -168,24 +196,30 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h4>Pixel density</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <div id="pixel-density">
+        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
+      </div>
     </div>
     <div class="col-6">
       <h4>Relative pixel size</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <div id="relative-pixel-size">
+        <img src="https://via.placeholder.com/500x320?text=Graphic" alt="">
+      </div>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-bordered">
   <div class="row">
-    <h2>What CPU and memory do users have?</h2>
+    <h3>What CPU and memory do users have?</h3>
   </div>
   <div class="row">
-    <h3>Number of CPUs</h3>
+    <h4>Number of CPUs</h4>
   </div>
-  <div class="row">
-    <div class="col-6">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center">
+      <div id="number-of-cpus">
+        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
+      </div>
     </div>
     <div class="col-6">
       <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output functions required by the user and software. A computer may have multiple to be able to perform more complex tasks in parallel.</p>
@@ -194,27 +228,31 @@
 </section>
 <section class="p-strip is-bordered">
   <div class="row">
-    <h3>Size of RAM (GB)</h3>
+    <h4>Size of RAM (GB)</h4>
   </div>
-  <div class="row">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
       <p>The more memory, the more power the computer has to carry out functions. Some users reported having RAM upwards of 96GB!</p>
     </div>
-    <div class="col-6">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    <div class="col-6 u-align--center">
+      <div id="size-of-ram">
+        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
+      </div>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-bordered">
   <div class="row">
-    <h2>What physical disks do people have?</h2>
+    <h3>What physical disks do people have?</h3>
   </div>
   <div class="row">
-    <h3>Physical disk</h3>
+    <h4>Physical disk</h4>
   </div>
-  <div class="row">
-    <div class="col-6">
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center">
+      <div id="physical-disk">
+        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
+      </div>
     </div>
     <div class="col-6">
       <p>Physical disks denote how much data can be stored on a computer. For this report the total disk size is inferred from the number and size of partitions of a disk.</p>
@@ -228,7 +266,9 @@
   <div class="row">
     <p>There are a number of ways to partition a disk when installing Ubuntu depending on what the user wants to do.</p>
     <div class="u-align--center">
-      <img src="https://via.placeholder.com/1040x320?text=Chart" alt="">
+      <div id="partition-type">
+        <img src="https://via.placeholder.com/1040x320?text=Bar chart" alt="">
+      </div>
     </div>
   </div>
 </section>
@@ -236,61 +276,96 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h4>Size of partitions</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <div id="size-of-partition">
+        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
+      </div>
     </div>
     <div class="col-6">
       <h4>Number of partitions</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <div id="number-of-partitions">
+        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
+      </div>
     </div>
   </div>
 </section>
-<section id="configuration" class="p-strip--light">
+
+<section id="configuration" class="p-strip--image u-no-background--small is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
   <div class="row">
     <h2>Configuring Ubuntu</h2>
     <p>Users configure Ubuntu in many different ways, we recorded some key points and this will help inform the design of future releases.</p>
   </div>
 </section>
-<section class="p-strip--light is-shallow u-no-padding--top">
-  <div class="row u-equal-height">
+<section class="p-strip is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h4>Users who installed Ubuntu using all the default settings</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <h3 class="p-heading--four">Users who installed Ubuntu using all the default settings.</h3>
     </div>
-    <div class="col-6">
-      <h4>Users who restricted at least one add-on when installing</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
-    </div>
-  </div>
-</section>
-<section class="p-strip--light is-shallow">
-  <div class="row u-equal-height">
-    <div class="col-6">
-      <h4>Users who use auto-login, which lets users automatically log in when they start up their computer.</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
-    </div>
-    <div class="col-6">
-      <h4>Users who used Minimal Install; a stripped down Ubuntu that contains a web browser and other basic applications.</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+    <div class="col-6 u-align--center">
+      <div id="default-settings">
+        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
+      </div>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-shallow is-bordered">
-  <div class="row u-equal-height">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center">
+      <div id="restrict-add-on">
+        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
+      </div>
+    </div>
     <div class="col-6">
-      <h4>Users who chose to download and update the software Ubuntu would be using at install time.</h4>
-      <img src="https://via.placeholder.com/500x320?text=Chart" alt="">
+      <h3 class="p-heading--four">Users who restricted at least one add-on when installing.</h3>
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered">
+<section class="p-strip is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
+      <h3 class="p-heading--four">Users who use auto-login, which lets users automatically log in when they start up their computer.</h3>
+    </div>
+    <div class="col-6 u-align--center">
+      <div id="auto-login">
+        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center">
+      <div id="minimal-install">
+        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
+      </div>
+    </div>
+    <div class="col-6">
+      <h3 class="p-heading--four">Users who used Minimal Install; a stripped down Ubuntu that contains a web browser and other basic applications.</h3>
+    </div>
+  </div>
+</section>
+<section class="p-strip is-shallow is-bordered">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
+      <h3 class="p-heading--four">Users who choose to download and update the software Ubuntu would be using at install time.</h3>
+    </div>
+    <div class="col-6 u-align--center">
+      <div id="update-install-time">
+        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
   <div class="row">
     <h3>How long to get Ubuntu running?</h3>
   </div>
   <div class="row">
-    <img src="https://via.placeholder.com/1040x320?text=Chart" alt="">
+    <div id="how-long-to-get-running">
+      <img src="https://via.placeholder.com/1040x400?text=Area chart" alt="">
+    </div>
   </div>
 </section>
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3>The Ubuntu Report tool</h3>

--- a/templates/desktop/user-report.html
+++ b/templates/desktop/user-report.html
@@ -331,7 +331,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip is-shallow is-bordered">
+<section class="p-strip--light is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 u-align--center">
       <div id="minimal-install">
@@ -365,7 +365,19 @@
     </div>
   </div>
 </section>
-<section class="p-strip">
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h3>Want to know more?</h3>
+      <p>Read what Will Cooke, Head of the desktop team for Ubuntu 18.04 LTS release had to say about the methodology behind these metrics.</p>
+      <a class="p-link--external" href="https://blog.ubuntu.com/2018/06/22/a-first-look-at-desktop-metrics">Read on</a>
+    </div>
+    <div class="col-5 prefix-1">
+      <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}f3f53a95-ubuntu-18.04-survey-metrics.png" alt="User survey report">
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3>The Ubuntu Report tool</h3>


### PR DESCRIPTION
## Done

- Created the scaffolding for the new user report page ([copydoc](https://docs.google.com/document/d/153OkfZHM_eTfAoUZF3f38VMtiFzaa2txB9B2lvs8xXA/edit))
- Added the feature branch `user-report-page` based off beta

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/user-report
- Check that the page copy matches the [copydoc](https://docs.google.com/document/d/153OkfZHM_eTfAoUZF3f38VMtiFzaa2txB9B2lvs8xXA/edit) (though this is likely to change a lot, so it doesn't need to be 100% accurate for now)
- Check that it roughly matches the original [design](https://user-images.githubusercontent.com/23459065/43789362-af2f0aa8-9a67-11e8-9f19-3b6417980095.png)
- Check that the sticky nav changes active state on scroll

## Issue / Card

Fixes ubuntudesign/web-squad#763