### PR TITLE
Remove the brand store takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,6 @@
 
 {% block takeover_content %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
-  {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}


### PR DESCRIPTION
Marketing had requested we temporarily take down the brand store takeover.
