### PR TITLE
Update raspberry pi download instructions

### DIFF
--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -49,10 +49,9 @@
           <div class="p-list-step__content">
             <p>Get the correct Ubuntu Core image for your board:</p>
             <ul class="u-no-margin--left">
-              <li>Raspberry Pi 2 • <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Download Ubuntu Core 18 image</a>
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2</a>
               </li>
-              <li>Raspberry Pi 3 • <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Download Ubuntu Core 18 image</a> - the older kernel shipped with this image can trigger Wi-Fi issues during first boot, a network cable is recommended.
-              </li>
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3</a></li>
               <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
               </li>
             </ul>


### PR DESCRIPTION
## Done

- Updated the pi 2 & 3 instructions

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot/raspberry-pi-2-3](http://0.0.0.0:8001/download/iot/raspberry-pi-2-3)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the instructions match the [copy doc](https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit?ts=5c41bf64#) and the links work

## Issue / Card

Fixes #4577
