### PR TITLE
Swap Travis badge with CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # www.ubuntu.com codebase
 
-[![Build Status](https://travis-ci.org/canonical-websites/www.ubuntu.com.svg?branch=master)](https://travis-ci.org/ubuntudesign/www.ubuntu.com)
+[![CircleCI build status](https://circleci.com/gh/canonical-websites/www.ubuntu.com.svg?style=shield)](https://circleci.com/gh/canonical-websites/www.ubuntu.com)
 
 This is the codebase and content for [www.ubuntu.com](https://www.ubuntu.com), a simple databaseless informational website project based on [Django](https://www.djangoproject.com/).
 


### PR DESCRIPTION
## Done
Changed the badge from Travis to CircleCI

## QA
Go to https://github.com/jpmartinspt/www.ubuntu.com/tree/swap_badges and check the badge is now updated when you browse the readme.

## Fixes

Fixes https://github.com/ubuntudesign/base-squad/issues/293