### PR TITLE
Increase the z-index for the navigation

### DIFF
--- a/static/sass/_pattern_gaming.scss
+++ b/static/sass/_pattern_gaming.scss
@@ -13,7 +13,7 @@
         margin-bottom: 15%;
         margin-top: 15%;
         position: relative;
-        z-index: 3000;
+        z-index: 3;
       }
     }
 
@@ -28,7 +28,7 @@
       position: absolute;
       top: 0;
       width: 100%;
-      z-index: 2000;
+      z-index: 2;
     }
   }
 }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -22,7 +22,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
   .p-navigation {
     background-color: $nav-bg-color;
     flex-direction: column;
-    z-index: 10;
+    z-index: 40;
 
     &::after { // disable rule under nav
       background-color: none;
@@ -184,7 +184,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
       margin-top: 0;
       position: relative;
       width: 100%;
-      z-index: 3;
+      z-index: 38;
 
       @media (max-width: $breakpoint-x-small - 1) {
         padding-bottom: $sp-medium;
@@ -376,7 +376,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
     top: 0;
     transition: opacity .5s ease-in-out;
     width: 100%;
-    z-index: 3;
+    z-index: 38;
   }
 
   .dropdown-window {
@@ -386,7 +386,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
     flex-direction: column;
     position: absolute;
     width: 100%;
-    z-index: 4;
+    z-index: 39;
 
     &.slide-animation {
       box-shadow: none;


### PR DESCRIPTION
Since the navigation needs to overlay practically everything, it should be
high enough to provide plenty of lower layers for other things on the page
that need to use z-index.

I'm following a vague standard, which may be enshrined in team practices
soon, that the page gets to use z-index in the range `0-50`,
`51-100` should be reserved for plugins (like global-nav), and then
`100+` should be used to override plugins if needed.

So the nav uses `37-40`, to sit near the top-end of that range, but with a little space above it.

Fixes #4442

QA
---

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/desktop/features](http://0.0.0.0:8001/desktop/features)

Check:

- the nav drop-downs still work and are visible
- the nav successfully overlays everything else on the page
- the global nav still overlays the main nav