### PR TITLE
"Openstack, un jeu d enfant" - French landing page + takeover

### DIFF
--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -47,27 +47,27 @@
         <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
           <ul class="p-list u-no-margin--bottom">
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel ">Prénom:</label>
+              <label for="FirstName" class="mktoLabel ">Prénom :</label>
               <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name">
             </li>
             <li class="mktFormReq mktField">
-              <label for="LastName" class="mktoLabel ">Nom:</label>
+              <label for="LastName" class="mktoLabel ">Nom :</label>
               <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name">
             </li>
             <li class="mktFormReq mktField">
-              <label for="Email" class="mktoLabel ">Email:</label>
+              <label for="Email" class="mktoLabel ">Email :</label>
               <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email">
             </li>
             <li class="mktFormReq mktField">
-              <label for="Company" class="mktoLabel ">Entreprise:</label>
+              <label for="Company" class="mktoLabel ">Entreprise :</label>
               <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
             </li>
             <li class="mktFormReq mktField">
-              <label for="Title" class="mktoLabel ">Fonction:</label>
+              <label for="Title" class="mktoLabel ">Fonction :</label>
               <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
             </li>
             <li class="mktFormReq mktField">
-              <label for="Phone" class="mktoLabel ">Téléphone:</label>
+              <label for="Phone" class="mktoLabel ">Téléphone :</label>
               <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number">
             </li>
             <li class="mktField">

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -84,7 +84,7 @@
               <label for="canonicalUpdatesOptIn" class="mktoLabel">J'accepte de recevoir des informations sur les produits et services de Canonical.</label>
             </li>
             <li class="mktField">
