### PR TITLE
Added 18.10 buttons to the download menu

### DIFF
--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -6,11 +6,13 @@
           <h4 class="p-heading-four is-dense"><a href='/download/desktop'>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">Download Ubuntu desktop and replace your current operating system whether it’s Windows or Mac OS, or, run Ubuntu alongside it.</p>
           <a class="p-button--positive p-button--small" href="/download/desktop/thank-you?version={{lts_release_with_point}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{ lts_release_full }}</a>
+          <a class="p-button--neutral p-button--small" href="/download/desktop/thank-you?version={{latest_release_with_point}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release}}', 'eventValue' : undefined });">{{ latest_release }}</a>
         </div>
         <div class="col-3">
           <h4 class="p-heading-four is-dense"><a href='/download/server'>Ubuntu Server&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">The most popular server Linux in the cloud and data centre, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
           <a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive p-button--small" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">{{ lts_release_full }}</a>
+          <a href="/download/server/thank-you?version={{ latest_release_with_point }}&amp;architecture=amd64" class="p-button--neutral p-button--small" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release }}</a>
           <ul class='p-text-list--small is-bordered' >
             <li class="p-list__item"><a href="/download/alternative-downloads#alternate-ubuntu-server-installer">Use the traditional installer</a></li>
             <li class='p-list__item'><a class='p-link' href='/download/server/arm'>


### PR DESCRIPTION
## Done

- Added 18.10 buttons to the download menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/) and click on the download tab
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit#)
- NOTE the download will not work

## Issue / Card

Fixes #4102

## Screenshots

![image](https://user-images.githubusercontent.com/441217/46397898-66da5900-c6eb-11e8-80da-73e97c23539e.png)
