### PR TITLE
Removed suru background from /openstack/consulting

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit{% endblock meta_copydoc %}
 
 {% block content %}
-  <section class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
+  <section class="p-strip is-deep is-bordered">
     <div class="row">
       <div class="col-8">
         <h1>OpenStack consulting, design and delivery</h1>


### PR DESCRIPTION
## Done

- removed hero's background

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/consulting](http://0.0.0.0:8001/openstack/consulting)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that there is no background on the hero as per the design (in the issue #4440)

## Issue / Card

Fixes #4440

## Screenshots

![image](https://user-images.githubusercontent.com/441217/49182137-504e2800-f351-11e8-8f2c-40b22676c622.png)
