### PR TITLE
Fix class typo

### DIFF
--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col=10" style="overflow: auto;">
+  <div class="col-10" style="overflow: auto;">
     <table class="p-table" style="width: auto;">
       <thead>
         <tr>


### PR DESCRIPTION
## Done

Changed "col=10" to "col-10" on desktop pricing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/support/plans-and-pricing](http://0.0.0.0:8001/support/plans-and-pricing)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the table renders properly - especially the desktop pricing table