### PR TITLE
Correcting copy doc link

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Canonical Livepatch Service{% endblock %}
 {% block meta_description %}Automatic updates for Ubuntu 14.04, 16.04, and 18.04 LTS, reducing downtime whilst keeping on top of compliance and security.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Ofw9bQ4I40gy9hDIjuDMApz6sDK8qSdHI03-oY7xs-A/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip is-deep u-no-padding--bottom">


### PR DESCRIPTION
Being helpful

## Done

Updated browser extension link to new copy (Thanks @matthewpaulthomas )

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)

1. Go to the [livepatch](https://ubuntu.com/support/livepatch) page
1. Make sure you have the [browser extension](https://github.com/canonical-webteam/ubuntu-copy-docs) installed
1. Click the link
1. be taken to the correct copy doc
