### PR TITLE
Updates/fixes to release-cycle page

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -178,6 +178,7 @@ function formatKeyLabel(key) {
   var keyLowerCase = key.toLowerCase().replace(/_/g, ' ');
   var formattedKey = keyLowerCase.charAt(0).toUpperCase() + keyLowerCase.substr(1);
   formattedKey = formattedKey.replace(' lts ', ' LTS ');
+  formattedKey = formattedKey.replace(' openstack ', 'OpenStack ');
 
   return formattedKey;
 }

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -178,7 +178,7 @@ function formatKeyLabel(key) {
   var keyLowerCase = key.toLowerCase().replace(/_/g, ' ');
   var formattedKey = keyLowerCase.charAt(0).toUpperCase() + keyLowerCase.substr(1);
   formattedKey = formattedKey.replace(' lts ', ' LTS ');
-  formattedKey = formattedKey.replace(' openstack ', 'OpenStack ');
+  formattedKey = formattedKey.replace(' openstack ', ' OpenStack ');
 
   return formattedKey;
 }

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -177,6 +177,7 @@ function buildChartKey(chartSelector, taskStatus) {
 function formatKeyLabel(key) {
   var keyLowerCase = key.toLowerCase().replace(/_/g, ' ');
   var formattedKey = keyLowerCase.charAt(0).toUpperCase() + keyLowerCase.substr(1);
+  formattedKey = formattedKey.replace(' lts ', ' LTS ');
 
   return formattedKey;
 }

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -253,6 +253,12 @@ var kernelReleases = [
 var openStackReleases = [
   {
     startDate: new Date('2014-04-01T00:00:00'),
+    endDate: new Date('2017-04-01T00:00:00'),
+    taskName: 'OpenStack Icehouse',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2014-04-01T00:00:00'),
     endDate: new Date('2019-04-01T00:00:00'),
     taskName: 'Ubuntu 14.04 LTS',
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
@@ -260,7 +266,13 @@ var openStackReleases = [
   {
     startDate: new Date('2014-04-01T00:00:00'),
     endDate: new Date('2019-04-01T00:00:00'),
-    taskName: 'OpenStack Icehouse',
+    taskName: 'OpenStack Icehouse LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2014-10-01T00:00:00'),
+    endDate: new Date('2016-04-01T00:00:00'),
+    taskName: 'OpenStack Juno',
     status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
@@ -274,6 +286,12 @@ var openStackReleases = [
     endDate: new Date('2018-04-01T00:00:00'),
     taskName: 'OpenStack Kilo',
     status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2015-10-01T00:00:00'),
+    endDate: new Date('2017-04-01T00:00:00'),
+    taskName: 'OpenStack Liberty',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2016-04-01T00:00:00'),
@@ -290,8 +308,8 @@ var openStackReleases = [
   {
     startDate: new Date('2016-04-01T00:00:00'),
     endDate: new Date('2021-04-01T00:00:00'),
-    taskName: 'OpenStack Mitaka',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    taskName: 'OpenStack Mitaka LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2016-10-01T00:00:00'),
@@ -332,8 +350,8 @@ var openStackReleases = [
   {
     startDate: new Date('2018-04-01T00:00:00'),
     endDate: new Date('2023-04-01T00:00:00'),
-    taskName: 'OpenStack Queens',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    taskName: 'OpenStack Queens LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2018-08-01T00:00:00'),
@@ -374,8 +392,8 @@ var openStackReleases = [
   {
     startDate: new Date('2020-04-01T00:00:00'),
     endDate: new Date('2025-04-01T00:00:00'),
-    taskName: 'OpenStack U',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    taskName: 'OpenStack U LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
 ];
 
@@ -436,19 +454,25 @@ var kernelReleaseNames = [
 ];
 
 var openStackReleaseNames = [
+  'OpenStack U LTS',
   'Ubuntu 20.04 LTS',
   'OpenStack U',
   'OpenStack T',
   'OpenStack Stein',
   'OpenStack Rocky',
+  'OpenStack Queens LTS',
   'Ubuntu 18.04 LTS',
   'OpenStack Queens',
   'OpenStack Pike',
   'OpenStack Ocata',
   'OpenStack Newton',
+  'OpenStack Mitaka LTS',
   'Ubuntu 16.04 LTS',
   'OpenStack Mitaka',
+  'OpenStack Liberty',
   'OpenStack Kilo',
-  'OpenStack Icehouse',
-  'Ubuntu 14.04 LTS'
+  'OpenStack Juno',
+  'OpenStack Icehouse LTS',
+  'Ubuntu 14.04 LTS',
+  'OpenStack Icehouse'
 ];

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -432,7 +432,7 @@ var kernelReleaseNames = [
   'Ubuntu 12.04.5 LTS (v3.13)',
   'Ubuntu 14.04.0 LTS (v3.13)',
   'Ubuntu 12.04.1 LTS (v3.2)',
-  'Ubuntu 12.01.0 LTS (v3.2)'
+  'Ubuntu 12.04.0 LTS (v3.2)'
 ];
 
 var openStackReleaseNames = [

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -457,9 +457,7 @@ var openStackReleaseNames = [
   'OpenStack Mitaka LTS',
   'Ubuntu 16.04 LTS',
   'OpenStack Mitaka',
-  'OpenStack Liberty',
   'OpenStack Kilo',
-  'OpenStack Juno',
   'OpenStack Icehouse LTS',
   'Ubuntu 14.04 LTS',
   'OpenStack Icehouse'

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -270,12 +270,6 @@ var openStackReleases = [
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
-    startDate: new Date('2014-10-01T00:00:00'),
-    endDate: new Date('2016-04-01T00:00:00'),
-    taskName: 'OpenStack Juno',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
-  },
-  {
     startDate: new Date('2015-04-01T00:00:00'),
     endDate: new Date('2016-10-01T00:00:00'),
     taskName: 'OpenStack Kilo',
@@ -286,12 +280,6 @@ var openStackReleases = [
     endDate: new Date('2018-04-01T00:00:00'),
     taskName: 'OpenStack Kilo',
     status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
-  },
-  {
-    startDate: new Date('2015-10-01T00:00:00'),
-    endDate: new Date('2017-04-01T00:00:00'),
-    taskName: 'OpenStack Liberty',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2016-04-01T00:00:00'),

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -25,7 +25,7 @@ var serverAndDesktopReleases = [
   },
   {
     startDate: new Date('2017-04-01T00:00:00'),
-    endDate: new Date('2019-04-01T00:00:00'),
+    endDate: new Date('2020-04-01T00:00:00'),
     taskName: 'Ubuntu 12.04 LTS',
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
@@ -107,14 +107,14 @@ var kernelReleases = [
   {
     startDate: new Date('2012-04-01T00:00:00'),
     endDate: new Date('2017-04-01T00:00:00'),
-    taskName: 'Ubuntu 12.01.0 LTS (v3.2)',
+    taskName: 'Ubuntu 12.04.0 LTS (v3.2)',
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2017-04-01T00:00:00'),
-    endDate: new Date('2019-07-01T00:00:00'),
-    taskName: 'Ubuntu 12.01.0 LTS (v3.2)',
-    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+    endDate: new Date('2020-04-01T00:00:00'),
+    taskName: 'Ubuntu 12.04.0 LTS (v3.2)',
+    status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
   {
     startDate: new Date('2012-07-01T00:00:00'),
@@ -124,9 +124,9 @@ var kernelReleases = [
   },
   {
     startDate: new Date('2017-04-01T00:00:00'),
-    endDate: new Date('2019-07-01T00:00:00'),
+    endDate: new Date('2020-04-01T00:00:00'),
     taskName: 'Ubuntu 12.04.1 LTS (v3.2)',
-    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+    status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
   {
     startDate: new Date('2014-04-01T00:00:00'),
@@ -142,9 +142,9 @@ var kernelReleases = [
   },
   {
     startDate: new Date('2017-04-01T00:00:00'),
-    endDate: new Date('2019-07-01T00:00:00'),
+    endDate: new Date('2020-04-01T00:00:00'),
     taskName: 'Ubuntu 12.04.5 LTS (v3.13)',
-    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+    status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
   {
     startDate: new Date('2014-07-01T00:00:00'),
@@ -174,13 +174,13 @@ var kernelReleases = [
     startDate: new Date('2017-10-01T00:00:00'),
     endDate: new Date('2018-10-01T00:00:00'),
     taskName: 'Ubuntu 17.10 (v4.13)',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    status: 'STANDARD_RELEASE'
   },
   {
     startDate: new Date('2018-01-01T00:00:00'),
     endDate: new Date('2018-10-01T00:00:00'),
     taskName: 'Ubuntu 16.04.4 LTS (v4.13)',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2018-04-01T00:00:00'),
@@ -204,7 +204,7 @@ var kernelReleases = [
     startDate: new Date('2018-10-01T00:00:00'),
     endDate: new Date('2019-10-01T00:00:00'),
     taskName: 'Ubuntu 18.10',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    status: 'STANDARD_RELEASE'
   },
   {
     startDate: new Date('2019-01-01T00:00:00'),
@@ -216,7 +216,7 @@ var kernelReleases = [
     startDate: new Date('2019-04-01T00:00:00'),
     endDate: new Date('2020-04-01T00:00:00'),
     taskName: 'Ubuntu 19.04',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    status: 'STANDARD_RELEASE'
   },
   {
     startDate: new Date('2019-07-01T00:00:00'),
@@ -228,7 +228,7 @@ var kernelReleases = [
     startDate: new Date('2019-10-01T00:00:00'),
     endDate: new Date('2020-10-01T00:00:00'),
     taskName: 'Ubuntu 19.10',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+    status: 'STANDARD_RELEASE'
   },
   {
     startDate: new Date('2020-01-01T00:00:00'),
@@ -288,47 +288,95 @@ var openStackReleases = [
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
+    startDate: new Date('2016-04-01T00:00:00'),
+    endDate: new Date('2021-04-01T00:00:00'),
+    taskName: 'OpenStack Mitaka',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
     startDate: new Date('2016-10-01T00:00:00'),
     endDate: new Date('2018-04-01T00:00:00'),
     taskName: 'OpenStack Newton',
     status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
-    startDate: new Date('2017-04-01T00:00:00'),
-    endDate: new Date('2018-10-01T00:00:00'),
+    startDate: new Date('2017-02-01T00:00:00'),
+    endDate: new Date('2018-08-01T00:00:00'),
     taskName: 'OpenStack Ocata',
     status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
-    startDate: new Date('2018-10-01T00:00:00'),
-    endDate: new Date('2020-04-01T00:00:00'),
+    startDate: new Date('2018-08-01T00:00:00'),
+    endDate: new Date('2020-02-01T00:00:00'),
     taskName: 'OpenStack Ocata',
     status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
   },
   {
-    startDate: new Date('2017-10-01T00:00:00'),
-    endDate: new Date('2019-04-01T00:00:00'),
+    startDate: new Date('2017-08-01T00:00:00'),
+    endDate: new Date('2019-02-01T00:00:00'),
     taskName: 'OpenStack Pike',
     status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
-    startDate: new Date('2018-04-01T00:00:00'),
+    startDate: new Date('2018-03-01T00:00:00'),
     endDate: new Date('2021-04-01T00:00:00'),
     taskName: 'OpenStack Queens',
     status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2018-04-01T00:00:00'),
-    endDate: new Date('2023-07-01T00:00:00'),
+    endDate: new Date('2023-04-01T00:00:00'),
     taskName: 'Ubuntu 18.04 LTS',
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
-    startDate: new Date('2018-10-01T00:00:00'),
-    endDate: new Date('2020-04-01T00:00:00'),
+    startDate: new Date('2018-04-01T00:00:00'),
+    endDate: new Date('2023-04-01T00:00:00'),
+    taskName: 'OpenStack Queens',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-08-01T00:00:00'),
+    endDate: new Date('2020-02-01T00:00:00'),
     taskName: 'OpenStack Rocky',
     status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
-  }
+  },
+  {
+    startDate: new Date('2019-04-01T00:00:00'),
+    endDate: new Date('2020-10-01T00:00:00'),
+    taskName: 'OpenStack Stein',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2020-10-01T00:00:00'),
+    endDate: new Date('2022-04-01T00:00:00'),
+    taskName: 'OpenStack Stein',
+    status: 'EXTENDED_SUPPORT_FOR_CUSTOMERS'
+  },
+  {
+    startDate: new Date('2019-08-01T00:00:00'),
+    endDate: new Date('2021-02-01T00:00:00'),
+    taskName: 'OpenStack T',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2020-02-01T00:00:00'),
+    endDate: new Date('2023-04-01T00:00:00'),
+    taskName: 'OpenStack U',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2020-04-01T00:00:00'),
+    endDate: new Date('2025-04-01T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'UBUNTU_LTS_RELEASE_SUPPORT'
+  },
+  {
+    startDate: new Date('2020-04-01T00:00:00'),
+    endDate: new Date('2025-04-01T00:00:00'),
+    taskName: 'OpenStack U',
+    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
+  },
 ];
 
 var desktopServerStatus = {
@@ -340,8 +388,8 @@ var desktopServerStatus = {
 
 var kernelStatus = {
   UBUNTU_LTS_RELEASE_SUPPORT: 'chart__bar--orange',
-  MATCHING_OPENSTACK_RELEASE_SUPPORT: 'chart__bar--grey',
-  EXTENDED_SUPPORT_FOR_CUSTOMERS: 'chart__bar--aubergine'
+  STANDARD_RELEASE: 'chart__bar--grey',
+  EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS: 'chart__bar--aubergine'
 };
 
 var openStackStatus = {
@@ -388,6 +436,10 @@ var kernelReleaseNames = [
 ];
 
 var openStackReleaseNames = [
+  'Ubuntu 20.04 LTS',
+  'OpenStack U',
+  'OpenStack T',
+  'OpenStack Stein',
   'OpenStack Rocky',
   'Ubuntu 18.04 LTS',
   'OpenStack Queens',

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -1,6 +1,6 @@
 {% extends "templates/one-column.html" %}
 {% load versioned_static  %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ{% endblock meta_copydoc %}
 {% block meta_description %}Overview of the Ubuntu release cycle - maintenance, support and security coverage, lifetime, upgrade paths, kernel versions and the range of editions and images published by Canonical.{% endblock %}
 
 {% block title %}Ubuntu release cycle{% endblock %}

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -427,7 +427,7 @@
         <tbody>
           <tr>
             <td>OpenStack U LTS</td>
-            <td>Feburary 2020</td>
+            <td>April 2020</td>
             <td>April 2025</td>
             <td>&nbsp;</td>
           </tr>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -426,7 +426,7 @@
         </thead>
         <tbody>
           <tr>
-            <td>OpenStack U</td>
+            <td>OpenStack U LTS</td>
             <td>Feburary 2020</td>
             <td>April 2025</td>
             <td>&nbsp;</td>
@@ -449,7 +449,7 @@
             <td>February 2021</td>
             <td>&nbsp;</td>
           </tr>
-	  <tr>
+	        <tr>
             <td>OpenStack Stein</td>
             <td>April 2019</td>
             <td>October 2020</td>
@@ -462,7 +462,7 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>OpenStack Queens</td>
+            <td>OpenStack Queens LTS</td>
             <td>April 2018</td>
             <td>April 2023</td>
             <td>&nbsp;</td>
@@ -498,7 +498,7 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>OpenStack Mitaka</td>
+            <td>OpenStack Mitaka LTS</td>
             <td>April 2016</td>
             <td>April 2021</td>
             <td>&nbsp;</td>
@@ -534,7 +534,7 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>OpenStack Icehouse</td>
+            <td>OpenStack Icehouse LTS</td>
             <td>April 2014</td>
             <td>April 2019</td>
             <td>&nbsp;</td>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -1,6 +1,6 @@
 {% extends "templates/one-column.html" %}
 {% load versioned_static  %}
-
+{% block meta_copydoc %}https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#{% endblock meta_copydoc %}
 {% block meta_description %}Overview of the Ubuntu release cycle - maintenance, support and security coverage, lifetime, upgrade paths, kernel versions and the range of editions and images published by Canonical.{% endblock %}
 
 {% block title %}Ubuntu release cycle{% endblock %}
@@ -43,6 +43,7 @@
             <td>&nbsp;</td>
             <th scope="col">Released</th>
             <th scope="col">End of Life</th>
+            <th scope="col">Extended security maintenance</th>
           </tr>
         </thead>
         <tbody>
@@ -50,81 +51,97 @@
             <td><strong>Ubuntu 22.04 LTS</strong></td>
             <td>April 2022</td>
             <td>April 2027</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 21.10</td>
             <td>October 2021</td>
             <td>July 2022</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 21.04</td>
             <td>April 2021</td>
             <td>January 2022</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 20.10</td>
             <td>October 2020</td>
             <td>July 2021</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 20.04 LTS</strong></td>
             <td>April 2020</td>
             <td>April 2025</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 19.10</td>
             <td>October 2019</td>
             <td>July 2020</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 19.04</td>
             <td>April 2019</td>
             <td>January 2020</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 18.10</td>
             <td>October 2018</td>
             <td>July 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04 LTS</strong></td>
             <td>April 2018</td>
             <td>April 2023</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 17.10</td>
             <td>October 2017</td>
             <td>July 2018</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 17.04</td>
             <td>April 2017</td>
             <td>January 2018</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 16.10</td>
             <td>October 2016</td>
             <td>June 2017</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04 LTS</strong></td>
             <td>April 2016</td>
             <td>April 2021</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04 LTS</strong></td>
             <td>April 2014</td>
             <td>April 2019</td>
+            <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04 LTS</strong></td>
             <td>April 2012</td>
             <td>April 2017</td>
+            <td>April 2020</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 10.04 LTS</strong></td>
             <td>April 2010</td>
             <td>April 2015</td>
+            <td>&nbsp;</td>
           </tr>
         </tbody>
       </table>
@@ -246,7 +263,7 @@
             <th>Release</th>
             <th>Released</th>
             <th>End of life</th>
-            <th>Extended customer support</th>
+            <th>Extended security maintenance</th>
           </tr>
         </thead>
         <tbody>
@@ -356,7 +373,7 @@
             <td><strong>Ubuntu 12.04.5 LTS (v3.13)</strong></td>
             <td>August 2014</td>
             <td>April 2017</td>
-            <td>April 2019</td>
+            <td>April 2020</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
@@ -368,13 +385,13 @@
             <td><strong>Ubuntu 12.04.1 LTS (v3.2)</strong></td>
             <td>August 2012</td>
             <td>April 2017</td>
-            <td>April 2019</td>
+            <td>April 2020</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04.0 LTS (v3.2)</strong></td>
             <td>April 2012</td>
             <td>April 2017</td>
-            <td>April 2019</td>
+            <td>April 2020</td>
           </tr>
         </tbody>
       </table>
@@ -390,7 +407,7 @@
     <div class="col-8">
       <h2>Ubuntu OpenStack release cycle</h2>
       <p>Canonical’s Cloud Archive allows users the ability to install newer releases of Ubuntu <a href="https://wiki.ubuntu.com/OpenStack" class="p-link--external">OpenStack</a> on an Ubuntu server as they become available. A given LTS release of Ubuntu will have the current release of OpenStack packaged in its release archives. The next four releases of OpenStack will then be published in the Cloud Archive for that LTS.</p>
-      <p>That means that it is possible to upgrade OpenStack four times on the same Ubuntu LTS release base operating system (upgrading the OpenStack without upgrading the operating system), and then one has the same OpenStack version that is included with the subsequent LTS release, and can choose to upgrade the operating system without upgrading the openstack version.</p>
+      <p>That means that it is possible to upgrade OpenStack four times on the same Ubuntu LTS release base operating system (upgrading the OpenStack without upgrading the operating system), and then one has the same OpenStack version that is included with the subsequent LTS release, and can choose to upgrade the operating system without upgrading the OpenStack version.</p>
       <p>The middle OpenStack release (one year after the LTS release and one year before the next LTS release) is maintained for an extended period. Many customers therefore opt to make annual upgrades to their OpenStack rather than tracking each six-monthly release. The actual upgrade is fully supported using Canonical OpenStack tools and operator guides, and involves hopping through the six-monthly versions for database upgrade purposes, but the next effect is an annual upgrade to a version that is fully supportable.</p>
       <p>The Ubuntu OpenStack support lifecycle can be represented this way:</p>
     </div>
@@ -408,6 +425,36 @@
           </tr>
         </thead>
         <tbody>
+          <tr>
+            <td>OpenStack U</td>
+            <td>Feburary 2020</td>
+            <td>April 2025</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04 LTS</strong></td>
+            <td>April 2020</td>
+            <td>April 2025</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>OpenStack U</td>
+            <td>Feburary 2020</td>
+            <td>April 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>OpenStack T</td>
+            <td>August 2019</td>
+            <td>February 2021</td>
+            <td>&nbsp;</td>
+          </tr>
+	  <tr>
+            <td>OpenStack Stein</td>
+            <td>April 2019</td>
+            <td>October 2020</td>
+            <td>April 2022</td>
+          </tr>
           <tr>
             <td>OpenStack Rocky</td>
             <td>August 2018</td>
@@ -428,7 +475,7 @@
           </tr>
           <tr>
             <td>OpenStack Queens</td>
-            <td>February 2018</td>
+            <td>March 2018</td>
             <td>April 2021</td>
             <td>&nbsp;</td>
           </tr>
@@ -539,7 +586,7 @@
     </div>
   </div>
   <div class="row">
-    <p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive " class="p-link--external ">Ubuntu Cloud Archive wiki page</a>.</p>
+    <p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive " class="p-link--external ">Ubuntu Cloud Archive wiki page</a>.</p
   </div>
 </section>
 


### PR DESCRIPTION
## Done

Fix some release/EOL dates
Change 12.01.0 to 12.04.0
Update kernel legend wording
Change "Extended support" to "Extended security"
Add back LTS releases of OpenStack
Add next 4 releases of OpenStack

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [copydoc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#)


## Issue / Card

#3917 