### PR TITLE
1810 fix desk dev

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -87,13 +87,12 @@
     <div class="row">
       <div class="col-12">
         <ul class="p-list--divided is-split">
-          <li class="p-list__item is-ticked">Fingerprint unlock</li>
-          <li class="p-list__item is-ticked">Manage your Thunderbolt devices through a new settings panel</li>
+          <li class="p-list__item is-ticked">Yaru, the new community theme is now the default</li>
+          <li class="p-list__item is-ticked">Thousands of updated snaps and packages such as Spotify, VLC, Skype, Slack, Discord and Telegram</li>
           <li class="p-list__item is-ticked">The latest version of the GNOME Desktop including many performance upgrades</li>
-          <li class="p-list__item is-ticked">Thousands of updated packages</li>
+          <li class="p-list__item is-ticked">Manage your Thunderbolt devices through a new settings panel</li>
           <li class="p-list__item is-ticked">Disks application now supports VeraCrypt, allowing you to share important content more securely</li>
           <li class="p-list__item is-ticked">Optional automatic bug reporting</li>
-          <li class="p-list__item is-ticked">Yaru, the new community theme is now the default</li>
         </ul>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes">Read the full release notes</a></p>
       </div>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -93,7 +93,7 @@
         <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
       </tr>
       <tr>
-        <td>Unlimited Ubuntu KVM guest support</td>
+        <td>Unlimited Ubuntu guest support</td>
         <td>&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>


### PR DESCRIPTION
## Done

- minor update to what's new 18.10 for desktop and removed KVM on plans and pricing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/developers](http://0.0.0.0:8001/desktop/developers) and [http://0.0.0.0:8001/pricing](http://0.0.0.0:8001/pricing)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that they match the copy docs [dev](https://docs.google.com/document/d/1VJ3xT2ViC-CvL0UmsAUzpYFmvpuqUP4AbpnlPm8tqOA/edit#) and [pricing](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)

