### PR TITLE
Fix form validation on /legal/terms-and-policies/contact-us

### DIFF
--- a/templates/legal/terms-and-policies/contact-us.html
+++ b/templates/legal/terms-and-policies/contact-us.html
@@ -410,21 +410,17 @@
         // skip non-formassembly.com forms
         return;
       }
-      if (wFORMS && wFORMS.getBehaviorInstance) {
-        var _bs = wFORMS.getBehaviorInstance(f, 'switch');
-        var _bc = wFORMS.getBehaviorInstance(f, 'calculation');
-      }
       for (var fieldName in values) {
         var fld = f.elements[fieldName];
         if (fld) {
           if (fld.tagName) {
-            if ((fld.tagName == 'INPUT' && (fld.type == 'text' || fld.type == 'hidden' || fld.type == 'password')) ||
+            if ((fld.tagName == 'input' && (fld.type == 'text' || fld.type == 'hidden' || fld.type == 'password')) ||
               (fld.tagName == 'TEXTAREA'));
             fld.value = unescape(values[fieldName]);
-            if (fld.tagName == 'INPUT' && fld.type == 'checkbox') {
+            if (fld.tagName == 'input' && fld.type == 'checkbox') {
               fld.checked = values[fieldName] ? true : false;
             }
-            if (fld.tagName == 'SELECT') {
+            if (fld.tagName == 'select') {
               fld.value = values[fieldName];
             }
             if (_bs) { // trigger switch behavior if appropriate.


### PR DESCRIPTION
## Done

- fix form validation on /legal/terms-and-policies/contact-us

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/terms-and-policies/contact-us](http://0.0.0.0:8001/legal/terms-and-policies/contact-us)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that submitting the filled in form submits on the first click

## Issue / Card

Fixes #4184 

