### PR TITLE
Updated CTA and engage page for compliance

### DIFF
--- a/templates/engage/ubuntu-compliance.html
+++ b/templates/engage/ubuntu-compliance.html
@@ -14,7 +14,7 @@
           <p class="u-no-padding--top  u-sv3">Learn how Ubuntu’s trusted security and compliance solutions are at the forefront of solving regulatory issues across a wide range of industries.</p>
           <p class="u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up"></p>
             <p class="p-takeover__text">
-              Webinar live on 28 November 2018 - <a href="#register-section" class="p-link--inverted">Register now&nbsp;&rsaquo;</a></p>
+              Webinar live on 28 November 2018 - <a href="#register-section" class="p-link--inverted">Watch now&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-6 u-align--center u-hide--small prefix-1 u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up">

--- a/templates/takeovers/_compliance-webinar.html
+++ b/templates/takeovers/_compliance-webinar.html
@@ -6,7 +6,7 @@
       <p class="u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg"
           alt="Compliance Webinar" class="p-compliance-icon u-fade-up"></p>
       <p><a href="/engage/ubuntu-compliance?utm_source=takeover&utm_medium=takeover&utm_campaign=FY19_Cloud_Openstack_WBN_Compliance"
-          class="p-button--positive"> Register for the webinar</a></p>
+          class="p-button--positive"> Watch the webinar now</a></p>
     </div>
     <div class="col-4 u-hide--small prefix-1">
       <img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up">


### PR DESCRIPTION
## Done

- Updated CTA and engage page links from "register" to "watch now", as the webinar is now live. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the CTA for the compliance takeover has been updated
- Check the link on the Compliance engage page has been updated


## Issue / Card

Fixes: #4479