### PR TITLE
Takeovers changes (en, de)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
   #}
 
 {% block takeover_content %}
-    {% include "takeovers/_multicloud-operations.html" with default=True %}
+    {% include "takeovers/_robotics-takeover.html" with default=True %}
     {% include "takeovers/_fing_webinar.html" %}
     {% include "takeovers/_ai_webinar-2018-10-01.html" %}
     {% include "takeovers/_de-vmware-to-os.html" %}

--- a/templates/takeovers/_ai_webinar-2018-10-01.html
+++ b/templates/takeovers/_ai_webinar-2018-10-01.html
@@ -1,4 +1,4 @@
-<section data-lang="en" lang="en-gb" class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="en,de" lang="en-gb" class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">How to build and deploy your first AI/ML model on Ubuntu</h1>

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -1,4 +1,4 @@
-<section data-lang="en" lang="en-gb" class="p-strip--dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="en,de" lang="en-gb" class="p-strip--dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Future-proofing Fingbox the IoT home network monitoring device</h1>


### PR DESCRIPTION
## Done

* Replace multi-cloud with robotics OS takeover, the former already had a month of display, the latter, just 10 days.
* Add Fing and AIML takeovers to german loop

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- With your browser lang in english: ensure takeovers loop is: Robot OS, Fing, AI/ML
- With your browser lang in german: ensure takeovers loop is: VMWare (in german), Fing, AI/ML