### PR TITLE
Fix legal section secondary nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -332,39 +332,40 @@ legal:
       path: /legal
     - title: Terms and policies
       path: /legal/terms-and-policies
+
       children:
         - title: Legal Notice - System Information
           path: /legal/terms-and-policies/systems-information-notice
+
+          children:
+            - title: Terms and conditions
+              path: /legal/terms-and-policies/terms
+            - title: Intellectual property
+              path: /legal/terms-and-policies/intellectual-property-policy
+            - title: Intellectual property - 14th May 2013
+              path: /legal/terms-and-policies/intellectual-property-policy/2013-05-14
+              hidden: True
+            - title: Online account terms
+              path: /legal/terms-and-policies/online-account-terms
+            - title: U1 Terms of Service
+              path: /legal/terms-and-policies/terms-of-service
+            - title: Confidentiality agreement
+              path: /legal/terms-and-policies/confidentiality-agreement
+            - title: Developer terms
+              path: /legal/terms-and-policies/developer-terms-and-conditions
+            - title: Launchpad terms
+              path: /legal/terms-and-policies/launchpad-terms-of-service
+            - title: Livepatch terms
+              path: /legal/terms-and-policies/livepatch-terms-of-service
+            - title: JAAS terms
+              path: /legal/terms-and-policies/jaas-beta-terms-of-service
+
+    - title: Data privacy
+      path: /legal/dataprivacy
     - title: Data privacy enquiry
       path: /legal/data-privacy-enquiry
-
-      children:
-        - title: Terms and conditions
-          path: /legal/terms-and-policies/terms
-        - title: Intellectual property
-          path: /legal/terms-and-policies/intellectual-property-policy
-        - title: Intellectual property - 14th May 2013
-          path: /legal/terms-and-policies/intellectual-property-policy/2013-05-14
-          hidden: True
-        - title: Online account terms
-          path: /legal/terms-and-policies/online-account-terms
-        - title: U1 Terms of Service
-          path: /legal/terms-and-policies/terms-of-service
-        - title: Confidentiality agreement
-          path: /legal/terms-and-policies/confidentiality-agreement
-        - title: Developer terms
-          path: /legal/terms-and-policies/developer-terms-and-conditions
-        - title: Launchpad terms
-          path: /legal/terms-and-policies/launchpad-terms-of-service
-        - title: Livepatch terms
-          path: /legal/terms-and-policies/livepatch-terms-of-service
-        - title: JAAS terms
-          path: /legal/terms-and-policies/jaas-beta-terms-of-service
-        - title: Data privacy
-          path: /legal/dataprivacy
-        - title: Trademarks
-          path: /legal/trademarks
-
+    - title: Trademarks
+      path: /legal/trademarks
     - title: Ubuntu Advantage
       path: /legal/ubuntu-advantage
 
@@ -468,7 +469,7 @@ engage:
   title: Engage
   path: /resources
 
-  children: 
+  children:
     - title: VMWare to OpenStack
       path: /engage/vmware-to-openstack
     - title: Deutsche Version

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -334,31 +334,29 @@ legal:
       path: /legal/terms-and-policies
 
       children:
+        - title: Terms and conditions
+          path: /legal/terms-and-policies/terms
+        - title: Intellectual property
+          path: /legal/terms-and-policies/intellectual-property-policy
+        - title: Intellectual property - 14th May 2013
+          path: /legal/terms-and-policies/intellectual-property-policy/2013-05-14
+          hidden: True
+        - title: Online account terms
+          path: /legal/terms-and-policies/online-account-terms
+        - title: U1 Terms of Service
+          path: /legal/terms-and-policies/terms-of-service
+        - title: Confidentiality agreement
+          path: /legal/terms-and-policies/confidentiality-agreement
+        - title: Developer terms
+          path: /legal/terms-and-policies/developer-terms-and-conditions
+        - title: Launchpad terms
+          path: /legal/terms-and-policies/launchpad-terms-of-service
+        - title: Livepatch terms
+          path: /legal/terms-and-policies/livepatch-terms-of-service
+        - title: JAAS terms
+          path: /legal/terms-and-policies/jaas-beta-terms-of-service
         - title: Legal Notice - System Information
           path: /legal/terms-and-policies/systems-information-notice
-
-          children:
-            - title: Terms and conditions
-              path: /legal/terms-and-policies/terms
-            - title: Intellectual property
-              path: /legal/terms-and-policies/intellectual-property-policy
-            - title: Intellectual property - 14th May 2013
-              path: /legal/terms-and-policies/intellectual-property-policy/2013-05-14
-              hidden: True
-            - title: Online account terms
-              path: /legal/terms-and-policies/online-account-terms
-            - title: U1 Terms of Service
-              path: /legal/terms-and-policies/terms-of-service
-            - title: Confidentiality agreement
-              path: /legal/terms-and-policies/confidentiality-agreement
-            - title: Developer terms
-              path: /legal/terms-and-policies/developer-terms-and-conditions
-            - title: Launchpad terms
-              path: /legal/terms-and-policies/launchpad-terms-of-service
-            - title: Livepatch terms
-              path: /legal/terms-and-policies/livepatch-terms-of-service
-            - title: JAAS terms
-              path: /legal/terms-and-policies/jaas-beta-terms-of-service
 
     - title: Data privacy
       path: /legal/dataprivacy


### PR DESCRIPTION
## Done

- fix indentation of navigation.yaml for the legal section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal](http://0.0.0.0:8001/legal)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- see that data privacy enquiry is at the top level of /legal
- see that terms and policies has the right children - http://0.0.0.0:8001/legal/terms-and-policies

## Issue / Card

Fixes #3689

