### PR TITLE
Updated enterprise nav

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -6,7 +6,7 @@
         <div class="tablet-col-2 col-3 p-card--navigation">
           <div class="u-hide--small">
             <h4 class="p-heading-four is-dense">
-              <a href="/openstack">OpenStack solutions&nbsp;&rsaquo;</a>
+              <a href="/openstack">OpenStack&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
               Canonical is the leading provider of managed OpenStack. We help design, build and operate your cloud, and train your team to take over.
@@ -16,10 +16,10 @@
             </a>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
-            <a href="/openstack">OpenStack solutions&nbsp;&rsaquo;</a>
+            <a href="/openstack">OpenStack&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/openstack">Get OpenStack</a></li>
+            <li class="p-list__item"><a href="/openstack">Get OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/consulting">Build private clouds</a></li>
             <li class="p-list__item"><a href="/openstack/managed">Fully managed OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/training">Transfer and training</a></li>
@@ -31,7 +31,7 @@
         <div class="tablet-col-2 col-3 p-card--navigation">
           <div class="u-hide--small">
             <h4 class="p-heading-four is-dense">
-              <a href="/kubernetes">Kubernetes solutions&nbsp;&rsaquo;</a>
+              <a href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
               Canonical delivers the leading Kubernetes distribution and provides workshops, training, deployment and consulting services. On VMware, cloud, OpenStack and bare metal.
@@ -41,10 +41,10 @@
             </a>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
-            <a href="/kubernetes">Kubernetes solutions&nbsp;&rsaquo;</a>
+            <a href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/kubernetes">Get Kubernetes</a></li>
+            <li class="p-list__item"><a href="/kubernetes">Get Kubernetes</a></li>
             <li class="p-list__item"><a href="/kubernetes/features">Multicloud K8s on bare metal, VMware, and all public clouds</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
             <li class="p-list__item"><a href="/kubernetes/features#ai">Upgrades and automation included</a></li>
@@ -54,35 +54,36 @@
             <li class="p-list__item"><a href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">GKE with Ubuntu on Google Cloud</a></li>
           </ul>
         </div>
-        <!-- AI and Machine learning -->
+        <!-- >Internet of Things -->
         <div class="tablet-col-2 col-3 p-card--navigation">
           <div class="u-hide--small">
             <h4 class="p-heading-four is-dense">
-              <a href="/ai">AI and ML&nbsp;&rsaquo;</a>
+              <a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
-              Ubuntu and Kubernetes from Canonical provide perfect multi cloud portability for your artificial intelligence and machine learning workloads.
+              Embedded Ubuntu on your device gives you the best developer experience, security and long-term support.
             </p>
-            <a href="/ai/install" class="p-button--small p-button--positive u-align-text--left">
-              Get started with AI
+            <a href="/internet-of-things" class="p-button--small p-button--positive u-align-text--left">
+              Build your IoT on Ubuntu
             </a>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
-            <a href="/ai">AI and ML&nbsp;&rsaquo;</a>
+            <a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/ai/install">Get started with AI</a></li>
-            <li class="p-list__item"><a href="/ai/features">Google TensorFlow and Kubeflow</a></li>
-            <li class="p-list__item"><a href="https://developer.nvidia.com/deep-learning" title="Visit Nvidia developer - external site">Nvidia’s ML stack uses Ubuntu</a></li>
-            <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML toolchain on Ubuntu</a></li>
-            <li class="p-list__item"><a href="https://developer.nvidia.com/nvidia-nsight-tegra" title="Visit Nvidia Tegra page - external site">Edge devices like Tegra running AI models</a></li>
+            <li class="p-list__item"><a href="/core">Ubuntu Core - embedded, secure Ubuntu</a></li>
+            <li class="p-list__item"><a href="/internet-of-things/digital-signage">Digital signage and smart displays</a></li>
+            <li class="p-list__item"><a href="/internet-of-things/robotics">Robots and drones with Ubuntu</a></li>
+            <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
+            <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>
+            <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure app packages</a></li>
           </ul>
         </div>
         <!-- Enterprise support -->
         <div class="tablet-col-2 col-3 p-card--navigation">
           <div class="u-hide--small">
             <h4 class="p-heading-four is-dense">
-              <a href="/support">Enterprise support&nbsp;&rsaquo;</a>
+              <a href="/support">Enterprise Support&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
               Canonical provides 24/7 enterprise support, security, and break-fix engineering for Ubuntu, OpenStack, Docker and Kubernetes. Enterprise Linux done right.
@@ -92,10 +93,10 @@
             </a>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
-            <a href="/support">Enterprise support&nbsp;&rsaquo;</a>
+            <a href="/support">Enterprise Support&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
+            <li class="p-list__item"><a href="/support">Get support</a></li>
             <li class="p-list__item"><a href="/livepatch">Kernel Live Patch</a></li>
             <li class="p-list__item"><a href="/esm">Extended Ubuntu security</a></li>
             <li class="p-list__item"><a href="/support">Optimised Windows VMs</a></li>
