### PR TITLE
Support filtering search by site

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -11,8 +11,10 @@
         {% if query %}
           {% if estimatedTotal == 0 %}
             <h1 class="p-heading--two">Sorry we couldn't find "{{ query }}"</h1>
+            {% if siteSearch %}<h3>on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a></h3>{% endif %}
           {% else %}
             <h1 class="p-heading--two">Search results for "{{ query }}"</h1>
+            {% if siteSearch %}<h3>on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a></h3>{% endif %}
           {% endif %}
         {% else %}
           <h1>Search Ubuntu and Canonical sites</h1>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -28,7 +28,7 @@ if settings.SEARCH_API_KEY:
     )
 
 
-def _get_search_results(query, start, num):
+def _get_search_results(query, start, num, site=None):
     """
     Query the Google Custom Search API for search results
     """
@@ -42,6 +42,7 @@ def _get_search_results(query, start, num):
             'key': settings.SEARCH_API_KEY,
             'cx': settings.CUSTOM_SEARCH_ID,
             'q': query,
+            'siteSearch': site,
             'start': start,
             'num': num
         }
@@ -60,18 +61,20 @@ def search(request):
     """
 
     query = request.GET.get('q')
+    site = request.GET.get('siteSearch') or request.GET.get('domain')
     num = int(request.GET.get('num', '10'))
     start = int(request.GET.get('start', '1'))
 
     context = {
         'query': query,
         'start': start,
+        'siteSearch': site,
         'num': num
     }
 
     if query:
         try:
-            context['results'] = _get_search_results(query, start, num)
+            context['results'] = _get_search_results(query, start, num, site)
 
             if 'searchInformation' in context['results']:
                 context['estimatedTotal'] = int(


### PR DESCRIPTION
Filter search with a `siteSearch` parameter.

QA
--

Get key from @nottrobin for use as follows:

``` bash
./run  --env SEARCH_API_KEY=XXXXXX
```

Now go to:

- http://0.0.0.0:8001/search?q=ubuntu
- http://0.0.0.0:8001/search?q=sdfgsdfgsdgf
- http://0.0.0.0:8001/search?q=ubuntu&siteSearch=docs.jujucharms.com
- http://0.0.0.0:8001/search?q=sdfgsdfgsdgf&siteSearch=docs.jujucharms.com
- http://0.0.0.0:8001/search?q=ubuntu&domain=docs.jujucharms.com
- http://0.0.0.0:8001/search?q=sdfgsdfgsdgf&domain=docs.jujucharms.com

Check you see appropriately filtered results and missing results as expected.