### PR TITLE
User report page what lang 4125

### DIFF
--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -145,7 +145,7 @@ function createBarChart(selector, dataset, options) {
     bottom: 50,
     left: 0
   };
-  var colors = options.hasOwnProperty('colors') ? options.colors : ['#ed764d', '#ccc', '#925375'];
+  var colors = options.hasOwnProperty('colors') ? options.colors : ['#ed764d', '#925375'];
   var ordinalColors = d3.scaleOrdinal(colors);
 
   // Create copy of dataset and manipulate according to options

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -104,10 +104,11 @@ function wrapText(text, width) {
     var word;
     var line = [];
     var lineNumber = 0;
-    var lineHeight = 1.1;
+    var lineHeight = 1.5;
     var y = text.attr("y");
     var dy = parseFloat(text.attr("dy"));
-    var tspan = text.text(null).append("tspan").attr("x", 0).attr("y", y).attr("dy", dy + "em");
+    var tspan = text.text(null).style("font-size", "12px")
+    .append("tspan").attr("x", -12).attr("y", y).attr("dy", dy + "em");
 
     while (word = words.pop()) {
       line.push(word);
@@ -116,7 +117,7 @@ function wrapText(text, width) {
         line.pop();
         tspan.text(line.join(" "));
         line = [word];
-        tspan = text.append("tspan").attr("x", 0).attr("y", y).attr("dy", ++lineNumber * lineHeight + dy + "em").text(word);
+        tspan = text.append("tspan").attr("x", -12).attr("y", y).attr("dy", ++lineNumber * lineHeight + dy + "em").text(word);
       }
     }
   });
@@ -177,19 +178,15 @@ function createBarChart(selector, dataset, options) {
     }))]);
 
   // Generate axes
-  // g.append("g")
-  //   .attr("transform", "translate(0," + height +  ")")
-  //   .call(d3.axisBottom(x))
-  //   .selectAll(".tick text")
-  //   .attr("text-anchor", "middle")
-  //   .call(wrapText, x.bandwidth());
-
-  // g.append("g")
-  //   .call(d3.axisLeft(y)
-  //     .tickFormat(function (d) {
-  //       return d + '%'
-  //     })
-  //     .ticks(numTicks));
+  g.append("g")
+    .attr("transform", "translate(0," + height +  ")")
+    .call(d3.axisBottom(x).tickSize(0).tickPadding(16))
+    .selectAll(".tick text")
+    .attr("text-anchor", "middle")
+    .call(wrapText, x.bandwidth());
+    
+  // remove the x axis lines at the bottom
+  g.selectAll(".domain").remove();
 
   // Generate bars
   g.selectAll(".p-bar-chart__bar")
@@ -212,11 +209,12 @@ function createBarChart(selector, dataset, options) {
     });
   
     // Add text to the top of the bar
-    g.selectAll("text")
+    g.append("g")
+      .selectAll("text")
       .data(data)
       .enter()
       .append("text")
-      .style("font-size", "12px")
+      .style("font-size", "16px")
       .attr("x", function (d) {
         return x(d.label) + (x.bandwidth() / 2) - 24;
       })
