### PR TITLE
Updated /kubernetes/install with text updates

### DIFF
--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -27,7 +27,7 @@
       <div class="p-card__header">
         <h3>Workstation</h3>
       </div>
-      <p>Microk8s is a single-package install that brings up a standard workstation K8s in under 60 seconds.</p>
+      <p><a class="p-link--external" href="https://microk8s.io/">Microk8s</a> is a single-package install that brings up a standard workstation K8s in under 60 seconds.</p>
       <p>
         <a class="p-button--positive" href="https://microk8s.io/">
           <span class="p-link--external">Install now</span>
@@ -37,10 +37,10 @@
       <div class="p-card__header">
         <h3>Create your own cluster</h3>
       </div>
-      <p>The standard guided cluster installation with Ubuntu on any cloud or data centre from the CLI, try <code>conjure-up kubernetes</code> to install CDK, the Charmed Distribution of Kubernetes.</p>
+      <p>The standard guided cluster installation with Ubuntu on any cloud or data centre from the CLI, try <a class="p-link--external" href="https://conjure-up.io/"><code>conjure-up kubernetes</code></a> to install CDK, the Charmed Distribution of Kubernetes.</p>
       <p>
         <a class="p-button--neutral" href="https://conjure-up.io/">
-          <span class="p-link--external">Deploy k8s</span>
+          <span class="p-link--external">Deploy K8s</span>
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- text updates on /kubernetes/install

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/kubernetes/install](http://0.0.0.0:8001/kubernetes/install)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1oiD6UUomf2daZitS3UOosujYBXPbiOMzPtXVZBq-ph0/edit)

## Issue / Card

Fixes #4502 	

