### PR TITLE
Added the fingbox homepage takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,12 +18,12 @@
       section lang="en" data-lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}
 
   - Also, add a 'with default=True' below for one takeover to be the default
-  
+
   #}
 
 {% block takeover_content %}
-    {% include "takeovers/_robotics-takeover.html" with default=True %}
-    {% include "takeovers/_multicloud-operations.html" %}
-    {% include "takeovers/_financial-services.html" %}
+    {% include "takeovers/_multicloud-operations.html" with default=True %}
+    {% include "takeovers/_fing_webinar.html" %}
+    {% include "takeovers/_ai_webinar-2018-10-01.html" %}
     {% include "takeovers/_de-vmware-to-os.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -1,0 +1,46 @@
+<section data-lang="en" lang="en-gb" class="p-strip is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h1 class="p-takeover__title">Future-proofing Fingbox the home network monitoring device</h1>
+      <p class="p-takeover__text">Learn how Fing uses Ubuntu Core and Snaps to speed development, save budget and resources and ensure a future-proofed product.</p>
+      <img class="p-takeover__image u-hide--medium u-hide--large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
+      <p class="p-button--neutral"><a href="https://www.brighttalk.com/webcast/6793/336519" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center">
+      <img class="u-hide--small" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
+    </div>
+  </div>
+</section>
+
+<style>
+  .p-takeover--fing-webinar {
+    background-color: #006BA1;
+    background-image:  linear-gradient(32deg, #006ba1 0%,#009eee 84%,#08acff 100%);
+  }
+
+  .p-takeover--fing-webinar .p-takeover__title {
+    font-weight: 100;
+    color: #fff;
+  }
+
+  .p-takeover--fing-webinar .p-takeover__text {
+    color: #fff;
+    margin-bottom: 1.7rem;
+  }
+
+  .p-takeover--fing-webinar .p-takeover__image {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  @media (min-width: 768px) {
+    .p-takeover--fing-webinar {
+
+      background-image: url('{{ ASSET_SERVER_URL }}5175ed7b-fingbox-left-overlay.svg'), url('{{ ASSET_SERVER_URL }}1ce949ac-fingbox-right-overlay.svg'), linear-gradient(32deg, #006ba1 0%,#009eee 84%,#08acff 100%);
+      background-repeat: no-repeat;
+      background-size: contain;
+      background-position: bottom left, bottom right;
+    }
+  }
+</style>

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -1,10 +1,10 @@
 <section data-lang="en" lang="en-gb" class="p-strip--dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
-      <h1 class="p-takeover__title">Future-proofing Fingbox the home network monitoring device</h1>
-      <p class="p-takeover__text">Learn how Fing uses Ubuntu Core and Snaps to speed development, save budget and resources and ensure a future-proofed product.</p>
+      <h1 class="p-takeover__title">Future-proofing Fingbox the IoT home network monitoring device</h1>
+      <p class="p-takeover__text">Learn how Fing uses Ubuntu CoIoT re and Snaps to speed development, save budget and resources and ensure a future-proofed product.</p>
       <img class="p-takeover__image-small u-hide--medium u-hide--large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
-      <p class="p-button--neutral"><a href="/engage/future-proof-iot" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
+      <p class="p-button--neutral"><a href="/engage/future-proof-iot?utm_medium=takeover&utm_campaign=FY19_IOT_WBN_Fing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
     </div>
     <div class="col-6 u-align--center" style="margin-bottom: 0; margin-top: auto;">
       <img class="u-hide--small p-takeover__image-large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -2,7 +2,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Future-proofing Fingbox the IoT home network monitoring device</h1>
-      <p class="p-takeover__text">Learn how Fing uses Ubuntu CoIoT re and Snaps to speed development, save budget and resources and ensure a future-proofed product.</p>
+      <p class="p-takeover__text">Learn how Fing uses Ubuntu Core and Snaps to speed development, save budget and resources and ensure a future-proofed product.</p>
       <img class="p-takeover__image-small u-hide--medium u-hide--large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
       <p class="p-button--neutral"><a href="/engage/future-proof-iot?utm_medium=takeover&utm_campaign=FY19_IOT_WBN_Fing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
     </div>

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -1,4 +1,4 @@
-<section data-lang="en" lang="en-gb" class="p-strip is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="en" lang="en-gb" class="p-strip is-dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Future-proofing Fingbox the home network monitoring device</h1>
@@ -6,8 +6,8 @@
       <img class="p-takeover__image u-hide--medium u-hide--large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
       <p class="p-button--neutral"><a href="https://www.brighttalk.com/webcast/6793/336519" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
     </div>
-    <div class="col-6 u-align--center u-vertically-center">
-      <img class="u-hide--small" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
+    <div class="col-6 u-align--center" style="margin-bottom: 0; margin-top: auto;">
+      <img class="u-hide--small" style="animation: bounce 0.8s ease 1.5s 1;;" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
     </div>
   </div>
 </section>
@@ -41,6 +41,30 @@
       background-repeat: no-repeat;
       background-size: contain;
       background-position: bottom left, bottom right;
+    }
+  }
+
+  @keyframes bounce {
+    0% {
+      transform: translateY(0px);
+    }
+    17% {
+      transform: translateY(15px);
+    }
+    34% {
+      transform: translateY(0px);
+    }
+    51% {
+      transform: translateY(7px);
+    }
+    68% {
+      transform: translateY(0px);
+    }
+    85% {
+      transform: translateY(3px);
+    }
+    100% {
+      transform: translateY(0px);
     }
   }
 </style>

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -1,13 +1,13 @@
-<section data-lang="en" lang="en-gb" class="p-strip is-dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="en" lang="en-gb" class="p-strip--dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Future-proofing Fingbox the home network monitoring device</h1>
       <p class="p-takeover__text">Learn how Fing uses Ubuntu Core and Snaps to speed development, save budget and resources and ensure a future-proofed product.</p>
-      <img class="p-takeover__image u-hide--medium u-hide--large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
-      <p class="p-button--neutral"><a href="https://www.brighttalk.com/webcast/6793/336519" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
+      <img class="p-takeover__image-small u-hide--medium u-hide--large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
+      <p class="p-button--neutral"><a href="/engage/future-proof-iot" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
     </div>
     <div class="col-6 u-align--center" style="margin-bottom: 0; margin-top: auto;">
-      <img class="u-hide--small" style="animation: bounce 0.8s ease 1.5s 1;;" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
+      <img class="u-hide--small p-takeover__image-large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
     </div>
   </div>
 </section>
@@ -20,15 +20,13 @@
 
   .p-takeover--fing-webinar .p-takeover__title {
     font-weight: 100;
-    color: #fff;
   }
 
   .p-takeover--fing-webinar .p-takeover__text {
-    color: #fff;
     margin-bottom: 1.7rem;
   }
 
-  .p-takeover--fing-webinar .p-takeover__image {
+  .p-takeover--fing-webinar .p-takeover__image-small {
     display: block;
     margin-left: auto;
     margin-right: auto;
@@ -44,27 +42,16 @@
     }
   }
 
-  @keyframes bounce {
-    0% {
-      transform: translateY(0px);
+  .p-takeover--fing-webinar .p-takeover__image-large {
+    animation: move-in 1s ease 0s 1;
+  }
+
+  @keyframes move-in {
+    from {
+      transform: translatex(200px);
     }
-    17% {
-      transform: translateY(15px);
-    }
-    34% {
-      transform: translateY(0px);
-    }
-    51% {
-      transform: translateY(7px);
-    }
-    68% {
-      transform: translateY(0px);
-    }
-    85% {
-      transform: translateY(3px);
-    }
-    100% {
-      transform: translateY(0px);
+    to {
+      transform: translatex(0px);
     }
   }
 </style>


### PR DESCRIPTION
## Done

Added the fingbox homepage takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare the text and link to the [copy doc](https://docs.google.com/document/d/1Af5L4jNaEj0U4KOllcTCBHfLbqBXfbzY7AsUg_X9Rqo/edit?ts=5baa4881#) and the design to the issue #4088
    - you should see 3 takeovers, fing, ai, multicloud


## Issue / Card

Fixes #4088

## Screenshots

large

![image](https://user-images.githubusercontent.com/441217/46462848-61980f80-c7ba-11e8-998a-274aba325145.png)


small

![image](https://user-images.githubusercontent.com/441217/46462732-1da50a80-c7ba-11e8-82c8-43462f672b33.png)

