### PR TITLE
3906: Hotfix for abbr styling

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -234,3 +234,11 @@ p.u-align--center {
     }
   }
 }
+
+/// XXX Caleb: abbr hotfix - to be fixed in Vanilla
+// https://github.com/vanilla-framework/vanilla-framework/issues/1962
+abbr[title] {
+  border-bottom: .1em dotted;
+  cursor: help;
+  text-decoration: none;
+}

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -12,10 +12,10 @@
   </div>
   <div class="row">
     <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu {{lts_release_full_with_point}}</h2>
+      <h2>Ubuntu {{lts_release_with_point}} LTS</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
-          <p class="p-card__content">Download the latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{lts_release_eol}}, of free security and maintenance updates, guaranteed.</p>
+          <p class="p-card__content">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{lts_release_eol}}, of free security and maintenance updates, guaranteed.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{lts_release_full}} release notes</a></p>
           <p>Recommended system requirements:</p>
           <ul class="p-list">

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -13,7 +13,7 @@
   </div>
   <div class="row">
     <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
+      <h2>Ubuntu Server {{lts_release_with_point}} LTS</h2>
       <div class="u-equal-height p-divider">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>


### PR DESCRIPTION
## Done

- Updated `abbr` styling to Vanilla 1.8 style with `cursor: help`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the dots underneath "LTS" in "Ubuntu 18.04.1 LTS" are better looking than the ones on http://www.staging.ubuntu.com/download/desktop, and the cursor changes to a help icon on hover

## Issue / Card

Fixes #3906 