### PR TITLE
Build the broadsign-arrow takeover

### DIFF
--- a/templates/takeovers/_broadsign-arrow_takeover.html
+++ b/templates/takeovers/_broadsign-arrow_takeover.html
@@ -1,0 +1,48 @@
+<section class="p-strip--image is-deep js-takeover p-takeover--broadsign u-image-position">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h1>Digital signage and smart displays</h1>
+      <p class="p-heading--four">Secure, reliable and remotely upgradable. Learn how Ubuntu is powering new age advertising.</p>
+      <p class="u-hide--small u-no-margin--bottom">
+        <a href="https://www.brighttalk.com/webcast/6793/346565?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_Digital Signage" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
+      </p>
+    </div>
+    <div class="col-6 prefix-2">
+      <p>
+        <img src="{{ ASSET_SERVER_URL }}3f59dacd-logos-lines-takeover-digital-signage.svg" class="u-image-position--top u-hide--small" alt="" />
+        <img src="{{ ASSET_SERVER_URL }}96f63d61-logos-takeover-digital-signage.svg" class="u-hide--large u-hide--medium" alt="" />
+      </p>
+      <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+        <a href="https://www.brighttalk.com/webcast/6793/346565?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_Digital Signage" class="p-button--positive">Register for the webinar</a>
+      </p>
+    </div>
+  </div>
+
+  <style>
+    .p-takeover--broadsign {
+      background-color: #DEDEDE;
+      background-image: linear-gradient(64deg, #DEDEDE 0%, #FFFFFF 100%);
+      background-repeat: no-repeat;
+      background-size: inherit;
+    }
+
+    @media only screen and (min-width: 876px) {
+      .p-takeover--broadsign {
+        background-image:
+          url('{{ ASSET_SERVER_URL }}621965fa-left-lines.svg'),
+          linear-gradient(64deg, #DEDEDE 0%, #FFFFFF 100%);
+        background-position: left 50%;
+      }
+    }
+
+    @media only screen and (min-width: 1300px) {
+      .p-takeover--broadsign {
+        background-image:
+          url('{{ ASSET_SERVER_URL }}621965fa-left-lines.svg'),
+          url('{{ ASSET_SERVER_URL }}3f540239-right-lines.svg'),
+          linear-gradient(64deg, #DEDEDE 0%, #FFFFFF 100%);
+        background-position: left 50%, right 75%;
+      }
+    }
+    </style>
+</section>

--- a/templates/takeovers/_broadsign-arrow_takeover.html
+++ b/templates/takeovers/_broadsign-arrow_takeover.html
@@ -1,7 +1,7 @@
-<section class="p-strip--image is-deep js-takeover p-takeover--broadsign u-image-position">
+<section class="p-strip--image is-deep js-takeover p-takeover u-image-position">
   <div class="row u-equal-height">
     <div class="col-6">
-      <h1>Digital signage and smart displays</h1>
+      <h1>Digital signage and smart displays on Ubuntu</h1>
       <p class="p-heading--four">Secure, reliable and remotely upgradable. Learn how Ubuntu is powering new age advertising.</p>
       <p class="u-hide--small u-no-margin--bottom">
         <a href="https://www.brighttalk.com/webcast/6793/346565?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_Digital Signage" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
@@ -9,8 +9,10 @@
     </div>
     <div class="col-6 prefix-2">
       <p>
-        <img src="{{ ASSET_SERVER_URL }}3f59dacd-logos-lines-takeover-digital-signage.svg" class="u-image-position--top u-hide--small" alt="" />
-        <img src="{{ ASSET_SERVER_URL }}96f63d61-logos-takeover-digital-signage.svg" class="u-hide--large u-hide--medium" alt="" />
+        <img src="{{ ASSET_SERVER_URL }}3f59dacd-logos-lines-takeover-digital-signage.svg" class="u-image-position--top u-hide--small" alt="Core, Arrow and Broadsign logos" />
+        <div class="u-align--center u-hide--large u-hide--medium u-sv3">
+          <img src="{{ ASSET_SERVER_URL }}96f63d61-logos-takeover-digital-signage.svg" alt="Core, Arrow and Broadsign logos" />
+        </div>
       </p>
       <p class="u-no-margin--bottom u-hide--large u-hide--medium">
         <a href="https://www.brighttalk.com/webcast/6793/346565?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_Digital Signage" class="p-button--positive">Register for the webinar</a>
@@ -19,7 +21,7 @@
   </div>
 
   <style>
-    .p-takeover--broadsign {
+    .p-takeover {
       background-color: #DEDEDE;
       background-image: linear-gradient(64deg, #DEDEDE 0%, #FFFFFF 100%);
       background-repeat: no-repeat;
@@ -27,7 +29,7 @@
     }
 
     @media only screen and (min-width: 876px) {
-      .p-takeover--broadsign {
+      .p-takeover {
         background-image:
           url('{{ ASSET_SERVER_URL }}621965fa-left-lines.svg'),
           linear-gradient(64deg, #DEDEDE 0%, #FFFFFF 100%);
@@ -36,7 +38,7 @@
     }
 
     @media only screen and (min-width: 1300px) {
-      .p-takeover--broadsign {
+      .p-takeover {
         background-image:
           url('{{ ASSET_SERVER_URL }}621965fa-left-lines.svg'),
           url('{{ ASSET_SERVER_URL }}3f540239-right-lines.svg'),
@@ -44,5 +46,11 @@
         background-position: left 50%, right 75%;
       }
     }
-    </style>
+
+    @media only screen and (min-width: 460px) and (max-width: 896px)  {
+      .p-takeover .u-align--center {
+        text-align: left !important;
+      }
+    }
+  </style>
 </section>


### PR DESCRIPTION
## Done
Build the broadsign-arrow takeover

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Open `index` and add the new takeover to the list
- Refresh the page and check it matches [the design](https://github.com/ubuntudesign/www.ubuntu.com-design/issues/175#issuecomment-454362813)
- Check it matches the [copy doc](https://docs.google.com/document/d/1SdsdEujcUMGsVyguCRaJhxvyQxSEGgOXq8xLEs0DM9c/edit)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4552