### PR TITLE
Fix desktop statistics contextual footer

### DIFF
--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -384,8 +384,7 @@ Ubuntu 18.04 LTS.{% endblock %}
   </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_desktop_contact_us"
-second_item="_support" third_item="_desktop_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_desktop_contact_us" second_item="_support" third_item="_desktop_further_reading" %}
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.5.0/d3.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-geo/1.9.1/d3-geo.min.js"></script>


### PR DESCRIPTION
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/statistics
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the contextual footer loads in properly

## Issues

Fixes #4421 