### PR TITLE
Takeover created to meet spec 4247

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,6 @@
   {% include "takeovers/_juju-webinar-takeover.html" %}
   {% include "takeovers/_ai_webinar-2018-10-01.html" %}
   {% include "takeovers/_tackling_iot.html" %}
-  {% include "takeovers/_de-vmware-to-os.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,4 +29,5 @@
   {% include "takeovers/_tackling_iot.html" %}
   {% include "takeovers/_de-vmware-to-os.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
+  {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_german_takeover_openstack_made_easy.html
+++ b/templates/takeovers/_german_takeover_openstack_made_easy.html
@@ -2,11 +2,11 @@
     <div class="row u-vertically-center">
         <div class="col-8">
             <h1 style="font-weight:100;">OpenStack problemlos installieren und skalieren</h1>
-            <h4 class="u-sv3">Mit den richtigen Tools wird OpenStack ganz einfach.</h4>
+            <h4 class="u-no-margin--bottom u-sv3">Mit den richtigen Tools wird OpenStack ganz einfach.</h4>
             <p class="u-align--center u-hide--medium u-hide--large">
                 <img src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg" alt="OpenStack Made Easy" style="width:342px; height:219px" />
             </p>
-            <p class="u-no-margin--top">
+            <p>
                 <a href="https://www.ubuntu.com/engage/de/openstack-made-easy?utm_source=takeover&utm_medium=takeover&utm_campaign=FY19_Cloud_OpenStack_Ebook_OpenStackMadeEasyDE" class="p-button--positive">eBook herunterladen</a>
             </p>
         </div>

--- a/templates/takeovers/_german_takeover_openstack_made_easy.html
+++ b/templates/takeovers/_german_takeover_openstack_made_easy.html
@@ -1,0 +1,26 @@
+<div data-lang="all" lang="de" class="p-strip--image js-takeover p-takeover--german-openstack-made-easy {% if not default %}u-hide{% endif %}">
+    <div class="row u-vertically-center">
+        <div class="col-8">
+            <h1 style="font-weight:100;">OpenStack problemlos installieren und skalieren</h1>
+            <h4 class="u-sv3">Mit den richtigen Tools wird OpenStack ganz einfach.</h4>
+            <p class="u-align--center u-hide--medium u-hide--large">
+                <img src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg" alt="OpenStack Made Easy" style="width:342px; height:219px" />
+            </p>
+            <p class="u-no-margin--top">
+                <a href="https://www.ubuntu.com/engage/de/openstack-made-easy?utm_source=takeover&utm_medium=takeover&utm_campaign=FY19_Cloud_OpenStack_Ebook_OpenStackMadeEasyDE" class="p-button--positive">eBook herunterladen</a>
+            </p>
+        </div>
+        <div class="col-4 u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg" alt="OpenStack Made Easy" style="width:342px; height:219px" />
+        </div>
+    </div>
+</div>
+<style>
+   .p-takeover--german-openstack-made-easy {
+        background-image: url("{{ ASSET_SERVER_URL }}d3edfcd5-left.png"),url("{{ ASSET_SERVER_URL }}17508275-right.png");
+        background-color: #F7F7F7;
+        background-repeat: no-repeat;
+        background-size: contain;
+        background-position: bottom left, bottom right;
+   }
+</style>


### PR DESCRIPTION
## Done

Created German Language Takeover for OpenStack Made Easy.
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Change default browser language to german and there refresh the screen until it shows the Openstack Made Easy Takeovers.


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4249
## Screenshots

![image](https://user-images.githubusercontent.com/43535482/47490396-88d58000-d840-11e8-9657-f7001d75555d.png)
![image](https://user-images.githubusercontent.com/43535482/47490493-bde1d280-d840-11e8-96c6-741b2782861b.png)

