### PR TITLE
Added microk8s takeover into rotation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
 #}
 
 {% block takeover_content %}
+  {% include "takeovers/_microk8s-takeover.html" %}
   {% include "takeovers/_desktop-developer-takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}


### PR DESCRIPTION
## Done

- Added microk8s takeover back into the rotation, following the newly updated[ spreadsheet](https://docs.google.com/spreadsheets/d/1MaFd-ZHWpRVjIP9Sj_dOCIGOtl-GJYbrXewt5EG4m80/edit#gid=564832475). 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the microk8s takeover alternates with the desktop developer takeover

