### PR TITLE
created new ai webinar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,4 +7,5 @@
   {% include "takeovers/_robotics-takeover.html" with nojs_fallback=True %}
   {% include "takeovers/_multicloud-operations.html" %}
   {% include "takeovers/_financial-services.html" %}
+  {% include "takeovers/_ai_webinar-2018-10-01.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_ai_webinar-2018-10-01.html
+++ b/templates/takeovers/_ai_webinar-2018-10-01.html
@@ -17,7 +17,7 @@
         <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
       </div>
       <div class="u-hide--medium u-hide--large">
-        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Watch on-demand</a>
+        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
       </div>
     </div>
   </div>

--- a/templates/takeovers/_ai_webinar-2018-10-01.html
+++ b/templates/takeovers/_ai_webinar-2018-10-01.html
@@ -1,0 +1,24 @@
+<section class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not nojs_fallback %}u-hide{% endif %}" data-lang="en" lang="en-gb">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h1 class="p-takeover__title">How to build and deploy your first AI/ML model on Ubuntu</h1>
+      <p class="p-takeover__text">We will walk you through running a Kaggle experiment using Kubeflow on Microk8s.</p>
+      <div class="u-hide--small">
+        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
+      </div>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center">
+      <div class="p-takeover__image-container u-align-text--center">
+        <img class="dotted-circle" src="{{ ASSET_SERVER_URL }}9f3f2b68-dotted-circle.svg" alt="">
+        <img class="ubuntu-logo" src="{{ ASSET_SERVER_URL }}54e24b4c-ubuntu-logo.svg" alt="">
+        <img class="desktop-picto" src="{{ ASSET_SERVER_URL }}5e8d3f1a-desktop-icon.svg" alt="">
+        <img class="iot-picto" src="{{ ASSET_SERVER_URL }}c2715a27-iot-icon.svg" alt="">
+        <img class="cloud-picto" src="{{ ASSET_SERVER_URL }}82c26ccc-cloud-icon.svg" alt="">
+        <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
+      </div>
+      <div class="u-hide--medium u-hide--large">
+        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Watch on-demand</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/templates/takeovers/_ai_webinar-2018-10-01.html
+++ b/templates/takeovers/_ai_webinar-2018-10-01.html
@@ -4,7 +4,7 @@
       <h1 class="p-takeover__title">How to build and deploy your first AI/ML model on Ubuntu</h1>
       <p class="p-takeover__text">We will walk you through running a Kaggle experiment using Kubeflow on Microk8s.</p>
       <div class="u-hide--small">
-        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
+        <a href="/engage/deploy-ai-ml-model?utm_medium=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIWebinar2" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
       </div>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
@@ -17,7 +17,7 @@
         <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
       </div>
       <div class="u-hide--medium u-hide--large">
-        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
+        <a href="/engage/deploy-ai-ml-model?utm_medium=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIWebinar2" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Created a duplicate of the original AI webinar
- TODO - add fing to rotation of takeovers when ready

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Load the homepage until the take over appears, look at S,M,L and compare to the [copy doc](https://docs.google.com/document/d/1P8BC483zp5bYS5SuKimBHSIBlLhyEL9O_AcH3-pAjVc/edit#)


## Issue / Card

Fixes #4087

