### PR TITLE
Add 18.10 to the download server page

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -27,6 +27,23 @@
       </div>
     </div>
   </div>
+  <div class="row">
+  <div class="col-12 p-card--highlighted">
+      <h2>Ubuntu Server {{ latest_release_with_point }}</h2>
+      <div class="u-equal-height p-divider">
+        <div class="col-8 p-divider__block">
+          <p class="p-card__content">The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{latest_release_eol}}.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ latest_release }} release notes</a></p>
+        </div>
+        <div class="col-4">
+          <p class="p-card__content">
+            <a class="p-button--positive is-wide" href="/download/server/thank-you?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a></p>
+            <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
  </section>
 
 <section class="p-strip--light is-shallow is-bordered">


### PR DESCRIPTION
## Done
Update the download server page content for the 18.10 release.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/server](http://0.0.0.0:8001/download/server)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the copy matches the [copy doc](https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit#)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4099

## Screenshots
![screenshot_2018-10-09 download ubuntu server download ubuntu](https://user-images.githubusercontent.com/1413534/46697710-227c1b00-cc0d-11e8-9a01-73480e4d8e57.png)

