### PR TITLE
New LP for Kubernetes Case Study

### DIFF
--- a/templates/engage/kubernetes-case-study.html
+++ b/templates/engage/kubernetes-case-study.html
@@ -7,9 +7,9 @@
 <section class="p-strip--light p-takeover--stats is-deep">
   <div class="row">
     <div class="col-7">
-      <h1>Allan Gray unlocks unprecedented availability and productivity with CDK</h1>
+      <h1 style="font-weight: 100">Allan Gray unlocks unprecedented availability and productivity with CDK</h1>
       </div>
-      <div class="col-5">
+      <div class="prefix-1 col-5">
           <img src="{{ ASSET_SERVER_URL }}071489b4-K8s+logo+mobile.svg" alt="Case study: Canonical Distrubution of Kubernetes" onclick="document.getElementById('FirstName').focus();">
           </div>
       </div>

--- a/templates/engage/kubernetes-case-study.html
+++ b/templates/engage/kubernetes-case-study.html
@@ -30,7 +30,7 @@
     </div>
 
   <div class="col-5">
-    {% include "../shared/forms/_landing_page_default.html" with id="3296" returnURL="https://pages.ubuntu.com/CStudy_AllanGray-TY.html" %}
+    {% include "../shared/forms/_landing_page_default.html" with id="3296" returnURL="https://pages.ubuntu.com/CStudy_AllanGray-TY.html" label="Download the case study" %}
    </div>
 
 </div>

--- a/templates/engage/kubernetes-case-study.html
+++ b/templates/engage/kubernetes-case-study.html
@@ -1,0 +1,38 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}Case study: Canonical's Distribution of Kubernetes (CDK) cut financial servies company, Allan Gray's, Kubernetes cluster deployment time from two months to two weeks, with enterprise Kubernetes support provided to ensure maximum availability.{% endblock %}
+{% block title %}Allan Gray unlocks unprecedented availability and productivity with CDK{% endblock %}
+
+{% block content %}
+<section class="p-strip--light p-takeover--stats is-deep">
+  <div class="row">
+    <div class="col-7">
+      <h1>Allan Gray unlocks unprecedented availability and productivity with CDK</h1>
+      </div>
+      <div class="col-5">
+          <img src="{{ ASSET_SERVER_URL }}071489b4-K8s+logo+mobile.svg" alt="Case study: Canonical Distrubution of Kubernetes" onclick="document.getElementById('FirstName').focus();">
+          </div>
+      </div>
+      </section>
+      <section class="p-strip is-shallow">
+
+      <div class="row">
+          <div class="col-7">
+        <p >Allan Gray, an investment banking company, originally managed their Kubernetes cluster in house, but soon realised lack of additional support and the resourcing associated with its management could pose issues.</p>
+        <p>To minimise risk and maximise revenues, Allan Gray turned to Canonical's Distrubution of Kubernetes to boost efficiency and availability.</p>
+        <h3>Case study highlights</h3>
+        <ul class="p-list">
+            <li class="p-list__item is-ticked">Allan Gray needed enterprise support for Kubernetes to ensure maximum availability for mission-critical systems</li>
+            <li class="p-list__item is-ticked">Canonical’s Distribution of Kubernetes (CDK) cut Kubernetes cluster deployment time from two months to two weeks</li>
+            <li class="p-list__item is-ticked">Canonical’s Ubuntu Advantage (UA) support saves Allan Gray two weeks of work per Kubernetes upgrade - freeing senior developers to focus on valuable DevOps work</li>
+          </ul>
+        <p>Download the case study to find out more.</p>
+    </div>
+
+  <div class="col-5">
+    {% include "../shared/forms/_landing_page_default.html" with id="3296" returnURL="https://pages.ubuntu.com/CStudy_AllanGray-TY.html" %}
+   </div>
+
+</div>
+</section>
+{% endblock content %}

--- a/templates/shared/forms/_landing_page_default.html
+++ b/templates/shared/forms/_landing_page_default.html
@@ -59,7 +59,7 @@
         <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
       </li>
       <li class="mktField">
-        <button type="submit" class="mktoButton u-no-margin--bottom">Download the whitepaper</button>
+        <button type="submit" class="mktoButton u-no-margin--bottom">{% if label %}{{ label }}{% else %}Download the whitepaper{% endif %}</button>
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input name="lpId" aria-label="lpId" class="mktoField " value="" type="hidden">
         <input name="subId" aria-label="subId" class="mktoField " value="" type="hidden">


### PR DESCRIPTION
## Done

New page for the new K8s case study to live. Please note the form CTA button will be updated from 'whitepaper' to 'case study' so ignore for now.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)