### PR TITLE
Ubuntu Core: Remove caveat for older RPi kernel

### DIFF
--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -49,7 +49,13 @@
           <div class="p-list-step__content">
             <p>Get the correct Ubuntu Core image for your board:</p>
             <ul class="u-no-margin--left">
+<<<<<<< HEAD
               <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
+=======
+              <li>Raspberry Pi 2 • <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Download Ubuntu Core 18 image</a>.
+              </li>
+              <li>Raspberry Pi 3 • <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Download Ubuntu Core 18 image</a>.
+>>>>>>> added period/fullstop for consistency with other bullets.
               </li>
               <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
               <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -49,9 +49,9 @@
           <div class="p-list-step__content">
             <p>Get the correct Ubuntu Core image for your board:</p>
             <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2</a>
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
               </li>
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3</a></li>
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
               <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
               </li>
             </ul>

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -49,13 +49,7 @@
           <div class="p-list-step__content">
             <p>Get the correct Ubuntu Core image for your board:</p>
             <ul class="u-no-margin--left">
-<<<<<<< HEAD
               <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
-=======
-              <li>Raspberry Pi 2 • <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Download Ubuntu Core 18 image</a>.
-              </li>
-              <li>Raspberry Pi 3 • <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Download Ubuntu Core 18 image</a>.
->>>>>>> added period/fullstop for consistency with other bullets.
               </li>
               <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
               <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.


### PR DESCRIPTION
## Done

- removed caveat for older RPi kernel on https://www.ubuntu.com/download/iot/raspberry-pi-2-3
- added period/fullstop for consistency with other bullets.

## QA

- Check out this feature branch 
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)

## Issue / Card

Fixes #4577 

## Screenshots

![screenshot_20190122_185159](https://user-images.githubusercontent.com/7047542/51558206-cd3fde80-1e76-11e9-8220-c9ac826ee2fe.png)

