### PR TITLE
Add a badge to display the Django version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # www.ubuntu.com codebase
 
-[![CircleCI build status](https://circleci.com/gh/canonical-websites/www.ubuntu.com.svg?style=shield)](https://circleci.com/gh/canonical-websites/www.ubuntu.com)
+[![CircleCI build status](https://circleci.com/gh/canonical-websites/www.ubuntu.com.svg?style=shield)](https://circleci.com/gh/canonical-websites/www.ubuntu.com) [![Django version](https://img.shields.io/badge/endpoint.svg?url=https%3A%2F%2Fdjango-from-requirements-txt-54rf3n1zxedi.runkit.sh%2F%3Fwebsite%3Dwww.ubuntu.com)](https://www.djangoproject.com/)
 
 This is the codebase and content for [www.ubuntu.com](https://www.ubuntu.com), a simple databaseless informational website project based on [Django](https://www.djangoproject.com/).
 


### PR DESCRIPTION
This is kinda a proof of concept. I created a JS API endpoint using Runkit for this badge:
https://runkit.com/docs/endpoint

But I think we should merge it for now and see how we get on.

QA
--

Go to [my new README.md](https://github.com/canonical-websites/www.ubuntu.com/blob/251b4933c42f64ea8579eb5784a0d6c28b527897/README.md) and see the Django version badge.