### PR TITLE
Revamp the robotics features sections to replace the matrix

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -79,33 +79,33 @@
 </div>
 
 <div class="p-strip--light is-deep is-bordered">
-  <div class="row">
-    <ul class="p-matrix is-split u-clearfix">
-      <li class="p-matrix__item" style="padding-left: 1rem;">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Robots that can think</h3>
-          <p class="p-matrix__desc">ROS (Robotic Operating System) is built on Ubuntu. With computer vision, AI libraries and a wide choice of sensors supported, it&rsquo;s the most popular development environment for autonomous machines from drones to self-driving cars.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">From prototype to production</h3>
-          <p class="p-matrix__desc">Commercialise your robotics projects with Ubuntu, taking machines to market with snaps for updates and security. Regular and reliable upgrades a fail-safe update mechanism improve your robots in the field.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Industry-leading security</h3>
-          <p class="p-matrix__desc">Ubuntu Core delivers application confinement, restricted file access and read-only applications, to ensure the integrity of the software running your robots. The result is security by design, from the drivers on your board to the apps that define your robot behaviours.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item" style="padding-left: 1rem;">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">New business models</h3>
-          <p class="p-matrix__desc">Offer an appstore for your drones and robots and you can generate revenue from updates, add-on functionality, support services or complete reconfigurations.</p>
-        </div>
-      </li>
-    </ul>
+  <div class="row u-equal-height">
+    <article class="col-6 p-card">
+      <header class="p-card__header">
+        <h3 class="p-card__image p-heading--four">Robots that can think</h3>
+      </header>
+      <p>ROS (Robotic Operating System) is built on Ubuntu. With computer vision, AI libraries and a wide choice of sensors supported, it&rsquo;s the most popular development environment for autonomous machines from drones to self-driving cars.</p>
+    </article>
+    <article class="col-6 p-card">
+      <header class="p-card__header">
+        <h3 class="p-card__image p-heading--four">From prototype to production</h3>
+      </header>
+      <p>Commercialise your robotics projects with Ubuntu, taking machines to market with snaps for updates and security. Regular and reliable upgrades a fail-safe update mechanism improve your robots in the field.</p>
+    </article>
+  </div>
+  <div class="row u-equal-height">
+    <article class="col-6 p-card u-no-margin--bottom">
+      <header class="p-card__header">
+        <h3 class="p-card__image p-heading--four">Industry-leading security</h3>
+      </header>
+      <p>Ubuntu Core delivers application confinement, restricted file access and read-only applications, to ensure the integrity of the software running your robots. The result is security by design, from the drivers on your board to the apps that define your robot behaviours.</p>
+    </article>
+    <article class="col-6 p-card u-no-margin--bottom">
+      <header class="p-card__header">
+        <h3 class="p-card__image p-heading--four">New business models</h3>
+      </header>
+      <p>Offer an appstore for your drones and robots and you can generate revenue from updates, add-on functionality, support services or complete reconfigurations.</p>
+    </article>
   </div>
 </div>
 


### PR DESCRIPTION
## Done
Replaced the matrix pattern with a card pattern which is used on openstack/features.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /internet-of-things/robotics
- Check the features section uses cards not matrix