@@ -133,16 +134,14 @@
           <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
         </ul>
       </div>
-      <!-- Internet of Things -->
+      <!-- AI and ML -->
       <div class="col-3">
-        <h4 class="p-muted-heading"><a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a></h4>
+        <h4 class="p-muted-heading"><a href="/ai">AI &amp; ML&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
-          <li class="p-list__item"><a href="/core">Ubuntu Core - embedded, secure Ubuntu</a></li>
-          <li class="p-list__item"><a href="/internet-of-things/digital-signage">Digital signage and smart displays</a></li>
-          <li class="p-list__item"><a href="/internet-of-things/robotics">Robots and drones with Ubuntu</a></li>
-          <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
-          <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>
-          <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure app packages</a></li>
+          <li class="p-list__item"><a href="/ai/features">Google TensorFlow and Kubeflow</a></li>
+          <li class="p-list__item"><a href="https://developer.nvidia.com/deep-learning" title="Visit Nvidia developer - external site">Nvidia’s ML stack uses Ubuntu</a></li>
+          <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML toolchain on Ubuntu</a></li>
+          <li class="p-list__item"><a href="https://developer.nvidia.com/nvidia-nsight-tegra" title="Visit Nvidia Tegra page - external site">Edge devices like Tegra running AI models</a></li>
         </ul>
       </div>
     </div>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -19,7 +19,7 @@
             <a href="/openstack">OpenStack&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/openstack">Get OpenStack</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/openstack">Get OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/consulting">Build private clouds</a></li>
             <li class="p-list__item"><a href="/openstack/managed">Fully managed OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/training">Transfer and training</a></li>
@@ -44,7 +44,7 @@
             <a href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/kubernetes">Get Kubernetes</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/kubernetes">Get Kubernetes</a></li>
             <li class="p-list__item"><a href="/kubernetes/features">Multicloud K8s on bare metal, VMware, and all public clouds</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
             <li class="p-list__item"><a href="/kubernetes/features#ai">Upgrades and automation included</a></li>
@@ -71,12 +71,13 @@
             <a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/core">Ubuntu Core - embedded, secure Ubuntu</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/internet-of-things">Build your IoT on Ubuntu</a></li>
+            <li class="p-list__item"><a href="/core">Ubuntu Core - embedded &amp; secure</a></li>
+            <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure packages for IoT</a></li>
+            <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>
             <li class="p-list__item"><a href="/internet-of-things/digital-signage">Digital signage and smart displays</a></li>
             <li class="p-list__item"><a href="/internet-of-things/robotics">Robots and drones with Ubuntu</a></li>
             <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
-            <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>
-            <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure app packages</a></li>
           </ul>
         </div>
         <!-- Enterprise support -->
@@ -102,6 +103,7 @@
             <li class="p-list__item"><a href="/support">Optimised Windows VMs</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/">Web-based remote management</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
+            <li class="p-list__item"><a href="/support/plans-and-pricing">Plans and pricing</a></li>        
           </ul>
         </div>
       </div>
@@ -141,7 +143,7 @@
           <li class="p-list__item"><a href="/ai/features">Google TensorFlow and Kubeflow</a></li>
           <li class="p-list__item"><a href="https://developer.nvidia.com/deep-learning" title="Visit Nvidia developer - external site">Nvidia’s ML stack uses Ubuntu</a></li>
           <li class="p-list__item"><a href="https://aws.amazon.com/machine-learning/" title="Visit AWS Machine Learning - external site">AWS ML toolchain on Ubuntu</a></li>
-          <li class="p-list__item"><a href="https://developer.nvidia.com/nvidia-nsight-tegra" title="Visit Nvidia Tegra page - external site">Edge devices like Tegra running AI models</a></li>
+          <li class="p-list__item"><a href="https://developer.nvidia.com/nvidia-nsight-tegra" title="Visit Nvidia Tegra page - external site">Edge devices running AI models</a></li>
         </ul>
       </div>
     </div>
@@ -152,7 +154,7 @@
     </div>
     <div class="row">
       <div class="col-3">
-        <h4 class="p-muted-heading--small">Sector starting points</h4>
+        <h4 class="p-muted-heading--small">Sectors</h4>
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -97,13 +97,13 @@
             <a href="/support">Enterprise Support&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/support">Get support</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
             <li class="p-list__item"><a href="/livepatch">Kernel Live Patch</a></li>
             <li class="p-list__item"><a href="/esm">Extended Ubuntu security</a></li>
             <li class="p-list__item"><a href="/support">Optimised Windows VMs</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/">Web-based remote management</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
-            <li class="p-list__item"><a href="/support/plans-and-pricing">Plans and pricing</a></li>        
+            <li class="p-list__item"><a href="/support/plans-and-pricing">Plans and pricing</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updated the enterprise nav per the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/#enterprise](http://0.0.0.0:8001/#enterprise)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Click on the Enterprise tab and confirm it matches the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit#)

## Issue / Card

Fixes #4444 	

