### PR TITLE
First version of the Fingbox webinar landing page

### DIFF
--- a/templates/engage/future-proof-iot.html
+++ b/templates/engage/future-proof-iot.html
@@ -1,0 +1,47 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}In this webinar, you’ll learn how Fingbox was built with Ubuntu Core and how Fingbox’s key features are updated and improved ongoing using Snaps.{% endblock %}
+
+{% block title %}Future-proofing Fingbox, the IoT home network monitoring device{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip p-takeover--ai-webinar">
+  <div class="row u-equal-height">
+    <div class="col-9">
+      <h1 class="p-takeover__title">Future-proofing Fingbox, the IoT home network monitoring device</h1>
+      <p class="p-takeover__text">
+        Webinar live on Oct 10 - <a href="#register-section" class="p-link--inverted">Register now&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h2>What you’ll learn</h2>
+      <ul>
+        <li>How Fingbox, a home network monitoring device, was built on Ubuntu Core</li>
+        <li>How its features such as Digital Fence and Digital Presence are improved on an ongoing basis using snaps</li>
+        <li>How the ability to upgrade the device within hours has impacted Fing launch phase</li>
+        <li>How a fleet of security-focused IoT devices is being maintained in the field</li>
+      </ul>
+    </div>
+    <div class="col-5">
+      <img src="{{ ASSET_SERVER_URL }}b73c04bf-Screenshot+from+2018-07-02+16-12-59.png" alt="Future-proofing Fingbox, the IoT home network monitoring device">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 id="register-section">Watch the webinar</h2>
+    </div>
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 336519, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/future-proof-iot.html
+++ b/templates/engage/future-proof-iot.html
@@ -4,7 +4,7 @@
 
 {% block title %}Future-proofing Fingbox, the IoT home network monitoring device{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1f8FiTxhMTDxgM96jhfaEKCdc5LNKXcn0-2_iiSE6ZWs/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip p-takeover--ai-webinar">


### PR DESCRIPTION
## Done

* [New landing page](http://www.ubuntu.com-canonical-websites-pr-4110.run.demo.haus/engage/future-proof-iot)
* [Copy doc](https://docs.google.com/document/d/1f8FiTxhMTDxgM96jhfaEKCdc5LNKXcn0-2_iiSE6ZWs/)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure [the page](http://www.ubuntu.com-canonical-websites-pr-4110.run.demo.haus/engage/future-proof-iot) looks good and is matching the [copy doc](https://docs.google.com/document/d/1f8FiTxhMTDxgM96jhfaEKCdc5LNKXcn0-2_iiSE6ZWs/)
