### PR TITLE
Improve desktop thankyou conversions

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -49,123 +49,99 @@ Thank you for your contribution
 <div class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8 suffix-1">
-      <h2>Help shape the future of Ubuntu</h2>
+      <h2 class="p-heading--three">Help shape the future of Ubuntu</h2>
       <noscript>
         <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
       </noscript>
-      <form action="https://www.paypal.com/cgi-bin/webscr" id="contributions-form" method="post" target="_top">
-        <fieldset class="p-card">
-
-          <section id="ubuntu-desktop">
-            <label for="amount-desktop">
-              <p class="p-heading--five">Ubuntu Desktop</p>
-              <p>Make the desktop even more amazing.</p>
-            </label>
-            <div class="p-slider__wrapper">
-              <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-desktop" type="range">
-              <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-desktop-input" name="amount_1" value="3" tabindex="1" type="number">
-              <input type="hidden" name="item_name_1" value="Ubuntu Desktop">
-            </div>
-          </section>
-
-          <hr class="u-sv3">
-
-          <section id="ubuntu-for-cloud">
-            <label for="amount-cloud">
-              <p class="p-heading--five">Ubuntu for cloud computing</p>
-              <p>I want Ubuntu running my cloud and as a guest in my cloud of choice.</p>
-            </label>
-            <div class="p-slider__wrapper">
-              <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-cloud" type="range">
-              <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-cloud-input" name="amount_2" value="3" tabindex="2" type="number">
-              <input type="hidden" name="item_name_2" value="Ubuntu for cloud computing">
-            </div>
-          </section>
-
-          <hr class="u-sv3">
-
-          <section id="ubuntu-for-things">
-            <label for="amount-things">
-              <p class="p-heading--five">Ubuntu for things</p>
-              <p>I want a secure, upgradeable Internet of Things, powered by Ubuntu.</p>
-            </label>
-            <div class="p-slider__wrapper">
-              <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-things" type="range">
-              <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-things-input" name="amount_3" value="3" tabindex="3" type="number">
-              <input type="hidden" name="item_name_3" value="Ubuntu for things">
-            </div>
-          </section>
-
-          <hr class="u-sv3">
-
-          <section id="community-projects">
-            <label for="amount-community">
-              <p class="p-heading--five">Community projects</p>
-              <p>I support LoCo teams, UbuCons and other events, upstream projects and all the good work the community does.</p>
-            </label>
-            <div class="p-slider__wrapper">
-              <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-community" type="range">
-              <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-community-input" name="amount_4" value="3" tabindex="4" type="number">
-              <input type="hidden" name="item_name_4" value="Community projects">
-            </div>
-          </section>
-
-          <hr class="u-sv3">
-
-          <section id="tip-to-canonical">
-            <label for="amount-canonical">
-              <p class="p-heading--five">Tip to Canonical</p>
-              <p>Hats off for making Ubuntu possible. Keep it up.</p>
-            </label>
-            <div class="p-slider__wrapper">
-              <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-canonical" type="range">
-              <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-canonical-input" name="amount_5" value="3" tabindex="5" type="number">
-              <input type="hidden" name="item_name_5" value="Tip to Canonical">
-            </div>
-          </section>
-        </fieldset>
-
-        <div class="row">
-          <div class="col-6">
-            <div class="p-media-object u-no-margin--bottom">
-              <img alt="T-shirt" src="{{ ASSET_SERVER_URL }}b26d26e5-t-shirt.png" class="p-media-object__image js-equivalent-image">
-              <div class="p-media-object__details">
-                <h3 class="p-media-object__title">The same price as</h3>
-                <p class="p-media-object__content js-equivalent-description">Peace, Love and Linux t-shirt</p>
-                <p class="p-media-object__content">$<span class="js-equivalent-value">20</span></p>
-              </div>
-            </div>
+      <form class="p-card contribute__options" action="https://www.paypal.com/cgi-bin/webscr" id="contributions-form" method="post" target="_top">
+        <section id="ubuntu-desktop" class="u-sv3">
+          <label for="amount-desktop">
+            <p class="p-heading--four">Ubuntu Desktop</p>
+          </label>
+          <div class="p-slider__wrapper">
+            <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-desktop" type="range">
+            <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-desktop-input" name="amount_1" value="3" tabindex="1" type="number">
+            <input type="hidden" name="item_name_1" value="Ubuntu Desktop">
           </div>
