### PR TITLE
Changed Canonical Distribution of Kubernetes to Charmed Distribution …

### DIFF
--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -121,7 +121,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Artificial Intelligence infrastructure architecture</h2>
-      <p class="u-sv3">To get the most out of Kubeflow, you&rsquo;ll want to run it on an effective supporting stack. Minimally, leveraging the Canonical Distribution of Kubernetes (CDK) gives you the benefits of perfect portability between your private data-center and the public cloud.  CDK on Canonical Openstack unlocks further benefits, as described below.</p>
+      <p class="u-sv3">To get the most out of Kubeflow, you&rsquo;ll want to run it on an effective supporting stack. Minimally, leveraging the Charmed Distribution of Kubernetes (CDK) gives you the benefits of perfect portability between your private data-center and the public cloud.  CDK on Canonical Openstack unlocks further benefits, as described below.</p>
     </div>
   </div>
   <div class="row u-equal-height">

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -7,7 +7,7 @@
   {% if product == 'containers-docker' %}
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Docker Engine on Ubuntu" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
   {% elif product == 'containers-kubernetes' %}
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Canonical Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about The Charmed Distribution of Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes' %}
   {% elif product == 'containers-kubernetes-foundation' %}
     {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Canonical's enterprise Kubernetes packages" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation' %}
   {% elif product == 'containers-lxd' %}

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 {% if product == 'containers-kubernetes' %}
-  {% include "shared/_thank_you.html" with thanks_context="enquiring about the Canonical Distribution of Kubernetes" %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about the Charmed Distribution of Kubernetes" %}
 {% elif product == 'containers-kubernetes-foundation' %}
     {% include "shared/_thank_you.html" with thanks_context="enquiring about the Enterprise Kubernetes Packages" %}
 {%  else %}

--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -50,7 +50,7 @@
         <li>The key concepts in Machine Learning</li>
         <li>How AI applications and their development are reshaping company’s IT</li>
         <li>How enterprises are applying devops practices to their ML infrastructure and workflows</li>
-        <li>How Canonical’s AI / ML portfolio from Ubuntu to the Canonical Distribution of Kubernetes and and how to get started
+        <li>How Canonical’s AI / ML portfolio from Ubuntu to the Charmed Distribution of Kubernetes and and how to get started
           quickly with your project</li>
       </ul>
       <h3>Other questions answered</h3>

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -7,7 +7,7 @@ context:
   description: How to backup and restore the state of your Kubernetes cluster in the etcd datastore.
 ---
 
-The state of your **Kubernetes** cluster is kept in the **etcd** datastore. This page shows how to backup and restore the etcd included in the **Canonical Distribution of Kubernetes <sup>&reg;</sup>**.
+The state of your **Kubernetes** cluster is kept in the **etcd** datastore. This page shows how to backup and restore the etcd included in the **Charmed Distribution of Kubernetes <sup>&reg;</sup>**.
 
 Backing up application specific data, normally stored in a persistent volume, is not currently supported by native Kubernetes. Various third party solutions are available -
 please refer to their own documentation for details.

--- a/templates/kubernetes/docs/base_docs.html
+++ b/templates/kubernetes/docs/base_docs.html
@@ -1,7 +1,7 @@
 {% extends "templates/base.html" %}
 {% load versioned_static  %}
 
-{% block title %}{{ title }} | Canonical Distribution of Kubernetes documentation{% endblock title %}
+{% block title %}{{ title }} | Charmed Distribution of Kubernetes documentation{% endblock title %}
 
 {% block meta_copydoc %}https://drive.google.com/drive/folders/1FyMcu6vqGnyQMdWLRjvxJVWm8gHgslk4{% endblock meta_copydoc %}
 

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -4,10 +4,10 @@ markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
   title: "Kubernetes documentation"
-  description: Documentation for the Canonical Distribution of Kubernetes.
+  description: Documentation for the Charmed Distribution of Kubernetes.
 ---
 
-The Canonical Distribution of Kubernetes<sup>&reg;</sup> (CDK), is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
+The Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK), is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
 
 Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabilities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
 

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -4,10 +4,10 @@ markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
   title: "Installing to a local machine"
