### PR TITLE
Removed emdash from citation on /openstack/managed

### DIFF
--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -277,7 +277,7 @@
         <blockquote class="p-pull-quote">
           <p>Canonical's BootStack gave us instant access and all the benefits of a cloud platform with fixed, predictable and manageable cost comparable to public cloud. We have the assurance of a reliable, run by experts cloud platform and can grow and adapt it as we need</p>
         </blockquote>
-        <cite class="p-pull-quote__citation"> -- Daniel Rylin, Head of IT Infrastructure and Cloud Solutions, Tele2</cite>
+        <cite class="p-pull-quote__citation">Daniel Rylin, Head of IT Infrastructure and Cloud Solutions, Tele2</cite>
       </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- removed emdash

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/managed](http://0.0.0.0:8001/openstack/managed)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that there is no -- on the quote cite

## Issue / Card

Fixes #4438

## Screenshots

![image](https://user-images.githubusercontent.com/441217/49182712-e6cf1900-f352-11e8-8f78-a761b393df03.png)
