### PR TITLE
Rotate the DE takeover with Financial Services takeover

### DIFF
--- a/templates/index_de.html
+++ b/templates/index_de.html
@@ -5,5 +5,5 @@
 
 {% block takeover_content %}
   {% include "takeovers/_de-vmware-to-os.html" with nojs_fallback=True %}
-  {% include "takeovers/_ai_webinar.html" %}
+  {% include "takeovers/_financial-services.html" %}
 {% endblock takeover_content %}


### PR DESCRIPTION
## Done
Swap the AI takeover with the Financial Services takeover on the German homepage.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/index_de](http://0.0.0.0:8001/index_de)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh and see you get the Financial Services takeover and the German one.

Fixes #4033 
