### PR TITLE
“Plans and pricing”: Tweaks heading levels

### DIFF
--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -107,7 +107,7 @@
 <section class="p-strip--light is-shallow">
   <div class="row" style="overflow-x: auto;">
     <div class="col-12">
-      <h2 id="server">For servers</h2>
+      <h3 id="server">For servers</h3>
       {% include "shared/pricing/_ua-server-support.html" %}
     </div>
   </div>
@@ -116,7 +116,7 @@
 <section class="p-strip--light is-shallow u-no-padding--bottom">
   <div class="row" style="overflow-x: auto;">
     <div class="col-12">
-      <h2 id="desktop">For desktops</h2>
+      <h3 id="desktop">For desktops</h3>
       {% include "shared/pricing/_ua-desktop-support.html" %}
     </div>
   </div>


### PR DESCRIPTION
Changes “For servers” and “For desktops” to `<h3>`, since they’re subsections of `<h2>Ubuntu Advantage</h2>`.

To test: http://www.ubuntu.com-pr-4064.run.demo.haus/support/plans-and-pricing