### PR TITLE
Import takeovers from a <template> element

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -7,8 +7,11 @@
 
 {% block outer_content %}
   {% block content %}
-    {% block takeover_content %}
-    {% endblock takeover_content %}
+    <template id="takeovers" class="u-hide">
+      {% block takeover_content %}
+      {% endblock takeover_content %}
+    </template>
+
     <section class="p-strip--accent is-shallow is-dark">
       <div class="row">
         <div class="col-12">

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -149,44 +149,63 @@
         }
       };
     </script>
+
     <script>
       if (window.localStorage && window.sessionStorage) {
-        var takeovers = document.getElementsByClassName('js-takeover');
-        for (t = 0; t < takeovers.length; ++t) {
-            // hide all takeovers
-            takeovers[t].classList.add('u-hide');
-        }
+        /**
+         * Choose a takeover
+         * ===
+         * 
+         * From the list of provided takeovers in the #takeovers template,
+         * choose one (that matches the client's language), and replace the
+         * base template with it.
+         */
+
+        var baseTakeover = document.querySelector('section#takeover');  // The base takeover element
+        var takeovers = document.querySelector('template#takeovers');  // The list of current takeovers to choose from
+
+        // For browsers that support <template> (all but IE), grab the template's ".content"
+        takeovers = 'content' in takeovers ? takeovers.content: takeovers;
+
         // get the users language and remove any extra detail suffix (e.g. -gb)
         var browserLanguage = detectLanguage();
         var languageClass = browserLanguage || 'en';
         languageClass = languageClass.split('-')[0];
 
-        // set the default takeover or if use the first one
-        var defaultTakeovers = document.querySelectorAll(
-          '.js-takeover[data-default="true"]'
-        );
-        if (!defaultTakeovers) {
-          defaultTakeovers = takeovers[0];
-        }
-
         // find any takeovers that match the users language
         var queryLang = ".js-takeover[data-lang*='"+languageClass+"']";
         var queryAll = ".js-takeover[data-lang*='all']";
-        var takeoversFiltered = (document.querySelectorAll([queryLang,queryAll].join(',')));
+        var takeoversFiltered = (takeovers.querySelectorAll([queryLang,queryAll].join(',')));
 
-        takeoversFiltered = (takeoversFiltered.length) ? takeoversFiltered : defaultTakeovers;
+        // If we have any takeovers
+        if (takeoversFiltered) {
+          var selectedIndex = null;
 
-        if (!localStorage.getItem('TAKEOVER')) {
-          var i = Math.floor(Math.random() * takeoversFiltered.length);
-          localStorage.setItem('TAKEOVER', i);
-        } else {
-          var i = parseInt(localStorage.getItem('TAKEOVER')) + 1;
-          if (i >= takeoversFiltered.length) {
-            i = 0;
+          if (
+            localStorage.getItem('selected_takeover_index') !== null &&
+            parseInt(localStorage.getItem('selected_takeover_index')) < takeoversFiltered.length
+          ) {
+            // If we previously chose a takeover, use that one
+            selectedIndex = parseInt(localStorage.getItem('selected_takeover_index'))
+          } else {
+            // Otherwise, randomly choose one of the takeovers and store it for next time
+            var selectedIndex = Math.floor(Math.random() * takeoversFiltered.length);
+            localStorage.setItem('selected_takeover_index', selectedIndex)
           }
+
+          // Get the takeover element
+          var selectedTakeover = takeoversFiltered[selectedIndex]
+
+          if (! document.contains(selectedTakeover)) {
+            // If it's not in the current document (as in, it's in a template) import it
+            // Note: This is for all browser *except* IE, which doesn't support <template>s
+            selectedTakeover = document.importNode(selectedTakeover, true);
+          }
+
+          // Replace the base takeover with the new one
+          // Note: We can't use Node.replaceWith (which would be nice), as it's not supported in IE
+          baseTakeover.parentNode.replaceChild(selectedTakeover, baseTakeover)
         }
-        localStorage.setItem('TAKEOVER', i);
-        takeoversFiltered[i].classList.remove('u-hide');
       }
     </script>
   {% endblock content %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -12,6 +12,17 @@
       {% endblock takeover_content %}
     </template>
 
+    <!-- Default Takeover: Download the latest Ubuntu -->
+    <section data-lang="all" id="takeover" class="p-strip--image is-dark is-deep" style="background-color: #5E2750; background-image: linear-gradient(110deg, #5E2750 20%, #2C001E 46%, #2C001E 60%);">
+      <div class="row">
+        <div class="col-12 suffix-4">
+          <h1 style="font-weight: 100;">Ubuntu {{ latest_release }} is here</h1>
+          <p>The latest version of the world’s most widely used Linux platform for Kubernetes, multi-cloud and machine learning.</p>
+          <p class="u-no-margin--bottom"><a href="/download" class="p-button--neutral u-no-margin--bottom">Download Ubuntu {{ latest_release }} now</a></p>
+        </div>
+      </div>
+    </section>
+
     <section class="p-strip--accent is-shallow is-dark">
       <div class="row">
         <div class="col-12">

--- a/templates/takeovers/_1810-webinar-takeover.html
+++ b/templates/takeovers/_1810-webinar-takeover.html
@@ -1,4 +1,4 @@
-<section lang="en" data-lang="{{ locale }}" class="p-strip--image is-dark is-deep u-image-position js-takeover p-takeover--1810--webinar {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="{{ locale }}" class="p-strip--image is-dark is-deep u-image-position p-takeover--1810--webinar">
     <div class="row u-vertically-center">
       <div class="col-6" >
         <h1 style="font-weight: 100;">What’s new in <br/>Ubuntu 18.10</h1>
@@ -79,26 +79,25 @@
       <p class="u-hide--large  u-hide--medium"><a href="https://www.brighttalk.com/webcast/6793/339391" class="p-button--neutral">Watch the webinar now</a></p>
       </div>
     </div>
+
+    <style>
+        .p-takeover--1810--webinar {
+          position: relative;
+          background-color: #5E2750;
+          background-image: linear-gradient(110deg, #5E2750 20%, #2C001E 46%, #2C001E 60%); 
+        }
+        
+        @media (max-width: 874px) {
+          .p-takeover--1810--webinar {
+            position: relative;
+            background-color: #5E2750;
+            background-image: linear-gradient(150deg, #5E2750 20%, #2C001E 46%, #2C001E 60%); 
+          }
+          
+          .p-takeover--1810--webinar .cuttlefish {
+            margin-top: -10px;
+            width: 100%;
+          }
+        }
+      </style>
   </section>
-  
-  <style>
-  
-    .p-takeover--1810--webinar {
-      position: relative;
-      background-color: #5E2750;
-      background-image: linear-gradient(110deg, #5E2750 20%, #2C001E 46%, #2C001E 60%); 
-    }
-    
-    @media (max-width: 874px) {
-      .p-takeover--1810--webinar {
-        position: relative;
-        background-color: #5E2750;
-        background-image: linear-gradient(150deg, #5E2750 20%, #2C001E 46%, #2C001E 60%); 
-      }
-      
-      .p-takeover--1810--webinar .cuttlefish {
-        margin-top: -10px;
-        width: 100%;
-      }
-    }
-  </style>

--- a/templates/takeovers/_german_takeover_k8.html
+++ b/templates/takeovers/_german_takeover_k8.html
@@ -1,4 +1,4 @@
-<div data-lang="{{ locale }}" lang="de" class="p-strip--image is-dark js-takeover {% if not default %}u-hide{% endif %}" style="background-color:#326DE6">
+<div data-lang="{{ locale }}" class="p-strip--image is-dark" style="background-color:#326DE6">
     <div class="row u-vertically-center">
         <div class="col-8">
             <h1 style="font-weight:100;">Wofür können Sie Kubernetes einsetzen?</h1>

--- a/templates/takeovers/_german_takeover_openstack_made_easy.html
+++ b/templates/takeovers/_german_takeover_openstack_made_easy.html
@@ -1,4 +1,4 @@
-<div data-lang="{{ locale }}" lang="de" class="p-strip--image js-takeover p-takeover--german-openstack-made-easy {% if not default %}u-hide{% endif %}">
+<div data-lang="{{ locale }}" class="p-strip--image p-takeover--german-openstack-made-easy">
     <div class="row u-vertically-center">
         <div class="col-8">
             <h1 style="font-weight:100;">OpenStack problemlos installieren und skalieren</h1>
@@ -14,13 +14,14 @@
             <img src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg" alt="OpenStack Made Easy" style="width:342px; height:219px" />
         </div>
     </div>
+
+    <style>
+        .p-takeover--german-openstack-made-easy {
+             background-image: url("{{ ASSET_SERVER_URL }}d3edfcd5-left.png"),url("{{ ASSET_SERVER_URL }}17508275-right.png");
+             background-color: #F7F7F7;
+             background-repeat: no-repeat;
+             background-size: contain;
+             background-position: bottom left, bottom right;
+        }
+     </style>
 </div>
-<style>
-   .p-takeover--german-openstack-made-easy {
-        background-image: url("{{ ASSET_SERVER_URL }}d3edfcd5-left.png"),url("{{ ASSET_SERVER_URL }}17508275-right.png");
-        background-color: #F7F7F7;
-        background-repeat: no-repeat;
-        background-size: contain;
-        background-position: bottom left, bottom right;
-   }
-</style>


### PR DESCRIPTION
Fixes #4143

This keeps all takeover markup inside a `<template>` element,
so as to avoid loading images, scripts and styles from unused takeovers.

This should improve performance for the client.

QA
--

`./run`, load the homepage. See that the "base" takeover gets replaced by the nicer CUTTLEFISH takeover.

Play around a bit, add some more takeovers, check they get chosen. Maybe try changing your language to German.

If you're feeling extra awesome, you might try testing in IE11.