### PR TITLE
Update the content to the appstore page

### DIFF
--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -199,7 +199,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Enterprise support for IoT app stores</h2>
-      <p>Many enterprises and device manufacturers depend on Canonical’s freely available IoT app store to distribute software onto their devices in the field. Additionally, Canonical can provide commercial support plans for enterprises through Ubuntu Advantage. And a Snap Enterprise Proxy for enterprises to control, update and isolate their devices from the internet.</p>
+      <p>Many enterprises and device manufacturers depend on Canonical’s freely available IoT app store to distribute software onto their devices in the field. Additionally, Canonical can provide commercial support plans for enterprises through Ubuntu Advantage. And a Snap Store Proxy for enterprises to control, update and isolate their devices from the internet.</p>
     </div>
   </div>
   <div class="row">
@@ -214,12 +214,13 @@
           <li class="p-list__item is-ticked">Guaranteed levels of service</li>
           <li class="p-list__item is-ticked">Enterprise proxy functionalities</li>
           <li class="p-list__item is-ticked">Own app ecosystem control and management</li>
+          <li class="p-list__item is-ticked">Snap Store Proxy functionality</li>
           <li class="p-list__item is-ticked">24/7 phone and web support</li>
           <li class="p-list__item is-ticked">Access to our world-class technical team and library</li>
         </ul>
       </div>
       <div class="col-6 p-card">
-        <h3>Snap Enterprise Proxy</h3>
+        <h3>Snap Store Proxy</h3>
         <p>
           A proxy gives you all the benefits of an IoT app store with device, OS and application updates all within your firewall.
         </p>


### PR DESCRIPTION
## Done
Replace `Snap Enterprise Proxy` with `Snap Store Proxy` on the appstore page

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/appstore](http://0.0.0.0:8001/internet-of-things/appstore)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check there is no reference to "Snap Enterprise Proxy" and see the content matches the [copy doc](https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit#)

