### PR TITLE
Enable renovate with standard config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "config:base",
+    "schedule:weekends"
+  ],
+  "packageRules": [
+    {
+      "depTypeList": ["devDependencies"],
+      "extends": [":automergeMinor"]
+    },
+    {
+      "packagePatterns": ["*"],
+      "minor": {
+        "groupName": "all non-major dependencies",
+        "groupSlug": "all-minor-patch"
+      }
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,9 @@
         "groupSlug": "all-minor-patch"
       }
     }
-  ]
+  ],
+  "compatibility": {
+    "python": "2.7"
+  }
 }
+


### PR DESCRIPTION
In this case we also add:

``` yaml
"compatibility": {
  "python": "2.7"
}
```

Because, while www.ubuntu.com is still hosted on the old wendigo infrastructure, we are stuck with Python 2.7.

This should specifically impact Django - we can't use Django 2 because it only works with Python 3. So with this constraint, Renovate shouldn't try to upgrade to Django 2.

This constraint should be removed once we move to Kubernetes (and we should then upgrade to Django 2).