### PR TITLE
Point "Engage" heading at /resources

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -466,7 +466,7 @@ community:
 
 engage:
   title: Engage
-  path: /engage
+  path: /resources
 
   children: 
     - title: VMWare to OpenStack


### PR DESCRIPTION
The "Engage" link points to /engage, which redirects to /resources.

This causes linkchecker to break in the jenkins jobs, and it's also
needlessly inefficient.

Since /engage doesn't actually exist, it would be better if the "Engage" breadcrumb nav "heading" simply wasn't a link - didn't go anywhere. But supporting that is more complex.

QA
--

See the jenkins job pass, hopefully.

Also `./run`, check the site works, especially http://0.0.0.0:8001/engage/de/vmware-to-openstack - click the "Engage" breadcrumb header and go to /resources.