### PR TITLE
Only use development Talisker settings in local development

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 PORT=8001
+DJANGO_DEBUG=true
+DEVEL=true

--- a/entrypoint
+++ b/entrypoint
@@ -2,5 +2,9 @@
 
 set -e
 
-talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --workers 3 --worker-class gevent --error-logfile - --bind $1
+if ${DJANGO_DEBUG}; then
+    talisker.gunicorn.gevent --reload --log-level debug --timeout 9999 --worker-class gevent --bind $1 webapp.wsgi
+else
+    talisker.gunicorn.gevent --worker-class gevent webapp.wsgi --name talisker-`hostname`
+fi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ canonicalwebteam.get-feeds==0.2.4
 canonicalwebteam.http==0.1.6
 whitenoise==3.3.0
 gunicorn[gevent]
+statsd==3.2.2
 talisker==0.9.13
 django-yaml-redirects==0.5.3
 django-asset-server-url==0.1


### PR DESCRIPTION
Production is using development settings, which is bad.

QA
--

Open up `webapp/views.py` and at line 62 (just below `def search(request):`) add:

``` bash
    raise Exception("We're just testing")
```

Then run the site in the normal way.

``` bash
./run
```

See pretty coloured Talisker output in the terminal. See that http://127.0.0.1:8001 works. Now go to http://127.0.0.1:8001/search and see the `NotImplementedError` displayed with a full debugging stack trace.

Now run it like production:

``` bash
docker build --tag ubuntu --build-arg COMMIT_ID=`git rev-parse --short HEAD` .
docker run --rm -p 8901:80 ubuntu
```

Now go to http://127.0.0.1:8901 and see that it works. Go to http://127.0.0.1:8901/search and see that you see the production "500 Server error" page, rather than the development stack trace.