### PR TITLE
Upgrade yaml-responses to avoid namespace clash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.16
 django-prometheus==1.0.11
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
-canonicalwebteam.yaml-responses[django]==1.0.2
+canonicalwebteam.yaml-responses[django]==1.1.0
 canonicalwebteam.get-feeds==0.2.4
 canonicalwebteam.http==0.1.6
 whitenoise==3.3.0

--- a/static/sass/_pattern_grid.scss
+++ b/static/sass/_pattern_grid.scss
@@ -1,19 +1,19 @@
 @mixin ubuntu-p-grid {
-    .mobile-col-2:nth-of-type(2n+1) {
-      @media (max-width: $breakpoint-small - 1px) {
-        margin-left: 0;
-      }
+  .mobile-col-2:nth-of-type(2n+1) {
+    @media (max-width: $breakpoint-small - 1px) {
+      margin-left: 0;
     }
-  
-    .tablet-col-2:nth-of-type(3n+1) {
-      @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium - 1px) {
-        margin-left: 0;
-      }
-    }
-
-    .col-2:nth-of-type(6n+1) {
-        @media (min-width: $breakpoint-large) {
-          margin-left: 0;
-        }
-      }
   }
+
+  .tablet-col-2:nth-of-type(3n+1) {
+    @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium - 1px) {
+      margin-left: 0;
+    }
+  }
+
+  .col-2:nth-of-type(6n+1) {
+    @media (min-width: $breakpoint-large) {
+      margin-left: 0;
+    }
+  }
+}

--- a/static/sass/_pattern_inline-images.scss
+++ b/static/sass/_pattern_inline-images.scss
@@ -6,6 +6,7 @@
       margin: $sp-medium;
       max-width: 7.25rem;
     }
+
     &--smaller {
       &__item {
         margin: 1rem;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -234,7 +234,7 @@ p.u-align--center {
 /// XXX Caleb: abbr hotfix - to be fixed in Vanilla
 // https://github.com/vanilla-framework/vanilla-framework/issues/1962
 abbr[title] {
-  border-bottom: 0.1em dotted;
+  border-bottom: .1em dotted;
   cursor: help;
   text-decoration: none;
 }

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,6 +1,6 @@
 # Third party modules
 from django.conf.urls import include, url
-from canonicalwebteam.yaml_responses.django import (
+from canonicalwebteam.yaml_responses.django_helpers import (
     create_deleted_views,
     create_redirect_views,
 )


### PR DESCRIPTION
QA
==

``` bash
virtualenv env2
source env2/bin/activate
pip install -r requirements
python ./manage.py runserver 0.0.0.0:8001
```

Visit http://0.0.0.0:8001, check you don't see an error - the site works fine.