### PR TITLE
Added core security whitepaper to security index

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -190,10 +190,10 @@
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
           <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' alt='' />
-          <h4 class='p-heading-icon__title'>Article</h4>
+          <h4 class='p-heading-icon__title'>White paper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2016/12/08/ubuntu-16-04-lts-security-a-comprehensive-overview/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - left', 'eventLabel' : 'Article - Ubuntu 16.04 LTS Security: A Comprehensive Overview', 'eventValue' : '1' });'><span hidden>Read the article </span>Ubuntu 16.04 LTS Security: A Comprehensive Overview</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='{{ ASSET_SERVER_URL }}66fcd858-canonical-ubuntu-core-security-2018-11-13.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - left', 'eventLabel' : 'White paper - Read Ubuntu Core Security Whitepaper', 'eventValue' : '1' });'><span hidden>Read the white paper </span>Ubuntu Core Security Whitepaper</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_security_center">


### PR DESCRIPTION
## Done

- Added Core security whitepaper to security index page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/security](http://0.0.0.0:8001/security)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the link works and goes to the correct whitepaper
- Matches the [copydoc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit#)

## Issue / Card

Fixes: #882

