### PR TITLE
Updated esm end date on /esm

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -9,7 +9,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>Ubuntu 12.04 ESM</h1>
-      <p>In April 2017, Ubuntu 12.04 LTS reached its end-of-life. For Ubuntu Advantage customers who can not upgrade to a newer version of Ubuntu Server, Canonical is offering Ubuntu 12.04 ESM (Extended Security Maintenance). ESM provides ongoing security fixes for the kernel and essential packages through April 2019.</p>
+      <p>In April 2017, Ubuntu 12.04 LTS reached its end-of-life. For Ubuntu Advantage customers who can not upgrade to a newer version of Ubuntu Server, Canonical is offering Ubuntu 12.04 ESM (Extended Security Maintenance). ESM provides ongoing security fixes for the kernel and essential packages through April 2020.</p>
       <p><a href="https://buy.ubuntu.com/" class="p-button--positive">Buy Ubuntu Advantage</a></p>
       <p><a href="/support" class="p-link--inverted">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>


### PR DESCRIPTION
## Done

- Updated esm end date on /esm

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/esm](http://0.0.0.0:8001/esm)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- check if it says 2020 for the end date
- Check if it matches [copydoc](https://docs.google.com/document/d/1BK-XXECYJJllG8jIe3WN3X8EMo_3wBBa03nlzYDP8xE/edit#heading=h.4n9o6kows08v)


## Issue / Card
Fixes: #4347 

