### PR TITLE
Adds the Juju whitepaper landing page

### DIFF
--- a/templates/engage/evolving-software.html
+++ b/templates/engage/evolving-software.html
@@ -9,18 +9,16 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h1 class="p-hero__title">Keep up with evolving software</h1>
-      <h4>Learn how Juju can help solve software management complexity.</h4>
+      <p class="p-heading--four">Learn how Juju can help solve software management complexity.</p>
     </div>
   </div>
 </section>
 
 <style>
-  @media {
-    .p-hero--evolving-software {
-      background-image: 
-        url('{{ ASSET_SERVER_URL }}30c32559-juju-k8s-bundle-folds.png'), 
-        linear-gradient(121deg, #022935 0%, #044F66 57%, #067597 100%);
-    }
+  .p-hero--evolving-software {
+    background-image: 
+      url('{{ ASSET_SERVER_URL }}30c32559-juju-k8s-bundle-folds.png'), 
+      linear-gradient(121deg, #022935 0%, #044F66 57%, #067597 100%);
   }
   .p-hero__title {
     font-weight: 100;

--- a/templates/engage/evolving-software.html
+++ b/templates/engage/evolving-software.html
@@ -1,0 +1,54 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}Software keeps evolving and management complexity tends to increase with successive stack updates. Learn how using Juju can solve software management complexity and how it provides a familiar approach to managing any type of stack.{% endblock %}
+
+{% block title %}Keep up with evolving software{% endblock %}
+
+{% block content %}
+<section class="p-strip--image is-dark p-hero--evolving-software">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h1 class="p-hero__title">Keep up with evolving software</h1>
+      <h4>Learn how Juju can help solve software management complexity.</h4>
+    </div>
+  </div>
+</section>
+
+<style>
+  @media {
+    .p-hero--evolving-software {
+      background-image: 
+        url('{{ ASSET_SERVER_URL }}30c32559-juju-k8s-bundle-folds.png'), 
+        linear-gradient(121deg, #022935 0%, #044F66 57%, #067597 100%);
+    }
+  }
+  .p-hero__title {
+    font-weight: 100;
+  }
+</style>
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <h3>About the whitepaper</h3>
+      <p>With developers increasingly moving towards microservices – and with the
+        growing prevalence of the cloud as the default platform – software has become
+        more complex than ever.</p>
+      <p>In the past, a stand-alone application was typically enough to solve a particular
+        problem or provide a service to end users. But today’s solutions increasingly
+        demand large bundles of interconnected microservices distributed across many
+        machines, and potentially operating systems, to fulfil a single function.
+      </p>
+      <h3>Whitepaper highlights:</h3>
+      <ul class="p-list">
+          <li class="p-list__item is-ticked">How constantly evolving softare impacts automation, testing, and onboarding, and how Juju solves these issues</li>
+          <li class="p-list__item is-ticked">How Juju lets operators focus on the software model, rather than machines and instances details</li>
+          <li class="p-list__item is-ticked">How upgrades and changes in configuration, scale and components are handled by Juju </li>
+      </ul>
+    </div>
+    <div class="col-5">
+    {% include "../shared/forms/_landing_page_default.html" with id="3287" returnURL="https://pages.ubuntu.com/Juju_Whitepaper_ty.html" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

* New landing page at [`/engage/evolving-software`](http://www.ubuntu.com-canonical-websites-pr-4265.run.demo.haus/engage/evolving-software)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshot

https://screenshotscdn.firefoxusercontent.com/images/cb7b5ef9-da4b-454c-a2bc-132f70ae3b82.png