### PR TITLE
Added what's new in Ubuntu 18.10 on the /server overview page

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -49,6 +49,27 @@
   </div>
 </div>
 
+
+<div class="p-strip--light is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>What&rsquo;s new in {{latest_release}}</h2>
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Supported by Canonical for 9 months</li>
+        <li class="p-list__item is-ticked">Runs on all major architectures – x86, x86-64, ARM v7, ARM64, POWER8, POWER9, and IBM s390x (LinuxONE)</li>
+        <li class="p-list__item is-ticked">Updated installer with advanced networking support (e.g. bridges, bonds, and vlans) and storage support (e.g. LVM, mdadm etc)</li>
+        <li class="p-list__item is-ticked">Linux 4.18 kernel</li>
+        <li class="p-list__item is-ticked">Updates to LXD (v3.5), qemu (v2.12) and more</li>
+        <li class="p-list__item is-ticked">NVDIMM support added</li>
+      </ul>
+      <p><a class="p-link--external"
+        href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes">Read more in the release notes
+      </a></p>
+    </div>
+  </div>
+</div>
+
+
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="u-equal-height">


### PR DESCRIPTION
## Done

Updated whats new in 18.10 for server overview page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/server](http://0.0.0.0:8001/server)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#) - NOTE - the update-settings PR will fix the variables for latest


## Issue / Card

Fixes #4100
