### PR TITLE
User report page cpu barchart 4130

### DIFF
--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -107,7 +107,7 @@ function wrapText(text, width) {
     var lineHeight = 1.5;
     var y = text.attr("y");
     var dy = parseFloat(text.attr("dy"));
-    var tspan = text.text(null).style("font-size", "12px")
+    var tspan = text.text(null).style("font-size", "16px")
     .append("tspan").attr("x", -12).attr("y", y).attr("dy", dy + "em");
 
     while (word = words.pop()) {
@@ -139,7 +139,6 @@ function createBarChart(selector, dataset, options) {
   options = options || {};
   var sort = options.hasOwnProperty('sort') ? options.sort : undefined;
   var truncPoint = options.hasOwnProperty('truncPoint') ? options.truncPoint : undefined;
-  var numTicks = options.hasOwnProperty('ticks') ? options.ticks : 5;
   var margin = options.hasOwnProperty('margin') ? options.margin : {
     top: 20,
     right: 5,
@@ -620,8 +619,24 @@ function buildCharts() {
       title: "VMs"
     }
   );
-  createBarChart('#number-of-cpus', dummyData.cpus.dataset);
-  createBarChart('#size-of-ram', dummyData.ram.dataset);
+  createBarChart('#number-of-cpus', dummyData.cpus.dataset, {
+    colors: ['#ed764d', '#925375'],
+    margin: {
+      top: 20,
+      right: 20,
+      bottom: 30,
+      left: -10
+    }
+  });
+  createBarChart('#size-of-ram', dummyData.ram.dataset, {
+    colors: ['#ed764d', '#925375'],
+    margin: {
+      top: 20,
+      right: 20,
+      bottom: 30,
+      left: -10
+    }
+  });
   createBarChart('#pixel-density', dummyData.pixelDensity.dataset);
   createBarChart('#partition-number', dummyData.partitionNum.dataset);
 

--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -620,7 +620,7 @@ function buildCharts() {
     }
   );
   createBarChart('#number-of-cpus', dummyData.cpus.dataset, {
-    colors: ['#ed764d', '#925375'],
+    colors: ['#E95420', '#772953' ],
     margin: {
       top: 20,
       right: 20,
@@ -629,7 +629,7 @@ function buildCharts() {
     }
   });
   createBarChart('#size-of-ram', dummyData.ram.dataset, {
-    colors: ['#ed764d', '#925375'],
+    colors: ['#E95420', '#772953' ],
     margin: {
       top: 20,
       right: 20,

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -166,12 +166,12 @@
     <h3>What CPU and memory do users have?</h3>
   </div>
   <div class="row p-mobile-flex-col u-equal-height p-divider">
-    <div class="col-5 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h4>Number of CPUs</h4>
       <svg id="number-of-cpus" height="200"></svg>
       <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output functions. Having multiple CPUs allows a computer to perform more tasks in parallel.</p>
     </div>
-    <div class="col-5 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h4>Size of RAM (GB)</h4>
       <svg id="size-of-ram" height="200"></svg>
       <p>The more memory, the more power the computer has to carry out functions. Some users reported having RAM upwards of 96GB!</p>

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -166,14 +166,14 @@
     <h3>What CPU and memory do users have?</h3>
   </div>
   <div class="row p-mobile-flex-col u-equal-height p-divider">
-    <div class="col-6 p-divider__block">
+    <div class="col-5 p-divider__block">
       <h4>Number of CPUs</h4>
-      <svg id="number-of-cpus" height="320"></svg>
+      <svg id="number-of-cpus" height="200"></svg>
       <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output functions. Having multiple CPUs allows a computer to perform more tasks in parallel.</p>
     </div>
-    <div class="col-6 p-divider__block">
+    <div class="col-5 p-divider__block">
       <h4>Size of RAM (GB)</h4>
-      <svg id="size-of-ram" height="320"></svg>
+      <svg id="size-of-ram" height="200"></svg>
       <p>The more memory, the more power the computer has to carry out functions. Some users reported having RAM upwards of 96GB!</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Updated the barchart for the user report page What CPU section to match the design documentation.
## QA

- Check out this feature branch user 
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- go to the url http://0.0.0.0:8001/desktop/statistics
- Check that the layout matches the design https://github.com/canonical-websites/www.ubuntu.com/issues/4094


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4130

## Screenshots

![image](https://user-images.githubusercontent.com/43535482/46959001-ec1e2000-d092-11e8-94fa-5039b91928b7.png)
