### PR TITLE
Add Appstore IOT & AI Webinar 2 Takeovers to rotation.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,4 +27,5 @@
     {% include "takeovers/_juju-webinar-takeover.html" %}
     {% include "takeovers/_ai_webinar-2018-10-01.html" %}
     {% include "takeovers/_tackling_iot.html" %}
+    {% include "takeovers/_de-vmware-to-os.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,4 +25,6 @@
 {% block takeover_content %}
     {% include "takeovers/_1810-takeover.html" with default=True %}
     {% include "takeovers/_juju-webinar-takeover.html" %}
+    {% include "takeovers/_ai_webinar-2018-10-01.html" %}
+    {% include "takeovers/_tackling_iot.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_1810-takeover.html
+++ b/templates/takeovers/_1810-takeover.html
@@ -1,4 +1,4 @@
-<section lang="en" data-lang="en" class="p-strip--image is-dark is-deep u-image-position js-takeover p-takeover--1810 {% if not default %}u-hide{% endif %}" style="background-image:url('https://assets.ubuntu.com/v1/0edc1ffc-Cosmic_Cuttlefish_WP_4096x2304.jpg'); background-position: bottom; overflow: hidden;" {% if default %}data-default="true"{% endif %}>
+<section lang="en" data-lang="all" class="p-strip--image is-dark is-deep u-image-position js-takeover p-takeover--1810 {% if not default %}u-hide{% endif %}" style="background-image:url('https://assets.ubuntu.com/v1/0edc1ffc-Cosmic_Cuttlefish_WP_4096x2304.jpg'); background-position: bottom; overflow: hidden;" {% if default %}data-default="true"{% endif %}>
   <div class="row">
     <div class="col-6" style="position: relative; z-index: 2;">
       <h1 style="font-weight: 100;">Ubuntu 18.10 is here</h1>

--- a/templates/takeovers/_tackling_iot.html
+++ b/templates/takeovers/_tackling_iot.html
@@ -1,4 +1,4 @@
-<section class="p-strip p-takeover is-deep js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="all" lang="en-gb" class="p-strip p-takeover is-deep js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-8 suffix-2">
       <h1 class="p-takeover__title">Tackling the I<span class="u-adjust-kerning">oT</span> monetisation challenge</h1>


### PR DESCRIPTION
## Done

Added _ai_webinar-2018-10-01.html &  _tackling_iot.html files to rotation. Also made changes to _tackling_iot.html to enable selection based on (user default) browser language.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh the browser to view the takeovers. For very refresh there should be different takeover.
- For the Germa takeover change your user browser language settings to german, then refresh the page.


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4263
## Screenshots

![screen shot 2018-10-22 at 15 26 28](https://user-images.githubusercontent.com/43535482/47298364-80e2c980-d60f-11e8-88e4-5fc1e5e7b81c.png)
![screen shot 2018-10-22 at 15 26 46](https://user-images.githubusercontent.com/43535482/47298365-80e2c980-d60f-11e8-945d-5d8e057201d9.png)
![screen shot 2018-10-22 at 15 27 00](https://user-images.githubusercontent.com/43535482/47298366-80e2c980-d60f-11e8-91f4-383933a8002e.png)
![screen shot 2018-10-22 at 15 27 12](https://user-images.githubusercontent.com/43535482/47298367-80e2c980-d60f-11e8-8e86-dc622c128b2a.png)


