### PR TITLE
Update the k8s add-on pricing copy

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -6,21 +6,21 @@
     </div>
     <div class="row">
       <div class="col-6">
-        <p>One additional workshop day dedicated to Kubeflow, including  Tensorflow and JupyterHub, covering everything your business needs for on-prem/off-prem AI/ML operations.</p>
+        <p>One week additional workshop dedicated to Kubeflow, including JupyterHub and your kubeflow-integrated frameworks of choice (e.g. TensorFlow, PyTorch, Pachyderm, Seldon Core, etc.), covering everything your business needs for on-prem/off-prem AI/ML operations.</p>
         <ul class="p-list">
           <li class="p-list__item is-ticked">On site or remote options</li>
-          <li class="p-list__item is-ticked">Hands-on K8s and Kubeflow</li>
+          <li class="p-list__item is-ticked">Hands-on Kubernetes and Kubeflow training</li>
           <li class="p-list__item is-ticked">Full pipeline view</li>
         </ul>
       </div>
       <div class="col-6">
-        <p>Canonical and a data science partner will deliver an AI assessment as part of the workshop to help you determine the readiness of your existing data and analytics for ML and AI approaches.</p>
+        <p>Canonical and a data science partner will deliver an AI assessment as part of the workshop to help you determine the readiness of your existing approaches and capabilities for data science.</p>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Understand AI lifecycle</li>
           <li class="p-list__item is-ticked">Preliminary data and process discovery</li>
           <li class="p-list__item is-ticked">Development capacity assessment</li>
           <li class="p-list__item is-ticked">Deploy and operate ML analysis</li>
-          <li class="p-list__item is-ticked">Finalize initial AI strategy</li>
+          <li class="p-list__item is-ticked">Finalise initial AI strategy</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done
Updated the k8s add-on pricing to match the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#).

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the copy in the "AI/ML Add-on for Discoverer and Discoverer Plus" section matches the [copy doc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit#)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4537
