### PR TITLE
Update CDK release notes for CVE

### DIFF
--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,6 +13,19 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# CVE-2018-18264 - January 10, 2019
+
+## What happened
+
+- A security vulnerability was found in the Kubernetes dashboard that affected all
+versions of the dashboard.
+
+A new dashboard version, v1.10.1, was released to address this vulnerability. This
+includes an important change to logging in to the dashboard. The Skip button is now
+missing from the login page and a user and password is now required. The easiest way
+to log in to the dashboard is to select your ~/.kube/config file and use credentials
+from there.
+
 # 1.13 Release Notes
 
 ## What's new


### PR DESCRIPTION
## Done

Updates the release notes page for kubernetes docs to include recent

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/kubernetes/docs/release-notes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the text includes the CVE release notes

