### PR TITLE
Added ua datasheet to support page

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -10,7 +10,10 @@
     <div class="col-7">
       <h1>Ubuntu Advantage commercial support</h1>
       <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Most packages include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu systems.</p>
-      <p><a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
+      <p>
+        <a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a>
+        <a href="{{ ASSET_SERVER_URL }}63deda69-canonical-ua-datasheet-2018-09-14.pdf" class="p-button--neutral">Download the datasheet</a>
+      </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       <img alt="" src="{{ ASSET_SERVER_URL }}11da76f5-image-management.svg" />

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -11,8 +11,8 @@
       <h1>Ubuntu Advantage commercial support</h1>
       <p>Canonical offers a range of Ubuntu Advantage packages to support and add value to your Ubuntu deployment. Most packages include Landscape, the Ubuntu systems management tool for security audit and compliance, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu systems.</p>
       <p>
-        <a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a>
-        <a href="{{ ASSET_SERVER_URL }}63deda69-canonical-ua-datasheet-2018-09-14.pdf" class="p-button--neutral">Download the datasheet</a>
+        <a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the store</span></a>
+        <a href="{{ ASSET_SERVER_URL }}63deda69-canonical-ua-datasheet-2018-09-14.pdf" class="p-button--neutral">Get the Ubuntu Advantage datasheet</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done

- Added a CTA to download the UA datasheet on the support index page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support](http://0.0.0.0:8001/support)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the link works and reflects the [copydoc ](https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit)


## Issue / Card

#4062 

