### PR TITLE
Fix SD TOC link typo

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -128,7 +128,7 @@
         <ol class="p-nested-counter-list">
           <li class="p-nested-counter-list__item"><a href="#service-description-overview">Overview&nbsp;&rsaquo;</a></li>
           <li class="p-nested-counter-list__item">
-            <a href="#appendix-support-scope">Support scope&nbsp;&rsaquo;</a>
+            <a href="#ua-support-scope">Support scope&nbsp;&rsaquo;</a>
             <ol class="p-nested-counter-list">
               <li class="p-nested-counter-list__item"><a href="#support-scope-releases">Releases&nbsp;&rsaquo;</a></li>
               <li class="p-nested-counter-list__item"><a href="#support-scope-hardware">Hardware&nbsp;&rsaquo;</a></li>


### PR DESCRIPTION
## Done

Fixed a link in the TOC

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)