### PR TITLE
Misc fixes on IoT takeover and Finserv lp

### DIFF
--- a/templates/engage/financial-services-month.html
+++ b/templates/engage/financial-services-month.html
@@ -6,7 +6,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-7">
       <h1 class="p-takeover__title">Canonical presents<br> Financial Services month</h1>
-      <p>Filmed at the London Stock exchange with representatives from Canonical, 451 Research, IBM, and former Deutsche Bank storage CTO, Canonical took a deep dive in to the rise of multi-cloud in the financial services industry. Join us for insights around emerging technologies including AI/ML, Blockchain and Containers in FinTech.</p>
+      <p>Filmed at the London Stock exchange with representatives from Canonical, 451 Research, IBM, and a former Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise of multi-cloud in the financial services industry. Join us for insights around emerging technologies including AI/ML, Blockchain and Containers in FinTech.</p>
     </div>
     <div class="col-1">&nbsp;</div>
     <div class="col-5 u-align--center u-vertically-center">
@@ -28,7 +28,7 @@
     <div class="col-8">
       <h4 class="p-muted-heading">September 5</h4>
       <h2>Ambitions and challenges mark financial services plans for cloud </h2>
-      <p>Referencing 451 Research’s Voice of the Enterprise data, Liam Eagle looks at the adoption trends of cloud within the financial services sector where investment in the promise of cloud is strong, but cautious in how central it is to their IT operations. </p>
+      <p>Referencing 451 Research’s Voice of the Enterprise data, Liam Eagle, Research Manager at 451 Research, looks at the adoption trends of cloud within the financial services sector where investment in the promise of cloud is strong, but cautious in how central it is to their IT operations. </p>
       <p>Watch this webinar to discover: </p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">How financial services are adopting cloud services</li>

--- a/templates/takeovers/_tackling_iot.html
+++ b/templates/takeovers/_tackling_iot.html
@@ -7,7 +7,7 @@
         <img src="{{ ASSET_SERVER_URL }}6d4f864b-Piggy+Bank+icon.svg" alt="" width="150">
       </p>
       <p>
-        <a href="/engage/iot-business-model?utm_source=takeover&utm_campaign=FY19_IOT_Appstore_Whitepaper_Appstore" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Tackling the IoT monetisation challenge', 'eventLabel' : 'Download whitepaper', 'eventValue' : undefined });" class="p-button--neutral">
+        <a href="/engage/iot-business-model?utm_source=takeover&utm_campaign=FY19_IOT_Appstore_Whitepaper_Appstore" class="p-button--neutral">
           Download whitepaper
         </a>
       </p>

--- a/templates/takeovers/_tackling_iot.html
+++ b/templates/takeovers/_tackling_iot.html
@@ -7,7 +7,7 @@
         <img src="{{ ASSET_SERVER_URL }}6d4f864b-Piggy+Bank+icon.svg" alt="" width="150">
       </p>
       <p>
-        <a href="/engage/iot-business-model" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Tackling the IoT monetisation challenge', 'eventLabel' : 'Download whitepaper', 'eventValue' : undefined });" class="p-button--neutral">
+        <a href="/engage/iot-business-model?utm_source=takeover&utm_campaign=FY19_IOT_Appstore_Whitepaper_Appstore" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Tackling the IoT monetisation challenge', 'eventLabel' : 'Download whitepaper', 'eventValue' : undefined });" class="p-button--neutral">
           Download whitepaper
         </a>
       </p>


### PR DESCRIPTION
## Done

* Add UTMs to IoT takeover
* Remove GA event from IoT takeover (link and button events are now auto-generated)
* Copy changes to Finserv landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [ ] Ensure the IoT takeover link is UTMized
- [ ] Ensure the Finserv landing page matches the [copy doc](https://docs.google.com/document/d/1THWC0QzAzGOoaLXWrxil100SkpvXm3tJd9fUlwRZGzg/edit#)

