### PR TITLE
Add custom ids to MAAS ebook sections versions

### DIFF
--- a/templates/download/shared/_get_ebook_v1.html
+++ b/templates/download/shared/_get_ebook_v1.html
@@ -1,4 +1,4 @@
-<div class="p-strip--accent is-deep {% if not default == 'true' %}u-hide{% endif %}">
+<div class="p-strip--accent is-deep {% if not default == 'true' %}u-hide{% endif %} js-ebook-1">
   <div class="row">
     <div class="col-12">
       <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>

--- a/templates/download/shared/_get_ebook_v1.html
+++ b/templates/download/shared/_get_ebook_v1.html
@@ -1,4 +1,4 @@
-<div class="p-strip--accent is-deep {% if not default == 'true' %}u-hide{% endif %} js-ebook-1">
+<div class="p-strip--accent is-deep {% if not default == 'true' %}u-hide{% endif %}" id="ebook-1">
   <div class="row">
     <div class="col-12">
       <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>

--- a/templates/download/shared/_get_ebook_v2.html
+++ b/templates/download/shared/_get_ebook_v2.html
@@ -1,4 +1,4 @@
-<div class="p-strip--light is-deep {% if not default == 'true' %}u-hide{% endif %}">
+<div class="p-strip--light is-deep {% if not default == 'true' %}u-hide{% endif %}" id="ebook-2">
     <div class="row">
       <div class="col-12">
         <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>

--- a/templates/download/shared/_get_ebook_v3.html
+++ b/templates/download/shared/_get_ebook_v3.html
@@ -1,4 +1,4 @@
-<div class="p-strip--light is-deep {% if not default == 'true' %}u-hide{% endif %}">
+<div class="p-strip--light is-deep {% if not default == 'true' %}u-hide{% endif %}" id="ebook-3">
     <div class="row">
       <div class="col-7 suffix-1">
         <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>


### PR DESCRIPTION
## Done

* Add custom ids to MAAS ebook strip versions

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- On `/download/server/thank-you`, ensure each MAAS ebook strip has a different `id`

