### PR TITLE
Updated k8s overview page text

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -5,20 +5,18 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-8">
       <h1>Multi-cloud Kubernetes</h1>
-      <p>The Canonical Distribution of Kubernetes (CDK) is pure upstream Kubernetes tested across the widest range of clouds &mdash; from public clouds to private data centers, from bare metal to virtualized infrastructure.</p>
+      <p>The Canonical Distribution of Kubernetes (CDK) is pure upstream Kubernetes tested across the widest range of clouds &mdash; from public clouds to private data centres, from bare metal to virtualized infrastructure.</p>
       <p>Canonical also provides a rich ecosystem of tools, libraries, services, modern metrics, and monitoring tools to make CDK easy to consume so you can innovate faster.</p>
       <p>
         <a class="p-button--positive" href="/kubernetes/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Get started today, install CDK yourself', 'eventLabel' : 'Get started today, install CDK yourself - Hero CTA' : undefined });">
-          Install CDK yourself
+          Install Kubernetes on Ubuntu
         </a>
-      </p>
-      <p>
-        <a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet - Hero CTA' : undefined });">
-          Download the Enterprise Kubernetes datasheet&nbsp;&rsaquo;
+        <a class="p-button--neutral" href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet - Hero CTA' : undefined });">
+          Download the Kubernetes datasheet
         </a>
       </p>
     </div>
@@ -28,7 +26,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <h2>Kubernetes services packages</h2>
   </div>
@@ -39,7 +37,7 @@
   <div class="row">
     <div class="col-12">
       <h3>AI/ML Add-on for Discoverer and Discoverer Plus</h3>
-      <p>Turn on the taps with a workshop to understand the full stack of machine learning. Build a full pipeline from developer stations to your data center, to the public cloud. Canonical works with the leading companies to ensure you have the widest range of choices.</p>
+      <p>Turn on the taps with a workshop to understand the full stack of machine learning. Build a full pipeline from developer stations to your data centre, to the public cloud. Canonical works with the leading companies to ensure you have the widest range of choices.</p>
     </div>
   </div>
 
@@ -140,7 +138,7 @@
       <p>CVE updates and TLS encryption across all components.</p>
     </div>
     <div class="col-4 p-divider__block">
-      <h3 class="u-no-margin--bottom">Fault Tolerant</h3>
+      <h3 class="u-no-margin--bottom">Fault tolerant</h3>
       <p>High availability and zero downtime upgrades are guaranteed.</p>
     </div>
   </div>
@@ -246,7 +244,7 @@
 
 <section class="p-strip">
   <div class="row">
-    <p id="fn1" class="note"><a href="#r1">*</a> Kubernetes&reg; is a registered trademark of The Linux Foundation in the United States and other countries, and is used pursuant to a license from The Linux Foundation</p>
+    <p id="fn1" class="note"><a href="#r1">*</a> Kubernetes&reg; is a registered trademark of The Linux Foundation in the United States and other countries and is used pursuant to a license from The Linux Foundation</p>
   </div>
 </section>
 

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <p>Canonical offers three service packages to help you launch your Kubernetes strategy.</p>
+  <p>Canonical works with the leading public clouds and institutions to optimise Kubernetes. We offer three service packages to help you establish your Kubernetes operations.</p>
 </div>
 
 <div class="row u-equal-height">


### PR DESCRIPTION
## Done

- Updated text on /kubernetes
    - Changed the text of the main CTA
    - Made the second CTA a button
    - Fixed other typos
    - Made the top strip white and the second light to make the secondary nav move visible

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #3998

