### PR TITLE
Enable the brand store takeover

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -11,7 +11,7 @@
     <div class="row u-equal-height">
       <div class="col-8">
         <h1>An introduction to IoT app stores</h1>
-        <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio</p>
+        <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio.</p>
         <p class="u-hide--small">
           <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
             <span class="p-link--external">Register for the webinar</span>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -6,18 +6,63 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--image p-banner-core-hero is-deep is-dark">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h1>Build secure IoT devices with Ubuntu Core</h1>
-      <!-- small screen version -->
-      <img class="u-visible--small u-hide--medium u-hide--large" src="{{ ASSET_SERVER_URL }}7b563def-core_white-orange_st_hex.svg" width="150" alt="" style="margin: 4rem 0;"/>
-      <h4>Everything you love about Ubuntu, locked down for security. Helping you make safer things - because we’re all connected.</h4>
+<section class="p-takeover">
+  <div class="p-strip--image is-dark is-deep p-takeover__suru">
+    <div class="row u-equal-height">
+      <div class="col-8">
+        <h1>An introduction to IoT app stores</h1>
+        <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio</p>
+        <p class="u-hide--small">
+          <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
+            <span class="p-link--external">Register for the webinar</span>
+          </a>
+        </p>
+      </div>
+      <div class="col-4">
+        <div class="u-align--center u-sv3 u-vertically-center">
+          <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
+        </div>
+        <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+          <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral">
+            <span class="p-link--external">Register for the webinar</span>
+          </a>
+        </p>
+      </div>
     </div>
-    <div class="col-5 u-align--center u-hide--small u-vertically-center">
-      <!-- medium and large screen version -->
-      <img src="{{ ASSET_SERVER_URL }}7b563def-core_white-orange_st_hex.svg" width="156" alt="" />
-    </div>
+
+    <style>
+      .p-takeover {
+        background-blend-mode: color;
+        background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
+        background-color: #2D6162;
+      }
+
+      @media only screen and (min-width: 768px) {
+        .p-takeover__suru {
+          background-image: url('{{ ASSET_SERVER_URL }}9a0310e3-suru-right-snapstore.svg');
+          background-position: top right;
+          background-size: auto 100%;
+        }
+      }
+
+      .p-takeover .p-takeover__image {
+        height: 229px;
+        width: 200px;
+      }
+
+      @media only screen and (max-width: 768px) {
+        .p-takeover .p-takeover__image {
+          height: 180px;
+          width: 157px;
+        }
+      }
+
+      @media only screen and (min-width: 460px) and (max-width: 896px)  {
+        .p-takeover .u-align--center {
+          text-align: left !important;
+        }
+      }
+    </style>
   </div>
 </section>
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -6,65 +6,8 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-takeover">
-  <div class="p-strip--image is-dark is-deep p-takeover__suru">
-    <div class="row u-equal-height">
-      <div class="col-8">
-        <h1>An introduction to IoT app stores</h1>
-        <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio.</p>
-        <p class="u-hide--small">
-          <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
-            <span class="p-link--external">Register for the webinar</span>
-          </a>
-        </p>
-      </div>
-      <div class="col-4">
-        <div class="u-align--center u-sv3 u-vertically-center">
-          <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
-        </div>
-        <p class="u-no-margin--bottom u-hide--large u-hide--medium">
-          <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral">
-            <span class="p-link--external">Register for the webinar</span>
-          </a>
-        </p>
-      </div>
-    </div>
 
-    <style>
-      .p-takeover {
-        background-blend-mode: color;
-        background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
-        background-color: #2D6162;
-      }
-
-      @media only screen and (min-width: 768px) {
-        .p-takeover__suru {
-          background-image: url('{{ ASSET_SERVER_URL }}9a0310e3-suru-right-snapstore.svg');
-          background-position: top right;
-          background-size: auto 100%;
-        }
-      }
-
-      .p-takeover .p-takeover__image {
-        height: 229px;
-        width: 200px;
-      }
-
-      @media only screen and (max-width: 768px) {
-        .p-takeover .p-takeover__image {
-          height: 180px;
-          width: 157px;
-        }
-      }
-
-      @media only screen and (min-width: 460px) and (max-width: 896px)  {
-        .p-takeover .u-align--center {
-          text-align: left !important;
-        }
-      }
-    </style>
-  </div>
-</section>
+{% include "takeovers/_snapcraft-brand-store_takeover.html" %}
 
 <nav class="p-tabs p-sticky-nav">
   <ul class="p-tabs__list" role="tablist">

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
 
 {% block takeover_content %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
+  {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}

--- a/templates/takeovers/_snapcraft-brand-store_takeover.html
+++ b/templates/takeovers/_snapcraft-brand-store_takeover.html
@@ -1,16 +1,16 @@
 <section class="js-takeover p-takeover">
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="row u-equal-height">
-      <div class="col-7">
-        <h1>An introduction to app stores</h1>
-        <p class="p-heading--four">Learn how to avoid costly custom builds and manage your customers' software using a Brand store - powered by Canonical</p>
+      <div class="col-8">
+        <h1>An introduction to IoT app stores</h1>
+        <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio</p>
         <p class="u-hide--small">
           <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
             <span class="p-link--external">Register for the webinar</span>
           </a>
         </p>
       </div>
-      <div class="col-5">
+      <div class="col-4">
         <div class="u-align--center u-sv3 u-vertically-center">
           <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
         </div>
@@ -28,6 +28,7 @@
         background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
         background-color: #2D6162;
       }
+
       @media only screen and (min-width: 768px) {
         .p-takeover__suru {
           background-image: url('{{ ASSET_SERVER_URL }}9a0310e3-suru-right-snapstore.svg');

--- a/templates/takeovers/_snapcraft-brand-store_takeover.html
+++ b/templates/takeovers/_snapcraft-brand-store_takeover.html
@@ -3,7 +3,7 @@
     <div class="row u-equal-height">
       <div class="col-8">
         <h1>An introduction to IoT app stores</h1>
-        <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio</p>
+        <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio.</p>
         <p class="u-hide--small">
           <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
             <span class="p-link--external">Register for the webinar</span>


### PR DESCRIPTION
## Done
Enable the brand store takeover and adding it to the /core page.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check out the brand store takeover on the homepage
- Go to /core
- See the same takeover
