### PR TITLE
Update juju photo on public cloud page

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -67,7 +67,7 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h2 class="p-heading--three">Fast service deployment with&nbsp;Juju</h2>
-      <p class="u-hide--small u-align--center"><img src="{{ ASSET_SERVER_URL }}86c8c01f-charms_juju.svg?h=211" alt="Grid of juju charm icons including wordpress, hadoop, django, MySQL, MongoDB and OpenStack" height="190" /></p>
+      <p class="u-hide--small u-align--center"><img src="{{ ASSET_SERVER_URL }}162002c2-charms_juju.svg" alt="Grid of juju charm icons including wordpress, hadoop, django, MySQL, MongoDB and OpenStack" height="190" /></p>
       <p>Juju is the fastest way to deploy and scale out your workloads on the leading public clouds. With Juju charm bundles, you can launch an entire cloud environment with one click, or just one command using the CLI. Use Juju to  deploy your entire application infrastructure, all in one.</p>
       <p><a class="p-link--external" href="https://jujucharms.com/">Learn more about Juju</a></p>
     </div>


### PR DESCRIPTION
## Done

- Updated the juju icons on /public-cloud

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/public-cloud](http://0.0.0.0:8001/public-cloud)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the icons are now circular rather than rectangles


## Issue / Card

Fixes: #3904 

