### PR TITLE
Build the brand store takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,6 @@
 
 {% block takeover_content %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
-  {% include "takeovers/_desktop-developer-takeover.html" %}
   {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,7 @@
 {% block takeover_content %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
   {% include "takeovers/_desktop-developer-takeover.html" %}
+  {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}

--- a/templates/takeovers/_snapcraft-brand-store_takeover.html
+++ b/templates/takeovers/_snapcraft-brand-store_takeover.html
@@ -2,8 +2,8 @@
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="row u-equal-height">
       <div class="col-7">
-        <h1>An introduction to brand stores</h1>
-        <p class="p-heading--four">Control what is offered to your customers and avoid timely and expensive custom builds with Canonicals brand store offering.</p>
+        <h1>An introduction to app stores</h1>
+        <p class="p-heading--four">Learn how to avoid costly custom builds and manage your customers' software using a Brand store - powered by Canonical</p>
         <p class="u-hide--small">
           <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
             <span class="p-link--external">Register for the webinar</span>

--- a/templates/takeovers/_snapcraft-brand-store_takeover.html
+++ b/templates/takeovers/_snapcraft-brand-store_takeover.html
@@ -1,0 +1,58 @@
+<section class="js-takeover p-takeover">
+  <div class="p-strip--image is-dark is-deep p-takeover__suru">
+    <div class="row u-equal-height">
+      <div class="col-7">
+        <h1>An introduction to brand stores</h1>
+        <p class="p-heading--four">Control what is offered to your customers and avoid timely and expensive custom builds with Canonicals brand store offering.</p>
+        <p class="u-hide--small">
+          <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
+            <span class="p-link--external">Register for the webinar</span>
+          </a>
+        </p>
+      </div>
+      <div class="col-5">
+        <div class="u-align--center u-sv3 u-vertically-center">
+          <img src="https://assets.ubuntu.com/v1/44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
+        </div>
+        <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+          <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral">
+            <span class="p-link--external">Register for the webinar</span>
+          </a>
+        </p>
+      </div>
+    </div>
+
+    <style>
+      .p-takeover {
+        background-blend-mode: color;
+        background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
+        background-color: #2D6162;
+      }
+      @media only screen and (min-width: 768px) {
+        .p-takeover__suru {
+          background-image: url('https://assets.ubuntu.com/v1/9a0310e3-suru-right-snapstore.svg');
+          background-position: top right;
+          background-size: auto 100%;
+        }
+      }
+
+      .p-takeover .p-takeover__image {
+        height: 229px;
+        width: 200px;
+      }
+
+      @media only screen and (max-width: 768px) {
+        .p-takeover .p-takeover__image {
+          height: 180px;
+          width: 157px;
+        }
+      }
+
+      @media only screen and (min-width: 460px) and (max-width: 896px)  {
+        .p-takeover .u-align--center {
+          text-align: left !important;
+        }
+      }
+    </style>
+  </div>
+</section>

--- a/templates/takeovers/_snapcraft-brand-store_takeover.html
+++ b/templates/takeovers/_snapcraft-brand-store_takeover.html
@@ -12,7 +12,7 @@
       </div>
       <div class="col-5">
         <div class="u-align--center u-sv3 u-vertically-center">
-          <img src="https://assets.ubuntu.com/v1/44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
+          <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
         </div>
         <p class="u-no-margin--bottom u-hide--large u-hide--medium">
           <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral">
@@ -30,7 +30,7 @@
       }
       @media only screen and (min-width: 768px) {
         .p-takeover__suru {
-          background-image: url('https://assets.ubuntu.com/v1/9a0310e3-suru-right-snapstore.svg');
+          background-image: url('{{ ASSET_SERVER_URL }}9a0310e3-suru-right-snapstore.svg');
           background-position: top right;
           background-size: auto 100%;
         }


### PR DESCRIPTION
## Done
Built the "Brand store" takeover

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh the homepage until you see the brand store page
- Check it matches [the design](https://github.com/ubuntudesign/www.ubuntu.com-design/issues/174#issuecomment-453536750)
- Check the [copy is correct](https://docs.google.com/document/d/1P9iXXka1qGS1D_n14CiraIzIE-NDmMXMxQyM8v4A0T0/edit#)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4550