-              <p>En soumettant ce formulaire, je confirme que j'ai lu et que j'accepte les conditions suivantes: <a href="/legal/data-privacy" target="_blank" class="mchNoDecorate">Politique de confidentialité</a></p>
+              <p>En soumettant ce formulaire, je confirme que j'ai lu et que j'accepte les conditions suivantes : <a href="/legal/data-privacy" target="_blank" class="mchNoDecorate">Politique de confidentialité</a></p>
               <input name="RichText" type="hidden" aria-label="RichText">
             </li>
             <li class="mktField">

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -1,0 +1,134 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Avec les bons outils, OpenStack est un jeu d'enfant.{% endblock %}
+{% block meta_description %}Cet eBook vous permettra de mieux comprendre pourquoi l'installation et l'exécution d'OpenStack peut sembler complexe, et comment Canonical OpenStack simplifie les choses et peut vous aider à construire une infrastructure cloud privée moderne, évolutive, répliquable et abordable.{% endblock %}
+
+{% block content %}
+
+<section class="p-strip is-deep p-takeover--private-cloud-economics">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h1 class="p-takeover__title">Installez et mettez OpenStack à l'échelle en toute simplicité</h1>
+      <p class="u-hide--medium u-hide--large u-align--center">
+        <img class="p-takeover__image" src="https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg" alt="">
+      </p>
+    </div>
+    <div class="col-3 u-hide--small u-align--left">
+      <img class="p-takeover__image" src="https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg" alt="" class="u-hide--small">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-7 p-takeover__text">
+      <h3>Avec les bons outils, OpenStack est un jeu d'enfant.</h3>
+      <p style="font-size:16px;">L'utilisation de plus en plus fréquente de gros logiciels basés sur des microservices multi-hôtes au lieu de logiciels  monolithiques traditionnels exige des perspectives et des approches fondamentalement nouvelles en matière d'installation, d'intégration et d'exploitation.</p>
+      <p style="font-size:16px;">Cet eBook vous permettra de mieux comprendre pourquoi l'installation et l'exécution d'OpenStack peut sembler complexe, et comment Canonical OpenStack simplifie les choses et peut vous aider à construire une infrastructure cloud privée moderne, évolutive, répliquable et abordable.</p>
+      <h3 class="p-muted-heading u-align--center">Nous fournissons des clouds privés aux plus grandes entreprises</h3>
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4ef05fb7-bestbuy.jpg" alt="BestBuy" style="max-width:90px;"/>
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b1fecbf0-logo-att-horizontal.png" width="242" alt="ATT" style="max-width:130px;"/>
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" alt="Bloomberg" style="max-width:100px;"/>
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1ccb6d93-logo-deutschetelekom.svg" alt="Deutsche Telekom" />
+        </li>
+      </ul>
+    </div>
+    <div class="col-5">
+      <!-- MARKETO FORM -->
+      <script src="{{ ASSET_SERVER_URL }}37b1db88-jquery.min.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}6ce35d3e-jquery-ui.min.js"></script>‌​
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3266" style="margin-top:-1em;">
+        <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+          <ul class="p-list u-no-margin--bottom">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel ">Prénom:</label>
+              <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="LastName" class="mktoLabel ">Nom:</label>
+              <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Email" class="mktoLabel ">Email:</label>
+              <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Company" class="mktoLabel ">Entreprise:</label>
+              <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Title" class="mktoLabel ">Fonction:</label>
+              <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Phone" class="mktoLabel ">Téléphone:</label>
+              <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number">
+            </li>
+            <li class="mktField">
+              <input name="utm_campaign" class="mktoField mktoFormCol" value="{{utm_campaign}}" type="hidden" aria-label="utm_campaign">
+            </li>
+            <li class="mktField">
+              <input name="utm_medium" class="mktoField mktoFormCol" value="{{utm_medium}}" type="hidden" aria-label="utm_medium">
+            </li>
+            <li class="mktField">
+              <input name="utm_source" class="mktoField mktoFormCol" value="{{utm_source}}" type="hidden" aria-label="utm_source">
+            </li>
+            <li class="mktField">
+              <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox">
+              <label for="canonicalUpdatesOptIn" class="mktoLabel">J'accepte de recevoir des informations sur les produits et services de Canonical.</label>
+            </li>
+            <li class="mktField">
+              <p>En soumettant ce formulaire, je confirme que j'ai lu et que j'accepte les conditions suivantes: <a href="/legal/data-privacy" target="_blank" class="mchNoDecorate">Politique de confidentialité</a></p>
+              <input name="RichText" type="hidden" aria-label="RichText">
+            </li>
+            <li class="mktField">
+              <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes" type="hidden" aria-label="Consent_to_Processing__c">
+            </li>
+            <li class="mktField">
+              <button type="submit" class="mktoButton">Télécharger l'eBook</button>
+              <input name="formid" class="mktoField" value="3266" type="hidden" aria-label="formid">
+              <input name="lpId" class="mktoField " value="" type="hidden" aria-label="lpId">
+              <input name="subId" class="mktoField " value="" type="hidden" aria-label="subId">
+              <input name="munchkinId" class="mktoField " value="" type="hidden" aria-label="munchkinId">
+              <input name="lpurl" class="mktoField " value="" type="hidden" aria-label="lpurl">
+              <input name="cr" class="mktoField " value="" type="hidden" aria-label="cr">
+              <input name="kw" class="mktoField " value="" type="hidden" aria-label="kw">
+              <input name="q" class="mktoField " value="" type="hidden" aria-label="q">
+            </li>
+          </ul>
+        </fieldset>
+        <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/openstack-made-easy-de-TY.html" aria-label="returnURL">
+        <input type="hidden" name="retURL" value="https://pages.ubuntu.com/openstack-made-easy-de-TY.html" aria-label="retURL">
+      </form>
+      <script>
+        $("#mktoForm_3266").validate({
+          errorElement: "span",
+          errorClass: "mktFormMsg mktError",
+          onkeyup: false,
+          onclick: false,
+          onblur: false
+        });
+        $(function () { $("#comments").hide() });
+        $('#Ubuntu_User__c').on('change', function () {
+          var selection = $(this).val();
+          if (selection == 'Commercially only') {
+            $('#comments').show();
+          } else {
+            $('#comments').hide();
+          }
+        });
+      </script>
+      <script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
+
+      <!-- /MARKETO FORM -->
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -43,7 +43,7 @@
       <script src="{{ ASSET_SERVER_URL }}37b1db88-jquery.min.js"></script>
       <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
       <script src="{{ ASSET_SERVER_URL }}6ce35d3e-jquery-ui.min.js"></script>‌​
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3266" style="margin-top:-1em;">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3323" style="margin-top:-1em;">
         <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
           <ul class="p-list u-no-margin--bottom">
             <li class="mktFormReq mktField p-list__item">
