### PR TITLE
Update the MAAS 2.5 images in /download/server/provisioning

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -96,7 +96,7 @@
               <li>Ubuntu images</li>
               <li><abbr title="Secure shell">SSH</abbr> keys (for currently logged in user)</li>
             </ul>
-            <p><a href="{{ ASSET_SERVER_URL }}267759eb-complete-the-first-user-configuration-journey.png" class="venobox venobox--expand" data-gall="installGallery" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}267759eb-complete-the-first-user-configuration-journey.png?w=552"  alt="First user journey screenshot"></a></p>
+            <p><a href="{{ ASSET_SERVER_URL }}0d7788a1-Complete+the+first+user+configuration+journey.png" class="venobox venobox--expand" data-gall="installGallery" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}0d7788a1-Complete+the+first+user+configuration+journey.png?w=552"  alt="First user journey screenshot"></a></p>
           </div>
         </li>
         <li class="p-list-step__item">
@@ -111,8 +111,8 @@
               <li>Select the subnet where to create the DHCP Dynamic range on.</li>
               <li>Fill in the details for the dynamic range.</li>
             </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}c3010cc2-turn-on-DHCP.png" class="venobox venobox--expand" data-gall="installGallery" title="VLAN details page in an active MAAS">
-              <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}c3010cc2-turn-on-DHCP.png?w=552" class="image--shadow" alt="VLAN details">
+            <p><a href="{{ ASSET_SERVER_URL }}57bf7d7e-Turn+on+DHCP.png" class="venobox venobox--expand" data-gall="installGallery" title="VLAN details page in an active MAAS">
+              <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}57bf7d7e-Turn+on+DHCP.png?w=552" class="image--shadow" alt="VLAN details">
             </a></p>
           </div>
         </li>
@@ -130,8 +130,8 @@
               <li>Select all the machines and &ldquo;Commission&rdquo; them using the &ldquo;Take action&rdquo; button</li>
               <li>When machines have a &ldquo;Ready&rdquo; status you can start deploying</li>
             </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}66a25be9-enlist-and-commission-servers.png" class="venobox venobox--expand" data-gall="installGallery" title="The node listing page in MAAS">
-              <img src="{{ ASSET_SERVER_URL }}66a25be9-enlist-and-commission-servers.png?w=552" class="p-image--bordered" alt="MAAS node listing">
+            <p><a href="{{ ASSET_SERVER_URL }}18191366-Enlist+and+commission+servers.png" class="venobox venobox--expand" data-gall="installGallery" title="The node listing page in MAAS">
+              <img src="{{ ASSET_SERVER_URL }}18191366-Enlist+and+commission+servers.png?w=552" class="p-image--bordered" alt="MAAS node listing">
             </a></p>
             <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
           </div>


### PR DESCRIPTION
## Done
Update the MAAS 2.5 images in /download/server/provisioning

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /download/server/provisioning
- Check that the images match the [2.5 branch on maas.io](https://maas-io-canonical-websites-pr-287.run.demo.haus/install)

## Issue / Card
Fixes https://github.com/ubuntudesign/MAAS-squad/issues/752