### PR TITLE
K8 Enterprise takeover created

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,11 +23,11 @@
   #}
 
 {% block takeover_content %}
-  {% include "takeovers/_1810-takeover.html" with default=True locale="all" %}
-  {% include "takeovers/_juju-webinar-takeover.html" with locale="all" %}
-  {% include "takeovers/_ai_webinar-2018-10-01.html" with locale="all" %}
-  {% include "takeovers/_tackling_iot.html" with locale="all" %}
-  {% include "takeovers/_german_takeover_k8.html" with locale="de" %}
-  {% include "takeovers/_german_takeover_openstack_made_easy.html" with locale="de" %}
+  {# include "takeovers/_1810-takeover.html" with default=True locale="all" #}
+  {# include "takeovers/_juju-webinar-takeover.html" with locale="all" #}
+  {# include "takeovers/_ai_webinar-2018-10-01.html" with locale="all" #}
+  {# include "takeovers/_tackling_iot.html" with locale="all" #}
+  {# include "takeovers/_german_takeover_k8.html" with locale="de" #}
+  {# include "takeovers/_german_takeover_openstack_made_easy.html" with locale="de" #}
   {% include "takeovers/_kubernetes-enterprise-takeover.html" with locale="all" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,4 +29,5 @@
   {% include "takeovers/_tackling_iot.html" with locale="all" %}
   {% include "takeovers/_german_takeover_k8.html" with locale="de" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" with locale="de" %}
+  {% include "takeovers/_kubernetes-enterprise-takeover.html" with locale="all" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,11 +23,11 @@
   #}
 
 {% block takeover_content %}
-  <!-- {% include "takeovers/_1810-takeover.html" with default=True locale="all" %}
+  {% include "takeovers/_1810-takeover.html" with default=True locale="all" %}
   {% include "takeovers/_juju-webinar-takeover.html" with locale="all" %}
   {% include "takeovers/_ai_webinar-2018-10-01.html" with locale="all" %}
   {% include "takeovers/_tackling_iot.html" with locale="all" %}
   {% include "takeovers/_german_takeover_k8.html" with locale="de" %}
-  {% include "takeovers/_german_takeover_openstack_made_easy.html" with locale="de" %} -->
+  {% include "takeovers/_german_takeover_openstack_made_easy.html" with locale="de" %}
   {% include "takeovers/_kubernetes-enterprise-takeover.html" with locale="all" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,11 +23,11 @@
   #}
 
 {% block takeover_content %}
-  {% include "takeovers/_1810-takeover.html" with default=True locale="all" %}
+  <!-- {% include "takeovers/_1810-takeover.html" with default=True locale="all" %}
   {% include "takeovers/_juju-webinar-takeover.html" with locale="all" %}
   {% include "takeovers/_ai_webinar-2018-10-01.html" with locale="all" %}
   {% include "takeovers/_tackling_iot.html" with locale="all" %}
   {% include "takeovers/_german_takeover_k8.html" with locale="de" %}
-  {% include "takeovers/_german_takeover_openstack_made_easy.html" with locale="de" %}
+  {% include "takeovers/_german_takeover_openstack_made_easy.html" with locale="de" %} -->
   {% include "takeovers/_kubernetes-enterprise-takeover.html" with locale="all" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_kubernetes-enterprise-takeover.html
+++ b/templates/takeovers/_kubernetes-enterprise-takeover.html
@@ -1,15 +1,15 @@
-<section lang="en" data-lang="{{ locale }}" class="p-strip--image is-deep js-takeover is-bordered p-takeover--kubernetes-solutions {% if not default %}u-hide{% endif %}"
+<section lang="en" data-lang="{{ locale }}" class="p-strip--image is-deep is-dark js-takeover is-bordered p-takeover--kubernetes-solutions {% if not default %}u-hide{% endif %}"
     {% if default %}data-default="true" {% endif %}>
     <div class="row u-vertically-center">
         <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
-            <p class="p-muted-heading" style="font-size: 1rem;">Kubernetes for the enterprise</p>
-            <h1 class="u-no-padding--top" style="font-weight: 100"><span class="event-title" itemprop="name">The Canonical Distribution of Kubernetes
+            <h1>Kubernetes for the enterprise</h1>
+            <p class="u-no-padding--top"><span class="event-title" itemprop="name">The Canonical Distribution of Kubernetes
                 Pure upstream, ready for multi-cloud, AI/ML and Edge!                
-                </span></h1>
-            <p class="col-5 u-hide--large"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes"></p>
+                </span></p>
+            <p class="col-5 u-hide--large .p-takeover--kubernetes-logo"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes"></p>
             <p><a itemprop="url" href="https://www.ubuntu.com/kubernetes" class="p-button--positive">Find out more / Read more</a></p>
         </div>
-        <div class="col-5 u-hide--small u-hide--medium">
+        <div class="col-5 u-hide--small u-hide--medium .p-takeover--kubernetes-logo">
             <img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes">
         </div>
     </div>
@@ -17,16 +17,32 @@
 
 <style>
     .p-takeover--kubernetes-solutions {
-        background-color: #f7f7f7;
+        background-color: #326ce5;
+        background-image: url('{{ ASSET_SERVER_URL }}7836831c-Takeover-small-screen.jpg?w=375');
+        background-position: bottom center;
+        background-size: none;
     }
 
-    @media (min-width: 768px) {
+    @media (min-width: 620px) {
         .p-takeover--kubernetes-solutions {
-            background-image: url('{{ ASSET_SERVER_URL }}d3edfcd5-left.png'),
-            url('{{ ASSET_SERVER_URL }}17508275-right.png');
-            background-repeat: no-repeat;
-            background-size: contain;
-            background-position: bottom left, bottom right;
+            background-image: url('{{ ASSET_SERVER_URL }}94206a69-Takeover-large-screen.jpg?w=1280');
         }
+    }
+
+    @media (min-width: 1200px) {
+        .p-takeover--kubernetes-solutions {
+            background-image: url('{{ ASSET_SERVER_URL }}94206a69-Takeover-large-screen.jpg');
+        }
+    }
+
+    @media (min-width: 1600px) {
+        .p-takeover--kubernetes-solutions {
+            background-size: cover;
+        }
+    }
+
+    .p-takeover--kubernetes-logo {
+        height: 257px;
+        width: 264px;
     }
 </style>

--- a/templates/takeovers/_kubernetes-enterprise-takeover.html
+++ b/templates/takeovers/_kubernetes-enterprise-takeover.html
@@ -6,10 +6,10 @@
             <p class="u-no-padding--top"><span class="event-title" itemprop="name">The Canonical Distribution of Kubernetes
                 Pure upstream, ready for multi-cloud, AI/ML and Edge!                
                 </span></p>
-            <p class="col-5 u-hide--large u-align--center"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes" class="p-takeover--kubernetes-logo"></p>
+            <p class="col-5 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes" class="p-takeover--kubernetes-logo"></p>
             <p><a itemprop="url" href="https://www.ubuntu.com/kubernetes" class="p-button--neutral">Find out more</a></p>
         </div>
-        <div class="col-5 u-hide--small u-hide--medium u-align--center">
+        <div class="col-5 u-hide--small u-align--center">
             <img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes" class="p-takeover--kubernetes-logo">
         </div>
     </div>

--- a/templates/takeovers/_kubernetes-enterprise-takeover.html
+++ b/templates/takeovers/_kubernetes-enterprise-takeover.html
@@ -6,11 +6,11 @@
             <p class="u-no-padding--top"><span class="event-title" itemprop="name">The Canonical Distribution of Kubernetes
                 Pure upstream, ready for multi-cloud, AI/ML and Edge!                
                 </span></p>
-            <p class="col-5 u-hide--large .p-takeover--kubernetes-logo"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes"></p>
-            <p><a itemprop="url" href="https://www.ubuntu.com/kubernetes" class="p-button--positive">Find out more / Read more</a></p>
+            <p class="col-5 u-hide--large u-align--center"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes" class="p-takeover--kubernetes-logo"></p>
+            <p><a itemprop="url" href="https://www.ubuntu.com/kubernetes" class="p-button--neutral">Find out more</a></p>
         </div>
-        <div class="col-5 u-hide--small u-hide--medium .p-takeover--kubernetes-logo">
-            <img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes">
+        <div class="col-5 u-hide--small u-hide--medium u-align--center">
+            <img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes" class="p-takeover--kubernetes-logo">
         </div>
     </div>
 </section>

--- a/templates/takeovers/_kubernetes-enterprise-takeover.html
+++ b/templates/takeovers/_kubernetes-enterprise-takeover.html
@@ -1,0 +1,32 @@
+<section lang="en" data-lang="{{ locale }}" class="p-strip--image is-deep js-takeover is-bordered p-takeover--kubernetes-solutions {% if not default %}u-hide{% endif %}"
+    {% if default %}data-default="true" {% endif %}>
+    <div class="row u-vertically-center">
+        <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
+            <p class="p-muted-heading" style="font-size: 1rem;">Kubernetes for the enterprise</p>
+            <h1 class="u-no-padding--top" style="font-weight: 100"><span class="event-title" itemprop="name">The Canonical Distribution of Kubernetes
+                Pure upstream, ready for multi-cloud, AI/ML and Edge!                
+                </span></h1>
+            <p class="col-5 u-hide--large"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes"></p>
+            <p><a itemprop="url" href="https://www.ubuntu.com/kubernetes" class="p-button--positive">Find out more / Read more</a></p>
+        </div>
+        <div class="col-5 u-hide--small u-hide--medium">
+            <img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes">
+        </div>
+    </div>
+</section>
+
+<style>
+    .p-takeover--kubernetes-solutions {
+        background-color: #f7f7f7;
+    }
+
+    @media (min-width: 768px) {
+        .p-takeover--kubernetes-solutions {
+            background-image: url('{{ ASSET_SERVER_URL }}d3edfcd5-left.png'),
+            url('{{ ASSET_SERVER_URL }}17508275-right.png');
+            background-repeat: no-repeat;
+            background-size: contain;
+            background-position: bottom left, bottom right;
+        }
+    }
+</style>


### PR DESCRIPTION
## Done

Created K8 Enterprise takeover as per design spec.
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh the page you see the kubernetes Enterprise Takover. Follow the QA steps to make sure that takeover matches [copy doc - Kubernetes Section (option 2)](https://docs.google.com/document/d/1H0sNENNBW3Xzy-SvMtjztEkLX4tU4x4ebiAvP0TDhuI/edit#) and the design style similar to [this](https://github.com/ubuntudesign/web-squad/issues/870)


## Issue / Card

Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4302
## Screenshots
![image](https://user-images.githubusercontent.com/43535482/47728252-e2c9b180-dc55-11e8-9db8-0905d7f7f16c.png)
![image](https://user-images.githubusercontent.com/43535482/47728296-f6751800-dc55-11e8-9ebc-922084796ff2.png)

