### PR TITLE
Update the enterprise dropdown menu

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -9,7 +9,7 @@
               <a href="/openstack">OpenStack&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
-              Canonical is the leading provider of managed OpenStack. We help design, build and operate your cloud, and train your team to take over.
+                Canonical is the leading provider of managed OpenStack. We also provide enterprise support, training, consulting, and will help you design and deliver your new private cloud.
             </p>
             <a href="/openstack" class="p-button--small p-button--positive u-align-text--left">
               Get OpenStack
@@ -34,7 +34,7 @@
               <a href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
-              Canonical delivers the leading Kubernetes distribution and provides workshops, training, deployment and consulting services. On VMware, cloud, OpenStack and bare metal.
+                Canonical supports Kubeadm, MicroK8s and Charmed Kubernetes on VMware, OpenStack, bare metal, AWS, Azure, Google, Oracle Cloud, IBM Cloud and Rackspace.
             </p>
             <a href="/kubernetes" class="p-button--small p-button--positive u-align-text--left">
               Get Kubernetes
@@ -61,7 +61,7 @@
               <a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">
-              Embedded Ubuntu on your device gives you the best developer experience, security and long-term support.
+                Embedded Ubuntu on your device gives you the best developer experience, security and long-term support. Choose between Classic Ubuntu Server or the new Ubuntu Core for appliances.
             </p>
             <a href="/internet-of-things" class="p-button--small p-button--positive u-align-text--left">
               Build your IoT on Ubuntu


### PR DESCRIPTION
## Done
Update the section descriptions in the enterprise dropdown menu

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the content matches the latest changes in the [copy doc](https://github.com/canonical-websites/www.ubuntu.com/issues/4517)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4517