### PR TITLE
Added border to tables and removed global nav links in print styles

### DIFF
--- a/static/sass/print.scss
+++ b/static/sass/print.scss
@@ -34,6 +34,13 @@ pre,
   page-break-inside: avoid;
 }
 
+
+th,
+td {
+    border-bottom: solid #333 !important;
+    border-width: 0 0 1px 0 !important;
+}
+
 h1,
 h2,
 h3,
@@ -81,6 +88,7 @@ footer,
 .p-navigation,
 .global-nav__dropdown-overlay,
 .global-nav,
+.global-nav__header-list,
 .dropdown-window,
 .dropdown-window-overlay,
 .p-navigation--secondary {


### PR DESCRIPTION
## Done

- cleaned up some print stylesheet bugs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/ubuntu-advantage-service-description](http://0.0.0.0:8001/legal/ubuntu-advantage-service-description)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the global nav heading links are hidden, the tables have border bottom, and the internal links also have a `< link >`

## Issue / Card

Fixes #4401 	

