### PR TITLE
Cleanup UASD

### DIFF
--- a/templates/legal/managed-services/service-description.html
+++ b/templates/legal/managed-services/service-description.html
@@ -1,7 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Managed Services description{% endblock %}
-{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1kHRTIFjuK3pbK3kp-hKGrlKsKBKG7_HnotmN4iy8_eU/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip">

--- a/templates/legal/managed-services/service-description.html
+++ b/templates/legal/managed-services/service-description.html
@@ -1,7 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Managed Services description{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1kHRTIFjuK3pbK3kp-hKGrlKsKBKG7_HnotmN4iy8_eU/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1kHRTIFjuK3pbK3kp-hKGrlKsKBKG7_HnotmN4iy8_eU{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip">

--- a/templates/legal/shared/_appendix-management-escalation.html
+++ b/templates/legal/shared/_appendix-management-escalation.html
@@ -1,7 +1,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-8">
-      <h1 id="appendix-management-escalation">Appendix {{number}} - Ubuntu Advantage Management Escalation</h1>
+      <h1 id="appendix-management-escalation">Appendix {{number}} - Management Escalation</h1>
     </div>
   </div>
   <div class="row">

--- a/templates/legal/shared/_appendix-management-escalation_toc.html
+++ b/templates/legal/shared/_appendix-management-escalation_toc.html
@@ -1,1 +1,1 @@
-<h3 class="p-heading--four"><a href="#appendix-management-escalation">Appendix {{ number }} - Ubuntu Advantage Management Escalation&nbsp;&rsaquo;</a></h3>
+<h3 class="p-heading--four"><a href="#appendix-management-escalation">Appendix {{ number }} - Management Escalation&nbsp;&rsaquo;</a></h3>

--- a/templates/legal/shared/_appendix-support-process.html
+++ b/templates/legal/shared/_appendix-support-process.html
@@ -1,7 +1,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-8">
-      <h1 id="appendix-support-process">Appendix {{number}} - Ubuntu Advantage Support Process</h1>
+      <h1 id="appendix-support-process">Appendix {{number}} - Support Process</h1>
     </div>
   </div>
   <div class="row">
@@ -67,22 +67,6 @@
             <li class="p-list__item">The customer is expected to provide all information requested by Canonical as we work to resolve the case.</li>
             <li class="p-list__item">Canonical will keep a record of each case within the support portal enabling the customer to track and respond to all current cases and allowing for review of historical cases.</li>
           </ol>
-        </li>
-        <li class="p-list__item">
-          <h2 id="appendix-support-severity-levels">Support severity levels</h2>
-          <ol class="p-list--ordered-legal">
-            <li class="p-list__item">Once a support request is opened, a Canonical Support Engineer will validate the case information and determine the severity level, working with the customer to assess the urgency of the case.</li>
-            <li class="p-list__item">Response times will be as set forth in the Service Description for the applicable service offering.</li>
-            <li class="p-list__item">When setting the severity level, Canonical's Support Team will use the definitions as stated below:</li>
-          </ol>
-          <h3>Severity Level 1 — Core functionality not available</h3>
-          <p>Canonical will use continuous effort according to the service level purchased, through appropriate support engineer(s) and/or development engineer(s), to provide a work-around or permanent solution. As soon as core functionality is available, the severity level will be lowered to the new appropriate severity level.</p>
-          <h3>Severity Level 2 — Core functionality severely degraded</h3>
-          <p>Canonical will provide concerted efforts during the applicable business hours to provide the customer with a work-around or permanent solution. As soon as core functionality is no longer severely degraded, the severity level will be lowered to level 3.</p>
-          <h3>Severity Level 3 — Standard support request</h3>
-          <p>Canonical will use reasonable efforts during the applicable business hours to provide the customer with a work-around or permanent solution as soon as possible, balanced against higher severity level cases. If a work-around is provided, Canonical's support engineers will continue to work on developing a permanent resolution to the case.</p>
-          <h3>Severity Level 4 — Non-urgent request</h3>
-          <p>Level 4 requests include cosmetic issues, informational requests, feature requests, and similar matters. Canonical does not provide a timeline or guarantee for inclusion of any feature requests. Canonical will review each level 4 case and determine whether it is a product enhancement to be considered for a future release, an issue to be fixed in the current release or an issue to be fixed in a future release. Canonical will review and respond to information requests with a reasonable level of effort during coverage hours. Canonical may close cases representing level 4 issues after responding if Canonical believes it is appropriate to do so.</p>
         </li>
         <li class="p-list__item">
           <h2 id="appendix-support-hotfixes">Hotfixes</h2>

--- a/templates/legal/shared/_appendix-support-scope.html
+++ b/templates/legal/shared/_appendix-support-scope.html
@@ -91,9 +91,9 @@
           <thead>
             <tr>
               <th scope="col">Features</th>
-              <th scope="col">Essential&emsp;</th>
-              <th scope="col">Standard&emsp;</th>
-              <th scope="col">Advanced</th>
+              <th scope="col" class="u-align--center">Essential&emsp;</th>
+              <th scope="col" class="u-align--center">Standard&emsp;</th>
+              <th scope="col" class="u-align--center">Advanced</th>
             </tr>
           </thead>
           <tbody>
@@ -452,13 +452,13 @@
         Canonical provides livepatches for High and Critical kernel CVEs. Note that some CVEs may be ineligible for livepatching due to technical limitations within the livepatching system.
       </p>
       <p>
-        Canonical can not provide kernel support bug fixes as kernel livepatches.
+        Canonical cannot provide kernel support bug fixes as kernel livepatches.
       </p>
       <p>
         Kernel livepatching is available for generic and low latency 64-bit Intel/AMD 4.4 kernels starting with the 4.4 kernel.
       </p>
       <p>
-        Only the default LTS kernel is available for livepatching, including it’s backport as the latest HWE kernel to the previous LTS release.
+        Only the default LTS kernel is available for livepatching. This includes its backport as the latest HWE kernel to the previous LTS release.
       </p>
 
       <h2 id="appendix-support-scope-fips">FIPS for Ubuntu</h2>
@@ -646,7 +646,7 @@
         <li class="p-list__item">Each release of Livepatch on Premises will be supported for 1 year from its release date.</li>
       </ul>
 
-      <h2 id="ubuntu-advantage-tancher">Ubuntu Advantage Rancher</h2>
+      <h2 id="ubuntu-advantage-rancher">Ubuntu Advantage Rancher</h2>
       <p>
         Definitions:
       </p>

--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -55,7 +55,7 @@
 
           <h2 id="ua-support-scope">Support scope</h2>
           <p>
-            Each service offering includes access to Canonical's knowledge base and the support described below within the scope and subject to the exceptions detailed in the <a href="#appendix-1">support scope documentation</a>.
+            Each service offering includes access to Canonical's knowledge base and the support described below within the scope and subject to the exceptions detailed in the <a href="#appendix-support-scope">support scope documentation</a>.
           </p>
           <ol class="p-list--ordered-legal">
             <li class="p-list__item" id="support-scope-releases">
@@ -105,8 +105,8 @@
             Canonical will use reasonable efforts to resolve support cases, but Canonical does not guarantee a work-around, resolution or resolution time.
           </p>
           <ol class="p-list--ordered-legal">
-            <li class="p-list__item">Canonical will provide the services <a href="#appendix-2">following the support process</a>.</li>
-            <li class="p-list__item">The customer may escalate support issues <a href="#appendix-3">following the escalation process</a>.</li>
+            <li class="p-list__item">Canonical will provide the services <a href="#appendix-support-process">following the support process</a>.</li>
+            <li class="p-list__item">The customer may escalate support issues <a href="#appendix-management-escalation">following the escalation process</a>.</li>
           </ol>
         </li>
 
@@ -128,7 +128,7 @@
         <ol class="p-nested-counter-list">
           <li class="p-nested-counter-list__item"><a href="#service-description-overview">Overview&nbsp;&rsaquo;</a></li>
           <li class="p-nested-counter-list__item">
-            <a href="#appendix-support-scope-support-scope">Support scope&nbsp;&rsaquo;</a>
+            <a href="#appendix-support-scope">Support scope&nbsp;&rsaquo;</a>
             <ol class="p-nested-counter-list">
               <li class="p-nested-counter-list__item"><a href="#support-scope-releases">Releases&nbsp;&rsaquo;</a></li>
               <li class="p-nested-counter-list__item"><a href="#support-scope-hardware">Hardware&nbsp;&rsaquo;</a></li>


### PR DESCRIPTION
## Done

Fix copydoc links
Remove duplicate support severity levels
Fix TOC and inline links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [copydoc](https://docs.google.com/document/d/1mrNrsC1WDf6QTg3nrVCEZS8vJzGz1fokvoFDVC4s_mI/edit)


## Issue / Card

#4010 