### PR TITLE
Added whitepaper resource on app store page

### DIFF
--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -117,7 +117,7 @@
         </div>
       </div>
       <h2 class='p-heading--four'>
-        <a class='p-link--external' href='https://pages.ubuntu.com/IOT_IoTReport2017.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - left', 'eventLabel' : 'White paper - How to pick a winning IoT business model', 'eventValue' : '1' });'><span hidden>Read the white paper </span>How to pick a winning IoT business model</a>
+        <a class='p-link--external' href='/engage/iot-business-model' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - left', 'eventLabel' : 'White paper - Establishing a software defined IoT business model', 'eventValue' : '1' });'><span hidden>Read the white paper </span>Establishing a software defined IoT business model</a>
       </h2>
       <!-- rtp section end -->
     </div>


### PR DESCRIPTION
## Done

- Changed a resource on app store page to a newer whitepaper

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/appstore](http://0.0.0.0:8001/internet-of-things/appstore)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the link works and it matches the [copydoc ](https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit)


## Issue / Card

Fixes: #4060 

