### PR TITLE
make sure printing doesn't start with a blank page

### DIFF
--- a/static/sass/print.scss
+++ b/static/sass/print.scss
@@ -74,15 +74,17 @@ header,
 nav,
 footer,
 #livechat-compact-view,
+.u-hide,
 .p-top,
 .u-hide--small,
 .p-heading-icon__img,
 .p-contextual-footer,
 .p-navigation,
-.dropdown-window,
-.dropdown-window__overlay,
+.global-nav__dropdown-overlay,
 .global-nav,
-.global-nav__dropdown-overlay {
+.dropdown-window,
+.dropdown-window-overlay,
+.p-navigation--secondary {
   display: none;
 }
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -31,7 +31,7 @@
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
-    <link rel="canonical" href="https://www.ubuntu.com{{ request.get_full_path }}" />
+    <link rel="canonical" href="https://ubuntu.com{{ request.get_full_path }}" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />
 


### PR DESCRIPTION
## Done

- s/dropdown-window__overlay/dropdown-window-overlay/
- also update the canonical tag to not use www.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/ubuntu-advantage/service-description](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- look at the print preview and see the text starts immediately, make sure printing doesn't start with a blank page


## Issue / Card

Fixes #4040

