### PR TITLE
Updated 18.04.1 Server download link

### DIFF
--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 <noscript>
-  <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-{{ architecture }}.iso">
+  <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}.0-live-server-{{ architecture }}.iso">
 </noscript>
 
 <div class="p-strip is-deep">


### PR DESCRIPTION
Like https://github.com/canonical-websites/www.ubuntu.com/pull/4460, we also
want to update the download link for the .iso.

Both changes are one-offs that will need to be reverted for 18.04.2.

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