@@ -228,23 +226,6 @@ function createBarChart(selector, dataset, options) {
       .text(function (d) {
         return Math.floor(calcPercentage(data, d.value), 1) + "%";
       });
-      
-    // Add text to the bottom of the bar
-    g.selectAll("text.y-axis")
-        .data(data)
-        .enter()
-        .append("text")
-        .attr("class", "y-axis")
-        .attr("x", function (d) {
-          return x(d.label) + (x.bandwidth() / 2) - 24;
-        })
-        .attr("y", function (d) {
-          return height + margin.top ;
-        })
-        .attr("class", "label")
-        .text(function (d) {
-            return d.label;
-        });
 }
 
 function createHorizontalBarChart(selector, dataset, options) {

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -726,7 +726,7 @@ function buildCharts() {
       colors: ['#ed764d', '#925375'],
       yTextOffset: 5,
       margin: {
-        top: 10,
+        top: 5,
         right: 20,
         bottom: 20,
         left: 150

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -107,8 +107,8 @@ function wrapText(text, width) {
     var lineHeight = 1.5;
     var y = text.attr("y");
     var dy = parseFloat(text.attr("dy"));
-    var tspan = text.text(null).style("font-size", "12px")
-    .append("tspan").attr("x", -12).attr("y", y).attr("dy", dy + "em");
+    var tspan = text.text(null).style("font-size", "14px")
+    .append("tspan").attr("x", 0).attr("y", y).attr("dy", dy + "em");
 
     while (word = words.pop()) {
       line.push(word);
@@ -117,7 +117,7 @@ function wrapText(text, width) {
         line.pop();
         tspan.text(line.join(" "));
         line = [word];
-        tspan = text.append("tspan").attr("x", -12).attr("y", y).attr("dy", ++lineNumber * lineHeight + dy + "em").text(word);
+        tspan = text.append("tspan").attr("x", 0).attr("y", y - 6).attr("dy", ++lineNumber * lineHeight + dy + "em").text(word);
       }
     }
   });
@@ -142,9 +142,9 @@ function createBarChart(selector, dataset, options) {
   var numTicks = options.hasOwnProperty('ticks') ? options.ticks : 5;
   var margin = options.hasOwnProperty('margin') ? options.margin : {
     top: 20,
-    right: 5,
+    right: 0,
     bottom: 50,
-    left: 40
+    left: 0
   };
   var colors = options.hasOwnProperty('colors') ? options.colors : ['#ed764d', '#ccc', '#925375'];
   var ordinalColors = d3.scaleOrdinal(colors);
@@ -180,7 +180,7 @@ function createBarChart(selector, dataset, options) {
   // Generate axes
   g.append("g")
     .attr("transform", "translate(0," + height +  ")")
-    .call(d3.axisBottom(x).tickSize(0).tickPadding(16))
+    .call(d3.axisBottom(x).tickSize(0).tickPadding(3))
     .selectAll(".tick text")
     .attr("text-anchor", "middle")
     .call(wrapText, x.bandwidth());
@@ -203,7 +203,7 @@ function createBarChart(selector, dataset, options) {
     .attr("y", function (d) {
       return y(calcPercentage(data, d.value))
     })
-    .attr("width", x.bandwidth() - 24 )
+    .attr("width", x.bandwidth() )
     .attr("height", function (d) {
       return height - y(calcPercentage(data, d.value))
     });
@@ -214,9 +214,9 @@ function createBarChart(selector, dataset, options) {
       .data(data)
       .enter()
       .append("text")
-      .style("font-size", "16px")
+      .style("font-size", "14px")
       .attr("x", function (d) {
-        return x(d.label) + (x.bandwidth() / 2) - 24;
+        return x(d.label) + (x.bandwidth() / 2) -  12;
       })
       .attr("dy", "-4px") // add padding to top of bar
       .attr("y", function (d) {

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -108,7 +108,7 @@ function wrapText(text, width) {
     var y = text.attr("y");
     var dy = parseFloat(text.attr("dy"));
     var tspan = text.text(null).style("font-size", "14px")
-    .append("tspan").attr("x", 0).attr("y", y).attr("dy", dy + "em");
+    .append("tspan").attr("x", -12).attr("y", y).attr("dy", dy + "em");
 
     while (word = words.pop()) {
       line.push(word);
@@ -117,7 +117,7 @@ function wrapText(text, width) {
         line.pop();
         tspan.text(line.join(" "));
         line = [word];
-        tspan = text.append("tspan").attr("x", 0).attr("y", y - 6).attr("dy", ++lineNumber * lineHeight + dy + "em").text(word);
+        tspan = text.append("tspan").attr("x", -12).attr("y", y - 6).attr("dy", ++lineNumber * lineHeight + dy + "em").text(word);
       }
     }
   });
@@ -139,7 +139,6 @@ function createBarChart(selector, dataset, options) {
   options = options || {};
   var sort = options.hasOwnProperty('sort') ? options.sort : undefined;
   var truncPoint = options.hasOwnProperty('truncPoint') ? options.truncPoint : undefined;
-  var numTicks = options.hasOwnProperty('ticks') ? options.ticks : 5;
   var margin = options.hasOwnProperty('margin') ? options.margin : {
     top: 20,
     right: 0,
@@ -180,7 +179,7 @@ function createBarChart(selector, dataset, options) {
   // Generate axes
   g.append("g")
     .attr("transform", "translate(0," + height +  ")")
-    .call(d3.axisBottom(x).tickSize(0).tickPadding(3))
+    .call(d3.axisBottom(x).tickSize(0).tickPadding(10))
     .selectAll(".tick text")
     .attr("text-anchor", "middle")
     .call(wrapText, x.bandwidth());
@@ -203,7 +202,7 @@ function createBarChart(selector, dataset, options) {
     .attr("y", function (d) {
       return y(calcPercentage(data, d.value))
     })
-    .attr("width", x.bandwidth() )
+    .attr("width", x.bandwidth() - 24 )
     .attr("height", function (d) {
       return height - y(calcPercentage(data, d.value))
     });
@@ -214,11 +213,11 @@ function createBarChart(selector, dataset, options) {
       .data(data)
       .enter()
       .append("text")
-      .style("font-size", "14px")
+      .style("font-size", "16px")
       .attr("x", function (d) {
-        return x(d.label) + (x.bandwidth() / 2) -  12;
+        return x(d.label) + (x.bandwidth() / 2) - 24;
       })
-      .attr("dy", "-4px") // add padding to top of bar
+      .attr("dy", "-10px") // add padding to top of bar
       .attr("y", function (d) {
         return y(calcPercentage(data, d.value));
       })

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -177,19 +177,19 @@ function createBarChart(selector, dataset, options) {
     }))]);
 
   // Generate axes
-  g.append("g")
-    .attr("transform", "translate(0," + height +  ")")
-    .call(d3.axisBottom(x))
-    .selectAll(".tick text")
-    .attr("text-anchor", "middle")
-    .call(wrapText, x.bandwidth());
+  // g.append("g")
+  //   .attr("transform", "translate(0," + height +  ")")
+  //   .call(d3.axisBottom(x))
+  //   .selectAll(".tick text")
+  //   .attr("text-anchor", "middle")
+  //   .call(wrapText, x.bandwidth());
 
-  g.append("g")
-    .call(d3.axisLeft(y)
-      .tickFormat(function (d) {
-        return d + '%'
-      })
-      .ticks(numTicks));
+  // g.append("g")
+  //   .call(d3.axisLeft(y)
+  //     .tickFormat(function (d) {
+  //       return d + '%'
+  //     })
+  //     .ticks(numTicks));
 
   // Generate bars
   g.selectAll(".p-bar-chart__bar")
@@ -218,19 +218,33 @@ function createBarChart(selector, dataset, options) {
       .append("text")
       .style("font-size", "12px")
       .attr("x", function (d) {
-        return x(calcPercentage(data, d.value));
+        return x(d.label) + (x.bandwidth() / 2) - 24;
       })
-      .attr("y", function (d, i) {
-        if (i > 0) {
-          return y(d.label) + (y.bandwidth() / 2) - 10;
-        } else {
-          return y(d.label) + (y.bandwidth() / 2) + 10;
-        }
+      .attr("dy", "-4px") // add padding to top of bar
+      .attr("y", function (d) {
+        return y(calcPercentage(data, d.value));
       })
       .attr("class", "label")
       .text(function (d) {
         return Math.floor(calcPercentage(data, d.value), 1) + "%";
       });
+      
+    // Add text to the bottom of the bar
+    g.selectAll("text.y-axis")
+        .data(data)
+        .enter()
+        .append("text")
+        .attr("class", "y-axis")
+        .attr("x", function (d) {
+          return x(d.label) + (x.bandwidth() / 2) - 24;
+        })
+        .attr("y", function (d) {
+          return height + margin.top ;
+        })
+        .attr("class", "label")
+        .text(function (d) {
+            return d.label;
+        });
 }
 
 function createHorizontalBarChart(selector, dataset, options) {

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -108,7 +108,7 @@ function wrapText(text, width) {
     var y = text.attr("y");
     var dy = parseFloat(text.attr("dy"));
     var tspan = text.text(null).style("font-size", "14px")
-    .append("tspan").attr("x", -12).attr("y", y).attr("dy", dy + "em");
+      .append("tspan").attr("x", -12).attr("y", y).attr("dy", dy + "em");
 
     while (word = words.pop()) {
       line.push(word);
@@ -178,12 +178,12 @@ function createBarChart(selector, dataset, options) {
 
   // Generate axes
   g.append("g")
-    .attr("transform", "translate(0," + height +  ")")
+    .attr("transform", "translate(0," + height + ")")
     .call(d3.axisBottom(x).tickSize(0).tickPadding(10))
     .selectAll(".tick text")
     .attr("text-anchor", "middle")
     .call(wrapText, x.bandwidth());
-    
+
   // remove the x axis lines at the bottom
   g.selectAll(".domain").remove();
 
@@ -202,29 +202,29 @@ function createBarChart(selector, dataset, options) {
     .attr("y", function (d) {
       return y(calcPercentage(data, d.value))
     })
-    .attr("width", x.bandwidth() - 24 )
+    .attr("width", x.bandwidth() - 24)
     .attr("height", function (d) {
       return height - y(calcPercentage(data, d.value))
     });
-  
-    // Add text to the top of the bar
-    g.append("g")
-      .selectAll("text")
-      .data(data)
-      .enter()
-      .append("text")
-      .style("font-size", "16px")
-      .attr("x", function (d) {
-        return x(d.label) + (x.bandwidth() / 2) - 24;
-      })
-      .attr("dy", "-10px") // add padding to top of bar
-      .attr("y", function (d) {
-        return y(calcPercentage(data, d.value));
-      })
-      .attr("class", "label")
-      .text(function (d) {
-        return Math.floor(calcPercentage(data, d.value), 1) + "%";
-      });
+
+  // Add text to the top of the bar
+  g.append("g")
+    .selectAll("text")
+    .data(data)
+    .enter()
+    .append("text")
+    .style("font-size", "16px")
+    .attr("x", function (d) {
+      return x(d.label) + (x.bandwidth() / 2) - 24;
+    })
+    .attr("dy", "-10px") // add padding to top of bar
+    .attr("y", function (d) {
+      return y(calcPercentage(data, d.value));
+    })
+    .attr("class", "label")
+    .text(function (d) {
+      return Math.floor(calcPercentage(data, d.value), 1) + "%";
+    });
 }
 
 function createHorizontalBarChart(selector, dataset, options) {
@@ -233,12 +233,12 @@ function createHorizontalBarChart(selector, dataset, options) {
   var sort = options.hasOwnProperty('sort') ? options.sort : undefined;
   var truncPoint = options.hasOwnProperty('truncPoint') ? options.truncPoint : undefined;
   var margin = options.hasOwnProperty('margin') ? options.margin : {
-    top: 20,
+    top: 5,
     right: 20,
     bottom: 20,
     left: 60
   };
-  var colors = options.hasOwnProperty('colors') ? options.colors : ['#ed764d', '#925375', '#ccc' ];
+  var colors = options.hasOwnProperty('colors') ? options.colors : ['#ed764d', '#925375', '#ccc'];
   var ordinalColors = d3.scaleOrdinal(colors);
   var chartTitle = options.hasOwnProperty('title') ? options.title : undefined;
 
@@ -279,10 +279,10 @@ function createHorizontalBarChart(selector, dataset, options) {
     })
     .attr("x", -3)
     .attr("y", function (d, i) {
-      if (i > 0) {
-        return y(d.label) - 16; 
+      if (chartTitle && i > 0) {
+        return y(d.label) - 16;
       } else {
-        return y(d.label); 
+        return y(d.label) - (margin.top / 2);
       }
     })
     .attr("height", "16px")
@@ -300,36 +300,58 @@ function createHorizontalBarChart(selector, dataset, options) {
       return x(calcPercentage(data, d.value));
     })
     .attr("y", function (d, i) {
-      if (i > 0) {
-        return y(d.label) + (y.bandwidth() / 2) - 10;
+      if (chartTitle) {
+        if (i > 0) {
+          return y(d.label) + (y.bandwidth() / 2) - 10;
+        } else {
+          return y(d.label) + (y.bandwidth() / 2) + 10;
+        }
       } else {
-        return y(d.label) + (y.bandwidth() / 2) + 10;
+        return y(d.label) + (y.bandwidth() / 2) + (margin.top / 2);
       }
     })
     .attr("class", "label")
     .text(function (d) {
       return Math.floor(calcPercentage(data, d.value), 1) + "%";
     });
-  
-    // Add text to the left Axis
-    if (chartTitle) {
-      g.selectAll("text.left-axis")
-        .data(data)
-        .enter()
-        .append("text")
-        .attr("class", "left-axis")
-        .attr("x", function (d) {
-          return -70;
-        })
-        .attr("y", function (d) {
-          return (y(d.label) + (y.bandwidth() / 2) + 5) - ((y.bandwidth()));
-        })
-        .attr("class", "label")
-        .text(function (d, i) {
-          if (i % 2 === 0)
-            return chartTitle;
-        });
-    }
+
+  if (chartTitle) {
+    // Add text to the left Axis but only one per group
+    g.selectAll("text.left-axis")
+      .data(data)
+      .enter()
+      .append("text")
+      .attr("class", "left-axis")
+      .attr("x", function (d) {
+        return -70;
+      })
+      .attr("y", function (d) {
+        return (y(d.label) + (y.bandwidth() / 2) + 5) - ((y.bandwidth()));
+      })
+      .attr("class", "label")
+      .text(function (d, i) {
+        if (i % 2 === 0)
+          return chartTitle;
+      });
+  } else {
+    // Generate the generic horizontal charts
+    // generate y axis text labels
+    g.append("g")
+      .call(d3.axisLeft(y).tickSize(0))
+      .selectAll(".tick text")
+      .attr("text-anchor", "left")
+      .call(wrapText, margin.left)
+      .attr("transform", function () {
+        var marginRight = 10;
+        var fontSize = window.getComputedStyle(this).fontSize;
+        var textHeight = this.getBBox().height - 1;
+        var yPos = (-textHeight / 2) + (parseInt(fontSize, 10) / 2);
+
+        return "translate(-" + marginRight + "," + yPos + ")";
+      });
+    // Remove the y axis border line
+    g.selectAll(".domain").remove();
+  }
 }
 
 function createOrderedList(target, dataset, options) {
@@ -608,8 +630,6 @@ function buildCharts() {
   createBarChart('#size-of-ram', dummyData.ram.dataset);
   createBarChart('#pixel-density', dummyData.pixelDensity.dataset);
   createBarChart('#partition-number', dummyData.partitionNum.dataset);
-
-  createBarChart('#language-list-chart', dummyData.languageList.dataset);
   createMap('#where-are-users', dummyData.whereUsersAre.datasets, '/static/js/world-110m.v1.json');
   createPieChart('#default-settings-hw', dummyData.defaultSettings.datasets.hardware, {
     size: 184,
@@ -648,7 +668,7 @@ function buildCharts() {
   });
 
   createPieChart('#default-settings-vm', dummyData.defaultSettings.datasets.virtual, {
-    colors: ['#925375','#ccc','#ed764d'],
+    colors: ['#925375', '#ccc', '#ed764d'],
     size: 184,
     donutRadius: 76,
     centreLabel: {
@@ -656,7 +676,7 @@ function buildCharts() {
     }
   });
   createPieChart('#restrict-add-on-vm', dummyData.restrictAddOn.datasets.virtual, {
-    colors: ['#925375','#ccc','#ed764d'],
+    colors: ['#925375', '#ccc', '#ed764d'],
     size: 184,
     donutRadius: 76,
     centreLabel: {
@@ -664,7 +684,7 @@ function buildCharts() {
     }
   });
   createPieChart('#auto-login-vm', dummyData.autoLogin.datasets.virtual, {
-    colors: ['#925375','#ccc','#ed764d'],
+    colors: ['#925375', '#ccc', '#ed764d'],
     size: 184,
     donutRadius: 76,
     centreLabel: {
@@ -672,7 +692,7 @@ function buildCharts() {
     }
   });
   createPieChart('#minimal-install-vm', dummyData.minimalInstall.datasets.virtual, {
-    colors: ['#925375','#ccc','#ed764d'],
+    colors: ['#925375', '#ccc', '#ed764d'],
     size: 184,
     donutRadius: 76,
     centreLabel: {
@@ -680,7 +700,7 @@ function buildCharts() {
     }
   });
   createPieChart('#update-at-install-vm', dummyData.updateAtInstall.datasets.virtual, {
-    colors: ['#925375','#ccc','#ed764d'],
+    colors: ['#925375', '#ccc', '#ed764d'],
     size: 184,
     donutRadius: 76,
     centreLabel: {
@@ -689,25 +709,57 @@ function buildCharts() {
   });
 
   if (window.innerWidth >= breakpoint) {
+    createBarChart('#language-list-chart', dummyData.languageList.dataset);
     createHorizontalBarChart('#popular-screen-sizes', dummyData.screenSizes.dataset);
     createBarChart('#physical-disk', dummyData.physicalDisk.dataset);
     createBarChart('#partition-type', dummyData.partitionType.dataset);
-    createHorizontalBarChart('#partition-size', dummyData.partitionSize.dataset);
+    createHorizontalBarChart('#partition-size', dummyData.partitionSize.dataset, {
+      margin: {
+        top: 5,
+        right: 20,
+        bottom: 20,
+        left: 150
+      }
+    });
   } else {
+    createHorizontalBarChart('#language-list-chart', dummyData.languageList.dataset, {
+      colors: ['#ed764d', '#925375'],
+      yTextOffset: 5,
+      margin: {
+        top: 10,
+        right: 20,
+        bottom: 20,
+        left: 150
+      }
+    });
     createHorizontalBarChart('#popular-screen-sizes', dummyData.screenSizes.dataset);
-    createHorizontalBarChart('#physical-disk', dummyData.physicalDisk.dataset);
+    createHorizontalBarChart('#physical-disk', dummyData.physicalDisk.dataset, {
+      margin: {
+        top: 10,
+        right: 20,
+        bottom: 20,
+        left: 100
+      }
+    });
     createHorizontalBarChart(
       '#partition-type',
       dummyData.partitionType.dataset, {
         margin: {
-          top: 20,
+          top: 5,
           right: 20,
           bottom: 20,
-          left: 100
+          left: 230
         }
       }
     );
-    createHorizontalBarChart('#partition-size', dummyData.partitionSize.dataset);
+    createHorizontalBarChart('#partition-size', dummyData.partitionSize.dataset, {
+      margin: {
+        top: 5,
+        right: 20,
+        bottom: 20,
+        left: 100
+      }
+    });
   }
 }
 

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -178,7 +178,7 @@ function createBarChart(selector, dataset, options) {
 
   // Generate axes
   g.append("g")
-    .attr("transform", "translate(0," + height + ")")
+    .attr("transform", "translate(0," + height +  ")")
     .call(d3.axisBottom(x))
     .selectAll(".tick text")
     .attr("text-anchor", "middle")
@@ -206,10 +206,31 @@ function createBarChart(selector, dataset, options) {
     .attr("y", function (d) {
       return y(calcPercentage(data, d.value))
     })
-    .attr("width", x.bandwidth())
+    .attr("width", x.bandwidth() - 24 )
     .attr("height", function (d) {
       return height - y(calcPercentage(data, d.value))
     });
+  
+    // Add text to the top of the bar
+    g.selectAll("text")
+      .data(data)
+      .enter()
+      .append("text")
+      .style("font-size", "12px")
+      .attr("x", function (d) {
+        return x(calcPercentage(data, d.value));
+      })
+      .attr("y", function (d, i) {
+        if (i > 0) {
+          return y(d.label) + (y.bandwidth() / 2) - 10;
+        } else {
+          return y(d.label) + (y.bandwidth() / 2) + 10;
+        }
+      })
+      .attr("class", "label")
+      .text(function (d) {
+        return Math.floor(calcPercentage(data, d.value), 1) + "%";
+      });
 }
 
 function createHorizontalBarChart(selector, dataset, options) {

--- a/static/js/dummyData.js
+++ b/static/js/dummyData.js
@@ -370,9 +370,6 @@ var dummyData = {
       label: 'Portuguese (Brazil)',
       value: 800,
     }, {
-      label: 'Turkish',
-      value: 60,
-    }, {
       label: 'French',
       value: 400,
     }, {
@@ -385,20 +382,11 @@ var dummyData = {
       label: 'Russian',
       value: 500,
     }, {
-      label: 'Dutch',
-      value: 70,
-    }, {
       label: 'Spanish',
       value: 900,
     }, {
-      label: 'Hungarian',
-      value: 80,
-    }, {
       label: 'German',
       value: 600,
-    }, {
-      label: 'Korean',
-      value: 90,
     }, {
       label: 'Polish',
       value: 100,

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -83,9 +83,7 @@
 </section>
 <section class="p-strip--light is-bordered">
   <div class="row u-equal-height u-vertically-center">
-    <div class="col-6">
-      <h2 class="p-heading--four">What language do they use?</h2>
-    </div>
+    <h3>What language do they use?</h3>
   </div>
   <div class="row">
     <div class="col-12 u-align--center">


### PR DESCRIPTION
## Done
Updated What Language Do they use section to match visual design

## QA

- Check out this feature branch user 
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- go to the url http://0.0.0.0:8001/desktop/statistics
- Check that the layout matches the design https://github.com/canonical-websites/www.ubuntu.com/issues/4094


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4125
## Screenshots

![image](https://user-images.githubusercontent.com/43535482/46873811-77977700-ce2f-11e8-836a-fc4c4d87c232.png)

Note: Could not use the 16px for the language values in the bar chart. I used a smaller value instead to prevent an overlap. Please see screen shot above to understand more.