### PR TITLE
Remove margin from search reset button

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -29,7 +29,7 @@
         <div class="p-navigation__search" role="menuitem">
           <form action="/search" class="p-search-box" id="google-appliance-search-form">
             <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="">
-            <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
+            <button type="reset" class="p-search-box__reset u-no-margin--right" alt="reset"><i class="p-icon--close"></i></button>
             <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
           </form>
         </div>


### PR DESCRIPTION
## Done

- Removed unnecessary margin-right from search reset button (Vanilla issue [here](https://github.com/vanilla-framework/vanilla-framework/issues/1960))

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Enter something into the nav search box
- Check that the reset button has no margin