### PR TITLE
Add impression events for takeovers, switch to absolute URLs inside events

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -163,7 +163,7 @@ function closeMainMenu() {
   }
 }
 
-var origin = window.location.pathname;
+var origin = window.location.href;
 
 addGANavEvents('.global-nav__row', 'www.ubuntu.com-nav-0');
 addGANavEvents('#canonical-products', 'www.ubuntu.com-nav-0-products');
@@ -182,12 +182,11 @@ function addGANavEvents(target, category){
   var t = document.querySelector(target);
   if (t) {
     t.querySelectorAll('a').forEach(function(a) {
-      var destination = a.href.replace('https://www.ubuntu.com', '');
-      a.addEventListener('click', function(event){
+      a.addEventListener('click', function(){
         dataLayer.push({
           'event' : 'GAEvent',
           'eventCategory' : category,
-          'eventAction' : `from:${origin} to:${destination}`,
+          'eventAction' : `from:${origin} to:${a.href}`,
           'eventLabel' : a.text,
           'eventValue' : undefined
         });
@@ -202,7 +201,6 @@ function addGAContentEvents(target){
   var t = document.querySelector(target);
   if (t) {
     t.querySelectorAll('a').forEach(function(a) {
-      var destination = a.href.replace('https://www.ubuntu.com', '');
       if (a.className.includes('p-button--positive')) {
         var category = 'www.ubuntu.com-content-cta-0';
       } else if (a.className.includes('p-button')) {
@@ -210,15 +208,35 @@ function addGAContentEvents(target){
       } else {
         var category = 'www.ubuntu.com-content-link';
       }
-      if (!destination.startsWith("#")){
-        a.addEventListener('click', function(event){
+      if (!a.href.startsWith("#")){
+        a.addEventListener('click', function(){
           dataLayer.push({
             'event' : 'GAEvent',
             'eventCategory' : category,
-            'eventAction' : `from:${origin} to:${destination}`,
+            'eventAction' : `from:${origin} to:${a.href}`,
             'eventLabel' : a.text,
             'eventValue' : undefined
           });
+        });
+      }
+    });
+  }
+}
+
+addGAImpressionEvents('.js-takeover')
+
+function addGAImpressionEvents(target){
+  var t = document.querySelectorAll(target);
+  if (t) {
+    t.forEach(function(section) {
+      if (! section.className.includes('u-hide')){
+        var a = section.querySelector("a");
+        dataLayer.push({
+          'event' : 'NonInteractiveGAEvent',
+          'eventCategory' : "www.ubuntu.com-impression",
+          'eventAction' : `from:${origin} to:${a.href}`,
+          'eventLabel' : a.text,
+          'eventValue' : undefined,
         });
       }
     });


### PR DESCRIPTION
## Done

* Use absolute URLs in auto-generated event actions (allows for more effective localhost instances excluding, will allow cross-site implementations of these events)
* Added non-interactive events to assess takeovers impressions (an event containing a takeover identifier is triggered on pageview)
* Added a new GTM trigger: `NonInteractiveGAEvent`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure this [GA RT view ](https://analytics.google.com/analytics/web/?authuser=1#/realtime/rt-event/a1018242w108544136p113106543/filter.list=40~~=impression/) gets a "www.ubuntu.com-impression" event per homepage view, referencing the right takeover, with absolute URLs in its Event Action.