@@ -92,7 +92,7 @@
             </li>
             <li class="mktField">
               <button type="submit" class="mktoButton">Télécharger l'eBook</button>
-              <input name="formid" class="mktoField" value="3266" type="hidden" aria-label="formid">
+              <input name="formid" class="mktoField" value="3323" type="hidden" aria-label="formid">
               <input name="lpId" class="mktoField " value="" type="hidden" aria-label="lpId">
               <input name="subId" class="mktoField " value="" type="hidden" aria-label="subId">
               <input name="munchkinId" class="mktoField " value="" type="hidden" aria-label="munchkinId">
@@ -103,11 +103,11 @@
             </li>
           </ul>
         </fieldset>
-        <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/openstack-made-easy-de-TY.html" aria-label="returnURL">
-        <input type="hidden" name="retURL" value="https://pages.ubuntu.com/openstack-made-easy-de-TY.html" aria-label="retURL">
+        <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/openstack-made-easy-fr-TY.html" aria-label="returnURL">
+        <input type="hidden" name="retURL" value="https://pages.ubuntu.com/openstack-made-easy-fr-TY.html" aria-label="retURL">
       </form>
       <script>
-        $("#mktoForm_3266").validate({
+        $("#mktoForm_3323").validate({
           errorElement: "span",
           errorClass: "mktFormMsg mktError",
           onkeyup: false,

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,7 @@
 
     <section class="p-strip js-takeover"></section> <!-- For all languages -->
     <section lang="de" class="p-strip js-takeover"></section> <!-- For german languages only -->
+    <section lang="fr" class="p-strip js-takeover"></section> <!-- For french languages only -->
 #}
 
 {% block takeover_content %}
@@ -29,4 +30,5 @@
   {% include "takeovers/_compliance-webinar.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
+  {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_french_takeover_openstack_made_easy.html
+++ b/templates/takeovers/_french_takeover_openstack_made_easy.html
@@ -1,0 +1,27 @@
+<div lang="fr" class="p-strip--image js-takeover p-takeover--french-openstack-made-easy">
+    <div class="row u-vertically-center">
+        <div class="col-8">
+            <h1 style="font-weight:100;">Comment installer OpenStack en toute simplicité</h1>
+            <h4 class="u-no-margin--bottom u-sv3">Avec les bons outils, OpenStack est un jeu d'enfant.</h4>
+            <p class="u-align--center u-hide--medium u-hide--large">
+                <img src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg" alt="OpenStack Made Easy" style="width:342px; height:219px" />
+            </p>
+            <p>
+                <a href="/engage/fr/openstack-made-easy?utm_source=takeover&utm_medium=takeover&utm_campaign=FY19_Cloud_OpenStack_Ebook_OpenStackMadeEasyFR" class="p-button--positive">Télécharger l'ebook</a>
+            </p>
+        </div>
+        <div class="col-4 u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg" alt="OpenStack Made Easy" style="width:342px; height:219px" />
+        </div>
+    </div>
+
+    <style>
+        .p-takeover--french-openstack-made-easy {
+             background-image: url("{{ ASSET_SERVER_URL }}d3edfcd5-left.png"),url("{{ ASSET_SERVER_URL }}17508275-right.png");
+             background-color: #F7F7F7;
+             background-repeat: no-repeat;
+             background-size: contain;
+             background-position: bottom left, bottom right;
+        }
+     </style>
+</div>


### PR DESCRIPTION
## Done

* French landing page at `/engage/fr/openstack-made-easy`
* French takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Change your browser lang to French and refresh the homepage until you see "Comment installer OpenStack en toute simplicité"
- Go to the landing page, ensure the form works and takes you to a french ty page with a french ebook

