### PR TITLE
Update text CTA on DE webinar page

### DIFF
--- a/templates/engage/de/vmware-to-openstack.html
+++ b/templates/engage/de/vmware-to-openstack.html
@@ -10,7 +10,7 @@
     <div class="col-9">
         <h1 class="p-takeover__title">Von VMware zu Canonical OpenStack</h1>
         <p class="p-takeover__text">
-            <a href="#register-section">Hier klicken um teilzunehmen&nbsp;&rsaquo;</a></p>
+            <a href="#register-section">Erfahren Sie auf Nachfrage&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Updated the CTA text now that webinar is passed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
