### PR TITLE
Spicule takeover build

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,10 +22,10 @@
 #}
 
 {% block takeover_content %}
+  {% include "takeovers/_spicule_takeover.html" %}
+  {% include "takeovers/_trilio_takeover.html" %}
   {% include "takeovers/_appelix-takeover.html" %}
-  {% include "takeovers/_improving_productivity_kubernetes.html" %}
   {% include "takeovers/_compliance-webinar.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
-  {% include "takeovers/_trilio_takeover.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_spicule_takeover.html
+++ b/templates/takeovers/_spicule_takeover.html
@@ -21,11 +21,13 @@
   <style>
     .p-takeover-spicule__image {
       width: 50vw;
+      right: 24px;
     }
 
     @media (min-width: 1280px) {
       .p-takeover-spicule__image {
-        top: 1rem;
+        top: 50%;
+        margin-top: -15% !important;
       }
     }
   </style>

--- a/templates/takeovers/_spicule_takeover.html
+++ b/templates/takeovers/_spicule_takeover.html
@@ -1,0 +1,32 @@
+<section class="p-strip--light is-deep u-image-position js-takeover p-takeover-spicule u-image-position">
+  <div class="row u-equal-height">
+    <div class="col-6" style="z-index: 10;">
+      <h1>Harness your big data</h1>
+      <p class="u-sv1">
+        <img src="{{ ASSET_SERVER_URL}}c7881d6c-spiculelogo-spacingx2-01.svg" alt="Spicule" width="140" />
+      </p>
+      <p class="p-heading--four u-sv3">
+        Discover how Spicule and Canonical are enabling businesses to create valuable insights from increasingly complex data sets.
+      </p>
+      <p>
+        <a href="https://www.brighttalk.com/webcast/6793/341856?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_Cloud_Openstack_WBN_Spicule" class="p-button--positive">
+          <span class="p-link--external">Register for the webinar</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-4 u-hide--medium u-hide--small">
+      <img src="{{ ASSET_SERVER_URL}}9834b392-test.svg" alt="" class="p-takeover-spicule__image u-image-position--right" />
+    </div>
+  </div>
+  <style>
+    .p-takeover-spicule__image {
+      width: 50vw;
+    }
+
+    @media (min-width: 1280px) {
+      .p-takeover-spicule__image {
+        top: 1rem;
+      }
+    }
+  </style>
+</section>


### PR DESCRIPTION
## Done
Build the Spicule takeover. Remove the k8s case study takeover as its removed the same day this one is released.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the takeover matches the [copy doc](https://docs.google.com/document/d/1REdh_YwHlvqlEPFdJFag_OSBcdFk6aa2__xLMwOq-oQ/edit)
- Check that the takeover matches [the design](https://github.com/ubuntudesign/www.ubuntu.com-design/issues/169#issuecomment-441229618)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4386
