### PR TITLE
Fix the small screen homepage takeover

### DIFF
--- a/templates/takeovers/_1810-takeover.html
+++ b/templates/takeovers/_1810-takeover.html
@@ -1,6 +1,6 @@
 <section lang="en" data-lang="en" class="p-strip--image is-dark is-deep u-image-position js-takeover p-takeover--1810 {% if not default %}u-hide{% endif %}" style="background-image:url('https://assets.ubuntu.com/v1/0edc1ffc-Cosmic_Cuttlefish_WP_4096x2304.jpg'); background-position: bottom; overflow: hidden;" {% if default %}data-default="true"{% endif %}>
   <div class="row">
-    <div class="col-6">
+    <div class="col-6" style="position: relative; z-index: 100;">
       <h1 style="font-weight: 100;">Ubuntu 18.10 is here</h1>
       <p>The latest version of the world’s most widely used Linux platform for Kubernetes, multi-cloud and machine learning.</p>
       <p class="u-no-margin--bottom"><a href="/download" class="p-button--neutral u-no-margin--bottom">Download 18.10 now</a></p>


### PR DESCRIPTION
## Done
Fix the small screen homepage takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Scale to small screens and check the button on the homepage is clickable.
