### PR TITLE
Changed the url for small screens to point to /desktop/developers

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -10,7 +10,7 @@
             <p class="p-p--small">The best Linux platform for modern cloud and IoT development.</p>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
-            <a href="/ai">Develop on Ubuntu&nbsp;&rsaquo;</a>
+            <a href="/desktop/developers">Develop on Ubuntu&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item">GCC, CLANG</li>


### PR DESCRIPTION
## Done

Changed the URL on Develop Link to point to /desktop/developers instead of /ai for small screens
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to any page on ubuntu.com.
- Size the browser window to be narrower than 875px.
- Open the “Developer” mega menu and click “Develop on Ubuntu” (the link, not the button).
- It should redirect to http://0.0.0.0:8001/desktop/developers


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/3995

