### PR TITLE
Remove Mythbuntu  from download dropdown

### DIFF
--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -100,9 +100,6 @@
             <a class='p-link' href='http://lubuntu.me/'>Lubuntu</a>
           </li>
           <li class='p-list__item'>
-            <a class='p-link' href='http://www.mythbuntu.org/'>Mythbuntu</a>
-          </li>
-          <li class='p-list__item'>
             <a class='p-link' href='https://ubuntubudgie.org/'>Ubuntu Budgie</a>
           </li>
           <li class='p-list__item'>


### PR DESCRIPTION
## Done

- removed Mythbuntu  from the download megamenu
- updated the [copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/#download](http://0.0.0.0:8001/#download)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that Mythbuntu has been removed from the flavours

## Issue / Card

Fixes #4254

