### PR TITLE
fixed display of card on /resources for topic tabs

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -82,13 +82,12 @@
   {% for group_slug, resources in posts.items %}
     <div class="row u-equal-height">
     {% for resource in resources.posts %}
-      {% if topic %}
-      <article class="col-4">
+      <article class="p-card--{{ resource.group.slug }} col-4" style="display: flex; flex-direction: column;">
+        {% if topic %}
         <h4 class="p-muted-heading">
           {{ topic.name }}
         </h4>
       {% else %}
-      <article class="p-card--{{ resource.group.slug }} col-4" style="display: flex; flex-direction: column;">
         <h4 class="p-muted-heading">
           {{ resource.group.name }}
         </h4>


### PR DESCRIPTION
## Done

-add p-card class to topic tabs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources?content=webinars](http://0.0.0.0:8001/resources?content=webinars)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- see that the cards look like they should with a border, etc...

## Issue / Card

Fixes #4012

