### PR TITLE
3902: Fix global nav overlay resize bug

### DIFF
--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -253,18 +253,19 @@ $nav-bg-color: lighten($global-nav-bg-color, $contrast-ratio);
     }
   }
 
-  @media (min-width: $breakpoint-navigation-threshold) {
-    .global-nav__dropdown-overlay {
+  .global-nav__dropdown-overlay {
+    opacity: 0;
+
+    @media (min-width: $breakpoint-navigation-threshold) {
       width: 100%;
       height: 100%;
       top: 0;
       left: 0;
       background-color: rgba(17,17,17, .4);
       position: fixed;
-      z-index: 5;
-      opacity: 0;
       pointer-events: none;
       transition: opacity .5s ease-in-out;
+      z-index: 5;
 
       &.is-visible {
         opacity: 1;


### PR DESCRIPTION
## Done

- Fixed a bug where resizing the viewport between mobile and desktop would make the overlay fade in and out

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Resize the window to mobile size and desktop size and check that the overlay doesn't fade in and out

## Issue / Card

Fixes #3902 