### PR TITLE
Launch the core 18 takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
 #}
 
 {% block takeover_content %}
-  {% include "takeovers/_microk8s-takeover.html" %}
+  {% include "takeovers/_ubuntu-core-18-takeover.html" %}
   {% include "takeovers/_desktop-developer-takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}


### PR DESCRIPTION
## Done
Launch the core 18 takeover

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to the homepage
- Check the mircok8s takeover has been replaced by the core 18 takeover
- Check links work

## Issue / Card
Fixes https://github.com/ubuntudesign/web-squad/issues/935