-  description: How to install the Canonical Distribution of Kubernetes on a single machine for easy testing and development.
+  description: How to install the Charmed Distribution of Kubernetes on a single machine for easy testing and development.
 ---
 
-Installing the Canonical Distribution of Kubernetes<sup>&reg;</sup> (CDK)
+Installing the Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)
 on a single machine is possible for the purposes of testing and development.
 
 Be aware that the full deployment of CDK has system requirements which may exceed a standard laptop or desktop machine. It is only recommended for a machine with 32GB RAM and 250GB of SSD storage.

--- a/templates/kubernetes/docs/logging.md
+++ b/templates/kubernetes/docs/logging.md
@@ -14,7 +14,7 @@ This documentation assumes you are using version 2.4.0 or later of <strong>Juju<
   </p>
 </div>
 
-Broadly, there are two types of logs you may be interested in. On cluster or node level; for the applications you are running inside your cluster, and at an infrastructure level, the applications which are responsible for running the cluster itself. As the **Canonical Distribution of Kubernetes<sup>&reg;</sup>** is pure Kubernetes, you can use any of the tools and techniques to examine cluster logs as [described in the Kubernetes documentation][k8-logs].
+Broadly, there are two types of logs you may be interested in. On cluster or node level; for the applications you are running inside your cluster, and at an infrastructure level, the applications which are responsible for running the cluster itself. As the **Charmed Distribution of Kubernetes<sup>&reg;</sup>** is pure Kubernetes, you can use any of the tools and techniques to examine cluster logs as [described in the Kubernetes documentation][k8-logs].
 
 For the infrastructure, your CDK deployment has centralised logging set up as default. Each unit in your cluster automatically sends logging information to the controller based on the current logging level. You can use the **Juju** command line to easily inspect these logs and to change the logging level, as explained below.
 

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -7,13 +7,13 @@ context:
   description: How to create monitoring solution that runs whether the cluster itself is running or not. It may also be useful to integrate monitoring into existing setups.
 ---
 
-The Canonical Distribution of Kubernetes<sup>&reg;</sup> includes the standard Kubernetes dashboard for monitoring your cluster. However, it is often advisable to have a monitoring solution which will run whether the cluster itself is running or not. It may also be useful to integrate monitoring into existing setups.
+The Charmed Distribution of Kubernetes<sup>&reg;</sup> includes the standard Kubernetes dashboard for monitoring your cluster. However, it is often advisable to have a monitoring solution which will run whether the cluster itself is running or not. It may also be useful to integrate monitoring into existing setups.
 
 Prometheus is the recommended way to monitor your deployment - instructions are provided below. There are also instructions for setting up other monitoring solutions, or connecting to existing monitoring setups.
 
 ## Monitoring with Prometheus
 
