### PR TITLE
Build progress bar charts for desktop statistics page

### DIFF
--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -80,8 +80,66 @@ function showMaxDatum(target, dataset) {
   );
 }
 
+function createProgressChart(selector, dataset, options) {
+  // Set option defaults
+  options = options || {};
+  var parentWidth = document.querySelector(selector).parentNode.clientWidth;
+  var color = options.hasOwnProperty('color') ? options.color : '#ed764d';
+  var size = options.hasOwnProperty('size') ? options.size : 300;
+
+  // Create copy of dataset
+  var data = dataset.slice();
+
+  // Orientate svg
+  size = Math.min(size, parentWidth);
+  var height = size;
+  var width = size;
+  var svg = d3.select(selector)
+    .attr('height', height)
+    .attr('width', width)
+    .attr('class', 'p-progress-chart');
+  var g = svg.append("g");
+
+  // Set axis domains and range
+  var x = d3.scaleBand()
+    .rangeRound([0, width]);
+
+  var y = d3.scaleLinear()
+    .rangeRound([height, 0])
+    .domain([0, 100]);
+
+  // Generate bar
+  g.selectAll(".p-progress-chart__bar")
+    .data(dataset)
+    .enter()
+    .append("rect")
+    .attr("class", "p-progress-chart__bar")
+    .attr('fill', color)
+    .attr("y", function(d) { return y(calcPercentage(data, d.value)) })
+    .attr("width", x.bandwidth())
+    .attr("height", function(d) {
+      if (d.show) return height - y(calcPercentage(data, d.value))
+    });
+
+  // Append percentage over top of graph
+  svg
+    .append("text")
+    .attr("class", "p-progress-chart__text")
+    .attr("transform", function() {
+      return "translate(" + height / 2 + "," + ((width + 20) / 2) + ")";
+    })
+    .attr("text-anchor", "middle")
+    .text(function() {
+      var value = Math.ceil(d3.max(data, function(d) {
+        if (d.show) return calcPercentage(data, d.value)
+      }));
+
+      return value + '%';
+    });
+}
+
 function clearCharts() {
-  var charts = document.querySelectorAll('.p-bar-chart, .p-pie-chart, .p-fill-chart');
+  var charts = document.querySelectorAll('.p-bar-chart, .p-pie-chart, .p-progress-chart');
   charts.forEach(function(chart) {
     chart.innerHTML = '';
   });
@@ -92,6 +150,12 @@ function buildCharts() {
   showMaxDatum('#display-server', dummyData.displayServer.dataset);
   showMaxDatum('#one-screen', dummyData.numberScreens.dataset);
   showMaxDatum('#one-gpu', dummyData.numberGPUs.dataset);
+
+  createProgressChart('#default-settings', dummyData.defaultSettings.dataset);
+  createProgressChart('#restrict-add-on', dummyData.restrictAddOn.dataset);
+  createProgressChart('#auto-login', dummyData.autoLogin.dataset);
+  createProgressChart('#minimal-install', dummyData.minimalInstall.dataset);
+  createProgressChart('#update-at-install', dummyData.updateAtInstall.dataset);
 }
 
 window.addEventListener('resize', debounce(function() {

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -130,9 +130,9 @@ function createProgressChart(selector, dataset, options) {
     })
     .attr("text-anchor", "middle")
     .text(function() {
-      var value = Math.ceil(d3.max(data, function(d) {
+      var value = round(d3.max(data, function(d) {
         if (d.show) return calcPercentage(data, d.value)
-      }));
+      }), 1);
 
       return value + '%';
     });
@@ -151,11 +151,16 @@ function buildCharts() {
   showMaxDatum('#one-screen', dummyData.numberScreens.dataset);
   showMaxDatum('#one-gpu', dummyData.numberGPUs.dataset);
 
-  createProgressChart('#default-settings', dummyData.defaultSettings.dataset);
-  createProgressChart('#restrict-add-on', dummyData.restrictAddOn.dataset);
-  createProgressChart('#auto-login', dummyData.autoLogin.dataset);
-  createProgressChart('#minimal-install', dummyData.minimalInstall.dataset);
-  createProgressChart('#update-at-install', dummyData.updateAtInstall.dataset);
+  createProgressChart('#default-settings-hw', dummyData.defaultSettings.datasets.hardware);
+  createProgressChart('#restrict-add-on-hw', dummyData.restrictAddOn.datasets.hardware);
+  createProgressChart('#auto-login-hw', dummyData.autoLogin.datasets.hardware);
+  createProgressChart('#minimal-install-hw', dummyData.minimalInstall.datasets.hardware);
+  createProgressChart('#update-at-install-hw', dummyData.updateAtInstall.datasets.hardware);
+  createProgressChart('#default-settings-vm', dummyData.defaultSettings.datasets.virtual, { color: '#925375' });
+  createProgressChart('#restrict-add-on-vm', dummyData.restrictAddOn.datasets.virtual, { color: '#925375' });
+  createProgressChart('#auto-login-vm', dummyData.autoLogin.datasets.virtual, { color: '#925375' });
+  createProgressChart('#minimal-install-vm', dummyData.minimalInstall.datasets.virtual, { color: '#925375' });
+  createProgressChart('#update-at-install-vm', dummyData.updateAtInstall.datasets.virtual, { color: '#925375' });
 }
 
 window.addEventListener('resize', debounce(function() {

--- a/static/js/dummyData.js
+++ b/static/js/dummyData.js
@@ -300,54 +300,104 @@ var dummyData = {
     ]
   },
   defaultSettings: {
-    dataset: [
-      {
-        show: true,
-        value: 310,
-      }, {
-        value: 690,
-      },
-    ]
+    datasets: {
+      hardware: [
+        {
+          show: true,
+          value: 318,
+        }, {
+          value: 682,
+        },
+      ],
+      virtual: [
+        {
+          show: true,
+          value: 589,
+        }, {
+          value: 411,
+        },
+      ],
+    },
   },
   restrictAddOn: {
-    dataset: [
-      {
-        show: true,
-        value: 600,
-      }, {
-        value: 400,
-      },
-    ]
+    datasets: {
+      hardware: [
+        {
+          show: true,
+          value: 591,
+        }, {
+          value: 409,
+        },
+      ],
+      virtual: [
+        {
+          show: true,
+          value: 273,
+        }, {
+          value: 727,
+        },
+      ],
+    },
   },
   autoLogin: {
-    dataset: [
-      {
-        show: true,
-        value: 290,
-      }, {
-        value: 710,
-      },
-    ]
+    datasets: {
+      hardware: [
+        {
+          show: true,
+          value: 294,
+        }, {
+          value: 706,
+        },
+      ],
+      virtual: [
+        {
+          show: true,
+          value: 287,
+        }, {
+          value: 713,
+        },
+      ],
+    },
   },
   minimalInstall: {
-    dataset: [
-      {
-        show: true,
-        value: 130,
-      }, {
-        value: 870,
-      },
-    ]
+    datasets: {
+      hardware: [
+        {
+          show: true,
+          value: 134,
+        }, {
+          value: 866,
+        },
+      ],
+      virtual: [
+        {
+          show: true,
+          value: 141,
+        }, {
+          value: 859,
+        },
+      ],
+    },
   },
   updateAtInstall: {
-    dataset: [
-      {
-        show: true,
-        value: 920,
-      }, {
-        value: 80,
-      },
-    ]
+    datasets: {
+      hardware: [
+        {
+          show: true,
+          value: 919,
+        }, {
+          value: 81,
+        },
+      ],
+      virtual: [
+        {
+          show: true,
+          value: 911,
+        }, {
+          value: 89,
+        },
+      ],
+    },
   },
   languageList: {
     title: 'What language do they use?',

--- a/static/sass/_pattern_desktop-statistics.scss
+++ b/static/sass/_pattern_desktop-statistics.scss
@@ -13,4 +13,22 @@
       }
     }
   }
+
+  .p-progress-chart {
+    background: $color-x-light;
+    border: 1px solid $color-mid-light;
+    box-shadow: 0 1px 5px 1px rgba(17, 17, 17, 0.2);
+
+    .p-progress-chart__bar {
+      opacity: .8;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+
+    .p-progress-chart__text {
+      font-size: 2.91029rem;
+    }
+  }
 }

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -285,50 +285,65 @@
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who installed Ubuntu ‘out the box’.</h3>
+      <h3 class="p-heading--four">Users who installed Ubuntu using the default settings</h3>
     </div>
-    <div class="col-6 u-align--center">
-      <svg id="default-settings"></svg>
+    <div class="col-3 u-align--center">
+      <svg id="default-settings-hw"></svg>
+    </div>
+    <div class="col-3 u-align--center">
+      <svg id="default-settings-vm"></svg>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-shallow is-bordered">
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
-    <div class="col-6 u-align--center">
-      <svg id="restrict-add-on"></svg>
+    <div class="col-3 u-align--center">
+      <svg id="restrict-add-on-hw"></svg>
+    </div>
+    <div class="col-3 u-align--center">
+      <svg id="restrict-add-on-vm"></svg>
     </div>
     <div class="col-6">
-      <h3 class="p-heading--four">Users who restricted at least one add-on.</h3>
+      <h3 class="p-heading--four">Users who opted out of at least one add-on</h3>
     </div>
   </div>
 </section>
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who auto-login, which automatically logs a user in on start-up.</h3>
+      <h3 class="p-heading--four">Users who auto-login on start-up</h3>
     </div>
-    <div class="col-6 u-align--center">
-      <svg id="auto-login"></svg>
+    <div class="col-3 u-align--center">
+      <svg id="auto-login-hw"></svg>
+    </div>
+    <div class="col-3 u-align--center">
+      <svg id="auto-login-vm"></svg>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-shallow is-bordered">
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
-    <div class="col-6 u-align--center">
-      <svg id="minimal-install"></svg>
+    <div class="col-3 u-align--center">
+      <svg id="minimal-install-hw"></svg>
+    </div>
+    <div class="col-3 u-align--center">
+      <svg id="minimal-install-vm"></svg>
     </div>
     <div class="col-6">
-      <h3 class="p-heading--four">Users who used the Minimal Install; a stripped down Ubuntu that contains a web browser and other basic applications.</h3>
+      <h3 class="p-heading--four">Users who opted for the Minimal Install; a stripped down Ubuntu that contains a few basic applications</h3>
     </div>
   </div>
 </section>
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who chose to download and update software whilst installing Ubuntu.</h3>
+      <h3 class="p-heading--four">Users who chose to download and update software whilst installing Ubuntu</h3>
     </div>
-    <div class="col-6 u-align--center">
-      <svg id="update-at-install"></svg>
+    <div class="col-3 u-align--center">
+      <svg id="update-at-install-hw"></svg>
+    </div>
+    <div class="col-3 u-align--center">
+      <svg id="update-at-install-vm"></svg>
     </div>
   </div>
 </section>

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -288,18 +288,14 @@
       <h3 class="p-heading--four">Users who installed Ubuntu ‘out the box’.</h3>
     </div>
     <div class="col-6 u-align--center">
-      <div id="default-settings">
-        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
-      </div>
+      <svg id="default-settings"></svg>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-shallow is-bordered">
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
     <div class="col-6 u-align--center">
-      <div id="restrict-add-on">
-        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
-      </div>
+      <svg id="restrict-add-on"></svg>
     </div>
     <div class="col-6">
       <h3 class="p-heading--four">Users who restricted at least one add-on.</h3>
@@ -312,18 +308,14 @@
       <h3 class="p-heading--four">Users who auto-login, which automatically logs a user in on start-up.</h3>
     </div>
     <div class="col-6 u-align--center">
-      <div id="auto-login">
-        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
-      </div>
+      <svg id="auto-login"></svg>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-shallow is-bordered">
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
     <div class="col-6 u-align--center">
-      <div id="minimal-install">
-        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
-      </div>
+      <svg id="minimal-install"></svg>
     </div>
     <div class="col-6">
       <h3 class="p-heading--four">Users who used the Minimal Install; a stripped down Ubuntu that contains a web browser and other basic applications.</h3>
@@ -336,9 +328,7 @@
       <h3 class="p-heading--four">Users who chose to download and update software whilst installing Ubuntu.</h3>
     </div>
     <div class="col-6 u-align--center">
-      <div id="update-install-time">
-        <img src="https://via.placeholder.com/250x250?text=Bar chart" alt="">
-      </div>
+      <svg id="update-at-install"></svg>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Built progress bar charts (the ones in the Configuration section) for desktop statistics page using dummy data

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/statistics
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the fill charts are reflective of the dummy data (you can test by editing the data in dummyData.js)

## Issues

Fixes #3991 