### PR TITLE
18.10 fix /download/server/power

### DIFF
--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -18,16 +18,18 @@
       <div class="col-6">
         <h2>Ubuntu Server</h2>
         <ul class="p-list">
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }} LTS&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/16.04.2/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.2 LTS&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/16.04.2/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.2 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
       <div class="col-6">
         <h2>Netboot image</h2>
         <ul class="p-list">
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }} LTS&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04.2/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.2 LTS&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04.2/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.2 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
@@ -38,12 +40,12 @@
 <div class="p-strip is-bordered">
   <div class="row u-equal-height p-divider">
     <div class="col-4 p-divider__block">
-      <h3>Ubuntu {{ latest_release }} LTS for IBM POWER</h3>
-      <p>Ubuntu {{ latest_release }} LTS adds support for Openstack Queens, LXD 3.0 with clustering and resource quotas, netplan.io, Chrony, and fresh package updates throughout the distribution.  Ubuntu 18.04 is the first release to support Power9.</p>
-      <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes">Ubuntu Server {{ latest_release }} LTS release notes&nbsp;&rsaquo;</a></p>
+      <h3>Ubuntu {{ lts_release }} <abbr title="Long-term support">LTS</abbr> for IBM POWER</h3>
+      <p>Ubuntu {{ lts_release }} LTS adds support for Openstack Queens, LXD 3.0 with clustering and resource quotas, netplan.io, Chrony, and fresh package updates throughout the distribution.  Ubuntu 18.04 is the first release to support Power9.</p>
+      <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes">Ubuntu Server {{ lts_release }} <abbr title="Long-term support">LTS</abbr> release notes&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
-      <h3>Ubuntu 16.04 LTS for IBM POWER8</h3>
+      <h3>Ubuntu 16.04 <abbr title="Long-term support">LTS</abbr> for IBM POWER8</h3>
       <p>Ubuntu 16.04 continues to enable rapid innovation for POWER8 including support for new POWER8 models, memory and PCI Hotplug, Docker 1.9.1, many performance and availability enhancements. Includes the only commercially available Linux to provide initial support for support the OpenPOWER Foundation’s industry leading NVLink technology.</p>
     </div>
     <div class="col-4 p-divider__block">

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -19,17 +19,17 @@
         <h2>Ubuntu Server</h2>
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/16.04.2/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.2 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/16.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '16.04.5', 'eventValue' : undefined });">16.04.5 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
       <div class="col-6">
         <h2>Netboot image</h2>
         <ul class="p-list">
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04.2/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.2 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.5 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Minor changes to listing on /download/server/power page
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/download/server/power](http://0.0.0.0:8001/download/server/power)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Make sure the list looks correct
