### PR TITLE
Copy updates to kubernetes index page

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -8,7 +8,7 @@
 <section class="p-strip--light is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-8">
-      <h1>Kubernetes anywhere</h1>
+      <h1>Multi-cloud Kubernetes</h1>
       <p>The Canonical Distribution of Kubernetes (CDK) is pure upstream Kubernetes tested across the widest range of clouds &mdash; from public clouds to private data centers, from bare metal to virtualized infrastructure.</p>
       <p>Canonical also provides a rich ecosystem of tools, libraries, services, modern metrics, and monitoring tools to make CDK easy to consume so you can innovate faster.</p>
       <p>
@@ -45,6 +45,15 @@
 
   {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
 
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">
+          Download the Enterprise Kubernetes datasheet&nbsp;&rsaquo;
+        </a>
+      </p>
+    </div>
+  </div>
 </section>
 
 <section class="p-strip is-bordered">


### PR DESCRIPTION
## Done

- Updated the heading and added a datasheet link in the k8s index page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the page reflects the [copydoc ](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#heading=h.erud5btthsqi)


## Issue / Card

Fixes: #3931 

