### PR TITLE
Takeover Language Detection

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -163,7 +163,7 @@ function closeMainMenu() {
   }
 }
 
-var origin = window.location.href;
+var origin = window.location.pathname;
 
 addGANavEvents('.global-nav__row', 'www.ubuntu.com-nav-0');
 addGANavEvents('#canonical-products', 'www.ubuntu.com-nav-0-products');
@@ -182,11 +182,12 @@ function addGANavEvents(target, category){
   var t = document.querySelector(target);
   if (t) {
     t.querySelectorAll('a').forEach(function(a) {
-      a.addEventListener('click', function(){
+      var destination = a.href.replace('https://www.ubuntu.com', '');
+      a.addEventListener('click', function(event){
         dataLayer.push({
           'event' : 'GAEvent',
           'eventCategory' : category,
-          'eventAction' : `from:${origin} to:${a.href}`,
+          'eventAction' : `from:${origin} to:${destination}`,
           'eventLabel' : a.text,
           'eventValue' : undefined
         });
@@ -201,6 +202,7 @@ function addGAContentEvents(target){
   var t = document.querySelector(target);
   if (t) {
     t.querySelectorAll('a').forEach(function(a) {
+      var destination = a.href.replace('https://www.ubuntu.com', '');
       if (a.className.includes('p-button--positive')) {
         var category = 'www.ubuntu.com-content-cta-0';
       } else if (a.className.includes('p-button')) {
@@ -208,35 +210,15 @@ function addGAContentEvents(target){
       } else {
         var category = 'www.ubuntu.com-content-link';
       }
-      if (!a.href.startsWith("#")){
-        a.addEventListener('click', function(){
+      if (!destination.startsWith("#")){
+        a.addEventListener('click', function(event){
           dataLayer.push({
             'event' : 'GAEvent',
             'eventCategory' : category,
-            'eventAction' : `from:${origin} to:${a.href}`,
+            'eventAction' : `from:${origin} to:${destination}`,
             'eventLabel' : a.text,
             'eventValue' : undefined
           });
-        });
-      }
-    });
-  }
-}
-
-addGAImpressionEvents('.js-takeover')
-
-function addGAImpressionEvents(target){
-  var t = document.querySelectorAll(target);
-  if (t) {
-    t.forEach(function(section) {
-      if (! section.className.includes('u-hide')){
-        var a = section.querySelector("a");
-        dataLayer.push({
-          'event' : 'NonInteractiveGAEvent',
-          'eventCategory' : "www.ubuntu.com-impression",
-          'eventAction' : `from:${origin} to:${a.href}`,
-          'eventLabel' : a.text,
-          'eventValue' : undefined,
         });
       }
     });

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -113,7 +113,8 @@
     {% endblock footer_content %}
     <script>
         var detectLanguage = function () {
-            var lang = window.navigator.languages ? window.navigator.languages[0] : null; lang = lang || window.navigator.language ||
+            var lang = window.navigator.languages ? window.navigator.languages[0] : null; 
+            lang = lang || window.navigator.language ||
             window.navigator.browserLanguage || window.navigator.userLanguage;
 
             if (lang && lang.length) {
@@ -130,10 +131,13 @@
             takeovers[t].classList.add('u-hide');
         }
         var browserLanguage = detectLanguage();
-        var languageClass = (browserLanguage && browserLanguage === 'de') ? 'de' : 'en';
-        var query = 'section[lang="'+languageClass+'"]';
-        var takeoversFiltered = document.querySelectorAll(query);
-        
+        var languageClass = browserLanguage || 'en';
+        languageClass = languageClass.split('-')[0];
+        var defaultTakeovers = document.querySelectorAll('.js-takeover[lang="en"]');
+        var query = '.js-takeover[lang="'+languageClass+'"]';
+        var takeoversFiltered = (document.querySelectorAll(query));
+        takeoversFiltered = (takeoversFiltered.length) ? takeoversFiltered : defaultTakeovers;
+         
         if (!localStorage.getItem('TAKEOVER')) {
           var i = Math.floor(Math.random() * takeoversFiltered.length);
           localStorage.setItem('TAKEOVER', i);

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -130,9 +130,10 @@
             takeovers[t].classList.add('u-hide');
         }
         var browserLanguage = detectLanguage();
-        var languageClass = (browserLanguage && browserLanguage === 'de') ? 'lang-de' : 'lang-all';
-        var takeoversFiltered = document.getElementsByClassName('js-takeover ' + languageClass);
-
+        var languageClass = (browserLanguage && browserLanguage === 'de') ? 'de' : 'en';
+        var query = 'section[lang="'+languageClass+'"]';
+        var takeoversFiltered = document.querySelectorAll(query);
+        
         if (!localStorage.getItem('TAKEOVER')) {
           var i = Math.floor(Math.random() * takeoversFiltered.length);
           localStorage.setItem('TAKEOVER', i);

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -132,5 +132,18 @@
         takeovers[i].classList.remove('u-hide');
       }
     </script>
+    <script>
+        
+        var detectLanguage = function () {
+            var lang = window.navigator.languages ? window.navigator.languages[0] : null; lang = lang || window.navigator.language ||
+            window.navigator.browserLanguage || window.navigator.userLanguage;
+
+            if (lang && lang.length) {
+                console.log(lang);
+            }
+        };
+        
+        detectLanguage();
+    </script>
   {% endblock content %}
 {% endblock outer_content %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -9,7 +9,6 @@
   {% block content %}
     {% block takeover_content %}
     {% endblock takeover_content %}
-
     <section class="p-strip is-deep is-bordered">
       {% include "shared/_insights_news_strip.html" with gtm_event_label="ubuntu.com homepage" %}
     </section>
@@ -112,38 +111,40 @@
     {% block footer_content %}
       {# include "ubuntu/takeovers/_footer_homepage.html" #}
     {% endblock footer_content %}
-
     <script>
-      if (window.localStorage && window.sessionStorage) {
-        var takeovers = document.getElementsByClassName('js-takeover');
-        for (t = 0; t < takeovers.length; ++t) {
-          takeovers[t].classList.add('u-hide');
-        }
-        if (!localStorage.getItem('TAKEOVER')) {
-          var i = Math.floor(Math.random() * takeovers.length);
-          localStorage.setItem('TAKEOVER', i);
-        } else {
-          var i = parseInt(localStorage.getItem('TAKEOVER')) + 1;
-          if (i >= takeovers.length) {
-            i = 0;
-          }
-        }
-        localStorage.setItem('TAKEOVER', i);
-        takeovers[i].classList.remove('u-hide');
-      }
-    </script>
-    <script>
-        
         var detectLanguage = function () {
             var lang = window.navigator.languages ? window.navigator.languages[0] : null; lang = lang || window.navigator.language ||
             window.navigator.browserLanguage || window.navigator.userLanguage;
 
             if (lang && lang.length) {
-                console.log(lang);
+                return lang;
+            } else {
+                return null
             }
         };
-        
-        detectLanguage();
+    </script>
+    <script>
+      if (window.localStorage && window.sessionStorage) {
+        var takeovers = document.getElementsByClassName('js-takeover');
+        for (t = 0; t < takeovers.length; ++t) {
+            takeovers[t].classList.add('u-hide');
+        }
+        var browserLanguage = detectLanguage();
+        var languageClass = (browserLanguage && browserLanguage === 'de') ? 'lang-de' : 'lang-all';
+        var takeoversFiltered = document.getElementsByClassName('js-takeover ' + languageClass);
+
+        if (!localStorage.getItem('TAKEOVER')) {
+          var i = Math.floor(Math.random() * takeoversFiltered.length);
+          localStorage.setItem('TAKEOVER', i);
+        } else {
+          var i = parseInt(localStorage.getItem('TAKEOVER')) + 1;
+          if (i >= takeoversFiltered.length) {
+            i = 0;
+          }
+        }
+        localStorage.setItem('TAKEOVER', i);
+        takeoversFiltered[i].classList.remove('u-hide');
+      }
     </script>
   {% endblock content %}
 {% endblock outer_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,8 +3,9 @@
 {% block head_extra %}
 {% endblock %}
 
-{% block takeover_content %}
-  {% include "takeovers/_robotics-takeover.html" with nojs_fallback=True %}
-  {% include "takeovers/_multicloud-operations.html" %}
-  {% include "takeovers/_financial-services.html" %}
+{% block takeover_content %} 
+    {% include "takeovers/_robotics-takeover.html" with nojs_fallback=True %} 
+    {% include "takeovers/_multicloud-operations.html" %} 
+    {% include "takeovers/_financial-services.html" %}
+    {% include "takeovers/_de-vmware-to-os.html" with nojs_fallback=True %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_de-vmware-to-os.html
+++ b/templates/takeovers/_de-vmware-to-os.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--vmware-to-os js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+<section lang="de" class="p-strip is-deep p-takeover--vmware-to-os js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1 class="p-takeover__title">Von VMware zu Canonical OpenStack</h1>

--- a/templates/takeovers/_financial-services.html
+++ b/templates/takeovers/_financial-services.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--financial-services js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+<section lang="en" class="p-strip is-deep p-takeover--financial-services js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de lang-all">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Financial Services Month</h1>

--- a/templates/takeovers/_multicloud-operations.html
+++ b/templates/takeovers/_multicloud-operations.html
@@ -1,4 +1,4 @@
-<section  class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not nojs_fallback %}u-hide{% endif %} lang-all">
+<section  lang="en" class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not nojs_fallback %}u-hide{% endif %} lang-all">
   <div class="row u-vertically-center">
     <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
       <p class="p-muted-heading" style="font-size: 1rem;">CIO Guide to multi-cloud operations</p>

--- a/templates/takeovers/_multicloud-operations.html
+++ b/templates/takeovers/_multicloud-operations.html
@@ -1,4 +1,4 @@
-<section class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not nojs_fallback %}u-hide{% endif %}">
+<section  class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not nojs_fallback %}u-hide{% endif %} lang-all">
   <div class="row u-vertically-center">
     <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
       <p class="p-muted-heading" style="font-size: 1rem;">CIO Guide to multi-cloud operations</p>

--- a/templates/takeovers/_robotics-takeover.html
+++ b/templates/takeovers/_robotics-takeover.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--robotics js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+<section lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-all">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Selecting the optimum OS for your robot</h1>

--- a/templates/takeovers/_robotics-takeover.html
+++ b/templates/takeovers/_robotics-takeover.html
@@ -1,4 +1,4 @@
-<section lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-all">
+<section lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Selecting the optimum OS for your robot</h1>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -102,7 +102,7 @@ def search(request):
 class UbuntuTemplateFinder(TemplateFinder):
     def get_context_data(self, **kwargs):
         """
-        Get context data fromt the database for the given page
+        Get context data from the database for the given page
         """
 
         # Get any existing context
@@ -116,9 +116,9 @@ class UbuntuTemplateFinder(TemplateFinder):
 
         # Add level_* context variables
         clean_path = self.request.path.strip('/')
+
         for index, path, in enumerate(clean_path.split('/')):
             context["level_" + str(index + 1)] = path
-
         return context
 
 


### PR DESCRIPTION
## Done
Takeovers now change based on the users browser default language. Takeovers are now only display for a particular region based on the language detected on the browser.
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Changed the default browser language to German (Deustche) or German
- Refresh the multiple times to German Takeover


## Issue / Card
Fixes #4081 

## Screenshots
