### PR TITLE
User report page piecharts 4134

### DIFF
--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -420,7 +420,7 @@ function createPieChart(selector, dataset, options) {
       return d.label.toUpperCase() === labelKey.toUpperCase();
     });
 
-    centreText = (labelData && labelData.value) ? ((labelData.value / sum) * 100) + '%' : undefined;
+    centreText = (labelData && labelData.value) ? Math.floor((labelData.value / sum) * 100) + '%' : '';
   }
 
   data = manipulateData(data, {
@@ -470,7 +470,7 @@ function createPieChart(selector, dataset, options) {
     .attr('dy', -5)
     .attr('class', 'p-heading--two');
   arcs.append("text")
-    .text((labelKey) ? labelKey.toLowerCase() : '')
+    .text((labelKey) ? labelKey : '')
     .attr('dy', 30)
     .attr('text-anchor', 'middle')
     .attr('class', 'p-pie-chart__text');
@@ -596,23 +596,81 @@ function buildCharts() {
 
   createBarChart('#language-list-chart', dummyData.languageList.dataset);
   createMap('#where-are-users', dummyData.whereUsersAre.datasets, '/static/js/world-110m.v1.json');
-  createProgressChart('#default-settings-hw', dummyData.defaultSettings.datasets.hardware);
-  createProgressChart('#restrict-add-on-hw', dummyData.restrictAddOn.datasets.hardware);
-  createProgressChart('#auto-login-hw', dummyData.autoLogin.datasets.hardware);
-  createProgressChart('#minimal-install-hw', dummyData.minimalInstall.datasets.hardware);
-  createProgressChart('#update-at-install-hw', dummyData.updateAtInstall.datasets.hardware);
+  createPieChart('#default-settings-hw', dummyData.defaultSettings.datasets.hardware, {
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Physical'
+    }
+  });
+  createPieChart('#restrict-add-on-hw', dummyData.restrictAddOn.datasets.hardware, {
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Physical'
+    }
+  });
+  createPieChart('#auto-login-hw', dummyData.autoLogin.datasets.hardware, {
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Physical'
+    }
+  });
+  createPieChart('#minimal-install-hw', dummyData.minimalInstall.datasets.hardware, {
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Physical'
+    }
+  });
+  createPieChart('#update-at-install-hw', dummyData.updateAtInstall.datasets.hardware, {
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Physical'
+    }
+  });
 
