### PR TITLE
Add 18.10 to the download desktop page

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -34,6 +34,27 @@
         </div>
       </div>
     </div>
+    <div class="row">
+      <div class="col-12 p-card--highlighted">
+        <h2>Ubuntu {{ latest_release_with_point }}</h2>
+        <div class="u-equal-height p-divider">
+          <div class="col-8 p-divider__block">
+            <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ latest_release_with_point }} comes with nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
+            <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{ latest_release }} release notes</a></p>
+            <p class="p-card__content"><a href="/desktop/1810">Find out more about {{ latest_release }}&nbsp;&rsaquo;</a></p>
+            <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
+          </div>
+          <div class="col-4">
+            <p class="p-card__content">
+              <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a>
+            </p>
+            <p class="p-card__content">
+              <a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -41,7 +41,6 @@
           <div class="col-8 p-divider__block">
             <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ latest_release_with_point }} comes with nine months, until {{latest_release_eol}}, of security and maintenance updates.</p>
             <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu {{ latest_release }} release notes</a></p>
-            <p class="p-card__content"><a href="/desktop/1810">Find out more about {{ latest_release }}&nbsp;&rsaquo;</a></p>
             <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
           </div>
           <div class="col-4">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -48,7 +48,7 @@
               <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a>
             </p>
             <p class="p-card__content">
-              <a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a>
+              <small><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></small>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done
Add the 18.10 download section to the desktop download page. 

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/desktop](http://0.0.0.0:8001/download/desktop)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the 18.10 download page matches the [copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit#heading=h.9lozrwd819is)
- Check the links all go to expected places

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4098

## Screenshots
![screenshot_2018-10-09 download ubuntu desktop download ubuntu 1](https://user-images.githubusercontent.com/1413534/46698058-00cf6380-cc0e-11e8-9ead-1aa9fa34f816.png)


