### PR TITLE
Update KVM command line example to use core18 image

### DIFF
--- a/templates/download/iot/kvm.html
+++ b/templates/download/iot/kvm.html
@@ -84,7 +84,7 @@ KVM acceleration can be used</code></pre>
           </h3>
           <div class="p-list-step__content">
             <p>You can now launch a virtual machine with KVM, using the following command:</p>
-            <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-16-amd64.img,format=raw</code></pre>
+            <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-18-amd64.img,format=raw</code></pre>
             <p>
               Note: this command sets up port redirections:
               <ul>


### PR DESCRIPTION
Trivial fix in the kvm command line to use `ubuntu-core-18-amd64.img` from previous steps instead of `ubuntu-core-16-amd64.img`.