### PR TITLE
Rotate takeovers

### DIFF
--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -11,8 +11,8 @@
   <div class="row u-equal-height">
     <div class="col-9">
       <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
-      <p class="p-takeover__text">Webinar live on Aug 22 -
-        <a href="#register-section">Register now&nbsp;&rsaquo;</a>
+      <p class="p-takeover__text">
+        <a href="#register-section">Watch the webinar&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -45,7 +45,7 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 id="register-section">Register for the webinar</h2>
+      <h2 id="register-section">Watch the webinar</h2>
     </div>
     <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 330440, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,25 @@
 {% block takeover_content %}
 
 {% include "takeovers/_tackling_iot.html" %}
+{% include "takeovers/_ai_webinar.html" %}
+{% include "takeovers/_rigado_webinar.html" %}
+
+<script>
+  if (window.localStorage && window.sessionStorage) {
+    var takeovers = document.getElementsByClassName('takeover');
+    if (!localStorage.getItem('TAKEOVER')) {
+      var i = 0;
+      localStorage.setItem('TAKEOVER', i);
+    } else {
+      var i = parseInt(localStorage.getItem('TAKEOVER')) + 1;
+      if (i >= takeovers.length) {
+        i = 0;
+      }
+    }
+    localStorage.setItem('TAKEOVER', i);
+    takeovers[i].classList.remove('u-hide');
+  }
+</script>
 
 <section class="p-strip is-deep is-bordered">
   {% include "shared/_insights_news_strip.html" with gtm_event_label="ubuntu.com homepage" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,15 +7,18 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_tackling_iot.html" %}
+{% include "takeovers/_tackling_iot.html" with nojs_fallback=True %}
 {% include "takeovers/_ai_webinar.html" %}
 {% include "takeovers/_rigado_webinar.html" %}
 
 <script>
   if (window.localStorage && window.sessionStorage) {
-    var takeovers = document.getElementsByClassName('takeover');
+    var takeovers = document.getElementsByClassName('js-takeover');
+    for (t = 0; t < takeovers.length; ++t) {
+      takeovers[t].classList.add('u-hide');
+    }
     if (!localStorage.getItem('TAKEOVER')) {
-      var i = 0;
+      var i = Math.floor(Math.random() * takeovers.length);
       localStorage.setItem('TAKEOVER', i);
     } else {
       var i = parseInt(localStorage.getItem('TAKEOVER')) + 1;

--- a/templates/takeovers/_ai_webinar.html
+++ b/templates/takeovers/_ai_webinar.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--ai-webinar u-hide takeover">
+<section class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>

--- a/templates/takeovers/_ai_webinar.html
+++ b/templates/takeovers/_ai_webinar.html
@@ -1,10 +1,10 @@
-<section class="p-strip is-deep p-takeover--ai-webinar u-hide js-primary-takeover">
+<section class="p-strip is-deep p-takeover--ai-webinar u-hide takeover">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
       <p class="p-takeover__text">Find out how you can use Ubuntu to power your AI and ML ambitions from developer workstations to the cloud.</p>
       <div class="u-hide--small">
-        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Watch on-demand</a>
       </div>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
@@ -17,7 +17,7 @@
         <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
       </div>
       <div class="u-hide--medium u-hide--large">
-        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Watch on-demand</a>
       </div>
     </div>
   </div>

--- a/templates/takeovers/_rigado_webinar.html
+++ b/templates/takeovers/_rigado_webinar.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--rigado-webinar u-hide takeover">
+<section class="p-strip is-deep p-takeover--rigado-webinar js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
   <div class="row u-equal-height">
     <div class="col-8 u-fade-left--medium">
       <h1 class="p-takeover__title">Managing IoT security at scale</h1>

--- a/templates/takeovers/_rigado_webinar.html
+++ b/templates/takeovers/_rigado_webinar.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--rigado-webinar u-hide js-secondary-takeover">
+<section class="p-strip is-deep p-takeover--rigado-webinar u-hide takeover">
   <div class="row u-equal-height">
     <div class="col-8 u-fade-left--medium">
       <h1 class="p-takeover__title">Managing IoT security at scale</h1>
@@ -7,7 +7,7 @@
         <img class="p-takeover__image u-fade-up" src="{{ ASSET_SERVER_URL }}91578edc-rigado-device-iot.png" alt="">
       </p>
       <p>
-        <a href="https://www.brighttalk.com/webcast/6793/330448" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Managing IoT security at scale', 'eventLabel' : 'Watch on-demand', 'eventValue' : undefined });" class="p-button--neutral">Watch on-demand</a>
+        <a href="https://www.brighttalk.com/webcast/6793/330448" class="p-button--neutral">Watch on-demand</a>
       </p>
     </div>
     <div class="col-4 u-hide--small u-align--center u-vertically-center">

--- a/templates/takeovers/_tackling_iot.html
+++ b/templates/takeovers/_tackling_iot.html
@@ -1,4 +1,4 @@
-<section class="p-strip p-takeover is-deep">
+<section class="p-strip p-takeover is-deep u-hide takeover">
   <div class="row u-equal-height">
     <div class="col-8 suffix-2">
       <h1 class="p-takeover__title">Tackling the I<span class="u-adjust-kerning">oT</span> monetisation challenge</h1>

--- a/templates/takeovers/_tackling_iot.html
+++ b/templates/takeovers/_tackling_iot.html
@@ -1,4 +1,4 @@
-<section class="p-strip p-takeover is-deep u-hide takeover">
+<section class="p-strip p-takeover is-deep js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
   <div class="row u-equal-height">
     <div class="col-8 suffix-2">
       <h1 class="p-takeover__title">Tackling the I<span class="u-adjust-kerning">oT</span> monetisation challenge</h1>


### PR DESCRIPTION
## Done

* Rotate takeovers on refresh / new session
* Refresh CTA text of AI wbn takeover and landing page
* Drop redundant event from Rigado CTA

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- On the homepage, ensure takeovers are rotating following this loop (you may enter in the middle of the loop): 
```
{% include "takeovers/_tackling_iot.html" %}
{% include "takeovers/_ai_webinar.html" %}
{% include "takeovers/_rigado_webinar.html" %}
```
- Close the tab, open a new one, ensure you are seeing the next takeover in the rotation