+        </section>
 
-          <div class="col-3 u-align--right">
-            <h5>Your contribution</h5>
-            <p class="p-heading--four">
-              &#36;
-              <span class="js-total-amount">16</span>
-            </p>
+        <section id="ubuntu-for-cloud" class="u-sv3">
+          <label for="amount-cloud">
+            <p class="p-heading--four">Ubuntu for cloud computing</p>
+          </label>
+          <div class="p-slider__wrapper">
+            <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-cloud" type="range">
+            <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-cloud-input" name="amount_2" value="3" tabindex="2" type="number">
+            <input type="hidden" name="item_name_2" value="Ubuntu for cloud computing">
+          </div>
+        </section>
+
+        <section id="ubuntu-for-things" class="u-sv3">
+          <label for="amount-things">
+            <p class="p-heading--four">Ubuntu for things</p>
+          </label>
+          <div class="p-slider__wrapper">
+            <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-things" type="range">
+            <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-things-input" name="amount_3" value="3" tabindex="3" type="number">
+            <input type="hidden" name="item_name_3" value="Ubuntu for things">
+          </div>
+        </section>
+
+        <section id="community-projects" class="u-sv3">
+          <label for="amount-community">
+            <p class="p-heading--four">Community projects</p>
+          </label>
+          <div class="p-slider__wrapper">
+            <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-community" type="range">
+            <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-community-input" name="amount_4" value="3" tabindex="4" type="number">
+            <input type="hidden" name="item_name_4" value="Community projects">
+          </div>
+        </section>
+
+        <section id="tip-to-canonical" class="u-sv3">
+          <label for="amount-canonical">
+            <p class="p-heading--four">Tip to Canonical</p>
+          </label>
+          <div class="p-slider__wrapper">
+            <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-canonical" type="range">
+            <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-canonical-input" name="amount_5" value="3" tabindex="5" type="number">
+            <input type="hidden" name="item_name_5" value="Tip to Canonical">
+          </div>
+        </section>
+
+        <div class="p-media-object u-no-margin--bottom u-sv3 u-vertically-center">
+          <img alt="T-shirt" src="{{ ASSET_SERVER_URL }}b26d26e5-t-shirt.png" class="p-media-object__image js-equivalent-image">
+          <div class="p-media-object__details">
+            <h3 class="p-media-object__title">The same price as</h3>
+            <p class="p-media-object__content u-no-margin--bottom js-equivalent-description">Peace, Love and Linux t-shirt</p>
           </div>
         </div>
 
-        <hr class="u-sv3">
+        <hr class="u-sv3" />
 
-        <div class="u-align--right">
-          <input type="hidden" name="cmd" value="_cart">
-          <input type="hidden" name="business" value="donations@ubuntu.com">
-          <input type="hidden" name="lc" value="GB">
-          <input type="hidden" name="upload" value="1">
-          <input type="hidden" name="currency_code" value="USD">
-          <input type="hidden" name="button_subtype" value="services">
-          <input type="hidden" name="no_note" value="1">
-          <input type="hidden" name="no_shipping" value="1">
-          <input type="hidden" name="rm" value="1">
+        <div class="row">
+          <div class="col-4">
+            <p>Your contribution &nbsp;<span class="p-card" style="padding: .5rem;">&#36;<span class="js-total-amount">16</span></span></p>
+          </div>
+          <div class="u-align--right">
+            <input type="hidden" name="cmd" value="_cart">
+            <input type="hidden" name="business" value="donations@ubuntu.com">
+            <input type="hidden" name="lc" value="GB">
+            <input type="hidden" name="upload" value="1">
+            <input type="hidden" name="currency_code" value="USD">
+            <input type="hidden" name="button_subtype" value="services">
+            <input type="hidden" name="no_note" value="1">
+            <input type="hidden" name="no_shipping" value="1">
+            <input type="hidden" name="rm" value="1">
 
