### PR TITLE
Updated MicroK8s link

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -37,7 +37,7 @@
         <li class="p-list__item is-ticked">Local instance storage</li>
       </ul>
       <p>Developers love MicroK8s as a fast, lean upstream K8s for rapid iteration. It&rsquo;s also popular as a secure and robust K8s for IoT and appliances.</p>
-      <p><a href="https://microk8s.io" class="p-link--external">Install instructions</a></p>
+      <p><a href="https://microk8s.io/" class="p-link--external">Learn more and install MicroK8s</a></p>
     </div>
     <div class="col-6 p-card">
       <div class="p-card__header">

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -37,7 +37,7 @@
         <li class="p-list__item is-ticked">Local instance storage</li>
       </ul>
       <p>Developers love MicroK8s as a fast, lean upstream K8s for rapid iteration. It&rsquo;s also popular as a secure and robust K8s for IoT and appliances.</p>
-      <p><a href="https://microk8s.io/#quick-start" class="p-link--external">Install instructions</a></p>
+      <p><a href="https://microk8s.io" class="p-link--external">Install instructions</a></p>
     </div>
     <div class="col-6 p-card">
       <div class="p-card__header">


### PR DESCRIPTION
It used to link directly to the install instructions. I changed this to land on the hero of the page.

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card
Updating based on @matthewpaulthomas [comment](https://github.com/canonical-websites/www.ubuntu.com/issues/4429#issuecomment-444803748)
