### PR TITLE
Updated /legal/data-privacy/enquiry text

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -427,7 +427,7 @@ legal:
       path: /legal/data-privacy
 
       children:
-        - title: Data privacy enquiry
+        - title: Data protection enquiry
           path: /legal/data-privacy/enquiry
         - title: Newsletter privacy notice
           path: /legal/data-privacy/newsletter

--- a/templates/legal/data-privacy/enquiry.html
+++ b/templates/legal/data-privacy/enquiry.html
@@ -12,7 +12,7 @@
 <div class="p-strip is-deep">
   <div class="row">
     <div class="col-8">
-      <h1>Data Protection enquiries</h1>
+      <h1>Data protection enquiries</h1>
       <p>Please contact us using the form below for any enquiry about how Canonical collects and processes personal data or for any other questions relating to privacy or data protection. A member of our team will be in touch with you shortly. Alternatively please contact us on <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
 
       <form method="post" action="https://www.tfaforms.com/responses/processor" class="hintsBelow labelsLeftAligned" id="tfa_0" enctype="multipart/form-data">
@@ -188,7 +188,7 @@
         </fieldset>
 
         <fieldset>
-          <p>Data collected from this survey will be handled in accordance with the Canonical <a href="/legal/data-privacy">privacy policy</a>.</p>
+          <p>Data collected from this survey will be handled in accordance with Canonical's <a href="/legal/data-privacy/contact">privacy notice</a> and <a href="/legal/data-privacy">privacy policy</a>.</p>
           <ul class="p-list">
             <li>
               <label for="tfa_55">

--- a/templates/legal/data-privacy/enquiry.html
+++ b/templates/legal/data-privacy/enquiry.html
@@ -1,6 +1,6 @@
 {% extends "legal/_base_legal.html" %}
 
-{% block title %}Contact Us | Ubuntu and Canonical Legal{% endblock %}
+{% block title %}Data protection enquiries | Ubuntu and Canonical Legal{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1_sM2dGQNd5FRda2gITWL1jD1oWsIekAw2jCxPTPD1Ss/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

1. Update the secondary nav to "Data protection enquiries"
2. Update the "Data collected sentence" to "Data collected from this survey will be handled in accordance with Canonical's privacy notice and privacy policy."
3. Update the document title

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/legal/data-privacy/enquiry](http://0.0.0.0:8001/legal/data-privacy/enquiry)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that it is called '' in the secondary nav
- See that the collection warning is as per the [copy doc](https://docs.google.com/document/d/1_sM2dGQNd5FRda2gITWL1jD1oWsIekAw2jCxPTPD1Ss/edit)

## Issue / Card

Fixes #4409 	

## Screenshots

![image](https://user-images.githubusercontent.com/441217/48736229-9c5ae780-ec42-11e8-9192-fc919ba522d7.png)


![image](https://user-images.githubusercontent.com/441217/48736190-82b9a000-ec42-11e8-8e04-2c40b7c6ed10.png)