-          <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you">
-          <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you">
+            <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you">
+            <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you">
 
-          <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
-          <button type="submit" class="js-contribute-submit p-button--positive u-no-margin--bottom" tabindex="9">Contribute with PayPal</button>
-        </form>
-      </div>
+            <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
+            <button type="submit" class="js-contribute-submit p-button--positive u-no-margin--bottom" tabindex="9">Contribute with PayPal</button>
+          </div>
+        </div>
+      </form>
     </div>
     <div class="col-4">
       <div class="p-card">
@@ -174,7 +150,7 @@ Thank you for your contribution
         </header>
         <h3 class="p-card--title">Select topics you&rsquo;re interested in</h3>
         <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-          <div class="p-card--content contribute__options">
+          <div class="p-card--content">
             <ul class="p-list">
               <li class="p-list__item u-no-margin--top u-clearfix">
                 <label>
@@ -221,7 +197,7 @@ Thank you for your contribution
             </p>
             <div class="u-margin-medium--top">
               <span class="mktoButtonWrap p-card--content">
-                <button type="submit">Subscribe now</button>
+                <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
               </span>
               <input type="hidden" name="Consent_to_Processing__c" value="yes" />
               <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
@@ -361,12 +337,10 @@ Thank you for your contribution
   var updateEquivalentItem = function(item, imageSelector, descriptionSelector, valueSelector) {
     var image = document.querySelector('.js-equivalent-image');
     var description = document.querySelector('.js-equivalent-description');
-    var value = document.querySelector('.js-equivalent-value');
 
     image.src = '{{ ASSET_SERVER_URL }}' + item['imageFile'];
     image.alt = item['description'];
     description.innerText = item['description'];
-    value.innerText = item['price'];
   }
 
   var toggleSubmit = function(total) {

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -23,39 +23,38 @@ Thank you for your contribution
 {% endif %}
 {% endif %}
 
-<div class="p-strip is-deep is-bordered">
+<div class="p-strip is-bordered">
   <div class="row">
-    <div class="col-12">
+    <div class="col-8">
       {% if start_download %}
-        <h1>Thank you for downloading Ubuntu Desktop</h1>
-        <p>Your download should start automatically. If it doesn&rsquo;t,
-          {% if architecture == 'amd64+mac' %}
-          <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
-          {% else %}
-          <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download now</a>.
-          {% endif %}
-        </p>
+      <h1 style="font-weight: 100;">Thank you for downloading Ubuntu Desktop</h1>
+      <p>Your download should start automatically. If it doesn&rsquo;t,
+        {% if architecture == 'amd64+mac' %}
+        <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
+        {% else %}
+        <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download now</a>.
+        {% endif %}
+      </p>
       {% else %}
-        <h1>Thank you for your contribution</h1>
-        <p>It will help further the open source development of Ubuntu.</p>
+      <h1>Thank you for your contribution</h1>
+      <p>It will help further the open source development of Ubuntu.</p>
       {% endif %}
     </div>
-  </div>
-  <div class="row">
-    <div class="col-9">
-      <div>
-        <h2>Help shape the future of Ubuntu</h2>
-        <noscript>
-          <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
-        </noscript>
-      </div>
+    <div class="col-4 u-align--center">
+      <img src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg" alt="" />
     </div>
   </div>
+</div>
 
+<div class="p-strip--light is-bordered">
   <div class="row">
-    <div class="col-9 p-card--highlighted">
+    <div class="col-8 suffix-1">
+      <h2>Help shape the future of Ubuntu</h2>
+      <noscript>
+        <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
+      </noscript>
       <form action="https://www.paypal.com/cgi-bin/webscr" id="contributions-form" method="post" target="_top">
-        <fieldset class="contribute__options" style="border-bottom-width: 1px; margin-bottom: 2rem;">
+        <fieldset class="p-card">
 
           <section id="ubuntu-desktop">
             <label for="amount-desktop">
@@ -165,92 +164,177 @@ Thank you for your contribution
 
           <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
           <button type="submit" class="js-contribute-submit p-button--positive u-no-margin--bottom" tabindex="9">Contribute with PayPal</button>
+        </form>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="p-card">
+        <header class="p-card__header">
+          <h5 class="p-muted-heading">Newsletter signup</h5>
+        </header>
+        <h3 class="p-card--title">Select topics you&rsquo;re interested in</h3>
+        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+          <div class="p-card--content contribute__options">
+            <ul class="p-list">
+              <li class="p-list__item u-no-margin--top u-clearfix">
+                <label>
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
+                  <label for="insightscloudserver">Cloud and server</label>
+                </label>
+              </li>
+              <li class="p-list__item u-no-margin--top u-clearfix">
+                <label>
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
+                  <label for="insightsdesktop">Desktop</label>
+                </label>
+              </li>
+              <li class="p-list__item u-no-margin--top u-clearfix">
+                <label>
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
+                  <label for="insightsiot">Internet of Things</label>
+                </label>
+              </li>
+              <li class="p-list__item u-no-margin--top u-clearfix">
+                <label>
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
+                  <label for="insightstutorials">Tutorials</label>
+                </label>
+              </li>
+            </ul>
+            <div class="mktFormReq mktField u-margin-medium--top">
+              <label>
+                <span class="u-no-margin--top">Work email: <span>*</span></span>
+                <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
+              </label>
+            </div>
+            <div class="mktField mktLblRight u-margin-medium--top">
+              <span class="mktInput mktLblRight">
+                  <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+                  <label for="canonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
+                    <small>I agree to receive information about Canonical’s products and services.</small>
+                  </label>
+                  <span class="mktFormMsg"></span>
+              </span>
+            </div>
+            <p class="u-margin-medium--top">
+              <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/dataprivacy/newsletter">Canonical’s Privacy Notice</a> and <a href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</small>
+            </p>
+            <div class="u-margin-medium--top">
+              <span class="mktoButtonWrap p-card--content">
+                <button type="submit">Subscribe now</button>
+              </span>
+              <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+              <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+              <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+              <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
+              <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+              <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
+              <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+              <input name="kw" value="" type="hidden">
+              <input name="cr" value="" type="hidden">
+              <input name="searchstr" value="" type="hidden">
+              <input name="_mkt_disp" value="return" type="hidden">
+              <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+            </div>
+          </form>
         </div>
-      </form>
+        <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+        <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+        <script>
+          $("#mktoForm_1212").validate({
+            errorPlacement: function(error, element) {
+              error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
+              error.appendTo( element.addClass( "p-form-validation__input" ));
+            },
+            errorElement: "span",
+            errorClass: "p-form-validation__message"
+          });
+        </script>
+      </div>
     </div>
   </div>
 </div>
 
 <script>
   /**
-    * Select an equivalent item for a certain contribution amount
-    */
+  * Select an equivalent item for a certain contribution amount
+  */
   var chooseEquivalentItem = function(totalAmount) {
     var items = [{
-        imageFile: '86981cf1-skull.png',
-        price: 0,
-        description: 'Nothing. Use Ubuntu for free.'
-      },
-      {
-        imageFile: '0617b159-ace-of-spades.png',
-        price: 1,
-        description: 'the Ace of Spades download'
-      },
-      {
-        imageFile: 'b52102d9-mocca.png',
-        price: 2,
-        description: 'grande extra shot mocha latta chino'
-      },
-      {
-        imageFile: '0ca1e249-pint-of-ale.png',
-        price: 5,
-        description: 'pint of Micro-brew Nevada Pale Ale'
-      },
-      {
-        imageFile: 'bd982caa-happy-meal.png',
-        price: 7,
-        description: 'A Royale with Cheese '
-      },
-      {
-        imageFile: 'e474c36d-cinema-ticket.png',
-        price: 10,
-        description: 'a night at the movies. By yourself.'
-      },
-      {
-        imageFile: '274c40d3-king-kong.png',
-        price: 15,
-        description: 'King Kong versus Godzilla on DVD'
-      },
-      {
-        imageFile: 'b26d26e5-t-shirt.png',
-        price: 20,
-        description: 'Peace, Love and Linux t-shirt (shirt not included)'
-      },
-      {
-        imageFile: '86f3bcab-frying-pan.png',
-        price: 30,
-        description: 'stainless steel copper-bottom frying pan'
-      },
-      {
-        imageFile: '733a3650-sega-controller.png',
-        price: 50,
-        description: 'vintage SNES game bundle'
-      },
-      {
-        imageFile: 'd6d7d638-levi-501.png',
-        price: 60,
-        description: 'pair of vintage acid wash Levi 501s'
-      },
-      {
-        imageFile: '76f933b2-drum-kit.png',
-        price: 100,
-        description: 'pair of LP Matador bongo drums'
-      },
-      {
-        imageFile: 'ae1705f2-emu-chicks.png',
-        price: 200,
-        description: 'pair of sexed Emu chicks'
-      },
-      {
-        imageFile: '4cbbd365-ldn-nyc-flight.png',
-        price: 500,
-        description: 'flight from New York to London (one way)'
-      },
-      {
-        imageFile: '7a47693f-camel.png',
-        price: 1000,
-        description: 'an eight year-old dromedary camel'
-      }
+      imageFile: '86981cf1-skull.png',
+      price: 0,
+      description: 'Nothing. Use Ubuntu for free.'
+    },
+    {
+      imageFile: '0617b159-ace-of-spades.png',
+      price: 1,
+      description: 'the Ace of Spades download'
+    },
+    {
+      imageFile: 'b52102d9-mocca.png',
+      price: 2,
+      description: 'grande extra shot mocha latta chino'
+    },
+    {
+      imageFile: '0ca1e249-pint-of-ale.png',
+      price: 5,
+      description: 'pint of Micro-brew Nevada Pale Ale'
+    },
+    {
+      imageFile: 'bd982caa-happy-meal.png',
+      price: 7,
+      description: 'A Royale with Cheese '
+    },
+    {
+      imageFile: 'e474c36d-cinema-ticket.png',
+      price: 10,
+      description: 'a night at the movies. By yourself.'
+    },
+    {
+      imageFile: '274c40d3-king-kong.png',
+      price: 15,
+      description: 'King Kong versus Godzilla on DVD'
+    },
+    {
+      imageFile: 'b26d26e5-t-shirt.png',
+      price: 20,
+      description: 'Peace, Love and Linux t-shirt (shirt not included)'
+    },
+    {
+      imageFile: '86f3bcab-frying-pan.png',
+      price: 30,
+      description: 'stainless steel copper-bottom frying pan'
+    },
+    {
+      imageFile: '733a3650-sega-controller.png',
+      price: 50,
+      description: 'vintage SNES game bundle'
+    },
+    {
+      imageFile: 'd6d7d638-levi-501.png',
+      price: 60,
+      description: 'pair of vintage acid wash Levi 501s'
+    },
+    {
+      imageFile: '76f933b2-drum-kit.png',
+      price: 100,
+      description: 'pair of LP Matador bongo drums'
+    },
+    {
+      imageFile: 'ae1705f2-emu-chicks.png',
+      price: 200,
+      description: 'pair of sexed Emu chicks'
+    },
+    {
+      imageFile: '4cbbd365-ldn-nyc-flight.png',
+      price: 500,
+      description: 'flight from New York to London (one way)'
+    },
+    {
+      imageFile: '7a47693f-camel.png',
+      price: 1000,
+      description: 'an eight year-old dromedary camel'
+    }
     ];
 
     var matchingItem = false;
@@ -258,8 +342,8 @@ Thank you for your contribution
     items.forEach(
       function(item, itemIndex) {
         if (
-          item['price'] == totalAmount ||
-          (item['price'] > totalAmount && items[itemIndex - 1]['price'] < totalAmount)
+        item['price'] == totalAmount ||
+        (item['price'] > totalAmount && items[itemIndex - 1]['price'] < totalAmount)
         ) {
           matchingItem = items[itemIndex];
         }
@@ -310,8 +394,8 @@ Thank you for your contribution
   }
 
   /**
-    * Generate a random ID including the datestamp for uniqueness
-    */
+  * Generate a random ID including the datestamp for uniqueness
+  */
   function generateRandomId() {
     // really crude unique ID
     var date = new Date();
@@ -320,9 +404,9 @@ Thank you for your contribution
   }
 
   /**
-    * Send form values to Google Analytics
-    * Also send which header has been shown
-    */
+  * Send form values to Google Analytics
+  * Also send which header has been shown
+  */
   function sendContributionFormAnalytics(submitEvent) {
     form = submitEvent.target;
 
@@ -364,8 +448,8 @@ Thank you for your contribution
   );
 
   /**
-    * Reset fields back to 0, if missing values
-    */
+  * Reset fields back to 0, if missing values
+  */
   document.querySelectorAll('.p-slider__input').forEach(
     function(valueElement) {
       valueElement.addEventListener(
@@ -514,22 +598,22 @@ Thank you for your contribution
   }
 
   /**
-   * Kick off a download link
-   * after a certain delay in milliseconds
-   */
+  * Kick off a download link
+  * after a certain delay in milliseconds
+  */
   function delayStartDownload(downloadLink, delay) {
     window.setTimeout(
-      function() {
-        window.location.href = downloadLink;
-      },
-      delay
+    function() {
+      window.location.href = downloadLink;
+    },
+    delay
     )
   }
 
   /**
-   * Choose randomly from a given list of mirrors
-   * Weight the choice by the bandwidth of each mirror
-   */
+  * Choose randomly from a given list of mirrors
+  * Weight the choice by the bandwidth of each mirror
+  */
   function chooseRandomMirror(mirrors) {
     var selectedMirror = null;
 

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -23,6 +23,18 @@ Thank you for your contribution
 {% endif %}
 {% endif %}
 
+{% if request.GET.newsletter == 'true' %}
+<div class="p-strip is-shallow u-no-padding--bottom">
+  <div class="row">
+    <div class="p-notification--positive">
+      <p class="p-notification__response">
+        <span class="p-notification__status">Success:</span> Thank you for subscribing! You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.
+      </p>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <div class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
@@ -204,7 +216,7 @@ Thank you for your contribution
               <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
               <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
               <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-              <input type="hidden" name="ret" value="http://{{request.host}}{{request.path}}?newsletter=true" />
+              <input type="hidden" name="ret" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
               <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
               <input name="kw" value="" type="hidden">
               <input name="cr" value="" type="hidden">


### PR DESCRIPTION
## Done
Updated the styling of the contribution panel and added the newsletter sign up form to the desktop thank you page.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/desktop/thank-you](http://0.0.0.0:8001/download/desktop/thank-you)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that it matches [the design](https://github.com/ubuntudesign/web-squad/issues/848)
- Check that the newsletter submits and displays a notification
- Check that the contribution for is working

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4039

## Screenshots
![screenshot_2018-10-09 thank you for your contribution ubuntu](https://user-images.githubusercontent.com/1413534/46669148-7e6f8100-cbc6-11e8-9f4d-fa2081dfaf80.png)

