### PR TITLE
Added a landing page for the AI/ML webinar

### DIFF
--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -4,6 +4,8 @@
 
 {% block title %}AI, ML and Ubuntu: Everything you need to know{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit{% endblock meta_copydoc %}
+
 {% block content %}
 <section class="p-strip p-takeover--ai-webinar">
   <div class="row u-equal-height">
@@ -35,7 +37,7 @@
       </ul>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/1793c307-slide-preview.png" alt="AI, ML and Ubuntu webinar - slides preview">
+      <img src="{{ ASSET_SERVER_URL }}1793c307-slide-preview.png" alt="AI, ML and Ubuntu webinar - slides preview">
     </div>
   </div>
 </section>

--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -10,7 +10,7 @@
     <div class="col-9">
       <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
       <p class="p-takeover__text">Webinar live on Aug 22 -
-        <a href="#register-section">Register now</a>
+        <a href="#register-section">Register now&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>

--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -1,0 +1,52 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}Ready to make the migration from proprietary virtualisation to OpenStack?{% endblock %}
+
+{% block title %}AI, ML and Ubuntu: Everything you need to know{% endblock %}
+
+{% block content %}
+<section class="p-strip p-takeover--ai-webinar">
+  <div class="row u-equal-height">
+    <div class="col-9">
+      <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
+      <p class="p-takeover__text">Webinar live on Aug 22 -
+        <a href="#register-section">Register now</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h2>What you’ll learn</h2>
+      <ul>
+        <li>The key concepts in Machine Learning</li>
+        <li>How AI applications and their development are reshaping company’s IT</li>
+        <li>How enterprises are applying devops practices to their ML infrastructure and workflows</li>
+        <li>How Canonical’s AI / ML portfolio from Ubuntu to the Canonical Distribution of Kubernetes and and how to get started
+          quickly with your project</li>
+      </ul>
+      <h3>Other questions answered</h3>
+      <ul>
+        <li>What do Kubeflow, Tensorflow, Jupyter, and GPGPUs do?</li>
+        <li>What’s the difference between AI, ML and DL?</li>
+        <li>What is an AI model? How do you train it? How do you develop / improve it? How do you execute it?</li>
+      </ul>
+    </div>
+    <div class="col-6">
+      <img src="https://assets.ubuntu.com/v1/1793c307-slide-preview.png">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 id="register-section">Register for the webinar</h2>
+    </div>
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 330440, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -35,7 +35,7 @@
       </ul>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/1793c307-slide-preview.png">
+      <img src="https://assets.ubuntu.com/v1/1793c307-slide-preview.png" alt="AI, ML and Ubuntu webinar - slides preview">
     </div>
   </div>
 </section>

--- a/templates/takeovers/_ai_webinar.html
+++ b/templates/takeovers/_ai_webinar.html
@@ -4,7 +4,7 @@
       <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
       <p class="p-takeover__text">Find out how you can use Ubuntu to power your AI and ML ambitions from developer workstations to the cloud.</p>
       <div class="u-hide--small">
-        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
       </div>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
@@ -17,7 +17,7 @@
         <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
       </div>
       <div class="u-hide--medium u-hide--large">
-        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning, and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
       </div>
     </div>
   </div>

--- a/templates/takeovers/_ai_webinar.html
+++ b/templates/takeovers/_ai_webinar.html
@@ -4,7 +4,7 @@
       <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
       <p class="p-takeover__text">Find out how you can use Ubuntu to power your AI and ML ambitions from developer workstations to the cloud.</p>
       <div class="u-hide--small">
-        <a href="https://www.brighttalk.com/webcast/6793/330440?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
       </div>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
@@ -17,7 +17,7 @@
         <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
       </div>
       <div class="u-hide--medium u-hide--large">
-        <a href="https://www.brighttalk.com/webcast/6793/330440?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning, and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Artificial intelligence, machine learning, and Ubuntu', 'eventLabel' : 'Register for webinar', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

* Created a landing page for the AI/ML webinar on Aug 22
* [Copydoc](https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit#) 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001//engage/ai-ml-ubuntu](http://0.0.0.0:8001//engage/ai-ml-ubuntu)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure the page looks nice and registration works

## Notes

* Design review appreciated