### PR TITLE
Created Apellix webinar landing page

### DIFF
--- a/templates/engage/industrial-drones.html
+++ b/templates/engage/industrial-drones.html
@@ -8,11 +8,11 @@
 
 {% block content %}
 <section class="p-takeover--appelix">
-  <div class="p-strip is-deep p-takeover--appelix-suru">
+  <div class="p-strip p-takeover--appelix-suru">
     <div class="row u-vertically-center">
       <div class="col-7">
-        <h1>Precision drone flights at the edge of innovation</h1>
-        <h4>Discover how Apellix uses Ubuntu to solve industrial IoT challenges with precision drones.</h4>
+        <h1>Precision drones to solve industrial IoT challenges</h1>
+        <h4>How Apellix uses Ubuntu on drones to replace human workers in potentially dangerous scenarios.</h4>
         <p class="p-takeover__text">
               Webinar live on 5 December 2018 - <a href="#register-section" class="p-link">Register now&nbsp;&rsaquo;</a></p>
       </div>
@@ -39,22 +39,7 @@
           background-position: bottom left, bottom right, top right;
           background-repeat: no-repeat;
         }
-        .p-takeover--appelix .p-takeover__image {
-          animation: drone-in 1.5s ease 0s 1;
-        }
-      }
-      @keyframes drone-in {
-        0% {
-          transform: translatex(50vw) rotate(0deg) scale(1.1);
-        }
-        75% {
-         transform: translatex(1vw) rotate(150deg) scale(1.1);
-        }
-        100% {
-          transform: translatex(0px) rotate(180deg) scale(1);
-        }
-      }
-    </style>
+        </style>
 </section>
 
 <style>

--- a/templates/engage/industrial-drones.html
+++ b/templates/engage/industrial-drones.html
@@ -1,0 +1,77 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}This webinar discusses how Apellix uses Ubuntu to solve industrial IoT challenges with precision drones.{% endblock %}
+
+{% block title %}Precision drones on Ubuntu: flying at the edge of innovation{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1rhPmuqLVGRXUmPnDsaOvp09LvCkLBHieZh-sjEROf6g/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-takeover--appelix">
+  <div class="p-strip is-deep p-takeover--appelix-suru">
+    <div class="row u-vertically-center">
+      <div class="col-7">
+        <h1>Precision drone flights at the edge of innovation</h1>
+        <h4>Discover how Apellix uses Ubuntu to solve industrial IoT challenges with precision drones.</h4>
+        <p class="p-takeover__text">
+              Webinar live on 5 December 2018 - <a href="#register-section" class="p-link">Register now&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 u-hide--small">
+        <div class="u-align--center u-sv3">
+          <img src="https://assets.ubuntu.com/v1/f42b7e29-drone.svg" class="p-takeover__image" alt="" />
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <style>
+      .p-takeover--appelix {
+        background-color: #9AAF55;
+        background-image: linear-gradient(-46deg, #82A08D 0%, #9AAF55 100%);
+      }
+      @media (min-width: 874px) {
+        .p-takeover--appelix-suru {
+          background-blend-mode: multiply;
+          background-image: url("{{ ASSET_SERVER_URL }}2eb4cbf6-left.svg"),
+          url("{{ ASSET_SERVER_URL }}53ca89d2-right+1.svg"),
+          url("{{ ASSET_SERVER_URL }}35352e1c-right+2.svg"),
+          linear-gradient(74deg, #82A08D 0%, #9AAF55 92%);
+          background-position: bottom left, bottom right, top right;
+          background-repeat: no-repeat;
+        }
+        .p-takeover--appelix .p-takeover__image {
+          animation: drone-in 1.5s ease 0s 1;
+        }
+      }
+      @keyframes drone-in {
+        0% {
+          transform: translatex(50vw) rotate(0deg) scale(1.1);
+        }
+        75% {
+         transform: translatex(1vw) rotate(150deg) scale(1.1);
+        }
+        100% {
+          transform: translatex(0px) rotate(180deg) scale(1);
+        }
+      }
+    </style>
+</section>
+
+<style>
+  .p-takeover--compliance {
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+  }
+  .p-compliance-icon {
+    height: 154px;
+    width: 154px;
+  }
+</style>
+
+<section class="p-strip" id="register-section">
+  <div class="row">
+    <div class="jsBrightTALKEmbedWrapper" style="width:900px; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 338628, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_further_reading" second_item="_iot_newsletter_signup" third_item="_iot_contact" %}
+{% endblock content %}


### PR DESCRIPTION
## Done

* New landing page for Apellix wbn at `/engage/industrial-drones`
- [x] [Copy doc](https://docs.google.com/document/d/1rhPmuqLVGRXUmPnDsaOvp09LvCkLBHieZh-sjEROf6g/edit#heading=h.llax9gp4qt3c)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure [the landing page](https://www-ubuntu-com-canonical-websites-pr-4417.run.demo.haus/engage/industrial-drones) matches the copy doc and works well with the takeover: #4405
