### PR TITLE
Update the styling of the Where are Ubuntu users? section

### DIFF
--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -478,8 +478,9 @@ function createPieChart(selector, dataset, options) {
 
 function createMap(selector, options, mapData) {
   var options = options || {};
-  var width = document.querySelector(selector).clientWidth;
-  var height = document.querySelector(selector).clientHeight;
+  var element = document.querySelector(selector).getBoundingClientRect();
+  var width = element.width;
+  var height = element.height;
 
   function render(world) {
     //   Snapdata = country mapped to ids in objects

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -85,13 +85,13 @@ function colorShade(usageRange, colors) {
     index = 0;
   } else if (usageRange > 1 && usageRange <= 5) {
     index = 1;
-  } else if (usageRange > 5 && usageRange <= 10) {
+  } else if (usageRange > 5 && usageRange <= 20) {
     index = 2;
-  } else if (usageRange > 10 && usageRange <= 15) {
+  } else if (usageRange > 20 && usageRange <= 35) {
     index = 3;
-  } else if (usageRange > 15 && usageRange <= 30) {
+  } else if (usageRange > 35 && usageRange <= 50) {
     index = 4;
-  } else if (usageRange > 30) {
+  } else if (usageRange > 50) {
     index = 5;
   }
   return colors[index];
@@ -265,9 +265,9 @@ function createHorizontalBarChart(selector, dataset, options) {
     .attr("x", -3)
     .attr("y", function (d, i) {
       if (i > 0) {
-        return y(d.label) - 16; 
+        return y(d.label) - 16;
       } else {
-        return y(d.label); 
+        return y(d.label);
       }
     })
     .attr("height", "16px")
@@ -295,7 +295,7 @@ function createHorizontalBarChart(selector, dataset, options) {
     .text(function (d) {
       return Math.floor(calcPercentage(data, d.value), 1) + "%";
     });
-  
+
     // Add text to the left Axis
     if (chartTitle) {
       g.selectAll("text.left-axis")
@@ -483,15 +483,14 @@ function createMap(selector, options, mapData) {
 
   function render(world) {
     //   Snapdata = country mapped to ids in objects
-    // Get the countries and ids 
+    // Get the countries and ids
     var svg = d3.select(selector);
     var g = svg.append('g');
-    var offset = width * 0.2;
+    var offset = width * 0.1;
     var projection = d3.geoNaturalEarth1()
-      .scale(width * 0.15)
-      .translate([width / 2, (height + offset) / 2])
-      .precision(.1)
-      .rotate([-10, 0]);
+      .scale(width * 0.2)
+      .translate([(width / 2), ((height + offset) / 2) ])
+      .precision(.1);
     var geoPath = d3.geoPath().projection(projection);
     var countries = topojson.feature(world, world.objects.countries).features;
     g.selectAll('path')
@@ -510,7 +509,7 @@ function createMap(selector, options, mapData) {
             var shade = colorShade(countryRatio, options.legend.colors);
             return shade;
           }
-          return "#0000FF";
+          return "#fed6ca";
         }
 
       })

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -85,13 +85,13 @@ function colorShade(usageRange, colors) {
     index = 0;
   } else if (usageRange > 1 && usageRange <= 5) {
     index = 1;
-  } else if (usageRange > 5 && usageRange <= 20) {
+  } else if (usageRange > 5 && usageRange <= 10) {
     index = 2;
-  } else if (usageRange > 20 && usageRange <= 35) {
+  } else if (usageRange > 10 && usageRange <= 15) {
     index = 3;
-  } else if (usageRange > 35 && usageRange <= 50) {
+  } else if (usageRange > 15 && usageRange <= 30) {
     index = 4;
-  } else if (usageRange > 50) {
+  } else if (usageRange > 30) {
     index = 5;
   }
   return colors[index];

--- a/static/js/dummyData.js
+++ b/static/js/dummyData.js
@@ -430,11 +430,11 @@ var dummyData = {
       legend: {
         colors: [
           '#FFFFFF',
-          '#fed6ca',
-          '#eeb2a0',
-          '#eb987a',
-          '#e26e47',
-          '#772953'
+          '#F7C3B1',
+          '#F5B29B',
+          '#F29879',
+          '#ED764D',
+          '#E95420'
         ]
       },
       countryStats: [{

--- a/static/js/dummyData.js
+++ b/static/js/dummyData.js
@@ -430,11 +430,11 @@ var dummyData = {
       legend: {
         colors: [
           '#FFFFFF',
-          '#D3D3D3',
-          '#C0C0C0',
-          '#808080',
-          '#696969',
-          '#000000'
+          '#fed6ca',
+          '#eeb2a0',
+          '#eb987a',
+          '#e26e47',
+          '#772953'
         ]
       },
       countryStats: [{

--- a/static/sass/_pattern_desktop-statistics.scss
+++ b/static/sass/_pattern_desktop-statistics.scss
@@ -78,7 +78,7 @@
     .p-strip__row {
       >.p-strip__row--item {
         padding: $spv-intra--condensed;
-        
+
         &.col-6 {
           background: $color-x-light;
         }
@@ -104,6 +104,12 @@
       &.upgrades {
         border: 4px solid#925375;
       }
+    }
+  }
+
+  #where-are-users { // sass-lint:disable-line no-ids
+    @media only screen and (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+      transform: scale(.7);
     }
   }
 }

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -52,7 +52,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip--light is-shallow is-bordered">
+<section class="p-strip--light is-shallow">
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center p-divider">
     <div class="col-6 p-divider-block">
       <h3>Clean install or upgrade?</h3>
@@ -69,15 +69,15 @@
       </div>
     </div>
   </div>
-</section>  
-<section class="p-strip is-shallow is-bordered">
-  <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
+</section>
+<section class="p-strip">
+  <div class="row u-vertically-center">
     <div class="col-4">
-      <h2 class="p-heading--four">Where are Ubuntu users?</h2>
+      <h3>Where are Ubuntu users?</h3>
       <p>Location is derived from the user setting the timezone and location in the installer and not from an identifiable IP address.</p>
     </div>
-    <div class="col-8 u-align--left p-where-user-are">
-      <svg id="where-are-users" height="250" width="500"></svg>
+    <div class="col-8">
+      <svg id="where-are-users" height="324.5" width="649"></svg>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Updated the Where are Ubuntu users? section mark up. Also, update the world map styling.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/statistics](http://0.0.0.0:8001/desktop/statistics)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the map and section styling matches [the design](https://github.com/canonical-websites/www.ubuntu.com/issues/4094)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4124

## Screenshots
![screenshot from 2018-10-10 23-34-38](https://user-images.githubusercontent.com/1413534/46769909-35fab500-cce5-11e8-8435-2be7b2d48119.png)

