### PR TITLE
Increase z-index for navigation components

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -18,7 +18,7 @@
   .p-navigation {
     background-color: $nav-bg-color;
     flex-direction: column;
-    z-index: 3;
+    z-index: 10;
 
     &::after { // disable rule under nav
       background-color: none;
@@ -181,7 +181,7 @@
       margin-top: 0;
       position: relative;
       width: 100%;
-      z-index: 1;
+      z-index: 5;
 
       @media (max-width: $breakpoint-x-small - 1) {
         padding-top: $sp-small / 2;
@@ -373,7 +373,7 @@
     background-color: rgba(17,17,17, .4);
     opacity: 1;
     position: fixed;
-    z-index: 1;
+    z-index: 3;
     transition: opacity .5s ease-in-out;
   }
 
@@ -384,7 +384,7 @@
     flex-direction: column;
     position: absolute;
     width: 100%;
-    z-index: 2;
+    z-index: 4;
 
     &.slide-animation {
       box-shadow: none;


### PR DESCRIPTION
## Done

- Increased z-index of navigation to fix a bug where page content sat above it

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/financial-services-month
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Open the primary nav and check that the clouds don't sit in front of the nav content
