### PR TITLE
Add link to RedHat statement on homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -14,8 +14,7 @@
         <div class="col-12">
           <p class="u-no-max-width p-heading--four u-no-margin--bottom u-vertically-center">
             <img src="https://assets.ubuntu.com/v1/838316ab-cof-25x25.png" alt="" />&nbsp;&nbsp;
-            <a href="/desktop/statistics" class="p-link--inverted">Ubuntu user statistics report is now available&nbsp;&rsaquo;</a>
-          </h3>
+            <a href="https://blog.ubuntu.com/2018/10/30/statement-on-ibm-acquisition-of-red-hat" class="p-link--inverted p-link--external">Statement on the IBM acquisition of Red Hat</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done

- Add link to RedHat statement on homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- see that the message under the takeover says [Statement on the IBM acquisition of Red Hat](https://blog.ubuntu.com/2018/10/30/statement-on-ibm-acquisition-of-red-hat)

## Issue / Card

Fixes #4304

## Screenshots

![image](https://user-images.githubusercontent.com/441217/47722958-6f22a700-dc4b-11e8-9a90-3e19d04373c1.png)
