### PR TITLE
add cloudinary and and srcset to resources

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -95,7 +95,18 @@
         <hr class="u-sv1">
         {% if resource.featuredmedia.source_url %}
         <a href="{{resource.link|replace_admin}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Resources', 'eventAction' : 'Clicked resource', 'eventLabel' : '{{resource.title.rendered}}', 'eventValue' : undefined });" >
-          <img src="{{resource.featuredmedia.source_url}}" alt="{{resource.featuredmedia.alt_text}}" />
+          <img
+            src="https://res.cloudinary.com/canonical/image/fetch/w_460/{{resource.featuredmedia.source_url}}"
+            srcset="https://res.cloudinary.com/canonical/image/fetch/w_460/{{resource.featuredmedia.source_url}} 460w,
+            https://res.cloudinary.com/canonical/image/fetch/w_620/{{resource.featuredmedia.source_url}} 620w,
+            https://res.cloudinary.com/canonical/image/fetch/w_875/{{resource.featuredmedia.source_url}} 875w"
+            sizes="(min-width: 1031px) 460px,
+            (max-width: 1030px) and (min-width: 876px) 460px,
+            (max-width: 875px) and (min-width: 621px) 875px,
+            (max-width: 620px) and (min-width: 461px) 620px,
+            (max-width: 460px) 460px"
+            alt="{{resource.featuredmedia.alt_text}}"
+          />
         </a>
         {% endif %}
         <h3 class="p-heading--four"><a href="{{resource.link|replace_admin}}">{{resource.title.rendered | safe}}</a></h3>


### PR DESCRIPTION
## Done

- signed up for cloudinary
- use cloudinary to resize images on the fly and use the srcset/size tags to get responsive images on the /resources page
- result is a 75% reduction in page size

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources](http://0.0.0.0:8001/resources)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the page shows much smaller thumbnails
