### PR TITLE
Add missing styles to engage pages

### DIFF
--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -7,12 +7,36 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
+<style>
+  .p-takeover--ai-webinar {
+    background-color: #171717 ;
+    background-image: linear-gradient(45deg, #171717 0%, #181818 9%, #262626 34%, #2d2d2d 67%, #383838 88%, #2e2e2e 100%, #393939 100%); /** sass-lint:disable-line no-color-literals **/
+  }
+
+  .p-takeover--ai-webinar .p-takeover__title {
+    color: #fff;
+    font-weight: 100;
+  }
+
+  .p-takeover--ai-webinar .p-takeover__text {
+    color: #fff;
+    font-size: 1.22176rem;
+    font-style: normal;
+    font-weight: 300;
+    line-height: 1.5rem;
+    margin-bottom: 1.7rem;
+    margin-top: 0;
+    max-width: 25em;
+    padding-top: 0.3rem;
+  }
+</style>
+
 <section class="p-strip p-takeover--ai-webinar">
   <div class="row u-equal-height">
     <div class="col-9">
       <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
       <p class="p-takeover__text">
-        <a href="#register-section">Watch the webinar&nbsp;&rsaquo;</a>
+        <a class="p-link--inverted" href="#register-section">Watch the webinar&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -5,6 +5,34 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1NtRmAB4Pkphc8WTU8n4-b10knVqqFhMDc_FtGAwQ7nw/edit{% endblock meta_copydoc %}
 
 {% block content %}
+<style>
+  .p-takeover--private-cloud-economics {
+    background-color: #0d5777;
+    background-image: linear-gradient(-36deg, #111 0%, rgba(38, 38, 38, .9) 100%);
+  }
+
+  .p-takeover__title {
+    color: #fff;
+    font-weight: 100;
+  }
+
+  .p-takeover__text {
+    color: #fff;
+    font-size: 1rem;
+  }
+
+  @media (min-width: 875px) {
+    .p-takeover--private-cloud-economics {
+      background-image: url('#{$assets-path}13fdbc5b-graph.png'), linear-gradient(-36deg, #111 0%, rgba(38, 38, 38, .9) 100%);
+      background-position: right bottom;
+      background-repeat: no-repeat;
+    }
+
+    .p-takeover__text {
+      font-size: 1.25rem;
+    }
+  }
+</style>
 <section class="p-strip is-deep p-takeover--private-cloud-economics">
   <div class="row u-equal-height">
     <div class="col-8">

--- a/templates/engage/deploy-ai-ml-model.html
+++ b/templates/engage/deploy-ai-ml-model.html
@@ -7,6 +7,30 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1BMqxhCOJfT43Mj2MFNgdM0X0c0rUYmBQBLeYFTCKfKY/edit{% endblock meta_copydoc %}
 
 {% block content %}
+<style>
+  .p-takeover--ai-webinar {
+    background-color: #171717 ;
+    background-image: linear-gradient(45deg, #171717 0%, #181818 9%, #262626 34%, #2d2d2d 67%, #383838 88%, #2e2e2e 100%, #393939 100%); /** sass-lint:disable-line no-color-literals **/
+  }
+
+  .p-takeover--ai-webinar .p-takeover__title {
+    color: #fff;
+    font-weight: 100;
+  }
+
+  .p-takeover--ai-webinar .p-takeover__text {
+    color: #fff;
+    font-size: 1.22176rem;
+    font-style: normal;
+    font-weight: 300;
+    line-height: 1.5rem;
+    margin-bottom: 1.7rem;
+    margin-top: 0;
+    max-width: 25em;
+    padding-top: 0.3rem;
+  }
+</style>
+
 <section class="p-strip p-takeover--ai-webinar">
   <div class="row u-equal-height">
     <div class="col-9">

--- a/templates/engage/future-proof-iot.html
+++ b/templates/engage/future-proof-iot.html
@@ -7,6 +7,30 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1f8FiTxhMTDxgM96jhfaEKCdc5LNKXcn0-2_iiSE6ZWs/edit{% endblock meta_copydoc %}
 
 {% block content %}
+<style>
+  .p-takeover--ai-webinar {
+    background-color: #171717 ;
+    background-image: linear-gradient(45deg, #171717 0%, #181818 9%, #262626 34%, #2d2d2d 67%, #383838 88%, #2e2e2e 100%, #393939 100%); /** sass-lint:disable-line no-color-literals **/
+  }
+
+  .p-takeover--ai-webinar .p-takeover__title {
+    color: #fff;
+    font-weight: 100;
+  }
+
+  .p-takeover--ai-webinar .p-takeover__text {
+    color: #fff;
+    font-size: 1.22176rem;
+    font-style: normal;
+    font-weight: 300;
+    line-height: 1.5rem;
+    margin-bottom: 1.7rem;
+    margin-top: 0;
+    max-width: 25em;
+    padding-top: 0.3rem;
+  }
+</style>
+
 <section class="p-strip p-takeover--ai-webinar">
   <div class="row u-equal-height">
     <div class="col-9">


### PR DESCRIPTION
## Done

- Added missing styles to engage pages (regression from https://github.com/canonical-websites/www.ubuntu.com/pull/4269)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the following pages have styling on the hero strip
  - /engage/deploy-ai-ml-model
  - /engage/ai-ml-ubuntu
  - /engage/cloud-economics
  - /engage/future-proof-iot

## Issue / Card

Fixes #4295 
