### PR TITLE
Removed google plus from the footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -108,9 +108,6 @@
           <li class="p-inline-list__item">
             <a class="p-inline-list__link--linkedin" title="Find Canonical on LinkedIn" href="https://www.linkedin.com/company/ubuntu/"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 33 33"><defs><style>.linkedin-icon{fill:#666666;}.cls-2{fill:#fff;}</style></defs><g ><path class="linkedin-icon" d="M16.26 0C7.28 0 0 7.28 0 16.26s7.28 16.262 16.26 16.262 16.262-7.28 16.262-16.26C32.522 7.28 25.242 0 16.262 0z"/></g><path class="cls-2" d="M7 8.512v16.38c0 .758.63 1.37 1.404 1.37h16.192c.775 0 1.404-.612 1.404-1.37V8.512c0-.755-.63-1.37-1.404-1.37H8.404C7.63 7.143 7 7.757 7 8.513zm5.76 14.636H9.89v-8.634h2.87v8.634zm-1.435-9.812h-.02c-.962 0-1.585-.663-1.585-1.492 0-.847.642-1.492 1.624-1.492s1.586.645 1.604 1.492c0 .83-.623 1.492-1.623 1.492zm3.022 9.812s.038-7.824 0-8.634h2.87v1.252h-.02c.38-.59 1.058-1.454 2.607-1.454 1.888 0 3.303 1.234 3.303 3.885v4.95h-2.87V18.53c0-1.162-.415-1.953-1.453-1.953-.793 0-1.265.534-1.472 1.05-.076.184-.095.44-.095.7v4.82h-2.87z"/></svg></a>
           </li>
-          <li class="p-inline-list__item">
-            <a class="p-inline-list__link--google" title="Follow Ubuntu on Google+" href="https://plus.google.com/+Ubuntu"><svg class="p-inline-list_icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 137.56 137.56"><defs><style>.google-plus{fill:#666666;}.cls-2{fill:#fff;}</style></defs><g ><path class="google-plus" d="M68.78 0a68.78 68.78 0 1 0 68.78 68.78A68.78 68.78 0 0 0 68.78 0z"/></g><path class="cls-2" d="M82.85 62.62H53.29v12.32H70a17.29 17.29 0 1 1-5-19.35l8.59-8.86a29.57 29.57 0 1 0 9.2 15.89zM117.28 63.41h-10.33V53.08H99.4v10.33H89.06v7.56H99.4V81.3h7.55V70.97h10.33v-7.56z"/></svg></a>
-          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Removed google plus from the footer as Google is shutting the service down

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the google+ icon has been removed


## Issue / Card

Fixes #4157

## Screenshots

![image](https://user-images.githubusercontent.com/441217/46676589-c26b8180-cbd8-11e8-8fb8-0f93d585dfab.png)