-The recommended way to monitor your cluster is to use a combination of Prometheus, Grafana and Telegraf. The fastest, easiest way to install and configure this is via conjure-up when installing the Canonical Distribution of Kubernetes<sup>&reg;</sup>, by selecting the box next to Prometheus from the `Add-on` menu. You can then log in to the dashboard as [described below](#retrieve-credentials-and-login). See the [quickstart guide][quickstart] for more details on installing CDK with conjure-up.
+The recommended way to monitor your cluster is to use a combination of Prometheus, Grafana and Telegraf. The fastest, easiest way to install and configure this is via conjure-up when installing the Charmed Distribution of Kubernetes<sup>&reg;</sup>, by selecting the box next to Prometheus from the `Add-on` menu. You can then log in to the dashboard as [described below](#retrieve-credentials-and-login). See the [quickstart guide][quickstart] for more details on installing CDK with conjure-up.
 
 If you have already installed your cluster, you will be able to add and configure the extra applications using Juju as described here:
 

--- a/templates/kubernetes/docs/news.md
+++ b/templates/kubernetes/docs/news.md
@@ -4,7 +4,7 @@ markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
   title: "News"
-  description: The latest news on the Canonical Distribution of Kubernetes.
+  description: The latest news on the Charmed Distribution of Kubernetes.
 ---
 
 ## 1.12 has been released

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -4,10 +4,10 @@ markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
   title: "Overview"
-  description: Understand how the Canonical Distribution of Kubernetes workloads.
+  description: Understand how the Charmed Distribution of Kubernetes workloads.
 ---
 
-Deliver ‘Containers as a Service’ across the enterprise with the **Canonical Distribution of Kubernetes<sup>&reg;</sup> (CDK)** , enabling each project to spin up a standardised K8s of arbitrary scale, on demand, with centralised operational control. **CDK** provides a well integrated, turn-key **Kubernetes<sup>&reg;</sup>** platform that is open, extensible, and secure.
+Deliver ‘Containers as a Service’ across the enterprise with the **Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)** , enabling each project to spin up a standardised K8s of arbitrary scale, on demand, with centralised operational control. **CDK** provides a well integrated, turn-key **Kubernetes<sup>&reg;</sup>** platform that is open, extensible, and secure.
 
 For more information on the features and benefits of **CDK**, including details on the [Managed Kubernetes][managedk8s] service, please see the [Kubernetes section][k8s-u-c].
 

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -7,7 +7,7 @@ context:
   description: With this quick start guide and some tools from Canonical, you'll have a Kubernetes cluster running on the cloud of your choice in minutes!
 ---
 
-The Canonical Distribution of Kubernetes<sup>&reg;</sup> delivers a ‘pure K8s’ experience, tested across a wide range of clouds and integrated with modern metrics and monitoring. It works across all major public clouds and private infrastructure, enabling your teams to operate Kubernetes clusters on demand, anywhere.
+The Charmed Distribution of Kubernetes<sup>&reg;</sup> delivers a ‘pure K8s’ experience, tested across a wide range of clouds and integrated with modern metrics and monitoring. It works across all major public clouds and private infrastructure, enabling your teams to operate Kubernetes clusters on demand, anywhere.
 
 With this quick start guide and some tools from Canonical, you'll have a Kubernetes cluster running on the cloud of your choice in minutes!
 
@@ -24,11 +24,11 @@ With this quick start guide and some tools from Canonical, you'll have a Kuberne
   - [Rackspace][cloud-rackspace]
 
 <div class="p-notification--positive"><p markdown="1" class="p-notification__response">
-<span class="p-notification__status">Note:</span> If you don't meet these requirements, there are additional ways of installing the <emphasis>Canonical Distribution of Kubernetes<sup>&reg;</sup></emphasis>, inluding additional OS support and an entirely local deploy. Please see the more general <a href="/kubernetes/install">Installing CDK</a> page for details. </p></div>
+<span class="p-notification__status">Note:</span> If you don't meet these requirements, there are additional ways of installing the <emphasis>Charmed Distribution of Kubernetes<sup>&reg;</sup></emphasis>, inluding additional OS support and an entirely local deploy. Please see the more general <a href="/kubernetes/install">Installing CDK</a> page for details. </p></div>
 
 ## Install the tools
 
-The recommended way to install the **Canonical Distribution of Kubernetes&reg;** is with the tools [Juju][jujucharms-com], an application modelling tool, and [conjure-up][conjure-up-io], a guided installer for complex applications.
+The recommended way to install the **Charmed Distribution of Kubernetes&reg;** is with the tools [Juju][jujucharms-com], an application modelling tool, and [conjure-up][conjure-up-io], a guided installer for complex applications.
 
 From the command line, run the following:
 
@@ -48,9 +48,9 @@ To start deploying Kubernetes, simply run:
 conjure-up
 ```
 
-This will start an interactive, guided deployment of the components of the **Canonical Distribution of Kubernetes**&nbsp;<sup>&reg;</sup>.
+This will start an interactive, guided deployment of the components of the **Charmed Distribution of Kubernetes**&nbsp;<sup>&reg;</sup>.
 
-**conjure-up** can be used to deploy many different applications, with a set of processing scripts known as _spells_. Use the arrow keys to select "**Canonical Distribution of Kubernetes**" and press `Enter`
+**conjure-up** can be used to deploy many different applications, with a set of processing scripts known as _spells_. Use the arrow keys to select "**Charmed Distribution of Kubernetes**" and press `Enter`
 
 ![conjure-up menu](https://assets.ubuntu.com/v1/37d476e5-CDK-choose.png)
 
@@ -119,7 +119,7 @@ Now **conjure-up** will start the set up by creating a Juju controller, and you 
 
 As mentioned previously, a Juju controller is a cloud instance which Juju uses to monitor and manage any other nodes and applications it deploys across any number of different models. You will typically only need one Juju controller per cloud, and you will be able to deploy multiple separate models containing additional Kubernetes clusters or other big software applications.
 
-Once the controller has been created, Juju will then create a model and instances within that model to contain the applications which make up the **Canonical Distribution of Kubernetes**. For a few minutes, **conjure-up** will display a status screen, reporting on the progress of the install. You will see the individual status messages change as the instances are created, software is installed on them, and then this software is configured to work with the other elements of the deployment.
+Once the controller has been created, Juju will then create a model and instances within that model to contain the applications which make up the **Charmed Distribution of Kubernetes**. For a few minutes, **conjure-up** will display a status screen, reporting on the progress of the install. You will see the individual status messages change as the instances are created, software is installed on them, and then this software is configured to work with the other elements of the deployment.
 
 ![conjure-up controller menu](https://assets.ubuntu.com/v1/92511391-CDK-waiting.png)
 
@@ -127,7 +127,7 @@ The actual time this takes will depend on a number of factors, including which c
 
 ![conjure-up status](https://assets.ubuntu.com/v1/bbe1b9f4-CDK-final.png)
 
-Congratulations! You now have a cluster up and running with the **Canonical Distribution of Kubernetes**&nbsp;<sup>&reg;</sup>
+Congratulations! You now have a cluster up and running with the **Charmed Distribution of Kubernetes**&nbsp;<sup>&reg;</sup>
 
 You can now check the status of the cluster yourself by running the command:
 

--- a/templates/kubernetes/docs/scaling.md
+++ b/templates/kubernetes/docs/scaling.md
@@ -7,7 +7,7 @@ context:
   description: Learn how various components of CDK can be horizontally scaled to meet demand or increase reliability.
 ---
 
-The **Canonical Distribution of Kubernetes<sup>&reg;</sup>** has been designed to be flexible enough to efficiently run your workloads. Various components of **CDK** can be horizontally scaled to meet demand or to increase reliability, as detailed below.
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** has been designed to be flexible enough to efficiently run your workloads. Various components of **CDK** can be horizontally scaled to meet demand or to increase reliability, as detailed below.
 
 ## kubernetes-master
 
@@ -100,7 +100,7 @@ Note that due to the numbering system used by **Juju**, if you subsequently add 
 
 ## etcd
 
-The **Canonical Distribution of Kubernetes<sup>&reg;</sup>** installs a three machine cluster for etcd, which provides tolerence for a single failure. Should you wish to extend the fault tolerance, you can add additional units of etcd.
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** installs a three machine cluster for etcd, which provides tolerence for a single failure. Should you wish to extend the fault tolerance, you can add additional units of etcd.
 
 ```bash
 juju add-unit etcd -n 2
@@ -110,8 +110,7 @@ The recommended cluster-size for etcd is three, five or seven machines. Adding l
 
 ## Juju high availability
 
-On a default deployment of the **Canonical Distribution of
-Kubernetes<sup>&reg;</sup>**, there is only one controller instance, which isn't desirable for critical applications. It is possible to scale out the controller itself to prevent a single point of failure.
+On a default deployment of the **Charmed Distribution of Kubernetes<sup>&reg;</sup>**, there is only one controller instance, which isn't desirable for critical applications. It is possible to scale out the controller itself to prevent a single point of failure.
 
 **Juju** supports a high availability mode to run multiple controllers with an automatic failover.
 

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -9,7 +9,7 @@ context:
 
 On-disk files in a container are ephemeral and can't be shared with other members of a pod. For some applications, this is not an issue, but for many persistent storage is required.
 
-The **Canonical Distribution of Kubernetes**<sup>&reg;</sup> makes it easy to add and configure different types of persistent storage for your **Kubernetes** cluster, as outlined below. For more detail on the concept of storage volumes in **Kubernetes**, please see the [Kubernetes documentation][kubernetes-storage-docs].
+The **Charmed Distribution of Kubernetes**<sup>&reg;</sup> makes it easy to add and configure different types of persistent storage for your **Kubernetes** cluster, as outlined below. For more detail on the concept of storage volumes in **Kubernetes**, please see the [Kubernetes documentation][kubernetes-storage-docs].
 
 ## Ceph storage
 

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -7,7 +7,7 @@ context:
   description: How to deal with specific, special circumstances you may encounter when upgrading between versions of Kubernetes.
 ---
 
-This page is intended to deal with specific, special circumstances you may encounter when upgrading between versions of the **Canonical Distribution of Kubernetes<sup>&reg;</sup>.** The notes are organised according to the upgrade path below, but also be aware that any upgrade that spans more than one minor version may need to beware of notes in any of the intervening steps.
+This page is intended to deal with specific, special circumstances you may encounter when upgrading between versions of the **Charmed Distribution of Kubernetes<sup>&reg;</sup>.** The notes are organised according to the upgrade path below, but also be aware that any upgrade that spans more than one minor version may need to beware of notes in any of the intervening steps.
 
 ## Upgrading from 1.9.x to 1.10.x
 

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -7,7 +7,7 @@ context:
   description: How to upgrade your version of CDK.
 ---
 
-It is recommended that you keep your **Kubernetes** deployment updated to the latest available stable version. You should also update the other applications which make up the **Canonical Distribution of Kubernetes<sup>&reg;</sup>.** Keeping up to date ensures you have the latest bug-fixes and security patches for smooth operation of your cluster.
+It is recommended that you keep your **Kubernetes** deployment updated to the latest available stable version. You should also update the other applications which make up the **Charmed Distribution of Kubernetes<sup>&reg;</sup>.** Keeping up to date ensures you have the latest bug-fixes and security patches for smooth operation of your cluster.
 
 New minor versions of **Kubernetes** are set to release once per quarter. You can check the latest release version on the [Kubernetes release page on GitHub][k8s-release]. The **CDK** is kept in close sync with upstream Kubernetes: updated versions will be released within a week of a new upstream version of **Kubernetes**.
 

--- a/templates/kubernetes/docs/validation.md
+++ b/templates/kubernetes/docs/validation.md
@@ -9,7 +9,7 @@ context:
 
 End-to-end (e2e) tests for **Kubernetes** provide a mechanism to test the behaviour of the system. This is a useful indicator that the cluster is performing properly, as well as a good validation of any code changes.
 
-For the **Canonical Distribution of Kubernetes<sup>&reg;</sup>**, these tests are encapsulated in an additional **Juju** charm which can be added to your cluster. Actual testing is then run through the charm's actions.
+For the **Charmed Distribution of Kubernetes<sup>&reg;</sup>**, these tests are encapsulated in an additional **Juju** charm which can be added to your cluster. Actual testing is then run through the charm's actions.
 
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -1,6 +1,6 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
-{% block title %}Features of Canonical Distribution of Kubernetes{% endblock %}
+{% block title %}Features of Charmed Distribution of Kubernetes{% endblock %}
 {% block meta_description %}CDK gives you the flexibility to place your services exactly where you want them while sharing operational code with a large community.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1mEOBW4pfsWJqTLm9Pn9myKtaslD-QB2RvUKcNQ52bXU/edit{% endblock meta_copydoc %}
 
@@ -9,7 +9,7 @@
 <section class="p-strip--light is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-8">
-      <h1>Canonical Distribution of Kubernetes features</h1>
+      <h1>Charmed Distribution of Kubernetes features</h1>
       <h4>Architectural freedom. Fully automated operations. Extensible Kubernetes for all.</h4>
       <p>Kubernetes on Ubuntu gives you perfect portability of workloads across all infrastructures, from the datacentre to public clouds. Deep integration with infrastructure features such as <abbr title="Load Balancing as a Service">LBaaS</abbr>, storage, and networking means freedom and preservation of choice in infrastructure. With a strong focus on AI/ML and providing a cloud-native platform for the enterprise, Ubuntu is the platform of choice for k8s.</p>
       <p><a class="p-button--positive" href="/kubernetes/contact-us?product=kubernetes-features">Talk to us</a></p>
@@ -25,7 +25,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Cloud Native Platform</h3>
       <hr>
-      <p>The Canonical Distribution of Kubernetes (CDK) provides a well integrated, turn-key Kubernetes platform that is optimized for your cloud &mdash; private or public. It is open, extensible, and secure.</p>
+      <p>The Charmed Distribution of Kubernetes (CDK) provides a well integrated, turn-key Kubernetes platform that is optimized for your cloud &mdash; private or public. It is open, extensible, and secure.</p>
       <p>Get started now and take advantage of our rapidly growing ecosystem of technology partners like Rancher Labs, JFrog and others. CDK is the best foundation for your cloud-native platform!</p>
       <p><a class="p-button--positive" href="/kubernetes/install">Get started</a></p>
     </div>

--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -25,7 +25,7 @@
   <div class="row u-vertically-spaced u-equal-height">
     <div class="col-8">
       <h3>Rancher Labs</h3>
-      <p>Rancher provides a turn-key application delivery platform, built on Ubuntu and the Canonical Distribution of Kubernetes (CDK). Maximise developer velocity, integrate CI/CD, and ease the path from development into production with enterprise-calibre container management. Canonical delivers a cloud native platform in partnership with Rancher Labs.</p>
+      <p>Rancher provides a turn-key application delivery platform, built on Ubuntu and the Charmed Distribution of Kubernetes (CDK). Maximise developer velocity, integrate CI/CD, and ease the path from development into production with enterprise-calibre container management. Canonical delivers a cloud native platform in partnership with Rancher Labs.</p>
       <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/292819">Watch the Introduction webinar</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
@@ -45,7 +45,7 @@
   <div class="row u-vertically-spaced u-equal-height">
     <div class="col-8">
       <h3>JFrog Artifactory</h3>
-      <p>JFrog Artifactory is the enterprise-ready Kubernetes registry fully integrated with both Rancher and the Canonical Distribution of Kubernetes (CDK). Long known to developers, Artifactory provides the governance, audit capability and artifact management. Canonical partners with JFrog to integrate CDK with a single point and click installation using conjure-up.</p>
+      <p>JFrog Artifactory is the enterprise-ready Kubernetes registry fully integrated with both Rancher and the Charmed Distribution of Kubernetes (CDK). Long known to developers, Artifactory provides the governance, audit capability and artifact management. Canonical partners with JFrog to integrate CDK with a single point and click installation using conjure-up.</p>
       <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/308887">Watch the JFrog Artifactory webinar</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">

--- a/templates/legal/shared/_appendix-support-scope.html
+++ b/templates/legal/shared/_appendix-support-scope.html
@@ -393,14 +393,14 @@
         Definitions:
       </p>
       <ul>
-        <li class="p-list__item">"Canonical Distribution of Kubernetes" means Kubernetes deployed using Juju and the official Canonical-Kubernetes bundle on bare metal, cloud guests, or virtual machines.</li>
-        <li class="p-list__item">"Deployment" means the process of deploying the Canonical Distribution of Kubernetes. A deployment is considered successful once Juju reports all applications in a "started" state.</li>
+        <li class="p-list__item">"Charmed Distribution of Kubernetes" means Kubernetes deployed using Juju and the official Canonical-Kubernetes bundle on bare metal, cloud guests, or virtual machines.</li>
+        <li class="p-list__item">"Deployment" means the process of deploying the Charmed Distribution of Kubernetes. A deployment is considered successful once Juju reports all applications in a "started" state.</li>
         <li class="p-list__item">"Upgrade" means the process of upgrading Kubernetes between versions. An upgrade is considered successful once Juju reports all applications in a "started" state. Canonical will provide support for valid bugs encountered during the Upgrade process.
         </li>
         <li class="p-list__item">"Support" means break-fix support and answering basic questions about Kubernetes. Deployment and Upgrade assistance, as well as configuration and optimization of Kubernetes fall outside the scope of support.</li>
       </ul>
       <p>
-        Minimum deployment of the Canonical Distribution of Kubernetes includes a highly-available Juju control plane plus the base configuration of the Canonical-Kubernetes bundle, as documented in <a class=" p-link--external" href="https://jujucharms.com/canonical-kubernetes/">https://jujucharms.com/canonical-kubernetes/</a>. Support must be purchased for all nodes in the supported Kubernetes environment.
+        Minimum deployment of the Charmed Distribution of Kubernetes includes a highly-available Juju control plane plus the base configuration of the Canonical-Kubernetes bundle, as documented in <a class=" p-link--external" href="https://jujucharms.com/canonical-kubernetes/">https://jujucharms.com/canonical-kubernetes/</a>. Support must be purchased for all nodes in the supported Kubernetes environment.
       </p>
       <p>
         Supported versions of Kubernetes include the current stable minor release and the two most recent minor releases in the stable release channel. Additional information can be found at:
@@ -412,11 +412,11 @@
         Support is limited to:
       </p>
       <ul>
-	      <li class="p-list__item">the software packages and Charms necessary for running the Canonical Distribution of Kubernetes.</li>
+	      <li class="p-list__item">the software packages and Charms necessary for running the Charmed Distribution of Kubernetes.</li>
 	      <li class="p-list__item">the software packages available from <a class="p-link--external" href="https://apt.kubernetes.io">apt.kubernetes.io</a>  and Kubernetes clusters deployed using kubeadm.</li>
       </ul>
       <p>
-        For any deployment of the Canonical Distribution of Kubernetes carried out by Canonical while under contract for this deployment, which result in the customization of any Charms, the customization will be supported for 90 days after the official
+        For any deployment of the Charmed Distribution of Kubernetes carried out by Canonical while under contract for this deployment, which result in the customization of any Charms, the customization will be supported for 90 days after the official
         release of the Charm which includes the customizations.
       </p>
 
@@ -652,7 +652,7 @@
         Service includes:
       </p>
       <ul>
-        <li class="p-list__item">Break-fix support for, and answering basic questions about, using Rancher 2.x in accordance with the compatibility matrix and support lifecycle published by Rancher Labs at <a href="https://rancher.com/support-maintenance-terms/" class="p-link--external">https://rancher.com/support-maintenance-terms/</a> when managing the Canonical Distribution of Kubernetes.</li>
+        <li class="p-list__item">Break-fix support for, and answering basic questions about, using Rancher 2.x in accordance with the compatibility matrix and support lifecycle published by Rancher Labs at <a href="https://rancher.com/support-maintenance-terms/" class="p-link--external">https://rancher.com/support-maintenance-terms/</a> when managing the Charmed Distribution of Kubernetes.</li>
       </ul>
       <p>
         Service excludes:

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -191,7 +191,7 @@
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">Financial services</h3>
             <p class="p-matrix__desc">
-              Marquee financial institutions the world over trust Canonical OpenStack and the Canonical Distribution of Kubernetes (CDK) for secure private and public cloud infrastructure services to host their mission-critical applications.
+              Marquee financial institutions the world over trust Canonical OpenStack and the Charmed Distribution of Kubernetes (CDK) for secure private and public cloud infrastructure services to host their mission-critical applications.
             </p>
           </div>
         </li>

--- a/templates/takeovers/_kubernetes-enterprise-takeover.html
+++ b/templates/takeovers/_kubernetes-enterprise-takeover.html
@@ -3,7 +3,7 @@
     <div class="row u-vertically-center">
         <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
             <h1>Kubernetes for the enterprise</h1>
-            <p class="u-no-padding--top"><span class="event-title" itemprop="name">The Canonical Distribution of Kubernetes.
+            <p class="u-no-padding--top"><span class="event-title" itemprop="name">The Charmed Distribution of Kubernetes.
                 Pure upstream, ready for multi-cloud, AI/ML and Edge.
                 </span></p>
             <p class="col-5 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="kubernetes" class="p-takeover--kubernetes-logo"></p>

--- a/templates/takeovers/_kubernetes_takeover.html
+++ b/templates/takeovers/_kubernetes_takeover.html
@@ -1,7 +1,7 @@
 <section class="row strip row-hero">
     <div class="strip-inner-wrapper">
         <div class="seven-col">
-            <h1 class="row-hero__heading">The Canonical Distribution of&nbsp;Kubernetes</h1>
+            <h1 class="row-hero__heading">The Charmed Distribution of&nbsp;Kubernetes</h1>
             <p class="intro">Enterprise Kubernetes, anywhere.</p>
             <p class="intro"><a class="button--primary" href="/cloud/kubernetes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Kubernetes takeover', 'eventLabel' : 'Learn more', 'eventValue' : undefined });">Learn more</a></p>
             <p class="intro"><a class="external" href="https://jujucharms.com/canonical-kubernetes/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Kubernetes takeover', 'eventLabel' : 'Deploy it with Juju', 'eventValue' : undefined });">Deploy it with Juju</a></p>

--- a/templates/takeovers/takeunders/_ubuntu-product-month.html
+++ b/templates/takeovers/takeunders/_ubuntu-product-month.html
@@ -6,7 +6,7 @@
       </div>
       <div class="col-8 u-no-margin--top">
         <h3><a href="https://pages.ubuntu.com/kubernetes-month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeunder', 'eventLabel' : 'Watch our Kubernetes webinars', 'eventValue' : undefined });">Watch our Kubernetes webinars&nbsp;&rsaquo;</a></h3>
-        <p>A series of on-demand webinars to learn more about Canonical&rsquo;s Distribution of Kubernetes.</p>
+        <p>A series of on-demand webinars to learn more about Charmed&rsquo;s Distribution of Kubernetes.</p>
       </div>
     </div>
   </div>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -78,7 +78,7 @@
               <a href="https://jujucharms.com/">Juju for standardised operations&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="/kubernetes">Canonical Distribution of Kubernetes&nbsp;&rsaquo;</a>
+              <a href="/kubernetes">Charmed Distribution of Kubernetes&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
               <a href="https://microk8s.io/">MicroK8s - single node k8s for devs&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Updated the name from Canonical Distribution of Kubernetes to Charmed Distribution of Kubernetes 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
* http://0.0.0.0:8001/containers/contact-us?product=containers-kubernetes
* http://0.0.0.0:8001/containers/thank-you?product=containers-kubernetes
* http://0.0.0.0:8001/engage/ai-ml-ubuntu - [copy doc](https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit)
* http://0.0.0.0:8001/rfp - [copy doc](https://docs.google.com/document/d/1OA_Eg1200fHpt7YYkE4qubiWfxL_U5fnlA0OObRe2n8/edit#)
* http://0.0.0.0:8001/kubernetes/docs/*
* http://0.0.0.0:8001/kubernetes/partners - [copy docs](https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit)
* http://0.0.0.0:8001/ai/features - [copy doc](https://docs.google.com/document/d/1DT5nCRSJH-OkvDmlyKh6vVhofeHPHZJHTTBDNu44wCY/edit)
* http://0.0.0.0:8001/uasd - [copy doc](https://docs.google.com/document/d/1mrNrsC1WDf6QTg3nrVCEZS8vJzGz1fokvoFDVC4s_mI/edit)

## Issue / Card

Fixes #4488
