### PR TITLE
Remove the trilio & Spicule takeovers [19th December]

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,8 +24,6 @@
 {% block takeover_content %}
   {% include "takeovers/_desktop-developer-takeover.html" %}
   {% include "takeovers/_microk8s-takeover.html" %}
-  {% include "takeovers/_spicule_takeover.html" %}
-  {% include "takeovers/_trilio_takeover.html" %}
   {% include "takeovers/_compliance-webinar.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}


### PR DESCRIPTION
## Done
Removed the Trilio and Spicule takeovers.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh through the homepage takeovers and see there is no spicule or trillo

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4528
