### PR TITLE
Removed superfluous marketing material checkbox

### DIFF
--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -30,7 +30,7 @@
 
         <form class="p-form u-no-margin--top" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
           <fieldset style="border: 1px solid #c0c0c0;">
-            <ul class="p-list">
+            <ul class="p-list u-no-margin--bottom">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name: <span>*</span></label>
                 <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -80,9 +80,6 @@
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox"> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
               </li>
-              <li class="mktField p-list__item">
-                <input name="Optin_cloud_nuture" id="Optin_cloud_nuture" type="checkbox" value="yes" class="mktoField"> <label for="Optin_cloud_nuture" class="mktoLabel">I would like to receive eBooks and White Papers by Canonical.</label>
-              </li>
               <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
               <li class="mktField p-list__item">
                 <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide">Accept terms and download</button>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -82,7 +82,7 @@
               </li>
               <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
               <li class="mktField p-list__item">
-                <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide">Accept terms and download</button>
+                <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
                 <input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
                   name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
                 <input


### PR DESCRIPTION
## Done

Removes superfluous checkbox from /download/server/s390x

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)

## Issue / Card

Fixes #4400

## Screenshots

[if relevant, include a screenshot]
