### PR TITLE
Removal of the Rigado takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,6 @@
 
 {% include "takeovers/_tackling_iot.html" with nojs_fallback=True %}
 {% include "takeovers/_ai_webinar.html" %}
-{% include "takeovers/_rigado_webinar.html" %}
 
 <script>
   if (window.localStorage && window.sessionStorage) {


### PR DESCRIPTION
## Done

* Putting the Rigado takeover to sleep

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh the page a couple times, takeovers should alternate between AI Webinar and IoT appstore

