### PR TITLE
Further optimisation of resources images

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -96,10 +96,10 @@
         {% if resource.featuredmedia.source_url %}
         <a href="{{resource.link|replace_admin}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Resources', 'eventAction' : 'Clicked resource', 'eventLabel' : '{{resource.title.rendered}}', 'eventValue' : undefined });" >
           <img
-            src="https://res.cloudinary.com/canonical/image/fetch/w_460/{{resource.featuredmedia.source_url}}"
-            srcset="https://res.cloudinary.com/canonical/image/fetch/w_460/{{resource.featuredmedia.source_url}} 460w,
-            https://res.cloudinary.com/canonical/image/fetch/w_620/{{resource.featuredmedia.source_url}} 620w,
-            https://res.cloudinary.com/canonical/image/fetch/w_875/{{resource.featuredmedia.source_url}} 875w"
+            src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{resource.featuredmedia.source_url}}"
+            srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{resource.featuredmedia.source_url}} 460w,
+            https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{resource.featuredmedia.source_url}} 620w,
+            https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{resource.featuredmedia.source_url}} 875w"
             sizes="(min-width: 1031px) 460px,
             (max-width: 1030px) and (min-width: 876px) 460px,
             (max-width: 875px) and (min-width: 621px) 875px,


### PR DESCRIPTION
## Done

- Used recommendation from cloudinary to deal with lossy images better, page went from 1.8mb to 1.2mb

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/resources](http://0.0.0.0:8001/resources)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare the page size and look of images with live site in the inspector

