### PR TITLE
Updated /kubernetes/managed copy

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -159,19 +159,6 @@
     </div>
   </section>
 
-  <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="col-8">
-        <h2>Security first &mdash; trusted by the OpenStack majority</h2>
-        <p>OpenStack can underpin your managed Kubernetes Private Cloud initiative. Canonical, a founding member of OpenStack, provides security updates for thousands of production OpenStack clouds worldwide. We offer multi-year maintenance for stable cloud deployments and upgrades for those who want to move to newer versions.</p>
-        <p>The OpenStack super-users who run the largest and most complex OpenStack deployments choose Ubuntu because of our quality and security. Canonical will help you meet telco, finance and government sector audit and compliance standards.</p>
-      </div>
-      <div class="col-4 prefix-1">
-        {% include "openstack/shared/_openstack-pie-chart.html" %}
-      </div>
-    </div>
-  </section>
-
   <section class="p-strip--light is-bordered">
     <div class="row">
       <div class="col-8">
@@ -194,11 +181,11 @@
       <div class="col-6">
         <h3>Multi-cloud ready</h3>
         <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Deep integration with cloud features such as <abbr title="Load Balancing as a Service">LBaaS</abbr>, storage and networking</li>
           <li class="p-list__item is-ticked">Elasticity for highly variable load</li>
           <li class="p-list__item is-ticked">Many regions for low latency</li>
           <li class="p-list__item is-ticked">OPEX as needed</li>
           <li class="p-list__item is-ticked">Network isolation</li>
-          <li class="p-list__item is-ticked">Potential for uneven cloud performance</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done

Updated /kubernetes/managed copy

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/kubernetes/managed](http://0.0.0.0:8001/kubernetes/managed)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to and accept suggestions on the [copy doc](https://docs.google.com/document/d/15jzhasokjH5Ql9Za56ZxRknXNNhEXYdIFXXtLODGxns/edit?ts=5bd75c89#heading=h.uuui703zqd0m)

## Issue / Card

Fixes #4308
