### PR TITLE
Removes non-link items from Developer navigation menu

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -13,13 +13,6 @@
             <a href="/ai">Develop on Ubuntu&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item">GCC, CLANG</li>
-            <li class="p-list__item">Go</li>
-            <li class="p-list__item">Python, Ruby, Node.js</li>
-            <li class="p-list__item">Deb, snap, and charm packages</li>
-            <li class="p-list__item">Android development</li>
-            <li class="p-list__item">Architectures and ISAs</li>
-            <li class="p-list__item">Kernel selection &amp; lifecycle</li>
             <li class="p-list__item">
               <a href="https://github.com/CanonicalLtd/multipass">Multipass&nbsp;&rsaquo;</a>
             </li>
@@ -52,9 +45,6 @@
             <li class="p-list__item">
               <a href="https://docs.snapcraft.io/reference/channels">Snap channels - track/risk/branch&nbsp;&rsaquo;</a>
             </li>
-            <li class="p-list__item">Cross-distro testing of snaps</li>
-            <li class="p-list__item">Rigorous snap security model</li>
-            <li class="p-list__item">Integration between snaps</li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="https://snapcraft.io/">Publish with Snapcraft</a></p>
         </div>
@@ -186,7 +176,6 @@
               <li class="p-list__item">
                   <a href="https://linuxcontainers.org/">Run pre-K8s apps in LXD containers&nbsp;&rsaquo;</a>
               </li>
-              <li class="p-list__item">Test CentOS apps on Ubuntu with LXD</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Done

Removes, from the “Developer” navigation, these items that do not link anywhere and don’t seem to have anywhere on ubuntu.com that they could link to.

“Develop on Ubuntu” items:
  - GCC, CLANG
  - Go
  - Python, Ruby, Node.js
  - Deb, snap, and charm packages
  - Android development
  - Architectures and ISAs
  - Kernel selection & lifecycle

“Publish apps” items:
  - Cross-distro testing of snaps
  - Rigorous snap security model
  - Integration between snaps

“Containers” item:
  - Test CentOS apps on Ubuntu with LXD

(Probably we _should_ have pages for all of these things, but showing them as unclickable items is a poor way of achieving this. The vast majority of people who see the items won’t be in a position to publish the pages.)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Open the “Developer” navigation and check that every remaining item is clickable