### PR TITLE
3873: Add small padding to th and highlight cells

### DIFF
--- a/static/sass/_pattern_table.scss
+++ b/static/sass/_pattern_table.scss
@@ -1,7 +1,12 @@
 @mixin ubuntu-p-tables {
-  .p-table {
-    &__cell--highlight {
+  tr {
+    th {
+      padding-top: $spv-intra;
+    }
+
+    .p-table__cell--highlight {
       background: $color-x-light;
+      padding: $spv-intra $sph-intra--condensed;
     }
   }
 }


### PR DESCRIPTION
## Done

- Added padding to `<th>` and `.p-table__cell--highlight`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support/plans-and-pricing
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the table styling looks good on desktop and mobile
- There are other tables at:
  - /about/release-cycle
  - /legal/dataprivacy

## Issue / Card

Fixes #3873 