### PR TITLE
Updated /kubernetes with SEO and text updates

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -1,6 +1,6 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
-{% block title %}Kubernetes{% endblock %}
+{% block title %}Multi-cloud Kubernetes on Ubuntu{% endblock %}
 {% block meta_description %}Ubuntu Kubernetes delivers a pure K8s experience, tested across a wide range of multi-cloud architectures for optimum Kubernetes performance and integrated with modern metrics and monitoring.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit{% endblock meta_copydoc %}
 
@@ -9,7 +9,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-7">
       <h1>Multi-cloud Kubernetes<br />on Ubuntu</h1>
-      <p>Ubuntu is the reference platform for Kubernetes<sup>&reg;</sup> on all major public clouds, including official support in Google’s GKE, Microsoft’s AKS and Amazon’s EKS CAAS offerings. Choose from the options below for pure upstream Kubernetes tested across the widest range of clouds &mdash; from public clouds to private data centres, from bare metal to virtualized infrastructure.</p>
+      <p>Ubuntu is the reference platform for Kubernetes on all major public clouds, including official support in Google’s GKE, Microsoft’s AKS and Amazon’s EKS CAAS offerings. Choose from the options below for pure upstream Kubernetes tested across the widest range of clouds &mdash; from public clouds to private data centres, from bare metal to virtualized infrastructure.</p>
     </div>
     <div class="col-4 prefix-1 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}dba11aee-kubernetes.svg?w=275" alt="" width="275" />
@@ -100,8 +100,8 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-12">
-      <h3>AI/ML Add-on for Discoverer and Discoverer Plus</h3>
-      <p>Extend your K8s workshop to understand the full stack of machine learning tooling and operations. Build a full AI analytics pipeline from developer workstations to your data centre and the public cloud. GPGPU integration, public cloud optimisation and tools like Kubeflow and Tensorflow are covered. Workshop includes an assessment by an independent data scientist. Canonical works with the leading hardware, cloud and data science companies to ensure you have the widest range of choices for integration in your enterprise AI strategy.</p>
+      <h3>AI/ML add-on for Discoverer and Discoverer Plus</h3>
+      <p>Extend your Kubernetes training to understand the full stack of machine learning tooling and operations. Build a full machine learning analytics pipeline from developer workstations to your data centre, the public cloud, and the edge. GPGPU integration, public cloud optimisation and tools like Kubeflow and Tensorflow are covered. Workshop includes an assessment by an independent data scientist. Canonical works with the leading hardware, cloud and data science companies to ensure you have the widest range of choices for integration in your enterprise AI strategy.</p>
     </div>
   </div>
 
@@ -121,40 +121,39 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <h2>The default platform for Kubernetes</h2>
-    <p>Google, Microsoft, Amazon, Cisco, IBM and others run cloud Kubernetes services on Ubuntu because we focus on the latest container capabilities in modern kernels. That’s why Ubuntu is the top choice for on-premise enterprise Kubernetes, too, with microk8s, kubeadm and charmed Ubuntu Kubernetes all supported by Canonical.</p>
+    <p>All leading cloud providers, such as Google, Microsoft, Amazon, Cisco,  and IBM and others run cloud Kubernetes services on Ubuntu because we focus on the latest container capabilities in modern kernels. This focus isThat’s  why Ubuntu is also the top choice for on-premise enterprise Kubernetes, too, with MmicroKk8s, kubeadm and Ccharmed Ubuntu Kubernetes all supported by Canonical.</p>
   </div>
   <div class="row">
     <div class="col-12">
       <ul class="p-matrix is-trisected">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--four">Multi-cloud</h3>
-            <p class="p-matrix__desc">Deploy and operate consistently on AWS, Azure, Google, Oracle, Rackspace, SoftLayer, or on private VMware and OpenStack</p>
+            <h3 class="p-matrix__title p-heading--four">Multi-cloud ready</h3>
+            <p class="p-matrix__desc">Deploy and operate consistently on AWS, Azure, Google, Oracle, Rackspace, SoftLayer, or on private VMware and OpenStack clouds.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--four">Fresh</h3>
-            <p class="p-matrix__desc">Canonical enables upgrades to each new stable upstream K8s release as well as edge builds, so you can migrate to the latest version as soon as you want.</p>
+            <h3 class="p-matrix__title p-heading--four">Updatable</h3>
+            <p class="p-matrix__desc">Canonical enables upgrades to each new stable upstream K8s release as well as edge builds, so you can migrate to the latest version when needed.</p>
           </div>
           </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title p-heading--four">Secure</h3>
-            <p class="p-matrix__desc">Every component of Canonical&rsquo;s K8s distribution receives security maintenance, and all components communicate with TLS encryption</p>
+            <p class="p-matrix__desc">Every component of Canonical&rsquo;s Kubernetes distribution receives security maintenance, and all components communicate with TLS encryption.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title p-heading--four">Supported</h3>
-            <p class="p-matrix__desc">K8s enterprise support by Canonical is included in standard Ubuntu support packages, with a range of SLA&rsquo;s and choice of physical / virtual / cloud. We support the full stack from kernel to k8s
-              </p>
+            <p class="p-matrix__desc">Ubuntu Advantage K8s enterprise support includes a range of SLA’s and choice of physical, virtual and/or cloud. Canonical supports the full stack from kernel to K8s.</p>
           </div>
           </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title p-heading--four">Extensible</h3>
-            <p class="p-matrix__desc">Easy integration of standard open source logging, monitoring, alerting, storage, networking, and container runtimes. We offer consulting for deeper customisation</p>
+            <p class="p-matrix__desc">Easy integration of standard open source logging, monitoring, alerting, storage, networking and container runtimes. Consulting for deeper customisation is available.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -191,7 +190,7 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title p-heading--four">Bare Metal</h3>
+            <h3 class="p-matrix__title p-heading--four">Bare metal</h3>
             <p class="p-matrix__desc">Deploy on bare metal servers for peak performance with high availability, GPGPU auto-detection and software-defined storage</p>
           </div>
         </li>
@@ -287,7 +286,7 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2 id="support-packages">Enterprise support packages</h2>
+      <h2 id="support-packages">Kubernetes enterprise support packages</h2>
       <p>Canonical provides enterprise support for Kubernetes as part of its standard Ubuntu Advantage support offering for infrastructure.</p>
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -121,7 +121,7 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <h2>The default platform for Kubernetes</h2>
-    <p>All leading cloud providers, such as Google, Microsoft, Amazon, Cisco,  and IBM and others run cloud Kubernetes services on Ubuntu because we focus on the latest container capabilities in modern kernels. This focus isThat’s  why Ubuntu is also the top choice for on-premise enterprise Kubernetes, too, with MmicroKk8s, kubeadm and Ccharmed Ubuntu Kubernetes all supported by Canonical.</p>
+    <p>All leading cloud providers, such as Google, Microsoft, Amazon, Cisco and IBM run cloud Kubernetes services on Ubuntu because we focus on the latest container capabilities in modern kernels. This focus is why Ubuntu is also the top choice for on-premise enterprise Kubernetes, with MicroK8s, kubeadm and Charmed Kubernetes all supported by Canonical.</p>
   </div>
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
## Done

- Updated /kubernetes index with SEO and text updates

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#)

## Issue / Card

Fixes #4500 	
