### PR TITLE
Fixed spicule takeover text drawing over nav

### DIFF
--- a/templates/takeovers/_spicule_takeover.html
+++ b/templates/takeovers/_spicule_takeover.html
@@ -1,6 +1,6 @@
 <section class="p-strip--light is-deep u-image-position js-takeover p-takeover-spicule u-image-position">
   <div class="row u-equal-height">
-    <div class="col-6" style="z-index: 10;">
+    <div class="col-6">
       <h1>Harness your big data</h1>
       <p class="u-sv1">
         <img src="{{ ASSET_SERVER_URL}}c7881d6c-spiculelogo-spacingx2-01.svg" alt="Spicule" width="140" />


### PR DESCRIPTION
## Done

[List of work items including drive-bys]
- Removed Z-index from `_spicule_takeover.html` to prevent writing over navbar.

@anthonydillon Not sure why this z-index style is here.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Tested change and verified bug on Chrome, Edge, and Firefox.


## Issue / Card

Takeover writing over navigation bar in Edge, Chrome and Firefox due to `z-index: 10` style. Removed this styling and noticed no functional abnormalities and was able to fix the bug.

### How to replicate

- Go to any browser
- Go to ubuntu.com
- Refresh page until Spicule takeover shows.

![image](https://user-images.githubusercontent.com/6903446/49138466-d49e9d80-f2b4-11e8-826e-0ed90df54dc7.png)

- Drop down any navigation bar.

![image](https://user-images.githubusercontent.com/6903446/49138482-e08a5f80-f2b4-11e8-8d04-253bf9e9e153.png)


## Screenshots

Chrome:
<img width="932" alt="chrome_2018-11-28_01-46-20" src="https://user-images.githubusercontent.com/6903446/49138382-a02ae180-f2b4-11e8-84a3-e2f75bbd288f.png">

Firefox:
![image](https://user-images.githubusercontent.com/6903446/49138573-25ae9180-f2b5-11e8-8095-f3aae2e7373f.png)

Edge:
<img width="959" alt="applicationframehost_2018-11-28_02-27-42" src="https://user-images.githubusercontent.com/6903446/49138787-c735e300-f2b5-11e8-9762-1d718cfe1026.png">


IE11 Emulation:
<img width="1706" alt="applicationframehost_2018-11-28_02-28-34" src="https://user-images.githubusercontent.com/6903446/49138788-c9983d00-f2b5-11e8-8a81-4106945ebfc9.png">