### PR TITLE
Fixed bad anchor link on /legal/ubuntu-advantage-service-description

### DIFF
--- a/templates/legal/shared/_appendix-support-scope_toc.html
+++ b/templates/legal/shared/_appendix-support-scope_toc.html
@@ -13,7 +13,7 @@
   <li class="p-nested-counter-list__item"><a href="#appendix-support-scope-livepatch">Canonical Livepatch Service&nbsp;&rsaquo;</a></li>
   <li class="p-nested-counter-list__item"><a href="#appendix-support-scope-fips">FIPS for Ubuntu&nbsp;&rsaquo;</a></li>
   <li class="p-nested-counter-list__item"><a href="#appendix-support-scope-landscape-seats">Landscape Seats&nbsp;&rsaquo;</a></li>
-  <li class="p-nested-counter-list__item"><a href="#tam">Technical Account Manager&nbsp;&rsaquo;</a></li>
+  <li class="p-nested-counter-list__item"><a href="#appendix-support-scope-tam">Technical Account Manager&nbsp;&rsaquo;</a></li>
   <li class="p-nested-counter-list__item"><a href="#appendix-support-scope-dedicated-tam">Dedicated Technical Account Manager&nbsp;&rsaquo;</a></li>
   <li class="p-nested-counter-list__item"><a href="#appendix-support-scope-dedicated-support-engineer">Dedicated Support Engineer&nbsp;&rsaquo;</a></li>
   <li class="p-nested-counter-list__item"><a href="#appendix-support-scope-landscape-on-premises">Landscape on Premises&nbsp;&rsaquo;</a></li>


### PR DESCRIPTION
## Done

- Fixed a bad internal link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/uasd#appendix-support-scope-tam](http://0.0.0.0:8001/legal/ubuntu-advantage-service-description#appendix-support-scope-tam)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the link to the Technical Account Manager works


## Issue / Card

Fixes #4547 

