### PR TITLE
Updated takeover CTA links

### DIFF
--- a/templates/engage/modern-cloud.html
+++ b/templates/engage/modern-cloud.html
@@ -13,7 +13,7 @@
         <h1>Modernise your cloud</h1>
         <h4>Discover how Trilio and Canonical help organisations transition to new, maintainable cloud architecture in just weeks.</h4>
         <p class="p-takeover__text">
-              Webinar live on 6 December 2018 - <a href="#register-section" class="p-link">Register now&nbsp;&rsaquo;</a></p>
+              Webinar live on 6 December 2018 - <a href="#register-section" class="p-link">Watch now&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-hide--small u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}9f54e0b0-Trilio+Final+Logo_GRAY+GREEN.png" alt="Trilio" class="p-takeover-trilio__image" />

--- a/templates/takeovers/_spicule_takeover.html
+++ b/templates/takeovers/_spicule_takeover.html
@@ -10,7 +10,7 @@
       </p>
       <p>
         <a href="https://www.brighttalk.com/webcast/6793/341856?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_Cloud_Openstack_WBN_Spicule" class="p-button--positive">
-          <span class="p-link--external">Register for the webinar</span>
+          <span class="p-link--external">Watch the webinar now</span>
         </a>
       </p>
     </div>

--- a/templates/takeovers/_trilio_takeover.html
+++ b/templates/takeovers/_trilio_takeover.html
@@ -8,7 +8,7 @@
         <img src="{{ ASSET_SERVER_URL }}9f54e0b0-Trilio+Final+Logo_GRAY+GREEN.png" alt="Trilio" class="p-takeover-trilio__image" />
       </p>
       <p class="u-no-margin--top u-no-margin--bottom"><a href="/engage/modern-cloud?utm_source=takeover&utm_campaign=FY19_Cloud_Openstack_WBN_Trilio"
-          class="p-button--positive">Register for the webinar</a></p>
+          class="p-button--positive">Watch the webinar now</a></p>
     </div>
     <div class="col-4 u-hide--small u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}9f54e0b0-Trilio+Final+Logo_GRAY+GREEN.png" alt="Trilio" class="p-takeover-trilio__image" />


### PR DESCRIPTION
## Done

Updated:

- Trilio takeover CTA
- Trilio landing page link
- Spicule takeover CTA

to say "Watch now", as webinars are now live. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the links work
