### PR TITLE
Barchart Layout and Data changed to design spec

### DIFF
--- a/static/js/desktopStatistics.js
+++ b/static/js/desktopStatistics.js
@@ -710,7 +710,9 @@ function buildCharts() {
 
   if (window.innerWidth >= breakpoint) {
     createHorizontalBarChart('#popular-screen-sizes', dummyData.screenSizes.dataset);
-    createBarChart('#physical-disk', dummyData.physicalDisk.dataset);
+    createBarChart('#physical-disk', dummyData.physicalDisk.dataset, {
+      colors: ['#E95420', '#772953']
+    });
     createBarChart('#partition-type', dummyData.partitionType.dataset);
     createHorizontalBarChart('#partition-size', dummyData.partitionSize.dataset);
   } else {

--- a/static/js/dummyData.js
+++ b/static/js/dummyData.js
@@ -149,23 +149,14 @@ var dummyData = {
   physicalDisk: {
     title: 'Physical disk (GB)',
     dataset: [{
-      label: '<30',
-      value: 255,
+      label: '1-3',
+      value: 1876,
     }, {
-      label: '30-99',
-      value: 154,
+      label: '4-6',
+      value: 282,
     }, {
-      label: '100-249',
-      value: 211,
-    }, {
-      label: '250-499',
-      value: 168,
-    }, {
-      label: '500-999',
+      label: '8+',
       value: 93,
-    }, {
-      label: '1TB+',
-      value: 19,
     },]
   },
   cpus: {


### PR DESCRIPTION
## Done

Changed the data and barcharts of the  Physical disk section to march the design documents.
## QA

- Check out this feature branch user 
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- go to the url http://0.0.0.0:8001/desktop/statistics
- Check that the layout matches the design https://github.com/canonical-websites/www.ubuntu.com/issues/4094

## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4131

## Screenshots

![image](https://user-images.githubusercontent.com/43535482/47011773-a3ba3d00-d13a-11e8-85ac-153ec8d79162.png)
