### PR TITLE
adding a u-no-print style to the print stylesheet

### DIFF
--- a/static/sass/print.scss
+++ b/static/sass/print.scss
@@ -117,3 +117,8 @@ footer,
     display: inline;
   }
 }
+
+// xxx until added to vanilla-framework
+.u-no-print {
+  display: none !important
+}

--- a/static/sass/print.scss
+++ b/static/sass/print.scss
@@ -116,11 +116,6 @@ footer,
   & > .p-list__item > h4 {
     display: inline;
   }
-
-  // xxx until added to vanilla-framework
-  .u-no-print {
-    display: none;
-  }
 }
 
 // xxx until added to vanilla-framework

--- a/static/sass/print.scss
+++ b/static/sass/print.scss
@@ -119,6 +119,7 @@ footer,
 }
 
 // xxx until added to vanilla-framework
+// https://github.com/vanilla-framework/vanilla-framework/issues/1982
 .u-no-print {
   display: none !important
 }

--- a/templates/shared/_feedback.html
+++ b/templates/shared/_feedback.html
@@ -5,7 +5,7 @@
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">User feedback</h2>
       <button class="p-modal__close js-modal-close" aria-label="Close active modal">Close</button>
-    </header>
+    </header> 
     <hr>
     <div class="p-feedback">
       <div class="js-feedback-question">

--- a/templates/shared/_feedback.html
+++ b/templates/shared/_feedback.html
@@ -1,6 +1,6 @@
-<button class="p-button p-feedback__button js-feedback-button">Site feedback</button>
+<button class="p-button p-feedback__button js-feedback-button u-no-print">Site feedback</button>
 
-<div class="p-modal--feedback js-feedback-modal u-hide" id="modal" aria-hidden="true">
+<div class="p-modal--feedback js-feedback-modal u-hide u-no-print" id="modal" aria-hidden="true">
   <div class="p-modal__dialog js-modal-dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">User feedback</h2>
@@ -28,7 +28,7 @@
           </li>
         </ul>
       </div>
-      <div class="js-feedback-result u-hide">
+      <div class="js-feedback-result u-hide ">
         <p>Thank you for your response.</p>
         <p><a href="https://docs.google.com/forms/d/e/1FAIpQLSd1FVXB3MQA5UNqQ4eV3a4xat9J0onPNsz-O8PBL_m6car1LA/viewform?c=0&w=1">Tell us more using this quick online survey&nbsp;&rsaquo;</a></p>
       </div>


### PR DESCRIPTION
## Done

- adding a `u-no-print` style to the print stylesheet

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- try printing and see that the survey form is not there anymore.

## Issue / Card

Fixes #4042

