### PR TITLE
Remove the IBM message on the homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -23,16 +23,6 @@
       </div>
     </section>
 
-    <section class="p-strip--accent is-shallow is-dark">
-      <div class="row">
-        <div class="col-12">
-          <p class="u-no-max-width p-heading--four u-no-margin--bottom u-vertically-center">
-            <img src="https://assets.ubuntu.com/v1/838316ab-cof-25x25.png" alt="" />&nbsp;&nbsp;
-            <a href="https://blog.ubuntu.com/2018/10/30/statement-on-ibm-acquisition-of-red-hat" class="p-link--inverted p-link--external">Statement on the IBM acquisition of Red Hat</a>
-        </div>
-      </div>
-    </section>
-
     <section class="p-strip is-deep is-bordered">
       {% include "shared/_insights_news_strip.html" with gtm_event_label="ubuntu.com homepage" %}
     </section>
@@ -140,7 +130,7 @@
       function getPrimaryParentLanguage() {
         /**
          * Get the primary parent language
-         * 
+         *
          * Get the user's default language, and if it's a sub-language,
          * infer the parent language - e.g. for "en-GB", infer "en"
          */
@@ -157,7 +147,7 @@
         /**
          * Choose a takeover
          * ===
-         * 
+         *
          * From the list of provided takeovers in the #takeovers template,
          * choose one (that matches the client's language), and replace the
          * base template with it.
@@ -186,7 +176,7 @@
           var selectedIndex = null;
 
           if (localStorage.getItem('selected_takeover_index') !== null) {
-            // If we previously chose a takeover, increment the number to show the next takeover 
+            // If we previously chose a takeover, increment the number to show the next takeover
             var nextIndex = parseInt(localStorage.getItem('selected_takeover_index')) + 1
             selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
           } else {


### PR DESCRIPTION
## Done
Remove the IBM message on the homepage

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to the homepage
- Check there is no IBM strip under the takeover.