### PR TITLE
Responsive takeover and k8 design complete as per design spec

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,10 +23,10 @@
   #}
 
 {% block takeover_content %}
-  <!-- {% include "takeovers/_1810-takeover.html" with default=True %}
+  {% include "takeovers/_1810-takeover.html" with default=True %}
   {% include "takeovers/_juju-webinar-takeover.html" %}
   {% include "takeovers/_ai_webinar-2018-10-01.html" %}
   {% include "takeovers/_tackling_iot.html" %}
-  {% include "takeovers/_de-vmware-to-os.html" %} -->
+  {% include "takeovers/_de-vmware-to-os.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,9 +23,10 @@
   #}
 
 {% block takeover_content %}
-    {% include "takeovers/_1810-takeover.html" with default=True %}
-    {% include "takeovers/_juju-webinar-takeover.html" %}
-    {% include "takeovers/_ai_webinar-2018-10-01.html" %}
-    {% include "takeovers/_tackling_iot.html" %}
-    {% include "takeovers/_de-vmware-to-os.html" %}
+  <!-- {% include "takeovers/_1810-takeover.html" with default=True %}
+  {% include "takeovers/_juju-webinar-takeover.html" %}
+  {% include "takeovers/_ai_webinar-2018-10-01.html" %}
+  {% include "takeovers/_tackling_iot.html" %}
+  {% include "takeovers/_de-vmware-to-os.html" %} -->
+  {% include "takeovers/_german_takeover_k8.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_german_takeover_k8.html
+++ b/templates/takeovers/_german_takeover_k8.html
@@ -9,7 +9,7 @@
             <p class="u-no-margin--top"><a href="" class="p-button--neutral">Hier klicken um teilzunehmen</a></p>
         </div>
         <div class="col-4 u-hide--small">
-            <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" />
+            <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" style="width:264px; height:227px"/>
         </div>
     </div>
 </div>

--- a/templates/takeovers/_german_takeover_k8.html
+++ b/templates/takeovers/_german_takeover_k8.html
@@ -1,0 +1,15 @@
+<div data-lang="all" lang="de" class="p-strip--image is-dark js-takeover {% if not default %}u-hide{% endif %}" style="background-color:#326DE6">
+    <div class="row u-vertically-center">
+        <div class="col-8">
+            <h1 style="font-weight:100;">Wofür können Sie Kubernetes einsetzen?</h1>
+            <h4 class="u-sv3">Dieses Webinar liefert Ihnen alles Wichtige zum Einstieg.</h4>
+            <p class="u-align--center u-hide--medium u-hide--large">
+                <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" />
+            </p>
+            <p class="u-no-margin--top"><a href="" class="p-button--neutral">Hier klicken um teilzunehmen</a></p>
+        </div>
+        <div class="col-4 u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" />
+        </div>
+    </div>
+</div>

--- a/templates/takeovers/_german_takeover_k8.html
+++ b/templates/takeovers/_german_takeover_k8.html
@@ -6,7 +6,7 @@
             <p class="u-align--center u-hide--medium u-hide--large">
                 <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" style="width:264px; height:227px"/>
             </p>
-            <p class="u-no-margin--top"><a href="" class="p-button--neutral">Hier klicken um teilzunehmen</a></p>
+            <p class="u-no-margin--top"><a href="/engage/de/what-can-you-do-with-kubernetes?utm_medium=takeover&utm_campaign=FY19_Cloud_K8s_WBR_WhatCanYouDoWithK8sDE" class="p-button--neutral">Hier klicken um teilzunehmen</a></p>
         </div>
         <div class="col-4 u-hide--small">
             <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" style="width:264px; height:227px"/>

--- a/templates/takeovers/_german_takeover_k8.html
+++ b/templates/takeovers/_german_takeover_k8.html
@@ -4,7 +4,7 @@
             <h1 style="font-weight:100;">Wofür können Sie Kubernetes einsetzen?</h1>
             <h4 class="u-sv3">Dieses Webinar liefert Ihnen alles Wichtige zum Einstieg.</h4>
             <p class="u-align--center u-hide--medium u-hide--large">
-                <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" />
+                <img src="{{ ASSET_SERVER_URL }}73fe5532-business+icon.svg" alt="K8 Webinar" style="width:264px; height:227px"/>
             </p>
             <p class="u-no-margin--top"><a href="" class="p-button--neutral">Hier klicken um teilzunehmen</a></p>
         </div>


### PR DESCRIPTION
## Done

Created the k8 german takeover for K8 and added responsiveness.
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Change browser to german refresh until K8 German takeover shows, check that it match the (design)[https://app.zenhub.com/workspace/o/canonical-websites/www.ubuntu.com/issues/4231]


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4232



## Screenshots
![screenshot 2018-10-24 at 11 33 04](https://user-images.githubusercontent.com/43535482/47424901-af33e680-d780-11e8-8ae0-502764508230.png)
![screenshot 2018-10-24 at 11 32 43](https://user-images.githubusercontent.com/43535482/47424902-af33e680-d780-11e8-97c8-cedcb151b909.png)