### PR TITLE
Add k8s datasheet and styling

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -13,7 +13,7 @@
       <p>Canonical also provides a rich ecosystem of tools, libraries, services, modern metrics, and monitoring tools to make CDK easy to consume so you can innovate faster.</p>
       <p>
         <a class="p-button--positive" href="/kubernetes/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get started today, install CDK yourself', 'eventLabel' : 'Get started today, install CDK yourself - Hero CTA' : undefined });">
-          Install CDK yourself&nbsp;&rsaquo;
+          Install CDK yourself
         </a>
       </p>
       <p>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -13,7 +13,7 @@
       <p>Canonical also provides a rich ecosystem of tools, libraries, services, modern metrics, and monitoring tools to make CDK easy to consume so you can innovate faster.</p>
       <p>
         <a class="p-button--positive" href="/kubernetes/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get started today, install CDK yourself', 'eventLabel' : 'Get started today, install CDK yourself - Hero CTA' : undefined });">
-          Get started today, install CDK yourself&nbsp;&rsaquo;
+          Install CDK yourself&nbsp;&rsaquo;
         </a>
       </p>
       <p>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -18,7 +18,7 @@
       </p>
       <p>
         <a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet - Hero CTA' : undefined });">
-          Download the Services datasheet&nbsp;&rsaquo;
+          Download the Enterprise Kubernetes datasheet&nbsp;&rsaquo;
         </a>
       </p>
     </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -12,8 +12,13 @@
       <p>The Canonical Distribution of Kubernetes (CDK) is pure upstream Kubernetes tested across the widest range of clouds &mdash; from public clouds to private data centers, from bare metal to virtualized infrastructure.</p>
       <p>Canonical also provides a rich ecosystem of tools, libraries, services, modern metrics, and monitoring tools to make CDK easy to consume so you can innovate faster.</p>
       <p>
-        <a href="/kubernetes/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get started today, install CDK yourself', 'eventLabel' : 'Get started today, install CDK yourself - Hero CTA' : undefined });">
+        <a class="p-button--positive" href="/kubernetes/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get started today, install CDK yourself', 'eventLabel' : 'Get started today, install CDK yourself - Hero CTA' : undefined });">
           Get started today, install CDK yourself&nbsp;&rsaquo;
+        </a>
+      </p>
+      <p>
+        <a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet - Hero CTA' : undefined });">
+          Download the Services datasheet&nbsp;&rsaquo;
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- Added k8's enterprise datasheet to k8's index page. 
- Updated the styling of primary CTA as per @anasereijo's request

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the link goes to the datasheet


## Issue / Card

Fixes: #3915 

