### PR TITLE
ITstrategen-case-study

### DIFF
--- a/templates/engage/ITstrategen-case-study.html
+++ b/templates/engage/ITstrategen-case-study.html
@@ -1,0 +1,38 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}ITstrategen keeps legacy applications secure with Extended Security Maintenance{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1gbdgX7y1s22YBcm4N1dzuqgDwQwhJRMaNreHObZ8SdA/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip u-no-margin--bottom u-no-padding--bottom">
+  <div class="row">
+    <div class="col-7">
+      <h1 style="font-weight: 100">ITstrategen keeps legacy applications secure with Extended Security Maintenance</h1>
+      </div>
+      <div class="prefix-1 col-5">
+          <img src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="Case study: Fing serves 30,000 customers with a secure, future-proof IoT device" onclick="document.getElementById('FirstName').focus();">
+          </div>
+      </div>
+      </section>
+      <section class="p-strip is-shallow">
+
+      <div class="row">
+          <div class="col-7">
+        <p>Extended Security Maintenance (ESM) extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.</p>
+        <p>As the five-year support window for Ubuntu 12.04 came to an end, some of ITstrategen’s customers still depended on servers running the now out of support operating system and without support, the security of those servers was at risk. To tackle this issue, ITstrategen decided to purchase Extended Support Maintenance (ESM) for Ubuntu 12.04, a service offered as part of their Ubuntu Advantage subscription.</p>
+        <h3>Case study highlights</h3>
+        <ul class="p-list">
+            <li class="p-list__item is-ticked">ESM saves ITstrategen’s customers from 6-figure application update costs</li>
+            <li class="p-list__item is-ticked">It eliminates need for time-consuming security workarounds</li>
+            <li class="p-list__item is-ticked">And boosts service quality and customer loyalty</li>
+          </ul>
+        <p>Download the case study to find out more.</p>
+    </div>
+
+  <div class="col-5">
+    {% include "../shared/forms/_landing_page_default.html" with id="2495" returnURL="https://pages.ubuntu.com/Cloud_CS_ITstrategen_TY.html" label="Download the case study" %}
+   </div>
+
+</div>
+</section>
+{% endblock content %}

--- a/templates/engage/ITstrategen-case-study.html
+++ b/templates/engage/ITstrategen-case-study.html
@@ -1,16 +1,16 @@
 {% extends "engage/base_engage.html" %}
 
-{% block meta_description %}ITstrategen keeps legacy applications secure with Extended Security Maintenance{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1gbdgX7y1s22YBcm4N1dzuqgDwQwhJRMaNreHObZ8SdA/edit{% endblock meta_copydoc %}
+{% block meta_description %}ITstrategen keeps legacy applications secure with Extended Security Maintenance (ESM), a feature of the Ubuntu Advantage support subscriptions from Canonical.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1TIg0rYTrAp7yeu41GFwuCaXgS4SR2rjJrAp7D6zDocQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip u-no-margin--bottom u-no-padding--bottom">
+<section class="p-strip is-deep u-no-margin--bottom u-no-padding--bottom">
   <div class="row">
     <div class="col-7">
       <h1 style="font-weight: 100">ITstrategen keeps legacy applications secure with Extended Security Maintenance</h1>
       </div>
-      <div class="prefix-1 col-5">
-          <img src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="Case study: Fing serves 30,000 customers with a secure, future-proof IoT device" onclick="document.getElementById('FirstName').focus();">
+      <div class="col-5 u-vertically-center u-align--center u-hide--small">
+          <img src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="Case study: ITstrategen keeps legacy applications secure with Extended Security Maintenance" onclick="document.getElementById('FirstName').focus();">
           </div>
       </div>
       </section>
@@ -19,7 +19,7 @@
       <div class="row">
           <div class="col-7">
         <p>Extended Security Maintenance (ESM) extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.</p>
-        <p>As the five-year support window for Ubuntu 12.04 came to an end, some of ITstrategen’s customers still depended on servers running the now out of support operating system and without support, the security of those servers was at risk. To tackle this issue, ITstrategen decided to purchase Extended Support Maintenance (ESM) for Ubuntu 12.04, a service offered as part of their Ubuntu Advantage subscription.</p>
+        <p>As the five-year support window for Ubuntu 12.04 came to an end, some of ITstrategen’s customers still depended on servers running the now out of support operating system and without support, the security of those servers was at risk. To tackle this issue, ITstrategen decided to purchase Extended Security Maintenance (ESM) for Ubuntu 12.04, a service offered as part of their Ubuntu Advantage subscription.</p>
         <h3>Case study highlights</h3>
         <ul class="p-list">
             <li class="p-list__item is-ticked">ESM saves ITstrategen’s customers from 6-figure application update costs</li>


### PR DESCRIPTION
## Done

New page for ITstrategen case study to live. I assume form button label will be fixed once this is live - https://github.com/canonical-websites/www.ubuntu.com/commit/95f98d2c1926d902753015d936c46ae1fde3ba74 @caldav 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)