### PR TITLE
Update the navigation menus for developer and enterprise

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -61,7 +61,7 @@
         <div class="tablet-col-2 col-3 p-card--navigation">
           <div class="u-hide--small">
             <h4 class="is-dense">Devops</h4>
-            <p class="p-p--small">Automate everything from dev to production.</p>
+            <p class="p-p--small">Automate everything from development to production.</p>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">Devops</h4>
           <ul class="p-text-list--small is-bordered">
@@ -117,7 +117,9 @@
             <li class="p-list__item">
               <a href="/internet-of-things/digital-signage">The leading OS for digital signage&nbsp;&rsaquo;</a>
             </li>
-            <li class="p-list__item">Drones and autopilots</li>
+            <li class="p-list__item">
+              <a href="/internet-of-things/robotics">Drones and autopilots&nbsp;&rsaquo;</a>
+            </li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="/internet-of-things/contact-us">Accelerate to market</a></p>
         </div>
@@ -154,27 +156,29 @@
                 <a href="https://pytorch.org/">Pytorch</a> &middot; <a href="http://www.paddlepaddle.org/">PaddPaddle</a> &middot; <a href="https://chainer.org/">Chainer</a>
               </li>
             </ul>
-            <p><a class="p-button--positive p-button--small" href="https://jujucharms.com/">Develop for AI/ML</a></p>
+            <p><a class="p-button--positive p-button--small" href="/ai">Develop for AI/ML</a></p>
           </div>
         </div>
         <div class="col-3">
           <h4 class="p-muted-heading">
-            <a href="https://jujucharms.com/">Cloud packages&nbsp;&rsaquo;</a>
+            <a href="https://jujucharms.com/store">Cloud packages&nbsp;&rsaquo;</a>
           </h4>
           <div>
-            <p class="p-p--small">Standard ways to deploy and operate cloud software like Hadoop, Spark, OpenStack and Kubernetes.</p>
+            <p class="p-p--small">A standard way to deploy and operate cloud software like Hadoop, Spark, OpenStack and Kubernetes.</p>
             <p><a class="p-button--positive p-button--small" href="https://jujucharms.com/">Discover Charm Packages</a></p>
           </div>
         </div>
         <div class="col-3">
-          <h4 class="p-muted-heading">Containers</h4>
+          <h4 class="p-muted-heading">
+            <a href="/containers">Containers&nbsp;&rsaquo;</a>
+          </h4>
           <div>
             <ul class="p-text-list--small is-bordered">
               <li class="p-list__item">
                 <a href="/kubernetes">Kubernetes on Ubuntu&nbsp;&rsaquo;</a>
               </li>
               <li class="p-list__item">
-                <a href="/kubernetes/install">Install K8s &ndash; workstations&nbsp;&rsaquo;</a>
+                <a href="https://microk8s.io/">Install K8s &ndash; workstations&nbsp;&rsaquo;</a>
               </li>
               <li class="p-list__item">
                 <a href="/kubernetes/install">Install K8s &ndash; clouds and clusters&nbsp;&rsaquo;</a>
@@ -250,7 +254,7 @@
             <a href="https://www.brighttalk.com/search?q=Canonical">Webinars</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://blog.ubuntu.com/category/white-papers">Whitepapers</a>
+            <a href="/resources?content=whitepapers">Whitepapers</a>
           </li>
           <li class="p-inline-list__item">
             <a href="https://blog.ubuntu.com/">Blog</a>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -130,6 +130,7 @@
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">Metal as a Service provisioning</a></li>
           <li class="p-list__item"><a href="https://jujucharms.com" title="Visit jujucharms.com - external site">Multi cloud operations</a></li>
+          <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
         </ul>
       </div>
       <!-- Internet of Things -->


### PR DESCRIPTION
## Done
Update the developer and enterprise navigation menu content.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the Enterprise menu matches the copy doc: https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit
- Check that the Developer menu matches the copy doc: https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit
