### PR TITLE
Build bar charts for desktop statistics page

### DIFF
--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -181,8 +181,15 @@ function createHorizontalBarChart(selector, dataset, options) {
     .call(d3.axisLeft(y))
     .selectAll(".tick text")
     .attr("text-anchor", "left")
-    .attr("transform", "translate(-10,0)")
-    .call(wrapText, margin.left);
+    .call(wrapText, margin.left)
+    .attr("transform", function() {
+      var marginRight = 10;
+      var fontSize = window.getComputedStyle(this).fontSize;
+      var textHeight = this.getBBox().height - 1;
+      var yPos = (-textHeight / 2) + (parseInt(fontSize, 10) / 2);
+
+      return "translate(-" + marginRight + "," + yPos + ")";
+    });
 
   // Generate bars
   g.selectAll(".p-bar-chart__bar")
@@ -242,7 +249,7 @@ function buildCharts() {
   createHorizontalBarChart(
     '#language-list-chart',
     dummyData.languageList.dataset,
-    { sort: 'ascending', truncPoint: 10, margin: { top: 20, right: 20, bottom: 20, left: 60 } }
+    { sort: 'ascending', truncPoint: 10, margin: { top: 20, right: 20, bottom: 20, left: 70 } }
   );
 
   if (window.innerWidth >= breakpoint) {

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -96,7 +96,7 @@ function createBarChart(selector, dataset, options) {
 
   // Orientate svg and give it class name
   var svg = d3.select(selector).attr("class", "p-bar-chart");
-  var width = document.querySelector(selector).clientWidth - margin.right - margin.left;
+  var width = document.querySelector(selector).getBoundingClientRect().width - margin.right - margin.left;
   var height = +svg.attr("height") - margin.top - margin.bottom;
   var g = svg.append("g")
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
@@ -155,7 +155,7 @@ function createHorizontalBarChart(selector, dataset, options) {
 
   // Orientate svg and give it class name
   var svg = d3.select(selector).attr("class", "p-bar-chart");
-  var width = document.querySelector(selector).clientWidth - margin.right - margin.left;
+  var width = document.querySelector(selector).getBoundingClientRect().width - margin.right - margin.left;
   var height = +svg.attr("height") - margin.top - margin.bottom;
   var g = svg.append("g")
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -80,6 +80,143 @@ function showMaxDatum(target, dataset) {
   );
 }
 
+function createBarChart(selector, dataset, options) {
+  // Set option defaults
+  options = options || {};
+  var sort = options.hasOwnProperty('sort') ? options.sort : undefined;
+  var truncPoint = options.hasOwnProperty('truncPoint') ? options.truncPoint : undefined;
+  var numTicks = options.hasOwnProperty('ticks') ? options.ticks : 5;
+  var margin = options.hasOwnProperty('margin') ? options.margin : { top: 20, right: 5, bottom: 50, left: 40 };
+  var colors = options.hasOwnProperty('colors') ? options.colors : ['#ed764d', '#ccc', '#925375'];
+  var ordinalColors = d3.scaleOrdinal(colors);
+
+  // Create copy of dataset and manipulate according to options
+  var data = dataset.slice();
+  data = manipulateData(data, { sort: sort, truncPoint: truncPoint });
+
+  // Orientate svg and give it class name
+  var svg = d3.select(selector).attr("class", "p-bar-chart");
+  var width = document.querySelector(selector).clientWidth - margin.right - margin.left;
+  var height = +svg.attr("height") - margin.top - margin.bottom;
+  var g = svg.append("g")
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+  // Set axis domains and range
+  var x = d3.scaleBand()
+    .rangeRound([0, width])
+    .padding(0.1)
+    .domain(data.map(function(d) { return d.label }));
+
+  var y = d3.scaleLinear()
+    .rangeRound([height, 0])
+    .domain([0, Math.ceil(d3.max(data, function(d) { return calcPercentage(data, d.value) }))]);
+
+  // Generate axes
+  g.append("g")
+    .attr("transform", "translate(0," + height + ")")
+    .call(d3.axisBottom(x))
+    .selectAll(".tick text")
+    .attr("text-anchor", "middle")
+    .call(wrapText, x.bandwidth());
+
+  g.append("g")
+    .call(d3.axisLeft(y)
+      .tickFormat(function(d) { return d + '%' })
+      .ticks(numTicks));
+
+  // Generate bars
+  g.selectAll(".p-bar-chart__bar")
+    .data(data)
+    .enter()
+    .append("rect")
+    .attr("class", "p-bar-chart__bar")
+    .attr('fill', function(d, i) {
+      return ordinalColors(i);
+    })
+    .attr("x", function(d) { return x(d.label) })
+    .attr("y", function(d) { return y(calcPercentage(data, d.value)) })
+    .attr("width", x.bandwidth())
+    .attr("height", function(d) { return height - y(calcPercentage(data, d.value)) });
+}
+
+function createHorizontalBarChart(selector, dataset, options) {
+  // Set option defaults
+  options = options || {};
+  var sort = options.hasOwnProperty('sort') ? options.sort : undefined;
+  var truncPoint = options.hasOwnProperty('truncPoint') ? options.truncPoint : undefined;
+  var numTicks = options.hasOwnProperty('ticks') ? options.ticks : 5;
+  var margin = options.hasOwnProperty('margin') ? options.margin : { top: 20, right: 20, bottom: 20, left: 60 };
+  var colors = options.hasOwnProperty('colors') ? options.colors : ['#ed764d', '#ccc', '#925375'];
+  var ordinalColors = d3.scaleOrdinal(colors);
+
+  // Create copy of dataset and manipulate according to options
+  var data = dataset.slice().reverse();
+  data = manipulateData(data, { sort: sort, truncPoint: truncPoint });
+
+  // Orientate svg and give it class name
+  var svg = d3.select(selector).attr("class", "p-bar-chart");
+  var width = document.querySelector(selector).clientWidth - margin.right - margin.left;
+  var height = +svg.attr("height") - margin.top - margin.bottom;
+  var g = svg.append("g")
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+  // Set axis domains and range
+  var y = d3.scaleBand()
+    .range([height, 0])
+    .padding(0.1)
+    .domain(data.map(function(d) { return d.label }));
+
+  var x = d3.scaleLinear()
+    .range([0, width])
+    .domain([0, Math.ceil(d3.max(data, function(d) { return calcPercentage(data, d.value) }))]);
+
+  // Generate axes
+  g.append("g")
+    .attr("transform", "translate(0," + height + ")")
+    .call(d3.axisBottom(x)
+      .tickFormat(function(d) { return d + '%' })
+      .ticks(numTicks));
+
+  g.append("g")
+    .call(d3.axisLeft(y))
+    .selectAll(".tick text")
+    .attr("text-anchor", "left")
+    .attr("transform", "translate(-10,0)")
+    .call(wrapText, margin.left);
+
+  // Generate bars
+  g.selectAll(".p-bar-chart__bar")
+    .data(data)
+    .enter()
+    .append("rect")
+    .attr("class", "p-bar-chart__bar")
+    .attr('fill', function(d, i) {
+      return ordinalColors(i);
+    })
+    .attr("x", 1)
+    .attr("y", function(d) { return y(d.label) })
+    .attr("height", y.bandwidth())
+    .attr("width", function(d) { return x(calcPercentage(data, d.value)) });
+}
+
+function createOrderedList(target, dataset, options) {
+  // Set option defaults
+  options = options || {};
+  var truncPoint = options.hasOwnProperty('truncPoint') ? options.truncPoint : undefined;
+  var data = dataset.slice();
+
+  var sortedList = data
+    .sort(function(a, b) { return d3.descending(a.value, b.value) });
+  var count = Math.min(dataset.length, truncPoint);
+  var html = '';
+
+  for (var i = 0; i < count; i++) {
+    html += '<li>' + sortedList[i].label + '</li>';
+  }
+
+  document.querySelector(target).innerHTML = '<ol>' + html + '</ol>';
+}
+
 function clearCharts() {
   var charts = document.querySelectorAll('.p-bar-chart, .p-pie-chart, .p-fill-chart');
   charts.forEach(function(chart) {
@@ -88,10 +225,41 @@ function clearCharts() {
 }
 
 function buildCharts() {
+  var breakpoint = 875;
+
   showMaxDatum('#os-architecture', dummyData.osArchitecture.dataset);
   showMaxDatum('#display-server', dummyData.displayServer.dataset);
   showMaxDatum('#one-screen', dummyData.numberScreens.dataset);
   showMaxDatum('#one-gpu', dummyData.numberGPUs.dataset);
+
+  createBarChart('#install-or-upgrade', dummyData.installOrUpgrade.dataset);
+  createBarChart('#number-of-cpus', dummyData.cpus.dataset);
+  createBarChart('#size-of-ram', dummyData.ram.dataset);
+  createBarChart('#pixel-density', dummyData.pixelDensity.dataset);
+  createBarChart('#partition-number', dummyData.partitionNum.dataset);
+
+  createOrderedList('#language-list', dummyData.languageList.dataset, { truncPoint: 10 });
+  createHorizontalBarChart(
+    '#language-list-chart',
+    dummyData.languageList.dataset,
+    { sort: 'ascending', truncPoint: 10, margin: { top: 20, right: 20, bottom: 20, left: 60 } }
+  );
+
+  if (window.innerWidth >= breakpoint) {
+    createBarChart('#popular-screen-sizes', dummyData.screenSizes.dataset);
+    createBarChart('#physical-disk', dummyData.physicalDisk.dataset);
+    createBarChart('#partition-type', dummyData.partitionType.dataset);
+    createBarChart('#partition-size', dummyData.partitionSize.dataset);
+  } else {
+    createHorizontalBarChart('#popular-screen-sizes', dummyData.screenSizes.dataset);
+    createHorizontalBarChart('#physical-disk', dummyData.physicalDisk.dataset);
+    createHorizontalBarChart(
+      '#partition-type',
+      dummyData.partitionType.dataset,
+      { margin: { top: 20, right: 20, bottom: 20, left: 100 } }
+    );
+    createHorizontalBarChart('#partition-size', dummyData.partitionSize.dataset);
+  }
 }
 
 window.addEventListener('resize', debounce(function() {

--- a/static/js/dummyData.js
+++ b/static/js/dummyData.js
@@ -156,25 +156,25 @@ var dummyData = {
     ]
   },
   physicalDisk: {
-    title: 'Physical disk',
+    title: 'Physical disk (GB)',
     dataset: [
       {
-        label: '<30GB',
+        label: '<30',
         value: 255,
       }, {
-        label: '30-99GB',
+        label: '30-99',
         value: 154,
       }, {
-        label: '100-249GB',
+        label: '100-249',
         value: 211,
       }, {
-        label: '250-499GB',
+        label: '250-499',
         value: 168,
       }, {
-        label: '500-999GB',
+        label: '500-999',
         value: 93,
       }, {
-        label: '>1TB',
+        label: '1TB+',
         value: 19,
       },
     ]
@@ -255,25 +255,25 @@ var dummyData = {
     ]
   },
   partitionSize: {
-    title: 'Size of partitions',
+    title: 'Size of partitions (GB)',
     dataset: [
       {
-        label: '<1GB',
+        label: '<1',
         value: 35,
       }, {
-        label: '1-19GB',
+        label: '1-19',
         value: 17,
       }, {
-        label: '20-49GB',
+        label: '20-49',
         value: 14,
       }, {
-        label: '50-99GB',
+        label: '50-99',
         value: 13,
       }, {
-        label: '100-249GB',
+        label: '100-249',
         value: 25,
       }, {
-        label: '250-999GB',
+        label: '250-999',
         value: 20,
       }, {
         label: '1TB+',

--- a/static/sass/_pattern_desktop-statistics.scss
+++ b/static/sass/_pattern_desktop-statistics.scss
@@ -13,4 +13,20 @@
       }
     }
   }
+
+  .p-bar-chart {
+    width: 100%;
+
+    .p-bar-chart__bar {
+      opacity: .8;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+
+    .tick text {
+      font-size: .625rem;
+    }
+  }
 }

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -65,9 +65,7 @@
       <p>Users setting up a virtual machine are much more likely to perform a clean install rather than upgrading Ubuntu.</p>
     </div>
     <div class="col-6 u-align--center">
-      <div id="install-or-upgrade">
-        <img src="https://via.placeholder.com/400x250?text=Bar chart" alt="">
-      </div>
+      <svg id="install-or-upgrade" height="250"></svg>
     </div>
   </div>
 </section>
@@ -86,25 +84,12 @@
 </section>
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height u-vertically-center">
-    <div class="col-6">
+    <div class="col-5">
       <h2 class="p-heading--four">What language do they use?</h2>
-      <ol id="language-list">
-        <li>American English</li>
-        <li>English</li>
-        <li>German</li>
-        <li>Brazilian Portuguese</li>
-        <li>French</li>
-        <li>Chinese</li>
-        <li>Russian</li>
-        <li>Italian</li>
-        <li>Canadian English</li>
-        <li>Australian English</li>
-      </ol>
+      <div id="language-list"></div>
     </div>
-    <div class="col-6 u-align--center">
-      <div id="language-map">
-        <img src="https://via.placeholder.com/500x320?text=Tree map" alt="">
-      </div>
+    <div class="col-7 u-align--center">
+      <svg id="language-list-chart" height="500"></svg>
     </div>
   </div>
 </section>
@@ -167,25 +152,14 @@
     <p>This data set shows the 15 most popular screen sizes.</p>
   </div>
   <div class="row u-equal-height">
-    <div class="col-6">
-      <div id="popular-screen-sizes">
-        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
-      </div>
-    </div>
-    <div class="col-6">
-      <div id="screen-size-comparison">
-        <img src="https://via.placeholder.com/500x320?text=Graphic" alt="">
-      </div>
-    </div>
+    <svg id="popular-screen-sizes" height="320"></svg>
   </div>
 </section>
 <section class="p-strip--light is-bordered u-no-padding--top">
   <div class="row u-equal-height">
     <div class="col-6">
       <h4>Pixel density</h4>
-      <div id="pixel-density">
-        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
-      </div>
+      <svg id="pixel-density" height="320"></svg>
     </div>
     <div class="col-6">
       <h4>Relative pixel size</h4>
@@ -204,9 +178,7 @@
   </div>
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
     <div class="col-6 u-align--center">
-      <div id="number-of-cpus">
-        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
-      </div>
+      <svg id="number-of-cpus" height="320"></svg>
     </div>
     <div class="col-6">
       <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output functions. Having multiple CPUs allows a computer to perform more tasks in parallel.</p>
@@ -222,9 +194,7 @@
       <p>The more memory, the more power the computer has to carry out functions. Some users reported having RAM upwards of 96GB!</p>
     </div>
     <div class="col-6 u-align--center">
-      <div id="size-of-ram">
-        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
-      </div>
+      <svg id="size-of-ram" height="320"></svg>
     </div>
   </div>
 </section>
@@ -233,13 +203,11 @@
     <h3>What physical disks do people have?</h3>
   </div>
   <div class="row">
-    <h4>Physical disk</h4>
+    <h4>Physical disk (GB)</h4>
   </div>
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
     <div class="col-6 u-align--center">
-      <div id="physical-disk">
-        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
-      </div>
+      <svg id="physical-disk" height="320"></svg>
     </div>
     <div class="col-6">
       <p>Physical disks denote how much data can be stored on a computer. For this report the total disk size is inferred from the number and size of partitions of a disk.</p>
@@ -253,25 +221,19 @@
   <div class="row">
     <p>There are a number of ways to partition a disk when installing Ubuntu depending on what the user wants to do.</p>
     <div class="u-align--center">
-      <div id="partition-type">
-        <img src="https://via.placeholder.com/1040x320?text=Bar chart" alt="">
-      </div>
+      <svg id="partition-type" height="320"></svg>
     </div>
   </div>
 </section>
 <section class="p-strip--light is-bordered">
   <div class="row u-equal-height">
     <div class="col-6">
-      <h4>Size of partitions</h4>
-      <div id="size-of-partition">
-        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
-      </div>
+      <h4>Size of partitions (GB)</h4>
+      <svg id="partition-size" height="320"></svg>
     </div>
     <div class="col-6">
       <h4>Number of partitions</h4>
-      <div id="number-of-partitions">
-        <img src="https://via.placeholder.com/500x320?text=Bar chart" alt="">
-      </div>
+      <svg id="partition-number" height="320"></svg>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Built bar charts for desktop statistics page using dummy data (vertical and horizontal)
- Built the language list using dummy data as opposed to hardcoded values

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/statistics
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the bar charts are reflective of the dummy data (you can test by editing the data in dummyData.js)

## Issues

Fixes #3989 
