### PR TITLE
Remove link, but add similar styling for footer "sectors" link

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -37,7 +37,7 @@
         <ul class="p-footer__links">
           <li class="p-footer__item p-footer__item--spaced">
             <h2 class="p-footer__title">
-              <a href="#" class="p-link--soft">Sectors</a>
+              <span class="p-link--soft" style="font-weight: 400;">Sectors</span>
             </h2>
             <ul class="second-level-nav">
               <li><a href="/telecommunications">Telco</a></li>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -37,7 +37,7 @@
         <ul class="p-footer__links">
           <li class="p-footer__item p-footer__item--spaced">
             <h2 class="p-footer__title">
-              <span class="p-link--soft" style="font-weight: 400;">Sectors</span>
+              <span style="font-weight: 400;">Sectors</span>
             </h2>
             <ul class="second-level-nav">
               <li><a href="/telecommunications">Telco</a></li>


### PR DESCRIPTION
## Done

- in the footer 'Sectors' links to nothing, so I removed the a href and added styles to make it look like the other h2 headings

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that 'Sectors' in the footer looks like other h2's but doesn't act like a link

## Issue / Card

Fixes #3949