### PR TITLE
Alternative Ubuntu Server installer download link with point

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -74,7 +74,7 @@
     <div class="col-4 p-divider__block">
       <h2 id="alternate-ubuntu-server-installer">Alternative Ubuntu Server installer</h2>
       <p>If you require advanced networking and storage features such as; LVM, RAID, multipath, vlans, bonds, or re-using existing partitions, you will want to continue to use the alternate installer.</p>
-      <p><a href="http://cdimage.ubuntu.com/releases/{{ lts_release }}/release/" class="p-link--external">Download the alternate installer</a></p>
+      <p><a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" class="p-link--external">Download the alternate installer</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h2 id="other-images-and-mirrors">Other images and mirrors</h2>


### PR DESCRIPTION
## Done
Point alt server downloads to the point release.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/alternative-downloads#alternate-ubuntu-server-installer](http://0.0.0.0:8001/download/alternative-downloads#alternate-ubuntu-server-installer)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Click the Download the alternate installer link and see it goes to the point release page.

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3897

## Screenshots

[if relevant, include a screenshot]
