### PR TITLE
Remove takeovers to match the content tracker

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,8 +24,6 @@
 
 {% block takeover_content %}
   {% include "takeovers/_desktop-developer-takeover.html" %}
-  {% include "takeovers/_microk8s-takeover.html" %}
-  {% include "takeovers/_compliance-webinar.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}


### PR DESCRIPTION
## Done
Remove takeovers to match the [content tracker](https://docs.google.com/spreadsheets/d/1MaFd-ZHWpRVjIP9Sj_dOCIGOtl-GJYbrXewt5EG4m80/edit#gid=564832475)

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the takeovers match the [content tracker](https://docs.google.com/spreadsheets/d/1MaFd-ZHWpRVjIP9Sj_dOCIGOtl-GJYbrXewt5EG4m80/edit#gid=564832475)