### PR TITLE
Updated k8s pricing and OpenStack text on pricing page

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <p>Canonical works with the leading public clouds and institutions to optimise Kubernetes. We offer three service packages to help you establish your Kubernetes operations.</p>
+  <p>Canonical works with the leading public clouds and institutions to optimise Kubernetes. We offer three service packages to help you establish your Kubernetes operations. Please note that some options will incur additional costs.</p>
 </div>
 
 <div class="row u-equal-height">

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -25,6 +25,13 @@
           <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
         </tr>
         <tr>
+          <td>Price per node (physical) <sup><a href="#fn-ks">*</a></sup>, on OpenStack <sup><a href="#fn-ks">**</a></sup></td>
+          <td class="u-align--center">$0</td>
+          <td class="p-table__cell--highlight u-align--center">n/a</td>
+          <td class="p-table__cell--highlight u-align--center">$0</td>
+          <td class="p-table__cell--highlight u-align--center">$2,190/year</td>
+        </tr>
+        <tr>
           <td>Price per node (virtual) <sup><a href="#fn-ks">*</a></sup></td>
           <td class="u-align--center">$0</td>
           <td class="p-table__cell--highlight u-align--center">$200/year</td>
@@ -107,6 +114,7 @@
   <div class="row" id="fn-ks">
     <div class="col-12">
       <p><small><sup>*</sup> Minimums apply</small></p>
+      <p><small><sup>**</sup> ** <a href="/openstack/managed">BootStack</a> pricing is in addition to the managed Kubernetes price of $2,190. You can run an unlimited number of virtual Kubernetes nodes on top of each OpenStack physical node. Ubuntu Advantage for Kubernetes is provided at no additional charge if UA for OpenStack has already been purchased for the physical node.</small></p>
       <p><a href="/kubernetes/contact-us?product=kubernetes-support">For more information about Kubernetes support, contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>

--- a/templates/shared/pricing/_openstack-consulting.html
+++ b/templates/shared/pricing/_openstack-consulting.html
@@ -48,10 +48,10 @@
     </table>
 
     <p class="u-no-margin--bottom" id="fn-oc-1">
-      <small><sup>*</sup> Juniper Contrail, Cisco ACI, Nokia Nuage and more available as add-ons</small>
+      <small><sup>*</sup> Juniper Contrail, Cisco ACI, Nokia Nuage and more available as add-ons. Extra costs may apply.</small>
     </p>
     <p class="u-no-margin--top" id="fn-oc-2">
-      <small><sup>**</sup> Solidfire, ScaleIO and more available as add-ons</small>
+      <small><sup>**</sup> Solidfire, ScaleIO and more available as add-ons. Extra costs may apply.</small>
     </p>
   </div>
 </div>

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -159,14 +159,14 @@
 <section class="p-strip--light is-deep is-bordered" id="consulting">
   <div class="row">
     <div class="col-12">
-      <h2>OpenStack services packages</h2>
-      <p>Canonical delivers turnkey OpenStack software solutions, on-site, through its field consulting team. Two plans are offered: the Foundation Cloud, which is based on our award-winning reference architecture, and Foundation Plus, which packs in a complete set of enterprise features and  architectural flexibility.</p>
+      <h2>OpenStack service packages</h2>
+      <p>Canonical delivers turnkey OpenStack software solutions, on-site, through its field consulting team. Foundation Cloud is based on our award-winning reference architecture. And Foundation Plus packs in a complete set of enterprise features and architectural flexibility.</p>
     </div>
   </div>
     {% include "shared/pricing/_openstack-consulting.html" %}
   <div class="row">
     <div class="col-12">
-      <p>For more information about Foundation Cloud Build or if you are not sure which one is right for you, <a href="/openstack/contact-us?product=foundation-cloud">contact us&nbsp;&rsaquo;</a></p>
+      <p>For more information about Foundation Cloud or if you are not sure which one is right for you, <a href="/openstack/contact-us?product=foundation-cloud">contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated the OpenStack and K8S sections of the /pricing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/support/plans-and-pricing](http://0.0.0.0:8001/support/plans-and-pricing#openstack)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)

## Issue / Card

Fixes #4118 	

