### PR TITLE
remove duplicate 4.4 on UASD

### DIFF
--- a/templates/legal/shared/_appendix-support-scope.html
+++ b/templates/legal/shared/_appendix-support-scope.html
@@ -455,7 +455,7 @@
         Canonical cannot provide kernel support bug fixes as kernel livepatches.
       </p>
       <p>
-        Kernel livepatching is available for generic and low latency 64-bit Intel/AMD 4.4 kernels starting with the 4.4 kernel.
+        Kernel livepatching is available for generic and low latency 64-bit Intel/AMD kernels starting with the 4.4 kernel.
       </p>
       <p>
         Only the default LTS kernel is available for livepatching. This includes its backport as the latest HWE kernel to the previous LTS release.


### PR DESCRIPTION
## Done

- remove an extra 4.4
- s/Kernel livepatching is available for generic and low latency 64-bit Intel/AMD 4.4 kernels starting with the 4.4 kernel./Kernel livepatching is available for generic and low latency 64-bit Intel/AMD kernels starting with the 4.4 kernel./

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/ubuntu-advantage/service-description#appendix-support-scope-livepatch](http://0.0.0.0:8001/legal/ubuntu-advantage/service-description#appendix-support-scope-livepatch)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the line reads correctly
