### PR TITLE
3958: Build Financial Services Month takeover

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -35,8 +35,8 @@
 @import 'pattern_takeunders';
 @import 'pattern_table';
 @import 'pattern_feedback';
-@import 'takeovers/rigado-webinar';
 @import 'takeovers/ai-webinar';
+@import 'takeovers/financial-services';
 @import 'utility-animations';
 @import 'pattern_chart';
 
@@ -58,8 +58,8 @@
 @include ubuntu-p-takeunders;
 @include ubuntu-p-tables;
 @include ubuntu-p-feedback;
-@include p-takeover-rigado-webinar;
 @include p-takeover-ai-webinar;
+@include p-takeover-financial-services;
 @include u-animations;
 
 // Bug fixes

--- a/static/sass/takeovers/_financial-services.scss
+++ b/static/sass/takeovers/_financial-services.scss
@@ -1,0 +1,72 @@
+@mixin p-takeover-financial-services {
+  @keyframes fade-left {
+    0% {opacity: 0; transform: translateX(30%);}
+    100% {opacity: 1; transform: translateX(0);}
+  }
+
+  @keyframes fade-right {
+    0% {opacity: 0; transform: translateX(-10%);}
+    100% {opacity: 1; transform: translateX(0);}
+  }
+
+  .p-takeover--financial-services {
+    background-image: linear-gradient(45deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    background-color: #171717;
+
+    .p-takeover__title {
+      font-weight: 100;
+      color: $color-x-light;
+    }
+
+    .p-takeover__text {
+      @extend %vf-heading-4;
+      color: $color-x-light;
+      margin-bottom: 1.7rem;
+    }
+
+    .p-takeover__col {
+      @media (max-width: $breakpoint-medium) {
+        margin: 0 3rem;
+      }
+    }
+
+    .p-takeover__image-container {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      position: relative;
+
+      @media (max-width: $breakpoint-medium) {
+        margin-bottom: 3.5rem;
+        max-width: 300px;
+      }
+    }
+
+    .financial-cloud {
+      width: 100%;
+      z-index: 2;
+    }
+
+    .light-grey-cloud {
+      animation: fade-right 1.5s cubic-bezier(0.215, 0.61, 0.355, 1) .75s 1 forwards;
+      bottom: -12%;
+      left: -18%;
+      opacity: 0;
+      position: absolute;
+      transform: translateX(-10%);
+      width: 66%;
+      z-index: 1;
+    }
+
+    .aubergine-cloud {
+      animation: fade-left 1.25s cubic-bezier(0.215, 0.61, 0.355, 1) .5s 1 forwards;
+      bottom: -20%;
+      opacity: 0;
+      position: absolute;
+      transform: translateX(30%);
+      right: -20%;
+      width: 50%;
+      z-index: 3;
+    }
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,9 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_tackling_iot.html" with nojs_fallback=True %}
+{% include "takeovers/_financial-services.html" with nojs_fallback=True %}
 {% include "takeovers/_ai_webinar.html" %}
+{% include "takeovers/_tackling_iot.html" %}
 
 <script>
   if (window.localStorage && window.sessionStorage) {

--- a/templates/takeovers/_financial-services.html
+++ b/templates/takeovers/_financial-services.html
@@ -1,0 +1,23 @@
+<section class="p-strip is-deep p-takeover--financial-services js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h1 class="p-takeover__title">Financial Services Month</h1>
+      <p class="p-takeover__text">Join Canonical for a deep dive into the rise of multi-cloud in the financial services industry.</p>
+      <div class="u-hide--small">
+        <a href="/engage/financial-services-month" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+      </div>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center">
+      <div class="p-takeover__col">
+        <div class="p-takeover__image-container u-align-text--center">
+          <img class="financial-cloud" src="{{ ASSET_SERVER_URL }}bac38d84-financial-cloud.svg" alt="">
+          <img class="light-grey-cloud" src="{{ ASSET_SERVER_URL }}5eac5b8b-light-grey-cloud.svg" alt="">
+          <img class="aubergine-cloud" src="{{ ASSET_SERVER_URL }}3e777a03-aubergine-cloud.svg" alt="">
+        </div>
+        <div class="u-hide--medium u-hide--large">
+          <a href="/engage/financial-services-month" class="p-button--positive u-no-margin--bottom">Register for webinar</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Built Financial Services Month takeover and added it to rotation with AI/ML and IoT App Store takeovers
- **Note:** this PR is linked to the `landing-financial-services-month` branch, not `master`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh the page until the Financial Services takeover shows
- Check that the copy matches the [brief](https://docs.google.com/document/d/1ZBXfhlfks9m10Enm5oe1L8xdasNc6YM3UWma7eYT1NQ/edit)
- Check that it matches the [design](https://github.com/ubuntudesign/www.ubuntu.com-design/issues/156) and has a sweet animation (check desktop and mobile)
- Check that the CTA takes you to the (currently WIP) /engage/financial-services-month landing page

## Issue / Card

Fixes #3958 