### PR TITLE
Fix overlay preventing interaction with page

### DIFF
--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -265,11 +265,11 @@ $nav-bg-color: lighten($global-nav-bg-color, $contrast-ratio);
       position: fixed;
       pointer-events: none;
       transition: opacity .5s ease-in-out;
-      z-index: 5;
 
       &.is-visible {
         opacity: 1;
         pointer-events: all;
+        z-index: 5;
       }
     }
   }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -429,10 +429,12 @@
 
   .fade-animation {
     opacity: 0;
+    visibility: hidden;
 
     .u-visible-nav & {
       opacity: 1;
       transform: none;
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
## Done

- Re-added visibility styles to primary nav overlay that were removed in #3908 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that you can click the takeover button
- Open primary nav
- Check that clicking the overlay closes it
