### PR TITLE
Optimise the desktop overview page images

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -8,7 +8,7 @@
 
 {# 0 -180px #}
 
-<section class="p-strip--image is-light is-deep is-bordered" style="background-image:url('{{ ASSET_SERVER_URL }}50c18622-insitu-laptop-overview.jpg'); background-position: 0 75%; padding: 6.25rem 0; min-height: 573px">
+<section class="p-strip--image is-light is-deep is-bordered" style="background-image:url('{{ ASSET_SERVER_URL }}50c18622-insitu-laptop-overview.jpg?w=1800'); background-position: 0 75%; padding: 6.25rem 0; min-height: 573px">
   <div class="row">
     <div class="col-6">
       <div class="p-card--overlay">
@@ -25,7 +25,7 @@
   <div class="row">
     <div class="u-equal-height">
       <div class="col-8 u-vertically-center u-hide--small">
-        <img src="{{ ASSET_SERVER_URL }}3a05fc34-Dell_XPS_Laptop_Front-news.png" alt="The Guardian website on Firefox in 16.04 LTS" />
+        <img src="{{ ASSET_SERVER_URL }}3a05fc34-Dell_XPS_Laptop_Front-news.png?w=681" alt="The Guardian website on Firefox in 16.04 LTS" />
       </div>
       <div class="col-4">
         <h2>Complete</h2>
@@ -58,7 +58,7 @@
     <div class="row">
       <div class="u-equal-height">
         <div class="col-7">
-          <img src="{{ ASSET_SERVER_URL }}d4f0c4b1-movie.png" alt="Whatsnew screenshot">
+          <img src="{{ ASSET_SERVER_URL }}d4f0c4b1-movie.png?w=592" alt="Whatsnew screenshot">
         </div>
         <div class="col-5 prefix-1 u-vertically-center">
           <div>
@@ -83,7 +83,7 @@
         <p><a href="https://partners.ubuntu.com/programmes" class="p-link--external">Find out more about our partners</a></p>
       </div>
       <div class="col-5 u-vertically-center u-hide--small">
-        <img src="{{ ASSET_SERVER_URL }}d9105909-Dell_XPS_Laptop_Left-Desktop.png" alt="Photo of laptop running Ubuntu" />
+        <img src="{{ ASSET_SERVER_URL }}d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" alt="Photo of laptop running Ubuntu" />
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done
Optimise the desktop overview page images

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop](http://0.0.0.0:8001/desktop)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the page weight has dropped from 6MB+ to 1.48MB
