### PR TITLE
Update, move webinar embed

### DIFF
--- a/templates/engage/de/vmware-to-openstack.html
+++ b/templates/engage/de/vmware-to-openstack.html
@@ -7,7 +7,7 @@
 {% block content %}
 <section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'); background-position: 77% 0%;">
   <div class="row">
-    <div class="col-8">
+    <div class="col-6">
       <div class="p-card--overlay">
         <h1>Von VMware zu Canonical OpenStack</h1>
         <p>Sind Sie bereit für die Migration von proprietärer Virtualisierung auf OpenStack?</p>
@@ -16,7 +16,7 @@
 </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row">
       <h2>Ihre flexible Cloud</h2>
   </div>
@@ -35,6 +35,15 @@
     </div>
   </div>
 </section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Sehen Sie sich unser Demonstrationsvideo zu Kosten und Migration an!</h2>
+    </div>
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 17086, "language": "de-de", "commId" : 331348, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div></section>
+
 
 <section class="p-strip--light is-deep is-bordered">
   <div class="row">
@@ -61,15 +70,6 @@
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1ccb6d93-logo-deutschetelekom.svg" alt="Deutsche Telekom" />
       </li>
     </ul>    
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Sehen Sie sich unser Demonstrationsvideo zu Kosten und Migration an!</h2>
-    </div>
-    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 299913, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
   </div>
 </section>
 

--- a/templates/engage/vmware-to-openstack.html
+++ b/templates/engage/vmware-to-openstack.html
@@ -7,7 +7,7 @@
 {% block content %}
 <section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'); background-position: 77% 0%;">
   <div class="row">
-    <div class="col-8">
+    <div class="col-7">
       <div class="p-card--overlay">
         <h1>From VMWare to Canonical OpenStack</h1>
         <p>Ready to make the migration from proprietary virtualisation to OpenStack?</p>
@@ -36,6 +36,15 @@
   </div>
 </section>
 
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Watch the cost analysis and migration demo</h2>
+    </div>
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 299913, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
 <section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <h2>Built by the cloud experts</h2>
@@ -61,15 +70,6 @@
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1ccb6d93-logo-deutschetelekom.svg" alt="Deutsche Telekom" />
       </li>
     </ul>    
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Watch the cost analysis and migration demo</h2>
-    </div>
-    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 299913, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

Moved the BrightTALK webinar embed from the bottom to the top and replaced it with the German version of the webinar for this page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
