### PR TITLE
Fixed cropped inline images

### DIFF
--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -266,19 +266,19 @@
       </div>
       <div class="col-5">
         <ul class="p-inline-images">
-          <li class="p-inline-images__item p-inline-images__item--smaller">
+          <li class="p-inline-images__item">
             <img src="{{ ASSET_SERVER_URL }}82bf0621-logo-ceph-160.png" alt="Ceph">
           </li>
-          <li class="p-inline-images__item p-inline-images__item--smaller">
+          <li class="p-inline-images__item">
             <img src="{{ ASSET_SERVER_URL }}4f1e16bf-image-swift.svg" alt="Swift">
           </li>
-          <li class="p-inline-images__item p-inline-images__item--smaller">
+          <li class="p-inline-images__item">
             <img src="{{ ASSET_SERVER_URL }}836420d5-Nexenta-logo-600-dpi.png" alt="Nexenta">
           </li>
-          <li class="p-inline-images__item p-inline-images__item--smaller">
+          <li class="p-inline-images__item">
             <img src="{{ ASSET_SERVER_URL }}973c4256-storpool.svg" alt="Storpool">
           </li>
-          <li class="p-inline-images__item p-inline-images__item--smaller">
+          <li class="p-inline-images__item">
             <img src="{{ ASSET_SERVER_URL }}1702709d-quobyte.png" alt="Quobyte">
           </li>
         </ul>


### PR DESCRIPTION
## Done

- Fixed cropped inline images by removing "p-inline-images__item--smaller" class

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/openstack/features](http://0.0.0.0:8001/openstack/features)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the images are not cropped and are responsive. 


## Issue / Card

Fixes: #4459 

