### PR TITLE
Changed CTA text

### DIFF
--- a/templates/takeovers/_ai_webinar-2018-10-01.html
+++ b/templates/takeovers/_ai_webinar-2018-10-01.html
@@ -4,7 +4,7 @@
       <h1 class="p-takeover__title">How to build and deploy your first AI/ML model on Ubuntu</h1>
       <p class="p-takeover__text">We will walk you through running a Kaggle experiment using Kubeflow on Microk8s.</p>
       <div class="u-hide--small">
-        <a href="/engage/deploy-ai-ml-model?utm_medium=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIWebinar2" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
+        <a href="/engage/deploy-ai-ml-model?utm_medium=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIWebinar2" class="p-button--positive u-no-margin--bottom">Watch the webinar now</a>
       </div>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
@@ -17,7 +17,7 @@
         <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
       </div>
       <div class="u-hide--medium u-hide--large">
-        <a href="/engage/deploy-ai-ml-model?utm_medium=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIWebinar2" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
+        <a href="/engage/deploy-ai-ml-model?utm_medium=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIWebinar2" class="p-button--positive u-no-margin--bottom">Watch the webinar now</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- changed copy of cta to "Watch the webinar now"

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See cta copy has changed


## Issue / Card

Fixes #4277 
