### PR TITLE
Support for case-insensitive URLs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.16
 django-prometheus==1.0.11
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
-canonicalwebteam.django_views==1.1.1
+canonicalwebteam.django_views==1.3.2
 canonicalwebteam.yaml-responses[django]==1.1.0
 canonicalwebteam.get-feeds==0.2.4
 canonicalwebteam.http==0.1.6


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4448

This makes use of [v1.3.1 of TemplateFinder](https://github.com/canonical-webteam/django-views/pull/3) (please review that PR too =)) to find templates for URLs, ignoring case.

QA
--

`./run`, go to http://0.0.0.0:8001/Openstack, see that you end up at http://0.0.0.0:8001/openstack. Go to http://0.0.0.0:8001/download/Server, see that you end up at http://0.0.0.0:8001/download/server.