### PR TITLE
Remove the classnames from the docs navigaiton

### DIFF
--- a/static/sass/_layout_documentation.scss
+++ b/static/sass/_layout_documentation.scss
@@ -35,23 +35,33 @@
       margin-top: 2rem;
     }
 
-    &__list {
-      @extend .p-list;
-      margin-bottom: $spv-intra;
-      margin-top: -$spv-intra--condensed;
+    h3 {
+      font-size: 1rem;
+      font-weight: 400;
+      line-height: 2;
+      margin: 0;
+      padding: 0;
     }
 
-    &__item {
-      list-style: none;
-      padding-bottom: $spv-intra--condensed / 2;
-      padding-top: $spv-intra--condensed / 2;
+    ul {
+      margin-bottom: 0.625rem;
+      margin-left: 0;
+      padding-left: 1rem;
+    }
 
-      &:first-of-type {
-        padding-top: $spv-intra;
+    li {
+      padding-bottom: 0.125rem;
+      padding-top: 0.125rem;
+
+      a,
+      a:visited {
+        color: $color-x-dark;
+        text-decoration: none;
       }
 
-      &:last-of-type {
-        padding-bottom: $spv-intra + $spv-intra--condensed;
+      a:hover {
+        color: $color-link;
+        text-decoration: underline;
       }
 
       .is-active {
@@ -59,18 +69,14 @@
 
         &::before {
           background-color: $color-mid-light;
-          bottom: -$spv-intra--condensed;
+          bottom: -0.25rem;
           content: '';
-          left: -$sph-intra;
+          left: -1rem;
           position: absolute;
-          top: -$spv-intra--condensed;
-          width: $bar-thickness;
+          top: -0.25rem;
+          width: 0.1875rem;
         }
       }
-    }
-
-    &__item > &__list {
-      padding-left: $sph-intra;
     }
   }
 

--- a/templates/kubernetes/docs/base_docs.html
+++ b/templates/kubernetes/docs/base_docs.html
@@ -5,7 +5,41 @@
 {% block outer_content %}
   <div class="l-documentation">
     <div class="l-documentation__sidebar">
-    {% include "kubernetes/docs/shared/_side-navigation.html" %}
+      <aside class="p-sidebar" id="docs-navigation">
+        <div class="p-sidebar__banner u-hide--medium u-hide--large">
+          <i class="p-sidebar__toggle p-icon--menu"></i>
+        </div>
+        <div class="p-sidebar__content u-hide--small">
+          <nav class="p-sidebar-nav">
+            {% include "kubernetes/docs/shared/_side-navigation.html" %}
+          </nav>
+        </div>
+      </aside>
+
+      <script>
+      // Select the active navigation item
+      var navigation = document.getElementById('docs-navigation');
+      var links = navigation.getElementsByTagName('a');
+      var currentPage = window.location.pathname;
+      for (var i = 0; i < links.length; i++) {
+        var link = links[i];
+        if (link.getAttribute('href') === currentPage) {
+          link.classList.add('is-active');
+        }
+      };
+      </script>
+
+      <script>
+      // Toggle mobile sidebar nav
+      var toggle = document.querySelector('.p-sidebar__toggle');
+      var sidebarContent = document.querySelector('.p-sidebar__content');
+
+      toggle.addEventListener('click', function(e) {
+        toggle.classList.toggle('p-icon--menu');
+        toggle.classList.toggle('p-icon--close');
+        sidebarContent.classList.toggle('u-hide--small');
+      });
+      </script>
     </div>
     <div class="l-documentation__content">
       {% block content %}{% endblock %}

--- a/templates/kubernetes/docs/shared/_side-navigation.html
+++ b/templates/kubernetes/docs/shared/_side-navigation.html
@@ -1,71 +1,38 @@
-<aside class="p-sidebar" id="docs-navigation">
-  <div class="p-sidebar__banner u-hide--medium u-hide--large">
-    <i class="p-sidebar__toggle p-icon--menu"></i>
-  </div>
-  <div class="p-sidebar__content u-hide--small">
-    <nav class="p-sidebar-nav">
-      <ul class="p-sidebar-nav__list">
-        <li class="p-sidebar-nav__item first-level">
-          <strong>About</strong>
-          <ul class="p-sidebar-nav__list">
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/index">Home</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/overview">Overview</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/news">News</a></li>
-          </ul>
-        </li>
-        <li class="p-sidebar-nav__item first-level">
-          <strong>Install</strong>
-          <ul class="p-sidebar-nav__list">
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/quickstart">Quickstart</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/install-local">Local install</a></li>
-          </ul>
-        </li>
-        <li class="p-sidebar-nav__item first-level">
-          <strong>Operations</strong>
-          <ul class="p-sidebar-nav__list">
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/logging">Logging</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/monitoring">Monitoring</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/upgrading">Upgrading</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/storage">Storage</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/storage">Scaling</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/validation">Validation</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/decommissioning">Decommissioning</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/troubleshooting">Troubleshooting</a></li>
-          </ul>
-        </li>
-        <li class="p-sidebar-nav__item first-level">
-          <strong>Reference</strong>
-          <ul class="p-sidebar-nav__list">
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/reference-release-notes">Release notes</a></li>
-            <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/kubernetes/docs/upgrade-notes">Upgrade notes</a></li>
-          </ul>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</aside>
 
-<script>
-  // Select the active navigation item
-  var navigation = document.getElementById('docs-navigation');
-  var links = navigation.getElementsByTagName('a');
-  var currentPage = window.location.pathname;
-  for (var i = 0; i < links.length; i++) {
-    var link = links[i];
-    if (link.getAttribute('href') === currentPage) {
-      link.classList.add('is-active');
-    }
-  };
-</script>
-
-<script>
-  // Toggle mobile sidebar nav
-  var toggle = document.querySelector('.p-sidebar__toggle');
-  var sidebarContent = document.querySelector('.p-sidebar__content');
-
-  toggle.addEventListener('click', function(e) {
-    toggle.classList.toggle('p-icon--menu');
-    toggle.classList.toggle('p-icon--close');
-    sidebarContent.classList.toggle('u-hide--small');
-  });
-</script>
+<ul>
+  <li>
+    <strong>About</strong>
+    <ul>
+      <li><a href="/kubernetes/docs/index">Home</a></li>
+      <li><a href="/kubernetes/docs/overview">Overview</a></li>
+      <li><a href="/kubernetes/docs/news">News</a></li>
+    </ul>
+  </li>
+  <li>
+    <strong>Install</strong>
+    <ul>
+      <li><a href="/kubernetes/docs/quickstart">Quickstart</a></li>
+      <li><a href="/kubernetes/docs/install-local">Local install</a></li>
+    </ul>
+  </li>
+  <li>
+    <strong>Operations</strong>
+    <ul>
+      <li><a href="/kubernetes/docs/logging">Logging</a></li>
+      <li><a href="/kubernetes/docs/monitoring">Monitoring</a></li>
+      <li><a href="/kubernetes/docs/upgrading">Upgrading</a></li>
+      <li><a href="/kubernetes/docs/storage">Storage</a></li>
+      <li><a href="/kubernetes/docs/storage">Scaling</a></li>
+      <li><a href="/kubernetes/docs/validation">Validation</a></li>
+      <li><a href="/kubernetes/docs/decommissioning">Decommissioning</a></li>
+      <li><a href="/kubernetes/docs/troubleshooting">Troubleshooting</a></li>
+    </ul>
+  </li>
+  <li>
+    <strong>Reference</strong>
+    <ul>
+      <li><a href="/kubernetes/docs/reference-release-notes">Release notes</a></li>
+      <li><a href="/kubernetes/docs/upgrade-notes">Upgrade notes</a></li>
+    </ul>
+  </li>
+</ul>


### PR DESCRIPTION
## Done
Removed the classes from the docs navigation. Added styling to target the navigation elements.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /kubernetes/docs and check the navigation is ok

