### PR TITLE
Updated whitepaper strip to improve conversion on /kubernetes/install

### DIFF
--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -1,34 +1,75 @@
-<div class="p-strip--accent is-deep">
+<div class="p-strip--light is-bordered is-deep">
   <div class="row">
     <div class="col-12">
-      <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>
+      <h2>Before you start, you&rsquo;ll want this&nbsp;whitepaper</h2>
     </div>
   </div>
-  <div class="row u-equal-height">
-    <div class="col-8">
-      <p>This eBook is designed to help telecom executives understand industry best practices as they move towards &lsquo;cloudification&rsquo; of their network infrastructure.</p>
+  <div class="row">
+    <div class="col-7 suffix-1">
+      <p class="u-hide--small"><img style="max-width: 298px; padding: 1px; border: 1px solid #77216F" src="{{ ASSET_SERVER_URL }}daf4f278-k8s-ebook-cover-crop.jpg?w=298" alt="Cover of whitepaper"></p>
+      <h3>The no-nonsense way to accelerate your business with containers</h3>
       <p>Download this whitepaper to learn:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">The background and timeline to the development of containers and the most recent technology that has led to the proliferation of containers on the Linux platform</li>
         <li class="p-list__item is-ticked">The differences between and advantages and disadvantages of process containers and machine containers</li>
-        <li class="p-list__item is-ticked">About the two main software tools (Docker and LXD) that are used to manipulate containers</li>
         <li class="p-list__item is-ticked">Why containers present a new opportunity for the CTO to reduce cost, to increase agility, and to move to a more scalable and resilient architecture</li>
         <li class="p-list__item is-ticked">How to recognise that some use cases are better suited to containers than others</li>
       </ul>
     </div>
-    <div class="col-4 u-vertically-center">
-      <div class="p-card--highlighted">
-        <div class="p-card__header u-no-margin--bottom">
-          <p class="p-muted-heading">Ebook</p>
-        </div>
-        <div class="p-card__content u-no-margin--top">
-          <p class="u-align--center" style="margin-top: 2rem; margin-bottom: 2rem;">
-            <img style="max-width: 195px;" src="{{ ASSET_SERVER_URL }}a9aff224-Containers-illustration.svg" alt="">
-          </p>
-          <h3 class="p-card__title p-heading--four u-no-padding--top"><a href="https://pages.ubuntu.com/container-whitepaper.html">For CTOs: the no-nonsense way to accelerate your business with containers&nbsp;&rsaquo;</a></h3>
-          <p>Understand industry best practices when &lsquo;cloudifying&rsquo; your network infrastructure.</p>
-        </div>
-      </div>
+    <div class="col-4">
+
+      <!-- MARKETO FORM -->
+      <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_2542" class="marketo-form">
+          <ul class="p-list">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="3-FirstName" class="mktoLabel">First name:</label>
+              <input required id="3-FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="3-LastName" class="mktoLabel">Last name:</label>
+              <input required id="3-LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            </li>
+
+            <li class="mktFormReq mktField p-list__item">
+              <label for="3-Company" class="mktoLabel">Company name:</label>
+              <input required id="3-Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+            </li>
+
+            <li class="mktFormReq mktField p-list__item">
+              <label for="3-Email" class="mktoLabel">Email:</label>
+              <input required id="3-Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+            </li>
+
+            {% include "shared/forms/_country.html" %}
+
+            <li class="mktFormReq mktField p-list__item">
+              <label for="3-Phone" class="mktoLabel">Phone number:</label>
+              <input required id="3-Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+            </li>
+
+            <li class="mktField p-list__item u-sv3">
+              <input class="mktoField" value="yes" id="3-canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+              <label class="mktoLabel mktoHasWidth" for="3-canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
+            </li>
+
+            <li class="mktField p-list__item">
+              <button type="submit" class="p-button--positive mktoButton" aria-label="Submit" onsubmit="backgroundSubmitHandlerClosure();">Get the whitepaper</button>
+              <input type="hidden" name="formid" class="mktoField " value="2542" aria-label="">
+              <input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335" aria-label="">
+              <input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/ty-container-whitepaper.html?cr={creative}&amp;kw={keyword}" aria-label="">
+            </li>
+            <li><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></li>
+          </ul>
+
+        <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
+        <input type="hidden" name="retURL" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
+        <input type="hidden" name="Consent_to_Processing__c" value="yes" aria-label="" />
+      </form>
+      <!-- /MARKETO FORM -->
+
     </div>
   </div>
 </div>

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -69,13 +69,17 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+{% include "kubernetes/_get_ebook.html" %}
+
+<section class="p-strip is-bordered">
   <div class="row">
-    <h2>Full cluster deployment instructions</h2>
-    <p>The standard Ubuntu Kubernetes installation process creates a high-availability cluster of physical or virtual machines. It works on AWS, Azure, Google Cloud, VMware, OpenStack, and Metal-as-a-Service (MAAS). There is an optional logging, monitoring and alerting capability which uses the ELK stack to organise logs from the entire cluster. Support for various storage, networking and container runtime plugins is standard.</p>
-    <p>
-      <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up">Install Ubuntu Kubernetes</a>
-    </p>
+    <div class="col-8">
+      <h2>Full cluster deployment instructions</h2>
+      <p>The standard Ubuntu Kubernetes installation process creates a high-availability cluster of physical or virtual machines. It works on AWS, Azure, Google Cloud, VMware, OpenStack, and Metal-as-a-Service (MAAS). There is an optional logging, monitoring and alerting capability which uses the ELK stack to organise logs from the entire cluster. Support for various storage, networking and container runtime plugins is standard.</p>
+      <p>
+        <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/install-kubernetes-with-conjure-up">Install Ubuntu Kubernetes</a>
+      </p>
+    </div>
   </div>
 </section>
 
@@ -107,7 +111,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>Install on a physical cluster</h2>
@@ -157,8 +161,6 @@
     </div>
   </div>
 </section>
-
-{% include "kubernetes/_get_ebook.html" %}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
 


### PR DESCRIPTION
## Done

- Updated whitepaper strip to improve conversion on /kubernetes/install
- Updated the [copy doc](https://docs.google.com/document/d/1oiD6UUomf2daZitS3UOosujYBXPbiOMzPtXVZBq-ph0/edit#) with updated and trimmed copy
- Changed adjacent strips to a white background to allow for light whitepaper

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/install](http://0.0.0.0:8001/kubernetes/install)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- try the form and see that you go to the download page


## Issue / Card

Fixes #4164

## Screenshots

![image](https://user-images.githubusercontent.com/441217/46727185-e500a780-cc77-11e8-89a3-315be7630e88.png)

