### PR TITLE
Redirect for kubernetes docs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -683,3 +683,5 @@ usn/?: "https://usn.ubuntu.com/"
 (?P<page>.*)\.html: "/{page}"
 telco/?: "/telecommunications"
 telcos/?: "/telecommunications"
+kubernetes/docs/?: "http://blog.juju.solutions/kubernetes-docs/"
+

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -683,5 +683,5 @@ usn/?: "https://usn.ubuntu.com/"
 (?P<page>.*)\.html: "/{page}"
 telco/?: "/telecommunications"
 telcos/?: "/telecommunications"
-kubernetes/docs/?: "http://blog.juju.solutions/kubernetes-docs/"
+kubernetes/docs/?: "https://blog.juju.solutions/kubernetes-docs/"
 


### PR DESCRIPTION
For @evilnick

QA
--

`./run` and go to http://0.0.0.0:8001/kubernetes/docs - see you're redirected to the beautiful new Kubernetes docs at http://blog.juju.solutions/kubernetes-docs/.