### PR TITLE
Update /cloud redirect to /public-cloud

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -123,7 +123,7 @@ category/product/landscape/?: https://landscape.canonical.com/
 category/product/(server|ubuntu-server-edition)/?: /server
 category/product/ubuntu-advantage/?: /support
 category/product/ubuntu-light/?: http://lubuntu.net/
-cloud/?: "/openstack"
+cloud/?: "/public-cloud"
 cloud/awsome/?: "https://launchpad.net/awsome"
 cloud/azure/?: "/public-cloud"
 cloud/bootstack/?: "/openstack/managed"

--- a/templates/legal/shared/_appendix-support-scope.html
+++ b/templates/legal/shared/_appendix-support-scope.html
@@ -455,7 +455,7 @@
         Canonical cannot provide kernel support bug fixes as kernel livepatches.
       </p>
       <p>
-        Kernel livepatching is available for generic and low latency 64-bit Intel/AMD 4.4 kernels starting with the 4.4 kernel.
+        Kernel livepatching is available for generic and low latency 64-bit Intel/AMD kernels starting with the 4.4 kernel.
       </p>
       <p>
         Only the default LTS kernel is available for livepatching. This includes its backport as the latest HWE kernel to the previous LTS release.


### PR DESCRIPTION
## Done

- Update /cloud redirect from /openstack to /public-cloud to fix issues with links on our public cloud partner sites

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/cloud](http://0.0.0.0:8001/cloud)
- See that you end up on [http://0.0.0.0:8001/public-cloud](http://0.0.0.0:8001/public-cloud)

## Issue / Card

Fixes #4108

