### PR TITLE
Fixed concent checkbox on the /rfp form

### DIFF
--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -84,8 +84,7 @@
             </li>
 
             <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <p><label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label></p>
+              <p><input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" /> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label></p>
             </li>
 
             <li class="p-list__item">


### PR DESCRIPTION
## Done

- fixed location of p-tag to make input checkbox visible

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/rfp](http://0.0.0.0:8001/rfp)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- on the rfp page, see that the 'I agree to receive information about Canonical’s products and services.' has a checkbox next to it

## Issue / Card

Fixes #4155

## Screenshots

![image](https://user-images.githubusercontent.com/441217/46675659-cdbdad80-cbd6-11e8-9483-52d0f853cfe5.png)
