### PR TITLE
Add link to NPS notice on index page

### DIFF
--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -38,6 +38,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/webinar">Webinar privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/online-purchase">Online purchase privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/snap-store">Snap store privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/snapcraft-nps">Snapcraft NPS privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/contact">Contact us and enquiries privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/sso">Single sign on privacy notice&nbsp;&rsaquo;</a></li>
       </ul>


### PR DESCRIPTION
## Done

- Added a link to the Snapcraft NPS survey privacy notice

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/data-privacy](http://0.0.0.0:8001/legal/data-privacy)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit#)

## Issue / Card

Fixes #4555 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/51074518-fc38a200-1677-11e9-82f3-74723b766bbf.png)
