### PR TITLE
Removed suru background from /openstack/features hero

### DIFF
--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -5,11 +5,11 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1odFXuFtN1GjuZvgd8tW48HB4J9PjZJtP3w6wY0xlmog/edit{% endblock meta_copydoc %}
 
 {% block content %}
-  <section class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL }}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
+  <section class="p-strip is-deep is-bordered">
     <div class="row">
-      <div class="col-12">
+      <div class="col-9">
         <h1>Fast, reliable and open source cloud</h1>
-        <p class="p-heading--three" style="max-width: none;">Architectural freedom. Fully automated operations. Telco-grade OpenStack for all.</p>
+        <p class="p-heading--three" style="max-width: none;">Architectural freedom. Fully automated operations. Telco&#8209;grade OpenStack for all.</p>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
## Done

- removed hero's background

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/features](http://0.0.0.0:8001/openstack/features)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that there is no background on the hero and that it is col-9 now

## Issue / Card

Fixes #4439

## Screenshots

![image](https://user-images.githubusercontent.com/441217/49182386-16c9ec80-f352-11e8-97c7-03088d2b6cc5.png)
