### PR TITLE
Add the kubernetes docs to the navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -99,6 +99,56 @@ kubernetes:
       path: /kubernetes/partners
     - title: Docs
       path: /kubernetes/docs
+      
+      children:
+        - title: Backups
+          path: /kubernetes/docs/backups
+          hidden: True
+        - title: Ceph
+          path: /kubernetes/docs/ceph
+          hidden: True
+        - title: Decommissioning
+          path: /kubernetes/docs/decommissioning
+          hidden: True
+        - title: Install local
+          path: /kubernetes/docs/install-local
+          hidden: True
+        - title: Logging
+          path: /kubernetes/docs/logging
+          hidden: True
+        - title: Monitoring
+          path: /kubernetes/docs/monitoring
+          hidden: True
+        - title: News
+          path: /kubernetes/docs/news
+          hidden: True
+        - title: Overview
+          path: /kubernetes/docs/overview
+          hidden: True
+        - title: Quickstart
+          path: /kubernetes/docs/quickstart
+          hidden: True
+        - title: Release notes
+          path: /kubernetes/docs/release-notes
+          hidden: True
+        - title: Scaling
+          path: /kubernetes/docs/scaling
+          hidden: True
+        - title: Storage
+          path: /kubernetes/docs/storage
+          hidden: True
+        - title: Troubleshooting
+          path: /kubernetes/docs/troubleshooting
+          hidden: True
+        - title: Upgrade notes
+          path: /kubernetes/docs/upgrade-notes
+          hidden: True
+        - title: Upgrading
+          path: /kubernetes/docs/upgrading
+          hidden: True
+        - title: Validation
+          path: /kubernetes/docs/validation
+          hidden: True
 
     - title: Contact us
       path: /kubernetes/contact-us


### PR DESCRIPTION
## Done
Add the kubernetes docs pages to the navigation. This is to highlight the the pages in the navigation.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/docs](http://0.0.0.0:8001/kubernetes/docs)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Click through the pages in the docs and check the docs navigation item is selected
