### PR TITLE
Added a multicloud option for k8s contact-us and thank-you pages

### DIFF
--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -9,6 +9,8 @@
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you' %}
   {% elif product == 'kubernetes-managed' %}
       {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Managed Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed' %}
+  {% elif product == 'multicloud' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about multicloud" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=multicloud' %}
   {% elif product == 'kubernetes-install' %}
       {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=' %}
   {% elif product == 'kubernetes-features' %}

--- a/templates/kubernetes/thank-you.html
+++ b/templates/kubernetes/thank-you.html
@@ -10,6 +10,8 @@
     {% include "shared/_thank_you.html" with thanks_context="enquiring about Managed Kubernetes" %}
   {% elif product == 'kubernetes-install' %}
       {% include "shared/_thank_you.html" with thanks_context="enquiring about Kubernetes" %}
+  {% elif product == 'multicloud' %}
+      {% include "shared/_thank_you.html" with thanks_context="contacting us about multicloud." %}
   {% elif product == 'kubernetes-features' %}
       {% include "shared/_thank_you.html" with thanks_context="enquiring about Kubernetes" %}
   {% elif product == 'kubernetes-explorer' %}


### PR DESCRIPTION
## Done

- Added a multicloud option for k8s contact-us and thank-you pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/contact-us?product=multicloud](http://0.0.0.0:8001/kubernetes/contact-us?product=multicloud) and [http://0.0.0.0:8001/kubernetes/thank-you?product=multicloud](http://0.0.0.0:8001/kubernetes/thank-you?product=multicloud)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc - contact-us](https://docs.google.com/document/d/1Zf_xYK57S5T_T3HtKCPK7bf7vMVIMNuhJggSb-EdgAc/edit#heading=h.p0c4a9c3rl0j) [copy doc - thank-you](https://docs.google.com/document/d/1rkHUgJ4WqEL9Eu7GFgikr5dtIRVYNDjl8YV-tU4irLg/edit#heading=h.1exx3rsh3og4)

