### PR TITLE
Added desktop developer takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,10 +22,10 @@
 #}
 
 {% block takeover_content %}
+  {% include "takeovers/_desktop-developer-takeover.html" %}
   {% include "takeovers/_microk8s-takeover.html" %}
   {% include "takeovers/_spicule_takeover.html" %}
   {% include "takeovers/_trilio_takeover.html" %}
-  {% include "takeovers/_appelix-takeover.html" %}
   {% include "takeovers/_compliance-webinar.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}

--- a/templates/takeovers/_desktop-developer-takeover.html
+++ b/templates/takeovers/_desktop-developer-takeover.html
@@ -1,0 +1,34 @@
+<section class="p-strip--image is-dark is-deep js-takeover p-takeover--desktop-developer">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>Six reasons why developers choose Ubuntu Desktop</h1>
+      <p class="p-heading--four">Discover why Ubuntu Desktop is the preferred OS for development to production.</p>
+      <p class="u-hide--small">
+        <a href="" class="p-button--positive u-no-margin--bottom">
+          <span class="p-link">Download the whitepaper now</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center">
+      <div class="u-align--center">
+        <img src="https://assets.ubuntu.com/v1/b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="" />
+      </div>
+      <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+        <a href="" class="p-button--positive">
+          <span class="p-link">Download the whitepaper now</span>
+        </a>
+      </p>
+    </div>
+  </div>
+
+  <style>
+      .p-takeover--desktop-developer {
+				background-image: linear-gradient(225deg, #333333 0%, #111111 50%, #111111 100%);
+			}
+      @media only screen and (min-width: 460px) and (max-width: 896px)  {
+        .p-takeover--desktop-developer .u-align--center {
+					text-align: left !important;
+        }
+      }
+    </style>
+</section>

--- a/templates/takeovers/_desktop-developer-takeover.html
+++ b/templates/takeovers/_desktop-developer-takeover.html
@@ -1,30 +1,27 @@
 <section class="p-strip--image is-dark is-deep js-takeover p-takeover--desktop-developer">
-  <div class="row u-equal-height u-vertically-center">
+  <div class="row u-equal-height">
     <div class="col-7">
       <h1>Six reasons why developers choose Ubuntu Desktop</h1>
       <p class="p-heading--four">Discover why Ubuntu Desktop is the preferred OS for development to production.</p>
       <p class="u-hide--small">
-        <a href="" class="p-button--positive u-no-margin--bottom">
-          <span class="p-link">Download the whitepaper now</span>
-        </a>
+        <a href="/engage/developer-desktop" class="p-button--positive u-no-margin--bottom">Download the whitepaper now</a>
       </p>
     </div>
-    <div class="col-5">
+    <div class="col-5 u-vertically-center">
       <div class="u-align--center u-sv3">
-        <img src="https://assets.ubuntu.com/v1/b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="" />
+        <img src="{{ ASSET_SERVER_URL }}b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="" />
       </div>
       <p class="u-no-margin--bottom u-hide--large u-hide--medium">
-        <a href="" class="p-button--positive">
-          <span class="p-link">Download the whitepaper now</span>
-        </a>
+        <a href="/engage/developer-desktop" class="p-button--positive">Download the whitepaper now</a>
       </p>
     </div>
   </div>
 
   <style>
       .p-takeover--desktop-developer {
+        background-color: #333333;
 				background-image: linear-gradient(225deg, #333333 0%, #111111 50%, #111111 100%);
-			}
+      }
       @media only screen and (min-width: 460px) and (max-width: 896px)  {
         .p-takeover--desktop-developer .u-align--center {
 					text-align: left !important;

--- a/templates/takeovers/_desktop-developer-takeover.html
+++ b/templates/takeovers/_desktop-developer-takeover.html
@@ -10,7 +10,7 @@
       </p>
     </div>
     <div class="col-5">
-      <div class="u-align--center">
+      <div class="u-align--center u-sv3">
         <img src="https://assets.ubuntu.com/v1/b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="" />
       </div>
       <p class="u-no-margin--bottom u-hide--large u-hide--medium">

--- a/templates/takeovers/_desktop-developer-takeover.html
+++ b/templates/takeovers/_desktop-developer-takeover.html
@@ -4,7 +4,7 @@
       <h1>Six reasons why developers choose Ubuntu Desktop</h1>
       <p class="p-heading--four">Discover why Ubuntu Desktop is the preferred OS for development to production.</p>
       <p class="u-hide--small">
-        <a href="/engage/developer-desktop" class="p-button--positive u-no-margin--bottom">Download the whitepaper now</a>
+        <a href="/engage/developer-desktop?utm_source=takeover&utm_campaign=FY19_IOT_Desktop_Whitepaper_Developer" class="p-button--positive u-no-margin--bottom">Download the whitepaper now</a>
       </p>
     </div>
     <div class="col-5 u-vertically-center">

--- a/templates/takeovers/_desktop-developer-takeover.html
+++ b/templates/takeovers/_desktop-developer-takeover.html
@@ -1,5 +1,5 @@
 <section class="p-strip--image is-dark is-deep js-takeover p-takeover--desktop-developer">
-  <div class="row u-equal-height">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-7">
       <h1>Six reasons why developers choose Ubuntu Desktop</h1>
       <p class="p-heading--four">Discover why Ubuntu Desktop is the preferred OS for development to production.</p>
@@ -9,7 +9,7 @@
         </a>
       </p>
     </div>
-    <div class="col-5 u-vertically-center">
+    <div class="col-5">
       <div class="u-align--center">
         <img src="https://assets.ubuntu.com/v1/b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="" />
       </div>

--- a/templates/takeovers/_desktop-developer-takeover.html
+++ b/templates/takeovers/_desktop-developer-takeover.html
@@ -12,7 +12,7 @@
         <img src="{{ ASSET_SERVER_URL }}b4b238f8-Dell+XPS+13-1804-1.png" class="p-takeover-desktop-developer__image" alt="" />
       </div>
       <p class="u-no-margin--bottom u-hide--large u-hide--medium">
-        <a href="/engage/developer-desktop" class="p-button--positive">Download the whitepaper now</a>
+        <a href="/engage/developer-desktop?utm_source=takeover&utm_campaign=FY19_IOT_Desktop_Whitepaper_Developer" class="p-button--positive">Download the whitepaper now</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Added desktop developer takeover 
- Updated takeover cycle 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the takeover matches the [designs](https://github.com/ubuntudesign/www.ubuntu.com-design/issues/171#event-2012717388)


## Issue / Card

Fixes: #4483 

