### PR TITLE
Fix footer to have it on one line on html

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -83,8 +83,7 @@
           </ul>
         </nav>
 
-        <p class="p-footer--secondary__content"><small>&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are
-            registered trademarks of Canonical Ltd.</small></p>
+        <p class="p-footer--secondary__content"><small>&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</small></p>
         <nav>
           <ul class="p-inline-list--middot u-no-margin--bottom">
             <li class="p-inline-list__item">


### PR DESCRIPTION
# Summary

This is an attempt to fix the jenkins job that tests if the text "Canonical Ltd. Ubuntu and Canonical are registered trademarks" is on the frontpage.

Problem is that since it is on 2 lines the grep doens't work.

# QA

- `./run`
- on another terminal: `curl localhost:8001 | grep "Canonical Ltd. Ubuntu and Canonical are registered trademarks"`
- Make sure you have result