### PR TITLE
Update fing wbn from register to watch now

### DIFF
--- a/templates/engage/future-proof-iot.html
+++ b/templates/engage/future-proof-iot.html
@@ -12,7 +12,7 @@
     <div class="col-9">
       <h1 class="p-takeover__title">Future-proofing Fingbox, the IoT home network monitoring device</h1>
       <p class="p-takeover__text">
-        Webinar live on Oct 10 - <a href="#register-section" class="p-link--inverted">Register now&nbsp;&rsaquo;</a>
+        Webinar aired on Oct 10 - <a href="#register-section" class="p-link--inverted">Watch now&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>

--- a/templates/takeovers/_fing_webinar.html
+++ b/templates/takeovers/_fing_webinar.html
@@ -4,7 +4,7 @@
       <h1 class="p-takeover__title">Future-proofing Fingbox the IoT home network monitoring device</h1>
       <p class="p-takeover__text">Learn how Fing uses Ubuntu Core and Snaps to speed development, save budget and resources and ensure a future-proofed product.</p>
       <img class="p-takeover__image-small u-hide--medium u-hide--large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />
-      <p class="p-button--neutral"><a href="/engage/future-proof-iot?utm_medium=takeover&utm_campaign=FY19_IOT_WBN_Fing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Register for the webinar</a></p>
+      <p class="p-button--neutral"><a href="/engage/future-proof-iot?utm_medium=takeover&utm_campaign=FY19_IOT_WBN_Fing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'fing webinar takeover', 'eventLabel' : 'Future-proofing Fingbox the IoT home network monitoring device', 'eventValue' : undefined });" style="color: #000;">Watch the webinar</a></p>
     </div>
     <div class="col-6 u-align--center" style="margin-bottom: 0; margin-top: auto;">
       <img class="u-hide--small p-takeover__image-large" alt="Fing's Fingbox" src="{{ ASSET_SERVER_URL }}3811386c-fingbox_w-shadow.png" />


### PR DESCRIPTION
## Done

* Fing webinar (takeover, landing page) updated from "Register" to "Watch now"

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure the takeover and landing page show the webinar as immediately available

