### PR TITLE
Update the webinar data privacy page

### DIFF
--- a/templates/legal/data-privacy/webinar/2018-04-01.html
+++ b/templates/legal/data-privacy/webinar/2018-04-01.html
@@ -41,6 +41,14 @@
         <li class="p-list__item">SK9 5AF</li>
       </ul>
     </div>
+    <div class="col-4">
+      <div class="p-card u-hide--small">
+        <h3>Other versions</h3>
+        <ul class="p-list">
+          <li class="p-list__item"><a href="/legal/data-privacy/webinar">Latest version&nbsp;&rsaquo;</a></li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/templates/legal/data-privacy/webinar/index.html
+++ b/templates/legal/data-privacy/webinar/index.html
@@ -1,0 +1,53 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Privacy notice | Webinar signup{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1wMKqustrdcGK-yzGGe9we6nyHDvLUPukQaPpMA5T6wk/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Privacy Notice &ndash; Webinars via BrightTALK</h1>
+      <p>Version - May 2018</p>
+      <p>This privacy notice tells you about the information collected from you when you sign up to watch one of our webinars via the BrightTALK website. BrightTALK are a third party webinar platform provider and you may be directed to their website to register your details in order to watch a Canonical webinar. In collecting this information, BrightTALK are acting as a data controller and details of their privacy policy can be found here: <a href="https://business.brighttalk.com/company/privacy-policy/" class="p-link--external">https://business.brighttalk.com/company/privacy-policy/</a>. BrightTALK will be sharing your data with us and by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.</p>
+      <h2 id="who-are-we">Who are we?</h2>
+      <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of &ldquo;Legal&rdquo;.</p>
+      <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
+      <h2 id="what-personal-data-do-we-collect">What personal data do we collect?</h2>
+      <p>When you sign up to watch one of our webinars, BrightTALK may ask you for your name and your email address and related information. They will share this information with us.</p>
+      <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
+      <p>Your information will be used by us to conduct existing and future research of Canonical’s products and services.</p>
+      <p>Where you have agreed on BrightTALK’s website, we will use your information to send you other news and product updates from Canonical. This may involve us calling you, where we have your phone number in order to do so.</p>
+      <p>Consent is requested to do this, and we will only send you or tell you about news and product updates for as long as you continue to consent.</p>
+      <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
+      <p>Your information is stored in our database and is not shared with any third parties, except as reasonably required for Canonical to process and store your data. It is sent outside of the European Economic Area for our own internal processing purposes only.</p>
+      <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>
+      <p>We keep your information for so long as reasonably required in accordance with our record retention policy. Where you have agreed, your information is kept for as long as you continue to consent to receive our news and product updates.</p>
+      <h2 id="your-rights-over-your-information">Your rights over your information</h2>
+      <p>By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.</p>
+      <p>You can also ask for it to be erased and you can ask for us to give you a copy of the information.</p>
+      <p>You can also ask us to stop using your information for news or product updates – the simplest way to do this is to withdraw your consent, which you can do at any time, either by clicking the unsubscribe link at the end of any email, or by emailing, writing or telephoning us using the contact details above.</p>
+      <h2 id="your-right-to-complain">Your right to complain</h2>
+      <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="https://ico.org.uk/concerns/" class="p-link--external">ico.org.uk/concerns/</a> or write to them at:</p>
+      <ul class="p-list">
+        <li class="p-list__item">Information Commissioner&rsquo;s Office</li>
+        <li class="p-list__item">Wycliffe House</li>
+        <li class="p-list__item">Water Lane</li>
+        <li class="p-list__item">Wilmslow</li>
+        <li class="p-list__item">Cheshire</li>
+        <li class="p-list__item">SK9 5AF</li>
+      </ul>
+    </div>
+    <div class="col-4">
+      <div class="p-card u-hide--small">
+        <h3>Older versions</h3>
+        <ul class="p-list">
+          <li class="p-list__item"><a href="/legal/data-privacy/webinar/2018-04-01">01 April 2018&nbsp;&rsaquo;</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
## Done
Update the content in the webinar data privacy page. Moved the old version to a dated page. Added the version navigation.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to http://localhost:8001/legal/data-privacy/webinar
- Check that the content matches the [copy doc](https://docs.google.com/document/d/1wMKqustrdcGK-yzGGe9we6nyHDvLUPukQaPpMA5T6wk/edit#)

