### PR TITLE
Mongoose no more!

### DIFF
--- a/templates/ai/contact-us.html
+++ b/templates/ai/contact-us.html
@@ -5,19 +5,19 @@
 
 {% block content %}
   {% if product == 'ai-index-workshop' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our AI workshop" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://mongoose.ubuntu.com/ai/thank-you?product=ai-index-workshop' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our AI workshop" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-index-workshop' %}
   {% elif product == 'ai-index-assessment' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our ML / Data Science assessment" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://mongoose.ubuntu.com/ai/thank-you?product=ai-managed' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our ML / Data Science assessment" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' %}
   {% elif product == 'ai-index-managed' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our managed AI services" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://mongoose.ubuntu.com/ai/thank-you?product=ai-managed' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our managed AI services" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' %}
   {% elif product == 'ai-install' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about installing Kubeflow" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://mongoose.ubuntu.com/ai/thank-you?product=ai-managed' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about installing Kubeflow" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' %}
   {% elif product == 'ai-consulting' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical consulting" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://mongoose.ubuntu.com/ai/thank-you?product=ai-managed' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical consulting" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' %}
     {% elif product == 'ai-features' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about AI on Canonical" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://mongoose.ubuntu.com/ai/thank-you?product=ai-features' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about AI on Canonical" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-features' %}
   {% else %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Artificial Intelligence" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://mongoose.ubuntu.com/ai/thank-you?product=ai-managed' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Artificial Intelligence" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' %}
   {% endif %}
 {% endblock content %}
 

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -5,17 +5,17 @@
 
 {% block content %}
   {% if product == 'containers-docker' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Docker Engine on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://mongoose.ubuntu.com/containers/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Docker Engine on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% elif product == 'containers-kubernetes' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Canonical Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://mongoose.ubuntu.com/containers/thank-you?product=containers-kubernetes' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Canonical Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes' %}
   {% elif product == 'containers-kubernetes-foundation' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical's enterprise Kubernetes packages" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://mongoose.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical's enterprise Kubernetes packages" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation' %}
   {% elif product == 'containers-lxd' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about LXD" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://mongoose.ubuntu.com/containers/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about LXD" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% elif product == 'containers-overview' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about containers on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://mongoose.ubuntu.com/containers/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about containers on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% else %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about containers" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://mongoose.ubuntu.com/containers/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about containers" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% endif %}
 {% endblock content %}
 

--- a/templates/core/contact-us.html
+++ b/templates/core/contact-us.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-  {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything else, please fill in your details below and a member of our team will get in touch." formid="1266" lpId="2166"  returnURL="https://mongoose.ubuntu.com/core/thank-you" %}
+  {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything else, please fill in your details below and a member of our team will get in touch." formid="1266" lpId="2166"  returnURL="https://www.ubuntu.com/core/thank-you" %}
 
 {% endblock content %}
 

--- a/templates/desktop/contact-us.html
+++ b/templates/desktop/contact-us.html
@@ -6,11 +6,11 @@
 
 {% block content %}
   {% if product == 'desktop-education' %}
-    {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your school or university? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://mongoose.ubuntu.com/desktop/thank-you" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html" %}
+    {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your school or university? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html" %}
 
   {% else %}
 
-    {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your organisation? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://mongoose.ubuntu.com/desktop/thank-you" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html" %}
+    {% include "shared/_client-contact-us-form.html" with h1="Contact us"  intro_text="Considering Ubuntu for your organisation? Are you interested in cost-effective systems management and professional support?" formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" side1="shared/forms/_desktop_help.html" side2="shared/forms/_desktop_ua-shop.html" %}
 
   {% endif %}
 {% endblock content %}

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -93,8 +93,8 @@
               </li>
             </ul>
           </fieldset>
-          <input type="hidden" name="returnURL" value="https://mongoose.ubuntu.com/download/server/thank-you-s390x" />
-          <input type="hidden" name="retURL" value="https://mongoose.ubuntu.com/download/server/thank-you-s390x" />
+          <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
+          <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
         </form>
         <script>
           $("#mktoForm_1400").validate({

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -90,8 +90,8 @@
             </li>
           </ul>
         </fieldset>
-        <input type="hidden" name="returnURL" value="https://mongoose.ubuntu.com/download/server/linuxone-signup-thank-you" />
-        <input type="hidden" name="retURL" value="https://mongoose.ubuntu.com/download/server/linuxone-signup-thank-you" />
+        <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+        <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
       </form>
       <script>
         $("#mktoForm_1400").validate({

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -34,7 +34,7 @@
   </div>
 </div>
 
-{% include "download/shared/_get_ebook.html"  with return_url="https://mongoose.ubuntu.com/server/thank-you" %}
+{% include "download/shared/_get_ebook.html"  with return_url="https://www.ubuntu.com/server/thank-you" %}
 
 <div class="p-strip is-shallow">
   <div class="row">

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -84,8 +84,8 @@
           </ul>
         </fieldset>
 
-        <input type="hidden" name="returnURL" value="https://mongoose.ubuntu.com/download/server/provisioning#instructions">
-        <input type="hidden" name="retURL" value="https://mongoose.ubuntu.com/download/server/provisioning#instructions">
+        <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/provisioning#instructions">
+        <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/provisioning#instructions">
       </form>
       <!-- /MARKETO FORM -->
     </div>

--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -6,25 +6,25 @@
 {% block content %}
 
   {% if product == 'kubernetes' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you' %}
   {% elif product == 'kubernetes-managed' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Managed Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Managed Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed' %}
   {% elif product == 'kubernetes-install' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=' %}
   {% elif product == 'kubernetes-features' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=kubernetes-features' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features' %}
   {% elif product == 'kubernetes-explorer' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes Explorer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=kubernetes-explorer' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes Explorer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-explorer' %}
   {% elif product == 'kubernetes-discoverer' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes discoverer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=kubernetes-discoverer' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes discoverer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-discoverer' %}
   {% elif product == 'kubernetes-pioneer' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes pioneer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=kubernetes-pioneer' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes pioneer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-pioneer' %}
   {% elif product == 'kubernetes-add-on' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes with AI/ML" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes with AI/ML" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on' %}
   {% elif product == 'kubernetes-support' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes support" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you?product=kubernetes-support' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes support" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-support' %}
   {% else %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://mongoose.ubuntu.com/kubernetes/thank-you' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you' %}
   {% endif %}
 
 {% endblock content %}

--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -6,35 +6,35 @@
 {% block content %}
   {% if product == 'openstack-training' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1263" lpId="2163" returnURL="https://mongoose.ubuntu.com/openstack/thank-you?product=openstack-training" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" %}
 
   {% elif product == 'openstack-training-classroom' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Register for Ubuntu OpenStack Training" intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we’ll get back to you with available dates and locations." formid="1261" lpId="2161" returnURL="https://mongoose.ubuntu.com/openstack/thank-you?product=openstack-training-classroom" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Register for Ubuntu OpenStack Training" intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we’ll get back to you with available dates and locations." formid="1261" lpId="2161" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-classroom" %}
 
   {% elif product == 'openstack-training-onsite' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1223" lpId="1973" returnURL="https://mongoose.ubuntu.com/openstack/thank-you?product=openstack-training-onsite" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1223" lpId="1973" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-onsite" %}
 
   {% elif product == 'openstack-training-server-admin' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://mongoose.ubuntu.com/openstack/thank-you?product=openstack-training-server-admin" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-server-admin" %}
 
   {% elif product == 'ubuntu-advantage-storage' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://mongoose.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Ubuntu Advantage Storage" intro_text="Let Canonical help you build your own software-defined storage network." formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" %}
 
   {% elif product == 'openstack-managed-cloud' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about an OpenStack managed cloud" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://mongoose.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about an OpenStack managed cloud" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
 
     {% elif product == 'openstack-managed-cloud-demo' %}
 
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://mongoose.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Schedule a demo" intro_text="Fill in your details below and a member of our BootStack team will be in touch." formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
 
   {% elif product == 'foundation-cloud' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Talk to us about building your cloud" intro_text="Fill in your details below and a member of our Foundation Cloud Build team will be in touch." formid='1251'  lpId='2086' returnURL='https://mongoose.ubuntu.com/openstack/thank-you?product=foundation-cloud' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Talk to us about building your cloud" intro_text="Fill in your details below and a member of our Foundation Cloud Build team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' %}
 
   {% elif product == 'openstack-german' %}
 
@@ -42,7 +42,7 @@
 
   {% else %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about OpenStack" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://mongoose.ubuntu.com/openstack/thank-you' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about OpenStack" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' %}
 
   {% endif %}
 {% endblock content %}

--- a/templates/server/contact-us.html
+++ b/templates/server/contact-us.html
@@ -7,27 +7,27 @@
 {% block content %}
   {% if product == 'server-overview' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://mongoose.ubuntu.com/server/thank-you"  %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
 
   {% elif product == 'server-hyperscale' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server for hyperscale"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://mongoose.ubuntu.com/server/thank-you"  %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server for hyperscale"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
 
   {% elif product == 'server-management' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Advantage support"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://mongoose.ubuntu.com/server/thank-you"  %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Advantage support"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
 
   {% elif product == 'server-maas' or product == 'contextual-footer-server-maas' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about MAAS and server provisioning"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://mongoose.ubuntu.com/server/thank-you?product=server-maas"  %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about MAAS and server provisioning"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you?product=server-maas"  %}
 
   {% elif product == 'contextual-footer-maas' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about MAAS and server provisioning"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://mongoose.ubuntu.com/server/thank-you"  %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about MAAS and server provisioning"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
 
   {% else %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://mongoose.ubuntu.com/server/thank-you"  %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Ubuntu Server"   intro_text="Fill in your details below and a member of our sales team will be in touch."  formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you"  %}
 
 {% endif %}
 

--- a/templates/support/contact-us.html
+++ b/templates/support/contact-us.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-  {% include "shared/_cloud-contact-us-form.html" with  h1="Contact Canonical about Ubuntu Advantage"   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch."  formid="1240"   lpId="2065"  returnURL="https://mongoose.ubuntu.com/support/thank-you"  %}
+  {% include "shared/_cloud-contact-us-form.html" with  h1="Contact Canonical about Ubuntu Advantage"   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch."  formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you"  %}
 
 {% endblock content %}
 

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -130,7 +130,7 @@
       <div class="row">
         <div class="col-3">
           <h4 class="p-muted-heading">
-            <a href="">AI &amp; Machine Learning&nbsp;&rsaquo;</a>
+            <a href="/ai">AI &amp; Machine Learning&nbsp;&rsaquo;</a>
           </h4>
           <div>
             <p class="p-p--small">Ubuntu delivers hardware acceleration on Nvidia for all clouds and bare metal.</p>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -125,20 +125,20 @@
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Products</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://maas.io/">MAAS</a></li>
             <li class="p-list__item"><a class="p-link" href="https://landscape.canonical.com/">Landscape</a></li>
             <li class="p-list__item"><a class="p-link" href="https://jujucharms.com/">Juju</a></li>
             <li class="p-list__item"><a class="p-link" href="https://linuxcontainers.org/">LXD</a></li>
             <li class="p-list__item"><a class="p-link" href="https://snapcraft.io/">Snaps</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes</a></li>
+            <li class="p-list__item"><a class="p-link" href="/openstack">OpenStack</a></li>
+            <li class="p-list__item"><a class="p-link" href="/kubernetes">Kubernetes</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Other websites</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/support">Enterprise Support</a></li>
+            <li class="p-list__item"><a class="p-link" href="/support">Enterprise Support</a></li>
             <li class="p-list__item"><a class="p-link" href="https://wiki.ubuntu.com/Mir">Mir</a></li>
             <li class="p-list__item"><a class="p-link" href="https://cloud-images.ubuntu.com/">Image Service</a></li>
             <li class="p-list__item"><a class="p-link" href="https://conjure-up.io/">Conjure-up</a></li>
@@ -151,26 +151,26 @@
           <ul class="p-list is-split second-level-nav">
             <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
             <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/resources?content=videos" title="Visit the Videos">Videos</a></li>
+            <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
             <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/cloud/training">Training</a></li>
+            <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
             <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
+            <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
+            <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">About</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
             <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
             <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
+            <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>
           </ul>
         </div>
       </div>
@@ -180,11 +180,11 @@
         <div class="row u-hide--small">
           <ul class="p-matrix u-no-margin--bottom">
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com/">
+              <a href="/">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="/">Ubuntu&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s most popular Linux for servers, desktops and things, with enterprise support and enhanced security by Canonical</p>
               </div>
             </li>
@@ -234,20 +234,20 @@
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com/openstack">
+              <a href="/openstack">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}a7916513-picto-openstack.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s first choice for OpenStack - the leader in density and cost per VM</p>
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com/kubernetes">
+              <a href="/kubernetes">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}b81a45e4-kubernetes.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">Canonical works with Google GKE and Azure AKS for app portability between private and public infra</p>
               </div>
             </li>
@@ -263,7 +263,7 @@
             <h5 class="p-muted-heading">Other websites</h5>
             <div class="row">
               <div class="col-3">
-                <h5><a class="p-link" href="https://www.ubuntu.com/support">Enterprise Support&nbsp;&rsaquo;</a></h5>
+                <h5><a class="p-link" href="/support">Enterprise Support&nbsp;&rsaquo;</a></h5>
                 <p>Canonical supports Ubuntu for clouds, data centers and devices</p>
                 <h5><a class="p-link" href="https://mir-server.io/">Mir&nbsp;&rsaquo;</a></h5>
                 <p>Ultra-fast and light Wayland compositor for secure device display management</p>
@@ -287,24 +287,24 @@
             <ul class="p-list is-split">
               <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
               <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/resources?content=videos" title="Visit the Videos">Videos</a></li>
+              <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
               <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/cloud/training">Training</a></li>
+              <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
               <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
+              <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
+              <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
             </ul>
             <h5 class="p-muted-heading">About</h5>
             <ul class="p-list is-split u-no-margin--bottom">
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
+              <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
               <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
               <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
               <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
+              <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -125,20 +125,20 @@
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Products</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://maas.io/">MAAS</a></li>
             <li class="p-list__item"><a class="p-link" href="https://landscape.canonical.com/">Landscape</a></li>
             <li class="p-list__item"><a class="p-link" href="https://jujucharms.com/">Juju</a></li>
             <li class="p-list__item"><a class="p-link" href="https://linuxcontainers.org/">LXD</a></li>
             <li class="p-list__item"><a class="p-link" href="https://snapcraft.io/">Snaps</a></li>
-            <li class="p-list__item"><a class="p-link" href="/openstack">OpenStack</a></li>
-            <li class="p-list__item"><a class="p-link" href="/kubernetes">Kubernetes</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Other websites</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="/support">Enterprise Support</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/support">Enterprise Support</a></li>
             <li class="p-list__item"><a class="p-link" href="https://wiki.ubuntu.com/Mir">Mir</a></li>
             <li class="p-list__item"><a class="p-link" href="https://cloud-images.ubuntu.com/">Image Service</a></li>
             <li class="p-list__item"><a class="p-link" href="https://conjure-up.io/">Conjure-up</a></li>
@@ -151,26 +151,26 @@
           <ul class="p-list is-split second-level-nav">
             <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
             <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
-            <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/resources?content=videos" title="Visit the Videos">Videos</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
             <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
-            <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/cloud/training">Training</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
             <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-            <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
-            <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">About</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
             <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
             <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-            <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
           </ul>
         </div>
       </div>
@@ -180,11 +180,11 @@
         <div class="row u-hide--small">
           <ul class="p-matrix u-no-margin--bottom">
             <li class="p-matrix__item">
-              <a href="/">
+              <a href="https://www.ubuntu.com/">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="/">Ubuntu&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s most popular Linux for servers, desktops and things, with enterprise support and enhanced security by Canonical</p>
               </div>
             </li>
@@ -234,20 +234,20 @@
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="/openstack">
+              <a href="https://www.ubuntu.com/openstack">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}a7916513-picto-openstack.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s first choice for OpenStack - the leader in density and cost per VM</p>
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="/kubernetes">
+              <a href="https://www.ubuntu.com/kubernetes">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}b81a45e4-kubernetes.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">Canonical works with Google GKE and Azure AKS for app portability between private and public infra</p>
               </div>
             </li>
@@ -263,7 +263,7 @@
             <h5 class="p-muted-heading">Other websites</h5>
             <div class="row">
               <div class="col-3">
-                <h5><a class="p-link" href="/support">Enterprise Support&nbsp;&rsaquo;</a></h5>
+                <h5><a class="p-link" href="https://www.ubuntu.com/support">Enterprise Support&nbsp;&rsaquo;</a></h5>
                 <p>Canonical supports Ubuntu for clouds, data centers and devices</p>
                 <h5><a class="p-link" href="https://mir-server.io/">Mir&nbsp;&rsaquo;</a></h5>
                 <p>Ultra-fast and light Wayland compositor for secure device display management</p>
@@ -287,24 +287,24 @@
             <ul class="p-list is-split">
               <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
               <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
-              <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/resources?content=videos" title="Visit the Videos">Videos</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
               <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
-              <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/cloud/training">Training</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
               <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-              <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
-              <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
             </ul>
             <h5 class="p-muted-heading">About</h5>
             <ul class="p-list is-split u-no-margin--bottom">
-              <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
               <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
               <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
               <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-              <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -125,14 +125,14 @@
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Products</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://maas.io/">MAAS</a></li>
             <li class="p-list__item"><a class="p-link" href="https://landscape.canonical.com/">Landscape</a></li>
             <li class="p-list__item"><a class="p-link" href="https://jujucharms.com/">Juju</a></li>
             <li class="p-list__item"><a class="p-link" href="https://linuxcontainers.org/">LXD</a></li>
             <li class="p-list__item"><a class="p-link" href="https://snapcraft.io/">Snaps</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/openstack">OpenStack</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/kubernetes">Kubernetes</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes</a></li>
           </ul>
         </div>
         <div class="row">
@@ -158,19 +158,19 @@
             <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
             <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download/cloud">Install</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download">Download</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">About</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
             <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
             <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/about/contact-us">Contact</a></li>
+            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
           </ul>
         </div>
       </div>
@@ -180,11 +180,11 @@
         <div class="row u-hide--small">
           <ul class="p-matrix u-no-margin--bottom">
             <li class="p-matrix__item">
-              <a href="https://mongoose.ubuntu.com">
+              <a href="https://www.ubuntu.com">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://mongoose.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s most popular Linux for servers, desktops and things, with enterprise support and enhanced security by Canonical</p>
               </div>
             </li>
@@ -234,20 +234,20 @@
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://mongoose.ubuntu.com/openstack">
+              <a href="https://www.ubuntu.com/openstack">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}a7916513-picto-openstack.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://mongoose.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s first choice for OpenStack - the leader in density and cost per VM</p>
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://mongoose.ubuntu.com/kubernetes">
+              <a href="https://www.ubuntu.com/kubernetes">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}b81a45e4-kubernetes.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://mongoose.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">Canonical works with Google GKE and Azure AKS for app portability between private and public infra</p>
               </div>
             </li>
@@ -294,17 +294,17 @@
               <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
               <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download/cloud">Install</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/download">Download</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
             </ul>
             <h5 class="p-muted-heading">About</h5>
             <ul class="p-list is-split u-no-margin--bottom">
-              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com">Ubuntu</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com">Ubuntu</a></li>
               <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
               <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
               <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://mongoose.ubuntu.com/about/contact-us">Contact</a></li>
+              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
             </ul>
           </div>
         </div>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -125,20 +125,20 @@
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Products</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://maas.io/">MAAS</a></li>
             <li class="p-list__item"><a class="p-link" href="https://landscape.canonical.com/">Landscape</a></li>
             <li class="p-list__item"><a class="p-link" href="https://jujucharms.com/">Juju</a></li>
             <li class="p-list__item"><a class="p-link" href="https://linuxcontainers.org/">LXD</a></li>
             <li class="p-list__item"><a class="p-link" href="https://snapcraft.io/">Snaps</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes</a></li>
+            <li class="p-list__item"><a class="p-link" href="/openstack">OpenStack</a></li>
+            <li class="p-list__item"><a class="p-link" href="/kubernetes">Kubernetes</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">Other websites</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="http://www.ubuntu.com/support">Enterprise Support</a></li>
+            <li class="p-list__item"><a class="p-link" href="/support">Enterprise Support</a></li>
             <li class="p-list__item"><a class="p-link" href="https://wiki.ubuntu.com/Mir">Mir</a></li>
             <li class="p-list__item"><a class="p-link" href="https://cloud-images.ubuntu.com/">Image Service</a></li>
             <li class="p-list__item"><a class="p-link" href="https://conjure-up.io/">Conjure-up</a></li>
@@ -158,19 +158,19 @@
             <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
             <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
+            <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
+            <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
           </ul>
         </div>
         <div class="row">
           <h5 class="p-muted-heading p-footer__title">About</h5>
           <ul class="p-list is-split second-level-nav">
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com">Ubuntu</a></li>
+            <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
             <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
             <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
             <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
+            <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>
           </ul>
         </div>
       </div>
@@ -180,11 +180,11 @@
         <div class="row u-hide--small">
           <ul class="p-matrix u-no-margin--bottom">
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com">
+              <a href="/">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/">Ubuntu&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="/">Ubuntu&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s most popular Linux for servers, desktops and things, with enterprise support and enhanced security by Canonical</p>
               </div>
             </li>
@@ -234,20 +234,20 @@
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com/openstack">
+              <a href="/openstack">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}a7916513-picto-openstack.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="/openstack">OpenStack&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">The world’s first choice for OpenStack - the leader in density and cost per VM</p>
               </div>
             </li>
             <li class="p-matrix__item">
-              <a href="https://www.ubuntu.com/kubernetes">
+              <a href="/kubernetes">
                 <img class="p-logomark" src="{{ ASSET_SERVER_URL }}b81a45e4-kubernetes.svg" alt="icon">
               </a>
               <div class="p-matrix__content">
-                <h4 class="p-matrix__title"><a class="p-link" href="https://www.ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
+                <h4 class="p-matrix__title"><a class="p-link" href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a></h4>
                 <p class="p-matrix__desc">Canonical works with Google GKE and Azure AKS for app portability between private and public infra</p>
               </div>
             </li>
@@ -263,7 +263,7 @@
             <h5 class="p-muted-heading">Other websites</h5>
             <div class="row">
               <div class="col-3">
-                <h5><a class="p-link" href="http://www.ubuntu.com/support">Enterprise Support&nbsp;&rsaquo;</a></h5>
+                <h5><a class="p-link" href="/support">Enterprise Support&nbsp;&rsaquo;</a></h5>
                 <p>Canonical supports Ubuntu for clouds, data centers and devices</p>
                 <h5><a class="p-link" href="https://mir-server.io/">Mir&nbsp;&rsaquo;</a></h5>
                 <p>Ultra-fast and light Wayland compositor for secure device display management</p>
@@ -294,17 +294,17 @@
               <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
               <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download/cloud">Install</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/download">Download</a></li>
+              <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
+              <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
             </ul>
             <h5 class="p-muted-heading">About</h5>
             <ul class="p-list is-split u-no-margin--bottom">
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com">Ubuntu</a></li>
+              <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
               <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
               <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
               <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
               <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://www.ubuntu.com/about/contact-us">Contact</a></li>
+              <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Done

* s/mongoose/www/ in all forms return URLs
* Ensure all **global nav** URLs are ~1) absolute~ 2) not pointing to mongoose

### Drive-by
* Fixed blank `/ai` link in developer menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure links in global nav take you to www.ubuntu.com, not mongoose.ubuntu.com
- Ensure a form submission takes you to a "thank you" page on www.ubuntu.com, not on mongoose.ubuntu.com
