### PR TITLE
Add microk8s takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,10 +23,4 @@
 
 {% block takeover_content %}
   {% include "takeovers/_microk8s-takeover.html" %}
-  {% include "takeovers/_spicule_takeover.html" %}
-  {% include "takeovers/_trilio_takeover.html" %}
-  {% include "takeovers/_appelix-takeover.html" %}
-  {% include "takeovers/_compliance-webinar.html" %}
-  {% include "takeovers/_german_takeover_k8.html" %}
-  {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,4 +23,10 @@
 
 {% block takeover_content %}
   {% include "takeovers/_microk8s-takeover.html" %}
+  {% include "takeovers/_spicule_takeover.html" %}
+  {% include "takeovers/_trilio_takeover.html" %}
+  {% include "takeovers/_appelix-takeover.html" %}
+  {% include "takeovers/_compliance-webinar.html" %}
+  {% include "takeovers/_german_takeover_k8.html" %}
+  {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,7 @@
 #}
 
 {% block takeover_content %}
+  {% include "takeovers/_microk8s-takeover.html" %}
   {% include "takeovers/_spicule_takeover.html" %}
   {% include "takeovers/_trilio_takeover.html" %}
   {% include "takeovers/_appelix-takeover.html" %}

--- a/templates/takeovers/_microk8s-takeover.html
+++ b/templates/takeovers/_microk8s-takeover.html
@@ -1,25 +1,23 @@
-<section class="js-takeover p-takeover--microk8s">
-  <div class="p-strip--image is-dark is-deep">
-    <div class="row u-vertically-center">
-      <div class="col-7">
-        <h1>MicroK8s: Kubernetes for desktops and workstations</h1>
-        <h4>Zero-ops k8s on just about any Linux box</h4>
-        <p class="u-no-margin--bottom u-hide--small">
-          <a href="" class="p-button--neutral u-no-margin--bottom">
-            <span class="p-link--external">Get Microk8s now</span>
-          </a>
-        </p>
+<section class="p-strip--image is-dark is-deep js-takeover p-takeover--microk8s">
+  <div class="row u-equal-heights">
+    <div class="col-7">
+      <h1>MicroK8s: Kubernetes for desktops and workstations</h1>
+      <p class="p-heading--four">Zero-ops k8s on just about any Linux box.</p>
+      <p class="u-hide--small">
+        <a href="https://microk8s.io?utm_source=takeover&utm_campaign=microk8s" class="p-button--neutral u-no-margin--bottom">
+          <span class="p-link--external">Get Microk8s now</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-5">
+      <div class="u-align--center u-sv3 u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg" class="p-takeover-microk8s__image" alt="" />
       </div>
-      <div class="col-5">
-        <div class="u-align--center u-sv3">
-          <img src="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg" class="p-takeover-microk8s__image" alt="" />
-        </div>
-        <p class="u-no-margin--bottom u-hide--large u-hide--medium">
-          <a href="" class="p-button--neutral">
-            <span class="p-link--external">Get Microk8s now</span>
-          </a>
-        </p>
-      </div>
+      <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+        <a href="https://microk8s.io?utm_source=takeover&utm_campaign=microk8s" class="p-button--neutral">
+          <span class="p-link--external">Get Microk8s now</span>
+        </a>
+      </p>
     </div>
   </div>
 
@@ -27,14 +25,23 @@
       .p-takeover--microk8s {
 				background-image: url('https://assets.ubuntu.com/v1/8bc629a7-microk8s-suru-background.svg');
 			}
-			.p-takeover-microk8s__image{
+
+			.p-takeover--microk8s .p-takeover-microk8s__image {
 				height: 243px;
       	width: 180px;
 			}
+
 			@media only screen and (max-width: 460px) {
-      .p-takeover-microk8s__image {
-        height: 203px;
-				width: 150px;
+        .p-takeover--microk8s .p-takeover-microk8s__image {
+          height: 203px;
+          width: 150px;
+        }
+      }
+
+      @media only screen and (min-width: 460px) and (max-width: 896px)  {
+        .p-takeover--microk8s .u-align--center {
+          text-align: left !important;
+        }
       }
     }
     </style>

--- a/templates/takeovers/_microk8s-takeover.html
+++ b/templates/takeovers/_microk8s-takeover.html
@@ -24,6 +24,8 @@
   <style>
       .p-takeover--microk8s {
 				background-image: url('https://assets.ubuntu.com/v1/8bc629a7-microk8s-suru-background.svg');
+        background-color: #000;
+        background-position: -1px; // Fixes the backgrounds sub-pixelling
 			}
 
 			.p-takeover--microk8s .p-takeover-microk8s__image {

--- a/templates/takeovers/_microk8s-takeover.html
+++ b/templates/takeovers/_microk8s-takeover.html
@@ -1,0 +1,41 @@
+<section class="js-takeover p-takeover--microk8s">
+  <div class="p-strip--image is-dark is-deep">
+    <div class="row u-vertically-center">
+      <div class="col-7">
+        <h1>MicroK8s: Kubernetes for desktops and workstations</h1>
+        <h4>Zero-ops k8s on just about any Linux box</h4>
+        <p class="u-no-margin--bottom u-hide--small">
+          <a href="" class="p-button--neutral u-no-margin--bottom">
+            <span class="p-link--external">Get Microk8s now</span>
+          </a>
+        </p>
+      </div>
+      <div class="col-5">
+        <div class="u-align--center u-sv3">
+          <img src="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg" class="p-takeover-microk8s__image" alt="" />
+        </div>
+        <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+          <a href="" class="p-button--neutral">
+            <span class="p-link--external">Get Microk8s now</span>
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <style>
+      .p-takeover--microk8s {
+				background-image: url('https://assets.ubuntu.com/v1/8bc629a7-microk8s-suru-background.svg');
+			}
+			.p-takeover-microk8s__image{
+				height: 243px;
+      	width: 180px;
+			}
+			@media only screen and (max-width: 460px) {
+      .p-takeover-microk8s__image {
+        height: 203px;
+				width: 150px;
+      }
+    }
+    </style>
+</section>

--- a/templates/takeovers/_microk8s-takeover.html
+++ b/templates/takeovers/_microk8s-takeover.html
@@ -1,5 +1,5 @@
 <section class="p-strip--image is-dark is-deep js-takeover p-takeover--microk8s">
-  <div class="row u-equal-heights">
+  <div class="row u-equal-height">
     <div class="col-7">
       <h1>MicroK8s: Kubernetes for desktops and workstations</h1>
       <p class="p-heading--four">Zero-ops k8s on just about any Linux box.</p>


### PR DESCRIPTION
## Done

- Added "A" variant of  microk8s takeover
- Added takeover to the cycle

## TODO

- Add "B" variant takeover
- Add UTM links & CTA links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check it looks like the [design](https://github.com/ubuntudesign/www.ubuntu.com-design/issues/168#issuecomment-443182549)


## Issue / Card

Fixes: #4383 


