### PR TITLE
3889: Add opacity animation to primary nav overlay

### DIFF
--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -261,7 +261,7 @@ $nav-bg-color: lighten($global-nav-bg-color, $contrast-ratio);
       left: 0;
       background-color: rgba(17,17,17, .4);
       position: fixed;
-      z-index: 1;
+      z-index: 5;
       opacity: 0;
       pointer-events: none;
       transition: opacity .5s ease-in-out;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -371,8 +371,10 @@
     height: 100%;
     top: 0;
     background-color: rgba(17,17,17, .4);
+    opacity: 1;
     position: fixed;
     z-index: 1;
+    transition: opacity .5s ease-in-out;
   }
 
   .dropdown-window {
@@ -426,12 +428,11 @@
   }
 
   .fade-animation {
-    visibility: hidden;
+    opacity: 0;
 
     .u-visible-nav & {
       opacity: 1;
       transform: none;
-      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
## Done

- Added fade-in/out opacity animation to the primary nav (the same as the global-nav)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Open a dropdown from the primary nav
- Check that the overlay fades in gradually rather than instantly
- Check that it's the same as the global nav


## Issue / Card

Fixes #3889 