### PR TITLE
Update the content to the enterprise menu

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -45,12 +45,12 @@
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/kubernetes">Get Kubernetes</a></li>
-            <li class="p-list__item"><a href="/kubernetes/features#bare-metal">Bare metal, VMware, cloud</a></li>
+            <li class="p-list__item"><a href="/kubernetes/features">Multicloud K8s on bare metal, VMware, and all public clouds</a></li>
+            <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
             <li class="p-list__item"><a href="/kubernetes/features#ai">Upgrades and automation included</a></li>
             <li class="p-list__item"><a href="/kubernetes/features#ai">GPGPU support for <abbr title="Artificial intelligence">AI</abbr>/<abbr title="Machine learning">ML</abbr></a></li>
             <li class="p-list__item"><a href="/kubernetes/partners">CI/CD with Rancher &amp; Jenkins</a></li>
             <li class="p-list__item"><a href="/kubernetes/features#ai">AI and ML workflows</a></li>
-            <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
             <li class="p-list__item"><a href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">GKE with Ubuntu on Google Cloud</a></li>
           </ul>
         </div>
@@ -97,9 +97,9 @@
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
             <li class="p-list__item"><a href="/server/livepatch">Kernel Live Patch</a></li>
-            <li class="p-list__item"><a href="/support/esm">Extended Ubuntu Security</a></li>
+            <li class="p-list__item"><a href="/support/esm">Extended Ubuntu security</a></li>
             <li class="p-list__item"><a href="/support">Optimised Windows VMs</a></li>
-            <li class="p-list__item"><a href="https://landscape.canonical.com/">Management system</a></li>
+            <li class="p-list__item"><a href="https://landscape.canonical.com/">Web-based remote management</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Done
Updated the content on the enterprise menu

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Click the enterprise navigation item
- See that the links match the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit#heading=h.2if15nu6cgve)