### PR TITLE
Typo on /core: booth -> boot

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -379,7 +379,7 @@ store for access to all the standard apps, or curate your own collection.</p>
     </div>
     <div class="col-6">
       <h4>Backup boot paths</h4>
-      <p class='p-heading--five'>Low-level updates preserve the prior booth path.</p>
+      <p class='p-heading--five'>Low-level updates preserve the prior boot path.</p>
       <p>When you have to update the kernel or the operating system you want to know you can go back if needed. Ubuntu Core keeps the last working boot so you always have a safety net.</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fixed typo, raised in #4533 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]
