### PR TITLE
Add linting precommit hook for .scss and .py files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,15 @@
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "serve": "./entrypoint 0.0.0.0:${PORT}"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.scss": "yarn run lint-scss",
+    "*.py": "yarn run lint-py"
+  },
   "keywords": [
     "website",
     "ubuntu"
@@ -28,6 +37,8 @@
     "autoprefixer": "^6.3.1",
     "cssnano": "^3.10.0",
     "global-nav": "^1.1.1",
+    "husky": "^1.1.1",
+    "lint-staged": "^7.3.0",
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",


### PR DESCRIPTION
## Done

Add linting precommit hook for staged `.scss` and `.py` files.

## QA

- Check out this feature branch
- Amend a `.scss` file to offend the linter by adding extra spaces before a rule
- Try to commit your change with Git
- You should get an error telling you the Scss linter has failed
- Repeat the above for a `.py` file 
