### PR TITLE
Update Django to 1.11.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.1
+Django==1.11.16
 django-prometheus==1.0.11
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
@@ -18,4 +18,3 @@ feedparser==5.2.1
 requests==2.10.0
 requests-cache==0.4.12
 python-dateutil==2.6.1
-


### PR DESCRIPTION
## Done

- for security I updated Django from 1.11.1 to 1.11.16

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the site acts normally

