### PR TITLE
Create an All for data-lang

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -146,8 +146,10 @@
         }
 
         // find any takeovers that match the users language
-        var query = '.js-takeover[data-lang*="'+languageClass+'"]';
-        var takeoversFiltered = (document.querySelectorAll(query));
+        var queryLang = ".js-takeover[data-lang*='"+languageClass+"']";
+        var queryAll = ".js-takeover[data-lang*='all']";
+        var takeoversFiltered = (document.querySelectorAll([queryLang,queryAll].join(',')));
+
         takeoversFiltered = (takeoversFiltered.length) ? takeoversFiltered : defaultTakeovers;
 
         if (!localStorage.getItem('TAKEOVER')) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,16 +6,17 @@
 {#
   TAKEOVER INSTRUCTIONS
 
-  - A takeover can belong to more than one language group and therefore
-    you can build a queue of them to rotate based on the user's language
-    settings. For example data-lang="de" will be for german only, while
-    data-lang="en,de" will be for english and german.
-  - Additionally, you should add a lang="en-gb" or lang="de" for the
-    takeovers to allow for automatic translation
+  - A takeover can belong to all, one or more than one language group.
+    You can build a queue of them to rotate based on the user's language
+    settings. For ones that should appear for all languages, use
+    data-lang="all".  For example data-lang="de" will be for german only,
+    while data-lang="en,de" will be for english and german.
+  - Additionally, you should add a lang tag (eg lang="en" or lang="de")
+    for the takeovers to allow for automatic translation
 
     EXAMPLE SECTION TAG
 
-      section lang="en" data-lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}
+      section lang="en" data-lang="all" class="p-strip is-deep p-takeover--robotics js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}
 
   - Also, add a 'with default=True' below for one takeover to be the default
 

--- a/templates/takeovers/_ai_webinar-2018-10-01.html
+++ b/templates/takeovers/_ai_webinar-2018-10-01.html
@@ -1,4 +1,4 @@
-<section data-lang="en,de" lang="en-gb" class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="all" lang="en-gb" class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">How to build and deploy your first AI/ML model on Ubuntu</h1>

--- a/templates/takeovers/_financial-services.html
+++ b/templates/takeovers/_financial-services.html
@@ -1,4 +1,4 @@
-<section lang="en" data-lang="en,de" class="p-strip is-deep p-takeover--financial-services js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section lang="en" data-lang="all" class="p-strip is-deep p-takeover--financial-services js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Financial Services Month</h1>

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -1,4 +1,4 @@
-<section data-lang="en,de" lang="en-gb" class="p-strip--dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="all" lang="en-gb" class="p-strip--dark is-deep p-takeover--fing-webinar js-takeover {% if  default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Future-proofing Fingbox the IoT home network monitoring device</h1>

--- a/templates/takeovers/_robotics-takeover.html
+++ b/templates/takeovers/_robotics-takeover.html
@@ -1,4 +1,4 @@
-<section lang="en" data-lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section lang="en" data-lang="all" class="p-strip is-deep p-takeover--robotics js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Selecting the optimum OS for your robot</h1>


### PR DESCRIPTION
## Done

- Added the concept of 'all' for takeovers that can go to any language group.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Change your browser language to 'de' or 'pt' and see that it make sense compared to 'en'


## Issue / Card

Fixes #4144


