### PR TITLE
Updates to the /kubernetes overview

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -33,8 +33,9 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">Single-package install</li>
         <li class="p-list__item is-ticked">Upstream release tracking</li>
-        <li class="p-list__item is-ticked">Built-in Istio registry</li>
-        <li class="p-list__item is-ticked">Local instance storage</li>
+        <li class="p-list__item is-ticked">Istio support</li>
+        <li class="p-list__item is-ticked">Local registry support</li>
+        <li class="p-list__item is-ticked">Host storage</li>
       </ul>
       <p>Developers love MicroK8s as a fast, lean upstream K8s for rapid iteration. It&rsquo;s also popular as a secure and robust K8s for IoT and appliances.</p>
       <p><a href="https://microk8s.io/" class="p-link--external">Learn more and install MicroK8s</a></p>
@@ -46,14 +47,14 @@
       </div>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Bare metal, VMware infrastructure</li>
-        <li class="p-list__item is-ticked">AWS, Azure, Google, OpenStack, Oracle, Rackspace</li>
+        <li class="p-list__item is-ticked">AWS, Azure, Google, OpenStack, Oracle, Rackspace clouds</li>
         <li class="p-list__item is-ticked">Public cloud LBAAS, storage, networking integrations</li>
         <li class="p-list__item is-ticked">Built-in high availability</li>
         <li class="p-list__item is-ticked">Built-in Istio registry</li>
         <li class="p-list__item is-ticked">In place upgrades</li>
         <li class="p-list__item is-ticked">Automated scaling</li>
       </ul>
-      <p>Deploy, scale and upgrade Kubernetes clusters across multiple physical or virtual machines with Ubuntu Kubernetes. Long-term support and operations automation. Integrates with Graylog, Prometheus, and Grafana.</p>
+      <p>Deploy, scale and upgrade Kubernetes clusters across multiple physical or virtual machines with Ubuntu Kubernetes. Ubuntu Kubernetes includes long-term support, operations automation capabilities and Graylog, Prometheus and Grafana integration.</p>
 
       <p><a href="/kubernetes/install">Install instructions&nbsp;&rsaquo;</a></p>
       <p><a href="/kubernetes/managed">Learn more about Managed Kubernetes&nbsp;&rsaquo;</a>
@@ -66,9 +67,9 @@
         <p><em>Manual cluster operations</em></p>
       </div>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Works on a range of clouds</li>
-        <li class="p-list__item is-ticked">Experimental support for upgrades</li>
-        <li class="p-list__item is-ticked">Often used for hand-built clusters with custom operations regimes.</li>
+        <li class="p-list__item is-ticked">Available across a wide range of clouds</li>
+        <li class="p-list__item is-ticked">Experimental upgrade support</li>
+        <li class="p-list__item is-ticked">Supports hand-built clusters with custom operations regimes</li>
       </ul>
       <p><a href="https://kubernetes.io/docs/setup/independent/install-kubeadm/" class="p-link--external">Install instructions</a></p>
       <p><a href="/kubernetes/contact-us?product=kubernetes-kubeadm">Get support for kubeadm&nbsp;&rsaquo;</a></p>
@@ -79,8 +80,8 @@
 <section class="p-strip is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-7">
-      <h2>Canonical Support for Kubernetes</h2>
-      <p>Enterprise support for Kubernetes on Ubuntu is provided by Canonical as part of <a href="/support">Ubuntu Advantage</a>. UA also includes long-term security maintenance, kernel live patching and mission-critical infrastructure support for the full stack, from kernel to container. Canonical supports K8s on Ubuntu on public clouds, VMware, OpenStack and bare metal.</p>
+      <h2>Enterprise support</h2>
+      <p>Enterprise support for Kubernetes on Ubuntu is provided by Canonical as part of an <a href="/support">Ubuntu Advantage</a> (<abbr title="Ubuntu Advantage">UA</abbr>) support subscription.. UA also includes long-term security maintenance, kernel live patching and mission-critical infrastructure support for the full stack, from kernel to container. Canonical supports K8s on Ubuntu on public clouds, VMware, OpenStack and bare metal.</p>
     </div>
     <div class="col-4 prefix-1 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}ca4cff60-pictogram_support01b.svg" alt="" width="200" />


### PR DESCRIPTION
## Done

- updated the text in the top 1/3rd of the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy docs](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#) thru the *Enterprise support* section
