### PR TITLE
Updated /kubernetes/partners with text updates

### DIFF
--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -1,7 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
 {% block title %}Canonical Kubernetes Partners{% endblock %}
-{% block meta_description %}Canonical Kubernetes partners provide regional consulting and operations, hosting, and third party technology for storage, networking, monitoring and chargeback to the Ubuntu Kubernetes and OpenStack ecosystem.{% endblock meta_description %}
+{% block meta_description %}Canonical’s Kubernetes partners provide regional consulting and operations, hosting, and third-party technology for storage, networking, monitoring and chargeback to the Ubuntu Kubernetes and OpenStack ecosystem.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -34,9 +34,10 @@
   </div>
   <div class="row u-vertically-spaced u-equal-height">
     <div class="col-8">
-      <h3>In partnership with Google GKE</h3>
-      <p>Google and Canonical together enable smooth hybrid operations between Google&rsquo;s Container Engine (GKE) service with Ubuntu worker nodes, and Canonical’s Distribution of Kubernetes®*. Choose Canonical&rsquo;s Kubernetes to be sure your container workloads can migrate to GKE thanks to our kernel-to-k8s alignment.</p>
+      <h3>In partnership with Google</h3>
+      <p>Google and Canonical together enable smooth hybrid operations between Google’s Container Engine (GKE) and Elastic Container Service for Kubernetes (EKS) services with Ubuntu worker nodes, and the Charmed Distribution of Kubernetes. Choose Charmed Kubernetes to be sure your container workloads can migrate to GKE or EKS thanks to our kernel-to-k8s alignment.</p>
       <p><a class="p-button--positive" href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">Try GKE with Ubuntu now</a></p>
+      <p><a class="p-link--external" href="https://cloud-images.ubuntu.com/aws-eks/">Learn about EKS with Ubuntu</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img style="max-width: 250px;" src="{{ ASSET_SERVER_URL }}ba70dd8a-gce.png" alt="">
@@ -45,7 +46,7 @@
   <div class="row u-vertically-spaced u-equal-height">
     <div class="col-8">
       <h3>JFrog Artifactory</h3>
-      <p>JFrog Artifactory is the enterprise-ready Kubernetes registry fully integrated with both Rancher and the Charmed Distribution of Kubernetes (CDK). Long known to developers, Artifactory provides the governance, audit capability and artifact management. Canonical partners with JFrog to integrate CDK with a single point and click installation using conjure-up.</p>
+      <p>JFrog Artifactory is the enterprise-ready Kubernetes registry fully integrated with both Rancher and the Charmed Distribution of Kubernetes. Long known to developers, Artifactory provides the governance, audit capability and artifact management. Canonical partners with JFrog to integrate CDK with a single point and click installation using conjure-up.</p>
       <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/308887">Watch the JFrog Artifactory webinar</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">


### PR DESCRIPTION
## Done

- Updated /kubernetes/partners with text updates

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/kubernetes/partners](http://0.0.0.0:8001/kubernetes/partners)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit#)

## Issue / Card

Fixes #4504 