### PR TITLE
Add Kubernetes to release cycle page

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -179,7 +179,7 @@ function formatKeyLabel(key) {
   var formattedKey = keyLowerCase.charAt(0).toUpperCase() + keyLowerCase.substr(1);
   formattedKey = formattedKey.replace(' lts ', ' LTS ');
   formattedKey = formattedKey.replace(' openstack ', ' OpenStack ');
-
+  formattedKey = formattedKey.replace('Cdk ', 'CDK ');
   return formattedKey;
 }
 

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -385,6 +385,64 @@ var openStackReleases = [
   },
 ];
 
+var kubernetesReleases = [
+  {
+    startDate: new Date('2016-12-12T00:00:00'),
+    endDate: new Date('2017-09-28T00:00:00'),
+    taskName: 'Kubernetes 1.5',
+    status: 'CDK_EXPIRED_SUPPORT'
+  },
+
+  {
+    startDate: new Date('2017-03-28T00:00:00'),
+    endDate: new Date('2017-12-15T00:00:00'),
+    taskName: 'Kubernetes 1.6',
+    status: 'CDK_EXPIRED_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-06-30T00:00:00'),
+    endDate: new Date('2018-03-28T00:00:00'),
+    taskName: 'Kubernetes 1.7',
+    status: 'CDK_EXPIRED_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-09-28T00:00:00'),
+    endDate: new Date('2018-07-03T00:00:00'),
+    taskName: 'Kubernetes 1.8',
+    status: 'CDK_EXPIRED_SUPPORT'
+  },
+  {
+    startDate: new Date('2017-12-15T00:00:00'),
+    endDate: new Date('2018-09-25T00:00:00'),
+    taskName: 'Kubernetes 1.9',
+    status: 'CDK_EXPIRED_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-03-28T00:00:00'),
+    endDate: new Date('2018-12-18T00:00:00'),
+    taskName: 'Kubernetes 1.10',
+    status: 'CDK_EXPIRED_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-07-03T00:00:00'),
+    endDate: new Date('2019-03-25T00:00:00'),
+    taskName: 'Kubernetes 1.11',
+    status: 'CDK_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-09-25T00:00:00'),
+    endDate: new Date('2019-06-18T00:00:00'),
+    taskName: 'Kubernetes 1.12',
+    status: 'CDK_SUPPORT'
+  },
+  {
+    startDate: new Date('2018-12-18T00:00:00'),
+    endDate: new Date('2019-09-18T00:00:00'),
+    taskName: 'Kubernetes 1.13',
+    status: 'CDK_SUPPORT'
+  },
+];
+
 var desktopServerStatus = {
   HARDWARE_AND_MAINTENANCE_UPDATES: 'chart__bar--orange',
   MAINTENANCE_UPDATES: 'chart__bar--orange-light',
@@ -402,6 +460,11 @@ var openStackStatus = {
   UBUNTU_LTS_RELEASE_SUPPORT: 'chart__bar--orange',
   MATCHING_OPENSTACK_RELEASE_SUPPORT: 'chart__bar--grey',
   EXTENDED_SUPPORT_FOR_CUSTOMERS: 'chart__bar--aubergine'
+};
+
+var kubernetesStatus = {
+  CDK_SUPPORT: 'chart__bar--orange',
+  CDK_EXPIRED_SUPPORT: 'chart__bar--grey',
 };
 
 var desktopServerReleaseNames = [
@@ -461,4 +524,16 @@ var openStackReleaseNames = [
   'OpenStack Icehouse LTS',
   'Ubuntu 14.04 LTS',
   'OpenStack Icehouse'
+];
+
+var kubernetesReleaseNames = [
+  'Kubernetes 1.5',
+  'Kubernetes 1.6',
+  'Kubernetes 1.7',
+  'Kubernetes 1.8',
+  'Kubernetes 1.9',
+  'Kubernetes 1.10',
+  'Kubernetes 1.11',
+  'Kubernetes 1.12',
+  'Kubernetes 1.13'
 ];

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -402,7 +402,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light  is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>Ubuntu OpenStack release cycle</h2>
@@ -590,6 +590,84 @@
   </div>
 </section>
 
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Charmed Distribution of Kubernetes<sup>&reg;</sup> release cycle</h2>
+      <p>The release cycle of the Charmed Distribution of Kubernetes (CDK) is tightly
+         synchronised to the release of upstream Kubernetes<sup>&reg;</sup>.
+         The current release and two prior releases are supported, giving an effective
+         support period of nine months, subject to changes in the upstream release
+         cycle.</p>
+      <p>The CDK support lifecycle can be represented this way:</p>
+    </div>
+
+    <div class="row">
+      <div class="col-10" style="overflow: auto;">
+        <div class="u-hide--small" id="kubernetes-eol"></div>
+        <table class="u-hide--medium u-hide--large" style="width: auto;">
+          <thead>
+            <tr>
+              <th>Release</th>
+              <th>Released</th>
+              <th>End of life</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Kubernetes 1.5</td>
+              <td>December 2016</td>
+              <td>September 2017</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.6</td>
+              <td>March 2017</td>
+              <td>December 2017</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.7</td>
+              <td>June 2017</td>
+              <td>March 2018</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.8</td>
+              <td>September 2017</td>
+              <td>July 2018</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.9</td>
+              <td>December 2017</td>
+              <td>September 2018</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.10</td>
+              <td>March 2018</td>
+              <td>December 2018</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.11</td>
+              <td>July 2018</td>
+              <td>March 2019</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.12</td>
+              <td>September 2018</td>
+              <td>July 2019</td>
+            </tr>
+            <tr>
+              <td>Kubernetes 1.13</td>
+              <td>December 2018</td>
+              <td>September 2019</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="row">
+      <p>For more information on previous and current releases of CDK, please see the <a href="https://www.ubuntu.com/kubernetes/docs/release-notes" class="p-link--external ">CDK release notes</a>.</p>
+    </div>
+  </section>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
 <script src="{% versioned_static 'js/chartData.js' %}"></script>
 <script src="{% versioned_static 'js/chart.js' %}"></script>
@@ -611,12 +689,14 @@ function buildCharts() {
   createChart('#server-desktop-eol', desktopServerReleaseNames, desktopServerStatus, serverAndDesktopReleases);
   createChart('#kernel-eol', kernelReleaseNames, kernelStatus, kernelReleases);
   createChart('#openstack-eol', openStackReleaseNames, openStackStatus, openStackReleases);
+  createChart('#kubernetes-eol', kubernetesReleaseNames, kubernetesStatus, kubernetesReleases);
 }
 
 function clearCharts() {
   document.querySelector('#server-desktop-eol').innerHTML = '';
   document.querySelector('#kernel-eol').innerHTML = '';
   document.querySelector('#openstack-eol').innerHTML = '';
+  document.querySelector('#kubernetes-eol').innerHTML = '';
 }
 
 var mediumBreakpoint = 768;

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -664,7 +664,7 @@
       </div>
     </div>
     <div class="row">
-      <p>For more information on previous and current releases of CDK, please see the <a href="https://www.ubuntu.com/kubernetes/docs/release-notes" class="p-link--external ">CDK release notes</a>.</p>
+      <p>For more information on previous and current releases of CDK, please see the <a href="/kubernetes/docs/release-notes">CDK release notes</a>.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Done

Added text and table to the release-cycle page to detail CDK releases
Added Chart data for above to the chart data js file
Tweaked the chart script to use correct label

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/about/release-cycle](http://0.0.0.0:8001/about/release-cycle)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the Kubernetes section and chart is displayed

![cdk3](https://user-images.githubusercontent.com/115290/51738422-11a1c900-2087-11e9-960a-316314193c49.png)