-  createProgressChart('#default-settings-vm', dummyData.defaultSettings.datasets.virtual, {
-    color: '#925375'
+  createPieChart('#default-settings-vm', dummyData.defaultSettings.datasets.virtual, {
+    colors: ['#925375','#ccc','#ed764d'],
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Virtual'
+    }
   });
-  createProgressChart('#restrict-add-on-vm', dummyData.restrictAddOn.datasets.virtual, {
-    color: '#925375'
+  createPieChart('#restrict-add-on-vm', dummyData.restrictAddOn.datasets.virtual, {
+    colors: ['#925375','#ccc','#ed764d'],
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Virtual'
+    }
   });
-  createProgressChart('#auto-login-vm', dummyData.autoLogin.datasets.virtual, {
-    color: '#925375'
+  createPieChart('#auto-login-vm', dummyData.autoLogin.datasets.virtual, {
+    colors: ['#925375','#ccc','#ed764d'],
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Virtual'
+    }
   });
-  createProgressChart('#update-at-install-vm', dummyData.updateAtInstall.datasets.virtual, {
-    color: '#925375'
+  createPieChart('#minimal-install-vm', dummyData.minimalInstall.datasets.virtual, {
+    colors: ['#925375','#ccc','#ed764d'],
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Virtual'
+    }
+  });
+  createPieChart('#update-at-install-vm', dummyData.updateAtInstall.datasets.virtual, {
+    colors: ['#925375','#ccc','#ed764d'],
+    size: 184,
+    donutRadius: 76,
+    centreLabel: {
+      title: 'Virtual'
+    }
   });
 
   if (window.innerWidth >= breakpoint) {

--- a/static/js/dummyData.js
+++ b/static/js/dummyData.js
@@ -268,14 +268,17 @@ var dummyData = {
     }, ]
   },
   defaultSettings: {
+    title: 'Default Settings',
     datasets: {
       hardware: [{
+        label: 'Physical',
         show: true,
         value: 318,
       }, {
         value: 682,
       }, ],
       virtual: [{
+        label: 'Virtual',
         show: true,
         value: 589,
       }, {
@@ -284,14 +287,17 @@ var dummyData = {
     },
   },
   restrictAddOn: {
+    title: 'Default Settings',
     datasets: {
       hardware: [{
+        label: 'Physical',
         show: true,
         value: 591,
       }, {
         value: 409,
       }, ],
       virtual: [{
+        label: 'Virtual',
         show: true,
         value: 273,
       }, {
@@ -302,12 +308,14 @@ var dummyData = {
   autoLogin: {
     datasets: {
       hardware: [{
+        label: 'Physical',
         show: true,
         value: 294,
       }, {
         value: 706,
       }, ],
       virtual: [{
+        label: 'Virtual',
         show: true,
         value: 287,
       }, {
@@ -316,14 +324,17 @@ var dummyData = {
     },
   },
   minimalInstall: {
+    title: 'Minimal Install',
     datasets: {
       hardware: [{
+        label: 'Physical',
         show: true,
         value: 134,
       }, {
         value: 866,
       }, ],
       virtual: [{
+        label: 'Virtual',
         show: true,
         value: 141,
       }, {
@@ -332,14 +343,17 @@ var dummyData = {
     },
   },
   updateAtInstall: {
+    title: 'Users Who Installed Ubuntu While Upgrading',
     datasets: {
       hardware: [{
+        label: 'Physical',
         show: true,
         value: 919,
       }, {
         value: 81,
       }, ],
       virtual: [{
+        label: 'Virtual',
         show: true,
         value: 911,
       }, {

--- a/static/sass/_pattern_desktop-statistics.scss
+++ b/static/sass/_pattern_desktop-statistics.scss
@@ -1,4 +1,7 @@
 @mixin ubuntu-p-desktop-statistics {
+  $burnt-sienna: #ED764D;
+  $cannon-pink: #925375;
+  
   .p-mobile-flex-col {
     @media only screen and (max-width: $breakpoint-medium) {
       display: flex;
@@ -90,19 +93,19 @@
     height: 40px;
 
     .legend {
-      position: relative;
-      top: 4px;
+      border-radius: 50%;
       display: inline-block;
       height: 16px;
+      position: relative;
+      top: 4px;
       width: 16px;
-      border-radius: 50%;
 
       &.clean-install{
-        border: 4px solid #ed764d;
+        border: 5px solid $burnt-sienna;
       }
 
       &.upgrades {
-        border: 4px solid#925375;
+        border: 5px solid $cannon-pink;
       }
     }
   }

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -213,17 +213,19 @@
     </div>
   </div>
 </section>
-<section id="configuration" class="p-strip--image is-bordered">
+<section id="configuration" class="p-strip u-no-padding--bottom">
   <div class="row">
     <h2>Configuring Ubuntu</h2>
     <p>Users configure Ubuntu in many different ways, we recorded some key points and this will help inform the design of future releases.</p>
   </div>
   <div class="row">
-    <hr />
+    <hr class="u-no-margin--bottom"/>
   </div>
+</section>
+<section class="p-strip">
   <div class="row u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who installed Ubuntu using the default settings</h3>
+      <p class="p-heading--four">Users who installed Ubuntu using the default settings</p>
     </div>
     <div class="col-3 u-align--center">
       <svg id="default-settings-hw"></svg>
@@ -232,12 +234,14 @@
       <svg id="default-settings-vm"></svg>
     </div>
   </div>
-  <div class="row">
-    <hr />
-  </div>
+</section>
+<div class="row">
+  <hr class="u-no-margin--bottom"/>
+</div>
+<section class="p-strip">
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who opted out of at least one add-on</h3>
+      <p class="p-heading--four">Users who opted out of at least one add-on</p>
     </div>
     <div class="col-3 u-align--center">
       <svg id="restrict-add-on-hw"></svg>
@@ -246,13 +250,15 @@
       <svg id="restrict-add-on-vm"></svg>
     </div>
   </div>
-  <div class="row">
-    <hr />
-  </div>
+</section>
+<div class="row">
+  <hr class="u-no-margin--bottom"/>
+</div>
+<section class="p-strip">
   <div class="row">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-6">
-        <h3 class="p-heading--four">Users who auto-login on start-up</h3>
+        <p class="p-heading--four">Users who auto-login on start-up</p>
       </div>
       <div class="col-3 u-align--center">
         <svg id="auto-login-hw"></svg>
@@ -262,12 +268,14 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <hr />
-  </div>
+</section>
+<div class="row">
+  <hr class="u-no-margin--bottom"/>
+</div>
+<section class="p-strip">
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who opted for the Minimal Install; a stripped down Ubuntu that contains a few basic applications</h3>
+      <p class="p-heading--four">Users who opted for the Minimal Install; a stripped down Ubuntu that contains a few basic applications</p>
     </div>
     <div class="col-3 u-align--center">
       <svg id="minimal-install-hw"></svg>
@@ -276,12 +284,14 @@
       <svg id="minimal-install-vm"></svg>
     </div>
   </div>
-  <div class="row">
-    <hr />
-  </div>
+</section>
+<div class="row">
+  <hr class="u-no-margin--bottom"/>
+</div>
+<section class="p-strip">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
-      <h3 class="p-heading--four">Users who chose to download and update software whilst installing Ubuntu</h3>
+      <p class="p-heading--four">Users who chose to download and update software whilst installing Ubuntu</p>
     </div>
     <div class="col-3 u-align--center">
       <svg id="update-at-install-hw"></svg>
@@ -291,11 +301,14 @@
     </div>
   </div>
 </section>
+<div class="row">
+  <hr class="u-no-margin--bottom"/>
+</div>
 <section class="p-strip is-bordered">
     <div class="row">
-        <div class="col-6 prefix-1">
-          <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}f3f53a95-ubuntu-18.04-survey-metrics.png" alt="User survey report">
-        </div>
+      <div class="col-6 prefix-1">
+        <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}f3f53a95-ubuntu-18.04-survey-metrics.png" alt="User survey report">
+      </div>
     <div class="col-6">
       <h3>Want to know more?</h3>
       <p>Find out what Will Cooke, Engineering Director for Desktop, had to say about the methodology behind these metrics.</p>

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -213,15 +213,15 @@
     </div>
   </div>
 </section>
-<section id="configuration" class="p-strip u-no-padding--bottom">
+<section id="configuration" class="p-strip">
   <div class="row">
     <h2>Configuring Ubuntu</h2>
     <p>Users configure Ubuntu in many different ways, we recorded some key points and this will help inform the design of future releases.</p>
   </div>
-  <div class="row">
-    <hr class="u-no-margin--bottom"/>
-  </div>
 </section>
+<div class="row">
+  <hr class="u-no-margin--bottom"/>
+</div>
 <section class="p-strip">
   <div class="row u-vertically-center">
     <div class="col-6">


### PR DESCRIPTION
## Done
Updated the Configuring Ubuntu section of the user report page to match design.
- Changed the progress charts to piecharts
- Updated the data for the charts, dummyData.js
- Updated the colours & CSS to match  the design

## QA

- Check out this feature branch user 
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- go to the url http://0.0.0.0:8001/desktop/statistics
- Check that the layout matches the design https://github.com/canonical-websites/www.ubuntu.com/issues/4094


## Issue / Card
https://github.com/canonical-websites/www.ubuntu.com/issues/4134