### PR TITLE
Added noindex various thank you pages

### DIFF
--- a/templates/ai/thank-you.html
+++ b/templates/ai/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "ai/base_ai.html" %}
 
 {% block title %}Thank you | Artificial Intellegence{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1fLjt6qfj8p03d0wTZdN_yWbBcoi4umT2lGeiFT_c6NQ/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/kubernetes/thank-you.html
+++ b/templates/kubernetes/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
 {% block title %}Thank you | Kubernetes{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1rkHUgJ4WqEL9Eu7GFgikr5dtIRVYNDjl8YV-tU4irLg/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/legal/contributors/thank-you.html
+++ b/templates/legal/contributors/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Thank you for submitting your contributor licence agreement | Ubuntu and Canonical legal{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1hF6GE5Ui-OzrubtSgjTE5-es2Nu10U999lddwgu2ROA/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/openstack/newsletter-thank-you.html
+++ b/templates/openstack/newsletter-thank-you.html
@@ -1,6 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Thank you{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
 

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -1,6 +1,7 @@
 {% extends "support/base_support.html" %}
 
 {% block title %}Thank you | Support{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Vya-1Uq7bqJ7SFQ36j9-REp1iDT3rFENjYyCzuY02r4/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- added a **noindex** meta field to 5 thank-you pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- See that the following pages have the correct `{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}`
    - http://0.0.0.0:8001/ai/thank-you
    - http://0.0.0.0:8001/kubernetes/thank-you
    - http://0.0.0.0:8001/legal/contributors/thank-you
    - http://0.0.0.0:8001/support/thank-you.html
    - http://0.0.0.0:8001/openstack/newsletter-thank-you

## Issue / Card

Fixes #4523 	