### PR TITLE
removed enterprise proxy bullet from /internet-of-things/appstore

### DIFF
--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -212,7 +212,6 @@
         <ul class="p-list">
           <li class="p-list__item is-ticked">Private software repositories</li>
           <li class="p-list__item is-ticked">Guaranteed levels of service</li>
-          <li class="p-list__item is-ticked">Enterprise proxy functionalities</li>
           <li class="p-list__item is-ticked">Own app ecosystem control and management</li>
           <li class="p-list__item is-ticked">Snap Store Proxy functionality</li>
           <li class="p-list__item is-ticked">24/7 phone and web support</li>


### PR DESCRIPTION
## Done

- removed the bullet 'Enterprise proxy functionalities' 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/appstore](http://0.0.0.0:8001/internet-of-things/appstore)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit#)


## Issue / Card

Fixes #4019

