### PR TITLE
Create general dynamic form

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint-scss": "sass-lint 'static/sass/**/*.scss' --verbose --no-exit -i static/sass/prism.scss",
     "test-py": "python3 manage.py test",
     "test-links": "python3 manage.py runserver && sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --no-warnings http://127.0.0.1:8000",
-    "build": "cp node_modules/global-nav/dist/index.js static/js/global-nav.js && node-sass --include-path node_modules static/sass --source-map true --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --map false --use cssnano --dir static/minified 'static/css/**/*.css'",
+    "build": "cp node_modules/global-nav/dist/index.js static/js/global-nav.js && node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css'",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'node_modules/vanilla-framework/scss/*.scss' -c 'yarn run build'",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "serve": "./entrypoint 0.0.0.0:${PORT}"
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "autoprefixer": "^6.3.1",
-    "cssnano": "^3.10.0",
     "global-nav": "^1.2.1",
     "husky": "^1.1.1",
     "lint-staged": "^7.3.0",

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -39,6 +39,15 @@
     });
   }
 
+  if (contactModal) {
+    contactModal.addEventListener('click', function(e) {
+      if (e.target.id == 'contact-modal') {
+        e.preventDefault();
+        close();
+      }
+    });
+  }
+
   otherContainers.forEach(function(otherContainer) {
     var checkbox = otherContainer.querySelector('.js-other-container__checkbox');
     var input = otherContainer.querySelector('.js-other-container__input');

--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -1,0 +1,47 @@
+
+@mixin ubuntu-p-contact-modal {
+  #contact-modal { // sass-lint:disable-line no-ids
+    &.p-modal {
+      align-items: start;
+      position: fixed;
+      z-index: 100;
+
+      input[type="checkbox"] + label {
+        margin-bottom: 0;
+      }
+
+      .p-modal__dialog {
+        margin-bottom: 0;
+
+        @media (min-width: $breakpoint-medium + 100px) {
+          max-width: $breakpoint-medium;
+          min-width: $breakpoint-medium;
+        }
+      }
+
+      .p-modal__header {
+        border-bottom: 1px solid $color-mid-light;
+        margin-bottom: $spv-intra--expanded;
+      }
+
+      .p-modal__title {
+        margin-bottom: $spv-intra;
+      }
+
+      &.thank-you {
+        .p-modal__title {
+          opacity: 0;
+        }
+
+        .p-modal__header {
+          border-bottom: 0;
+        }
+      }
+
+      .pagination__link--next,
+      .pagination__link--previous {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -38,9 +38,11 @@
         }
       }
 
-      .pagination__link--next,
-      .pagination__link--previous {
-        margin-bottom: 0;
+      @media only screen and (min-width: $breakpoint-medium) {
+        .pagination__link--next,
+        .pagination__link--previous {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -34,6 +34,7 @@
 @import "pattern_grid";
 @import "pattern_desktop-statistics";
 @import "pattern_separator";
+@import "pattern_contact-modal";
 
 @include ubuntu-p-buttons;
 @include ubuntu-p-navigation;
@@ -56,6 +57,7 @@
 @include p-takeover-financial-services;
 @include u-animations;
 @include ubuntu-p-separator;
+@include ubuntu-p-contact-modal;
 
 // Layouts:
 @import "layout-documentation";
@@ -216,48 +218,4 @@ abbr[title] {
 // https://github.com/vanilla-framework/vanilla-framework/issues/2045
 [class^="p-strip"].is-bordered {
   margin-bottom: 0;
-}
-
-#contact-modal { // sass-lint:disable-line no-ids
-  &.p-modal {
-    position: fixed;
-    z-index: 100;
-
-    input[type="checkbox"] + label {
-      margin-bottom: 0;
-    }
-
-    .p-modal__dialog {
-      margin-bottom: 0;
-
-      @media (min-width: $breakpoint-medium + 100px) {
-        max-width: $breakpoint-medium;
-        min-width: $breakpoint-medium;
-      }
-    }
-
-    .p-modal__header {
-      border-bottom: 1px solid $color-mid-light;
-      margin-bottom: $spv-intra--expanded;
-    }
-
-    .p-modal__title {
-      margin-bottom: $spv-intra;
-    }
-
-    &.thank-you {
-      .p-modal__title {
-        opacity: 0;
-      }
-
-      .p-modal__header {
-        border-bottom: 0;
-      }
-    }
-
-    .pagination__link--next,
-    .pagination__link--previous {
-      margin-bottom: 0;
-    }
-  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -223,6 +223,10 @@ abbr[title] {
     position: fixed;
     z-index: 100;
 
+    input[type="checkbox"] + label {
+      margin-bottom: 0;
+    }
+
     .p-modal__dialog {
       margin-bottom: 0;
 
@@ -249,6 +253,11 @@ abbr[title] {
       .p-modal__header {
         border-bottom: 0;
       }
+    }
+
+    .pagination__link--next,
+    .pagination__link--previous {
+      margin-bottom: 0;
     }
   }
 }

--- a/templates/about/base_about.html
+++ b/templates/about/base_about.html
@@ -4,5 +4,6 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_generic_download" third_item="_further_reading" %}
 {% endblock %}

--- a/templates/ai/base_ai.html
+++ b/templates/ai/base_ai.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -13,7 +13,7 @@
       <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
       <p>Canonical&rsquo;s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
       <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
-      <p><a href="/ai/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI consulting&nbsp;&rsaquo;</a></p>
+      <p><a class="js-invoke-modal" href="/ai/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI consulting&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 prefix-1 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow" width="323" />
@@ -177,7 +177,7 @@
       <h2>Get the most from your workloads</h2>
       <p>Find out why Ubuntu is the standard for enterprise machine learning for Fortune 50 companies and for startups.</p>
       <p>For consulting on machine learning, deep learning and AI.</p>
-      <p><a class="p-button--positive" href="/ai/contact-us?product=ai-features">Contact us</a></p>
+      <p><a class="p-button--positive js-invoke-modal" href="/ai/contact-us?product=ai-features">Contact us</a></p>
     </div>
   </div>
 </section>

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -13,7 +13,7 @@
       <p>Canonical&rsquo;s Kubeflow supports the most popular tools for machine learning &mdash; starting with JupyterHub and Tensorflow &mdash; in a standardised workflow running on Kubernetes.</p>
       <p>
         <a class="p-button--positive" href="/ai/install">Get started by installing Kubeflow</a>
-        <a class="p-button--neutral" href="/ai/contact-us?product=ai-index">Call the experts</a>
+        <a class="p-button--neutral js-invoke-modal" href="/ai/contact-us?product=ai-index">Call the experts</a>
       </p>
     </div>
   </div>
@@ -200,7 +200,7 @@
   <div class="row">
     <h2>Get started with AI and Machine learning today.</h2>
     <p><a class="p-button--positive" href="/ai/install">Test drive Kubeflow now</a></p>
-    <p>Or <a href="/ai/contact-us?product=ai-index">contact our experts</a> to get started with consulting, training or outsourced operations.</p>
+    <p>Or <a class="js-invoke-modal" href="/ai/contact-us?product=ai-index">contact our experts</a> to get started with consulting, training or outsourced operations.</p>
   </div>
 </section>
 

--- a/templates/ai/install.html
+++ b/templates/ai/install.html
@@ -101,7 +101,7 @@
           <div class="col-12">
             <h2>Need more help?</h2>
             <p>Let our Kubernetes experts help you take the next step.</p>
-            <p><a class="p-button--positive" href="/ai/contact-us?product=ai-install">Contact us</a></p>
+            <p><a class="p-button--positive js-invoke-modal" href="/ai/contact-us?product=ai-install">Contact us</a></p>
           </div>
         </div>
       </div>

--- a/templates/community/_base_community.html
+++ b/templates/community/_base_community.html
@@ -4,5 +4,6 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_generic_download" third_item="_further_reading" %}
 {% endblock %}

--- a/templates/containers/base_containers.html
+++ b/templates/containers/base_containers.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -11,7 +11,7 @@
       <div class="col-7">
         <h1>Why is Ubuntu the #1 OS for Containers?</h1>
         <p>From Docker to Kubernetes, the experts choose Ubuntu for container operations. The single most important driver of quality, security and performance is the kernel version, and Canonical ensures that Ubuntu always has the very latest kernels with the latest security capabilities. That’s why the world’s biggest cloud operators and the world’s most sophisticated IT operations have chosen Ubuntu for containers.<p>
-        <p><a href="/containers/contact-us?product=containers-overview">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
+        <p><a class="js-invoke-modal" href="/containers/contact-us?product=containers-overview">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-5 u-align--center u-hide--small">
           <img class="u-float--right" src="{{ ASSET_SERVER_URL }}a9aff224-Containers-illustration.svg" width="350" alt="" />
@@ -114,7 +114,7 @@
         </ul>
         <ul class="p-inline-list">
           <li class="p-inline-list__item"><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></li>
-          <li class="p-inline-list__item">or <a href="/containers/contact-us?product=containers-overview">contact us&nbsp;&rsaquo;</a></li>
+          <li class="p-inline-list__item">or <a href="/containers/contact-us?product=containers-overview" class="js-invoke-modal">contact us&nbsp;&rsaquo;</a></li>
           </ul>
       </div>
     </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -568,7 +568,7 @@ store for access to all the standard apps, or curate your own collection.</p>
 </style>
 <script src="{% versioned_static 'js/stickyNav.js' %}"></script>
 
-{% include "shared/forms/_modal_form.html" with lpId="2166" formid="1266" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/core/thank-you" %}
+{% include "shared/forms/_modal_form.html" with lpId="2166" formid="1266" lpurl="https://pages.ubuntu.com/Cloud-contact-us.html" returnURL="https://www.ubuntu.com/core/thank-you" %}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/desktop/base_desktop.html
+++ b/templates/desktop/base_desktop.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
+    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -12,7 +12,7 @@
       <div class="p-card--overlay">
         <h1>Ubuntu in organisations</h1>
         <p>Ubuntu is adopted by small and large teams alike because it is easy to use, highly secure, has a low cost of ownership and a huge range of apps.</p>
-        <p><a class="p-button--positive" href="/desktop/contact-us">Contact us</a></p>
+        <p><a class="p-button--positive js-invoke-modal" href="/desktop/contact-us">Contact us</a></p>
         <p><a href="https://buy.ubuntu.com">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
       </div>
     </div>

--- a/templates/download/_base_download.html
+++ b/templates/download/_base_download.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
+    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/esm/base_esm.html
+++ b/templates/esm/base_esm.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -82,7 +82,7 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <p><a class="p-button--positive" href="/support/contact-us?product=server-esm">Any questions, contact us&nbsp;&rsaquo;</a></p>
+      <p><a class="p-button--positive js-invoke-modal" href="/support/contact-us?product=server-esm">Any questions, contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -111,7 +111,7 @@
     </div>
     <div class="col-8">
       <h2>Get ESM for Ubuntu</h2>
-      <p>If you would like to discuss ESM for Ubuntu please <a href="/support/contact-us?product=server-esm">get in touch</a>.</p>
+      <p>If you would like to discuss ESM for Ubuntu please <a href="/support/contact-us?product=server-esm" class="js-invoke-modal">get in touch</a>.</p>
       <p>Or <a href="https://buy.ubuntu.com" class="p-link--external">visit the Ubuntu Advantage store</a></p>
     </div>
   </div>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -228,7 +228,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <p class="p-heading--three">Talk to us about how Canonical can help you build a secure, agile infrastructure designed for scale.</p>
-      <p><a href="/contact-us" class="p-button">Contact us</a></p>
+      <p><a href="/contact-us" class="p-button js-invoke-modal">Contact us</a></p>
     </div>
     <div class="col-4 prefix-1 suffix-1 u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="144" class="u-hide--small" alt="" />
@@ -237,3 +237,5 @@
 </section>
 
 {% endblock content %}
+
+{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}

--- a/templates/internet-of-things/base_things.html
+++ b/templates/internet-of-things/base_things.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
+    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/kubernetes/base_kubernetes.html
+++ b/templates/kubernetes/base_kubernetes.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/kubernetes/docs/base_docs.html
+++ b/templates/kubernetes/docs/base_docs.html
@@ -58,6 +58,6 @@
 {% endblock %}
 
 {% block footer_extra %}
-<link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'minified/prism.css' %}" />
+<link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/prism.css' %}" />
 <script src="{% versioned_static 'js/prism.js' %}" async></script>
 {% endblock footer_extra %}

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -13,7 +13,7 @@
       <h4>Architectural freedom. Fully automated operations. Extensible Kubernetes for all.</h4>
       <p>Kubernetes on Ubuntu gives you perfect portability of workloads across all infrastructures, from the datacentre to the public cloud. With a strong focus on AI/ML and providing a cloud-native platform for the enterprise, Ubuntu is the platform of choice for K8s.</p>
       <p>Deep integration with infrastructure features such as <abbr title="Load Balancing as a Service">LBaaS</abbr>, storage, and networking means freedom and preservation of choice in infrastructure.</p>
-      <p><a class="p-button--positive" href="/kubernetes/contact-us?product=kubernetes-features">Talk to us</a></p>
+      <p><a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us?product=kubernetes-features">Talk to us</a></p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}96d35aa4-certified-kubernetes-logo.svg?w=300" width="300" alt="Kubernetes Certified Service Provider" />
@@ -169,7 +169,7 @@
   <div class="row">
     <h2>Get started with Kubernetes</h2>
     <p>Find out how Canonical enables Kubernetes on demand for your DevOps teams &mdash; on OpenStack, VMware, public clouds, and bare metal clusters.</p>
-    <p><a href="/kubernetes/contact-us" class="p-button--positive">Contact Canonical about Kubernetes</a></p>
+    <p><a href="/kubernetes/contact-us" class="p-button--positive js-invoke-modal">Contact Canonical about Kubernetes</a></p>
   </div>
 </section>
 

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -269,7 +269,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Test drive Ubuntu K8s today!</h2>
-      <p class="u-no-margin--top"><a href="/kubernetes/install" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Bottom CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/kubernetes/contact-us?product=kubernetes" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - Bottom CTA' : undefined });">Contact us</a></p>
+      <p class="u-no-margin--top"><a href="/kubernetes/install" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Try it now - Bottom CTA' : undefined });"><span class="p-link--external">Try it now</span></a>&#8195;<a href="/kubernetes/contact-us?product=kubernetes" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - Bottom CTA' : undefined });">Contact us</a></p>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -155,7 +155,7 @@
         <div class="col-12">
           <h2>Need more help?</h2>
           <p>Let our cloud experts help you take the next step.</p>
-          <p><a class="p-button--positive" href="/kubernetes/contact-us?product=kubernetes-install">Contact us</a></p>
+          <p><a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us?product=kubernetes-install">Contact us</a></p>
         </div>
       </div>
     </div>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -23,7 +23,7 @@
         <div>
           <a href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf" class="p-button--positive">Read the datasheet</a>
 
-          <a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--neutral">Talk to us</a>
+          <a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--neutral js-invoke-modal">Talk to us</a>
         </div>
       </div>
       <div class="col-5 u-align--center u-hide--small">
@@ -154,7 +154,7 @@
             </div>
           </li>
         </ol>
-        <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--positive">Free quote and architecture assessment</a></p>
+        <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--positive js-invoke-modal">Free quote and architecture assessment</a></p>
       </div>
     </div>
   </section>
@@ -379,7 +379,7 @@
     </div>
     <div class="row">
       <div class="col-6">
-        <p><a href="/kubernetes/contact-us?product=kubernetes-managed">Let&rsquo;s discuss your requirements&nbsp;&rsaquo;</a></p>
+        <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="js-invoke-modal">Let&rsquo;s discuss your requirements&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </section>
@@ -397,7 +397,7 @@
     <div class="row">
       <div class="col-8">
         <h3>Talk to Canonical&rsquo;s remote operations team about building and operating your Kubernetes cluster today.</h3>
-        <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Schedule a Kubernetes demo', 'eventLabel' : 'Schedule a Kubernetes demo - Bottom CTA' : undefined });">Schedule a Kubernetes demo</a></p>
+        <p><a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--positive js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Schedule a Kubernetes demo', 'eventLabel' : 'Schedule a Kubernetes demo - Bottom CTA' : undefined });">Schedule a Kubernetes demo</a></p>
       </div>
     </div>
   </section>

--- a/templates/livepatch/base_livepatch.html
+++ b/templates/livepatch/base_livepatch.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -172,7 +172,7 @@
     <div class="col-8">
       <h2>Get started with Livepatch today</h2>
       <p>Livepatch is free to use on your own PC or server. To discuss whether Livepatch is right for your business, talk to our sales team.</p>
-      <p class="u-no-margin--bottom"><a href="/support/contact-us" class="p-button u-no-margin--bottom">Contact us</a></p>
+      <p class="u-no-margin--bottom"><a href="/support/contact-us" class="p-button u-no-margin--bottom js-invoke-modal">Contact us</a></p>
     </div>
   </div>
 </div>

--- a/templates/openstack/_base_openstack.html
+++ b/templates/openstack/_base_openstack.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -12,7 +12,7 @@
         <h2 class="p-heading--three">Carrier grade, banking security, government scale. Serious private clouds are our business.</h2>
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>
-          <a href="/openstack/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Engage Canonical exports', 'eventLabel' : 'Engage Canonical exports - Top CTA', 'eventValue' : undefined });" class="p-button--positive">Engage Canonical experts</a>
+          <a href="/openstack/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Engage Canonical exports', 'eventLabel' : 'Engage Canonical exports - Top CTA', 'eventValue' : undefined });" class="p-button--positive js-invoke-modal">Engage Canonical experts</a>
           <a href="{{ ASSET_SERVER_URL }}b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf" class="p-button--neutral">Read our consulting datasheet</a>
         </p>
       </div>
@@ -99,8 +99,8 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-4 p-card u-align--center">
-        <a href="/openstack/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" width="32" alt="Talk to us" /></a>
-        <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
+        <a href="/openstack/contact-us?product=foundation-cloud"  class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" width="32" alt="Talk to us" /></a>
+        <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
       <div class="col-4 p-card u-align--center">
         <a href="{{ ASSET_SERVER_URL }}b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf"><img class="p-card__icon" src="{{ ASSET_SERVER_URL }}3e9e430a-icon-documentation.svg" width="32" alt="Read the datasheet" /></a>
@@ -120,7 +120,7 @@
     </div>
     {% include "shared/pricing/_openstack-consulting.html" %}
     <div class="row">
-      <p><a href="/openstack/contact-us?product=foundation-cloud">For more information about services please contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/contact-us?product=foundation-cloud" class="js-invoke-modal">For more information about services please contact us&nbsp;&rsaquo;</a></p>
     </div>
   </section>
 
@@ -226,7 +226,7 @@
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
         <p><a href="/openstack/features">Find out how</a> Canonical delivers the worlds favourite enterprise OpenStack. The choice of the largest operators in telco, finance, media, pharma, retail and government sectors, Canonical’s OpenStack on Ubuntu offers a flexible architecture and enables integration of GPGPUs, FPGAs and cloud network accelerators.</p>
-        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="{{ ASSET_SERVER_URL }}b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -15,7 +15,7 @@
     <div class="row">
       <div class="col-8">
         <p>Canonical&rsquo;s OpenStack on Ubuntu gives you the flexibility to place your OpenStack services exactly where you want them, while sharing all the operational code with a large community.</p>
-        <p><a href="/openstack/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact Us for OpenStack insights', 'eventLabel' : 'Contact Us for OpenStack insights - Top CTA', 'eventValue' : undefined });" class="p-button--positive">Contact us for OpenStack insights</a></p>
+        <p><a href="/openstack/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact Us for OpenStack insights', 'eventLabel' : 'Contact Us for OpenStack insights - Top CTA', 'eventValue' : undefined });" class="p-button--positive js-invoke-modal">Contact us for OpenStack insights</a></p>
       </div>
     </div>
   </section>
@@ -352,7 +352,7 @@
     <div class="row">
       <div class="col-8">
         <p>Find out how Canonical&rsquo;s OpenStack on Ubuntu can give you the flexibility to share operational code with a large community whilst placing your services exactly where you want them.</p>
-        <p><a href="/openstack/contact-us" class="p-button--positive u-no-margin--bottom">Contact Canonical about OpenStack</a></p>
+        <p><a href="/openstack/contact-us" class="p-button--positive u-no-margin--bottom js-invoke-modal">Contact Canonical about OpenStack</a></p>
       </div>
     </div>
   </section>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -165,7 +165,7 @@
         <li class="p-list__item is-ticked">Repeatable, automated deployment</li>
         <li class="p-list__item is-ticked">Hardware guidance</li>
       </ul>
-      <p><a href="/openstack/contact-us?product=foundation-cloud" class="p-button--positive">Contact us for custom OpenStack engineering</a></p>
+      <p><a href="/openstack/contact-us?product=foundation-cloud" class="p-button--positive js-invoke-modal">Contact us for custom OpenStack engineering</a></p>
       <p><a href="/openstack/consulting">Learn more about Foundation Cloud Build&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 prefix-1">

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -15,7 +15,7 @@
     <div class="u-equal-height">
       <div class="col-8">
         <p>Deploy your production Ubuntu OpenStack cloud across a rack of physical servers. You&rsquo;ll use <a href="https://maas.io/" class="p-link--external">MAAS</a> for physical server provisioning and <a href="https://conjure-up.io/" class="p-link--external">conjure-up</a> to guide you through the process.</p>
-        <p>If you run into issues, or if you want support, training or architecture design consulting, please <a href="/openstack/contact-us">do contact Canonical</a> &mdash; we help the world&rsquo;s largest OpenStack users keep their clouds running smoothly.</p>
+        <p>If you run into issues, or if you want support, training or architecture design consulting, please <a href="/openstack/contact-us" class="js-invoke-modal">do contact Canonical</a> &mdash; we help the world&rsquo;s largest OpenStack users keep their clouds running smoothly.</p>
       </div>
       <div class="col-4 u-vertically-center u-align--center u-hide--small">
         <img src="{{ ASSET_SERVER_URL }}95212c08-OpenStack_Logo_2016.svg" alt="OpenStack logo" width="275" />
@@ -42,7 +42,7 @@
         <li class="p-list__item is-ticked">Simple HA architecture supported</li>
         <li class="p-list__item is-ticked">Scalable from 12 to 200 nodes</li>
       </ul>
-      <p>This is a starting point for your production cloud. You&rsquo;ll step through the deployment of OpenStack services across machines in the cluster. A simple HA configuration is supported. For more sophisticated architectures, ongoing operations insight, alternative approaches to HA, or specialized telco, compliance, regulatory or HPC requirements, <a href="/openstack/contact-us">contact Canonical</a> for consulting and support.</p>
+      <p>This is a starting point for your production cloud. You&rsquo;ll step through the deployment of OpenStack services across machines in the cluster. A simple HA configuration is supported. For more sophisticated architectures, ongoing operations insight, alternative approaches to HA, or specialized telco, compliance, regulatory or HPC requirements, <a href="/openstack/contact-us" class="js-invoke-modal">contact Canonical</a> for consulting and support.</p>
       <p><a href="#cluster-deployment">Deploy OpenStack on cluster&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-card">
@@ -395,7 +395,7 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
           <div class="col-12">
             <h2>Need more help?</h2>
             <p>Let our cloud experts help you take the next step.</p>
-            <p><a class="p-button--positive" href="/openstack/contact-us?product=openstack-install-build">Contact us</a></p>
+            <p><a class="p-button--positive js-invoke-modal" href="/openstack/contact-us?product=openstack-install-build">Contact us</a></p>
           </div>
         </div>
       </div>

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -39,7 +39,7 @@
       <p>Focus on your business while Canonical takes care of your first OpenStack.</p>
       <p>
         <a href="{{ ASSET_SERVER_URL }}3465457b-Bootstack_datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the datasheet', 'eventLabel' : 'Bootstack datasheet - Top CTA', 'eventValue' : undefined });" class="p-button--positive">Read the BootStack datasheet</a>
-        <a href="/openstack/contact-us?product=cloud-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Bootstack - Top CTA', 'eventValue' : undefined });" class="p-button--neutral">Talk to us</a>
+        <a href="/openstack/contact-us?product=cloud-managed-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Bootstack - Top CTA', 'eventValue' : undefined });" class="p-button--neutral js-invoke-modal">Talk to us</a>
       </p>
     </div>
   </div>
@@ -402,7 +402,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><a href="/openstack/contact-us?product=openstack-managed-cloud-demo" class="p-button--positive">Schedule a demo</a></p>
+      <p><a href="/openstack/contact-us?product=openstack-managed-cloud-demo" class="p-button--positive js-invoke-modal">Schedule a demo</a></p>
     </div>
   </div>
 </section>
@@ -479,7 +479,7 @@
           </div>
         </li>
       </ol>
-      <p><a href="/openstack/contact-us?product=openstack-managed-cloud" class="p-button--positive">Free quote and architecture assessment</a></p>
+      <p><a href="/openstack/contact-us?product=openstack-managed-cloud" class="p-button--positive js-invoke-modal">Free quote and architecture assessment</a></p>
     </div>
   </div>
 </section>
@@ -536,7 +536,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><a href="/openstack/contact-us?product=openstack-managed-cloud" class="p-button--positive">Let&rsquo;s discuss your requirements</a></p>
+      <p><a href="/openstack/contact-us?product=openstack-managed-cloud" class="p-button--positive js-invoke-modal">Let&rsquo;s discuss your requirements</a></p>
     </div>
   </div>
 </section>

--- a/templates/openstack/partners.html
+++ b/templates/openstack/partners.html
@@ -63,7 +63,7 @@
     <div class="col-8">
       <h2>Become a cloud partner</h2>
       <p>To learn more about becoming a charm, Ubuntu certified public cloud or Ubuntu OpenStack partner, please contact us today.</p>
-      <p><a href="http://partners.ubuntu.com/contact-us" class="p-button--positive">Get in touch</a></p>
+      <p><a href="http://partners.ubuntu.com/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
       <p>or <a href="http://partners.ubuntu.com/partnering-with-us" class="p-link--external">learn more about partnering with us</a></p>
     </div>
   </div>

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -117,7 +117,7 @@
                 <p>Legacy storage solutions are often priced per-node or according to total disk capacity. This can lead to a penalty for good practices such as high durability&nbsp;replication.</p>
                 <p>Ubuntu Advantage Storage is different. Our pricing is based on the amount of data you record in your storage pool, regardless of how it is written or how much disk space is used.</p>
                 <p>Ubuntu Advantage Storage means you don&rsquo;t have to pay for replicas or empty space.</p>
-                <p><a href="/openstack/contact-us?product=ubuntu-advantage-storage">Find out how much you can save&nbsp;&rsaquo;</a></p>
+                <p><a href="/openstack/contact-us?product=ubuntu-advantage-storage" class="js-invoke-modal">Find out how much you can save&nbsp;&rsaquo;</a></p>
               </div>
               <div class="col-5 u-align--center">
                 <img src="{{ ASSET_SERVER_URL }}d8555ed7-storage-diagram-jy.png" alt="" width="330" />
@@ -136,7 +136,7 @@
                   <li class="p-list__item is-ticked">World-class support from Canonical, experts in large-scale, multi-site-replicated deployments.</li>
                   <li class="p-list__item is-ticked">Built with Ubuntu {{ lts_release_full }} with five years of support for every component in the stack.</li>
                 </ul>
-                <p><a class="p-button--neutral" href="/openstack/contact-us?product=ubuntu-advantage-storage">Request a demo</a></p>
+                <p><a class="p-button--neutral js-invoke-modal" href="/openstack/contact-us?product=ubuntu-advantage-storage">Request a demo</a></p>
               </div>
             </div>
           </section>

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -47,7 +47,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/contact-us?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -71,7 +71,7 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/contact-us?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -120,7 +120,7 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/contact-us?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -130,7 +130,7 @@
     <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
-      <p><a href="/openstack/contact-us?product=openstack-training">Contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/contact-us?product=openstack-training" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}9b170f06-picto-help-orange.svg" width="135" alt="" />

--- a/templates/public-cloud/_base_public-cloud.html
+++ b/templates/public-cloud/_base_public-cloud.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
+    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/rfp/_base_rfp.html
+++ b/templates/rfp/_base_rfp.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -270,7 +270,7 @@
         <li class="p-list__item is-ticked">Support: phone and web-based support at multiple service levels</li>
       </ul>
       <p><a href="https://buy.ubuntu.com" class="p-button--neutral"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
-      <p><a href="/support/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/support/contact-us" class="js-invoke-modal">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -282,7 +282,7 @@
       <p class="p-heading--four">We can recommend a security solution that best suits the needs of your&nbsp;organisation.</p>
       <ul class="p-inline-list">
         <li class="p-inline-list__item">
-          <a href="/support/contact-us" class="p-button">Contact us</a>
+          <a href="/support/contact-us" class="p-button js-invoke-modal">Contact us</a>
         </li>
         <li class="p-inline-list__item">
           <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/290073">Watch the Ubuntu security webinar</a>
@@ -295,6 +295,7 @@
   </div>
 </section>
 
+{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_security_discussion" second_item="_security_esm" third_item="_security_further_reading" %}
 
 {% endblock content %}

--- a/templates/server/base_server.html
+++ b/templates/server/base_server.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
+    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -151,7 +151,7 @@
   </div>
   <div class="row">
     <div class="col-8 suffix-4">
-      <p><a href="/server/contact-us?product=server-hyperscale">Contact us about hyperscale&nbsp;&rsaquo;</a></p>
+      <p><a href="/server/contact-us?product=server-hyperscale" class="js-invoke-modal">Contact us about hyperscale&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -228,7 +228,7 @@
       <div class="p-card">
         <h3 class="p-card__title">Get in touch</h3>
         <p class="p-card__content">Speak to our technical support team about your server requirements.</p>
-        <p class="p-card__content"><a class="p-button--positive" href="/server/contact-us?product=server-overview">Contact us</a></p>
+        <p class="p-card__content"><a class="p-button--positive js-invoke-modal" href="/server/contact-us?product=server-overview">Contact us</a></p>
       </div>
     </div>
   </div>

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -217,7 +217,7 @@
               <ul class="p-list">
                 <li class="mktFormReq mktField p-list__item">
                   <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField mktoRequired" maxlength="2000"></textarea>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -1,0 +1,263 @@
+{% load versioned_static  %}
+
+<div class="p-modal u-hide" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title">The Ubuntu Experts</h2>
+      <button class="p-modal__close" aria-label="Close active modal">Close</button>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <p id="modal-description" class="u-no-max-width u-no-margin--bottom">Canonical certifies, secures and enables enterprise open source on Ubuntu. Tell us about your project so we bring the right team to the conversation.</p>
+      <h3 class="p-heading--five">How would you like to make use of Ubuntu?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="make-use-of-workstations">
+          <label for="make-use-of-workstations">Workstations</label>
+          <input type="checkbox" id="make-use-of-servers">
+          <label for="make-use-of-servers">Servers</label>
+          <input type="checkbox" id="make-use-of-public-cloud">
+          <label for="make-use-of-public-cloud">Public cloud</label>
+          <input type="checkbox" id="make-use-of-private-cloud">
+          <label for="make-use-of-private-cloud">Private cloud</label>
+          <input type="checkbox" id="make-use-appliances">
+          <label for="make-use-appliances">Appliances</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="make-use-of-enterprise-infra">
+          <label for="make-use-of-enterprise-infra">Enterprise infra</label>
+          <input type="checkbox" id="make-use-of-enterprise-apps">
+          <label for="make-use-of-enterprise-apps">Enterprise apps</label>
+          <input type="checkbox" id="make-use-of-embedding">
+          <label for="make-use-of-embedding">Embedding</label>
+          <input type="checkbox" id="make-use-of-development">
+          <label for="make-use-of-development">Development</label>
+          <input type="checkbox" id="make-use-of-virtualization">
+          <label for="make-use-of-virtualization">Virtualization</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="make-use-of-storage">
+          <label for="make-use-of-storage">Storage</label>
+          <input type="checkbox" id="make-use-of-networking">
+          <label for="make-use-of-networking">Networking</label>
+          <input type="checkbox" id="make-use-of-kubernetes">
+          <label for="make-use-of-kubernetes">Kubernetes</label>
+          <input type="checkbox" id="make-use-of-openstack">
+          <label for="make-use-of-openstack">OpenStack</label>
+          <input type="checkbox" id="make-use-of-kubeflow">
+          <label for="make-use-of-kubeflow">Kubeflow</label>
+        </div>
+      </div>
+      <h3 class="p-heading--five">In any particular sectors?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="particular-sectors-airlines">
+          <label for="particular-sectors-airlines">Airlines</label>
+          <input type="checkbox" id="particular-sectors-aerospace">
+          <label for="particular-sectors-aerospace">Aerospace</label>
+          <input type="checkbox" id="particular-sectors-agriculture">
+          <label for="particular-sectors-agriculture">Agriculture</label>
+          <input type="checkbox" id="particular-sectors-automotive">
+          <label for="particular-sectors-automotive">Automotive</label>
+          <input type="checkbox" id="particular-sectors-chemical">
+          <label for="particular-sectors-chemical">Chemical</label>
+          <input type="checkbox" id="particular-sectors-computer">
+          <label for="particular-sectors-computer">Computer</label>
+          <input type="checkbox" id="particular-sectors-construction">
+          <label for="particular-sectors-construction">Construction</label>
+          <input type="checkbox" id="particular-sectors-defense">
+          <label for="particular-sectors-defense">Defense</label>
+          <input type="checkbox" id="particular-sectors-education">
+          <label for="particular-sectors-education">Education</label>
+          <input type="checkbox" id="particular-sectors-electronics">
+          <label for="particular-sectors-electronics">Electronics</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="particular-sectors-energy">
+          <label for="particular-sectors-energy">Energy</label>
+          <input type="checkbox" id="particular-sectors-entertainment">
+          <label for="particular-sectors-entertainment">Entertainment</label>
+          <input type="checkbox" id="particular-sectors-finance">
+          <label for="particular-sectors-finance">Finance</label>
+          <input type="checkbox" id="particular-sectors-food">
+          <label for="particular-sectors-food">Food</label>
+          <input type="checkbox" id="particular-sectors-government">
+          <label for="particular-sectors-government">Government</label>
+          <input type="checkbox" id="particular-sectors-healthcare">
+          <label for="particular-sectors-healthcare">Healthcare</label>
+          <input type="checkbox" id="particular-sectors-hospitality">
+          <label for="particular-sectors-hospitality">Hospitality</label>
+          <input type="checkbox" id="particular-sectors-information">
+          <label for="particular-sectors-information">Information</label>
+          <input type="checkbox" id="particular-sectors-logistics">
+          <label for="particular-sectors-logistics">Logistics</label>
+          <input type="checkbox" id="particular-sectors-manufacturing">
+          <label for="particular-sectors-manufacturing">Manufacturing</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="particular-sectors-mining">
+          <label for="particular-sectors-mining">Mining</label>
+          <input type="checkbox" id="particular-sectors-pharmaceutical">
+          <label for="particular-sectors-pharmaceutical">Pharmaceutical</label>
+          <input type="checkbox" id="particular-sectors-software">
+          <label for="particular-sectors-software">Software</label>
+          <input type="checkbox" id="particular-sectors-telecomms">
+          <label for="particular-sectors-telecomms">Telecomms</label>
+          <input type="checkbox" id="particular-sectors-service-provider">
+          <label for="particular-sectors-service-provider">Service provider</label>
+          <input type="checkbox" id="particular-sectors-transport">
+          <label for="particular-sectors-transport">Transport</label>
+          <input type="checkbox" id="particular-sectors-water">
+          <label for="particular-sectors-water">Water</label>
+          <input type="checkbox" id="particular-sectors-other">
+          <label for="particular-sectors-other">Other</label>
+        </div>
+      </div>
+      <div class="u-sv3">
+        <h3 class="p-heading--five">Do you have sector-specific requirements?</h3>
+        <textarea id="sector-specific-requirements" name="sector-specific-requirements" aria-label="Do you have sector-specific requirements?" rows="3"></textarea>
+      </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <h3 class="p-heading--five">What is important to you?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="important-to-you-security">
+          <label for="important-to-you-security">Security</label>
+          <input type="checkbox" id="important-to-you-regulatory-compliance">
+          <label for="important-to-you-regulatory-compliance">Regulatory compliance</label>
+          <input type="checkbox" id="important-to-you-eal">
+          <label for="important-to-you-eal">EAL</label>
+          <input type="checkbox" id="important-to-you-fips">
+          <label for="important-to-you-fips">FIPS</label>
+          <input type="checkbox" id="important-to-you-kernel-livepatch">
+          <label for="important-to-you-kernel-livepatch">Kernel livepatch</label>
+          <input type="checkbox" id="important-to-you-ai-ml">
+          <label for="important-to-you-ai-ml">AI/ML</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="important-to-you-training">
+          <label for="important-to-you-training">Training</label>
+          <input type="checkbox" id="important-to-you-certification">
+          <label for="important-to-you-certification">Certification</label>
+          <input type="checkbox" id="important-to-you-support">
+          <label for="important-to-you-support">Support</label>
+          <input type="checkbox" id="important-to-you-performance">
+          <label for="important-to-you-performance">Performance</label>
+          <input type="checkbox" id="important-to-you-managed-services">
+          <label for="important-to-you-managed-services">Managed services</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="important-to-you-10-year-updates">
+          <label for="important-to-you-10-year-updates">10-year updates</label>
+          <input type="checkbox" id="important-to-you-management">
+          <label for="important-to-you-management">Management</label>
+          <input type="checkbox" id="important-to-you-orchestration">
+          <label for="important-to-you-orchestration">Orchestration</label>
+          <input type="checkbox" id="important-to-you-operations">
+          <label for="important-to-you-operations">Operations</label>
+        </div>
+      </div>
+      <div class="u-sv3">
+        <h3 class="p-heading--five">Is there anything we should know about the project to bring the right people from our side?</h3>
+        <textarea id="right-people-from-our-side" name="right-people-from-our-side" aria-label="Is there anything we should know about the project to bring the right people from our side?" rows="3"></textarea>
+      </div>
+      <div class="pagination">
+        <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+        <a class="pagination__link--next p-button--positive" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Email address:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel">Phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" required="required" />
+              </li>
+              {% include "shared/forms/_country.html" %} {% include "shared/forms/_state.html" %}
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Company" class="mktoLabel">Company:</label>
+                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Title" class="mktoLabel">Job title:</label>
+                <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField mktoRequired" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--4 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about Ubuntu core</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>
+
+<script src="{% versioned_static 'js/dynamic-contact-form.js' %}"></script>

--- a/templates/support/base_support.html
+++ b/templates/support/base_support.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
+  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -10,7 +10,7 @@
   <div class="row">
     <h1>Plans and pricing</h1>
     <p>For enterprises with production workloads Canonical offers the following suite of tools, services and support packages.</p>
-    <p><a href="/support/contact-us?product=support-pricing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Learn more', 'eventLabel' : 'Get in touch - Top CTA' : undefined });" class="p-button--positive">Get in touch</a></p>
+    <p><a href="/support/contact-us?product=support-pricing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Learn more', 'eventLabel' : 'Get in touch - Top CTA' : undefined });" class="p-button--positive js-invoke-modal">Get in touch</a></p>
   </div>
 </section>
 
@@ -99,7 +99,7 @@
         <li class="p-list__item is-ticked">Support: phone and web-based support at multiple service levels</li>
       </ul>
       <p><a href="http://buy.ubuntu.com" class="p-button"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></p>
-      <p><a href="/support/contact-us?product=support-pricing">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/support/contact-us?product=support-pricing" class="js-invoke-modal">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -151,7 +151,7 @@
   {% include "shared/pricing/_openstack-support.html" %}
   <div class="row">
     <div class="col-12">
-      <p><a href="/openstack/contact-us">Get in touch&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/contact-us" class="js-invoke-modal">Get in touch&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -166,7 +166,7 @@
     {% include "shared/pricing/_openstack-consulting.html" %}
   <div class="row">
     <div class="col-12">
-      <p>For more information about Foundation Cloud or if you are not sure which one is right for you, <a href="/openstack/contact-us?product=foundation-cloud">contact us&nbsp;&rsaquo;</a></p>
+      <p>For more information about Foundation Cloud or if you are not sure which one is right for you, <a href="/openstack/contact-us?product=foundation-cloud" class="js-invoke-modal">contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -176,7 +176,7 @@
     <div class="col-12">
       <h2>Kubernetes</h2>
       <p>Scale-out container management is top of mind for savvy cloud architects around the world. Ubuntu is, by far, the world&rsquo;s leading platform for container-based workflows.  Canonical provides enterprise support for Kubernetes.</p>
-      <p>For more information about Kubernetes support, <a href="/containers/contact-us">contact us&nbsp;&rsaquo;</a></p>
+      <p>For more information about Kubernetes support, <a href="/containers/contact-us" class="js-invoke-modal">contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -229,7 +229,7 @@
 <div class="row">
   <div class="col-12">
     <div>
-      <p><a href="/cloud/contact-us?product=ubuntu-advantage-storage" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - cloud storage CTA' : undefined });">Contact us</a></p>
+      <p><a href="/cloud/contact-us?product=ubuntu-advantage-storage" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - cloud storage CTA' : undefined });">Contact us</a></p>
       <p><a href="https://insights.ubuntu.com/2015/05/18/ubuntu-advantage-storage-factsheet/?_ga=2.122490379.1666167933.1504515501-463981611.1499434659" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Try it now', 'eventLabel' : 'Download the datasheet - cloud storage CTA' : undefined });">Download the datasheet</a></p>
     </div>
   </div>

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -15,7 +15,7 @@
           <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290067" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch Cloud to Edge webinar', 'eventLabel' : 'Watch Cloud to Edge webinar', 'eventValue' : undefined });" ><span class="p-link--external">Watch the 'Cloud to Edge' webinar</span></a>
         </li>
         <li class="p-inline-list__item">
-          <a href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral">Contact us</a>
+          <a href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral js-invoke-modal">Contact us</a>
         </li>
       </ul>
     </p>
@@ -221,7 +221,7 @@
           <a href="https://www.brighttalk.com/webcast/6793/290067" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Footer CTA', 'eventLabel' : 'Watch Cloud to Edge webinar' });"><span class="p-link--external">Watch the 'Cloud to Edge' webinar</span></a>
         </li>
         <li class="p-inline-list__item">
-          <a href="/cloud/contact-us" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Footer CTA', 'eventLabel' : 'Contact us' });">Contact us</a>
+          <a href="/cloud/contact-us" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Footer CTA', 'eventLabel' : 'Contact us' });">Contact us</a>
         </li>
       </ul>
     </div>
@@ -231,5 +231,6 @@
   </div>
 </section>
 
+{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_newsletter" third_item="_telco_further_reading" %}
 {% endblock content %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -45,10 +45,10 @@
     <!-- stylesheets -->
 
     <!--[if !lte IE 9]> -->
-    <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'minified/styles.css' %}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/styles.css' %}" />
     <!-- <![endif]-->
 
-    <link rel="stylesheet" type="text/css" media="print" href="{% versioned_static 'minified/print.css' %}" />
+    <link rel="stylesheet" type="text/css" media="print" href="{% versioned_static 'css/print.css' %}" />
 
     <!-- javascript -->
     {% include "shared/_html5_shiv.html" %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,10 +46,6 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
-
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -201,10 +197,6 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
-balanced-match@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -267,7 +259,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
+browserslist@^1.7.6:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
   dependencies:
@@ -325,16 +317,7 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-api@^1.5.2:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
-  dependencies:
-    browserslist "^1.3.6"
-    caniuse-db "^1.0.30000529"
-    lodash.memoize "^4.1.2"
-    lodash.uniq "^4.5.0"
-
-caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
+caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000899"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000899.tgz#f66d667d507c2aa19603a4a3763d71aa89cc360f"
 
@@ -395,12 +378,6 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
-clap@^1.0.9:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
-  dependencies:
-    chalk "^1.1.3"
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -445,19 +422,9 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-clone@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-
-coa@~1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd"
-  dependencies:
-    q "^1.1.2"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -470,7 +437,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.3.0, color-convert@^1.9.0:
+color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   dependencies:
@@ -479,36 +446,6 @@ color-convert@^1.3.0, color-convert@^1.9.0:
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-
-color-name@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-
-color-string@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991"
-  dependencies:
-    color-name "^1.0.0"
-
-color@^0.11.0:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
-  dependencies:
-    clone "^1.0.2"
-    color-convert "^1.3.0"
-    color-string "^0.3.0"
-
-colormin@^1.0.5:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colormin/-/colormin-1.1.2.tgz#ea2f7420a72b96881a38aae59ec124a6f7298133"
-  dependencies:
-    color "^0.11.0"
-    css-color-names "0.0.4"
-    has "^1.0.1"
-
-colors@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
@@ -584,54 +521,6 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-css-color-names@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
-
-cssnano@^3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
-  dependencies:
-    autoprefixer "^6.3.1"
-    decamelize "^1.1.2"
-    defined "^1.0.0"
-    has "^1.0.1"
-    object-assign "^4.0.1"
-    postcss "^5.0.14"
-    postcss-calc "^5.2.0"
-    postcss-colormin "^2.1.8"
-    postcss-convert-values "^2.3.4"
-    postcss-discard-comments "^2.0.4"
-    postcss-discard-duplicates "^2.0.1"
-    postcss-discard-empty "^2.0.1"
-    postcss-discard-overridden "^0.1.1"
-    postcss-discard-unused "^2.2.1"
-    postcss-filter-plugins "^2.0.0"
-    postcss-merge-idents "^2.1.5"
-    postcss-merge-longhand "^2.0.1"
-    postcss-merge-rules "^2.0.3"
-    postcss-minify-font-values "^1.0.2"
-    postcss-minify-gradients "^1.0.1"
-    postcss-minify-params "^1.0.4"
-    postcss-minify-selectors "^2.0.4"
-    postcss-normalize-charset "^1.1.0"
-    postcss-normalize-url "^3.0.7"
-    postcss-ordered-values "^2.1.0"
-    postcss-reduce-idents "^2.2.2"
-    postcss-reduce-initial "^1.0.0"
-    postcss-reduce-transforms "^1.0.3"
-    postcss-svgo "^2.1.1"
-    postcss-unique-selectors "^2.0.2"
-    postcss-value-parser "^3.2.3"
-    postcss-zindex "^2.0.1"
-
-csso@~2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85"
-  dependencies:
-    clap "^1.0.9"
-    source-map "^0.5.3"
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -704,10 +593,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-defined@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
 del@^2.0.2:
   version "2.2.2"
@@ -875,10 +760,6 @@ espree@^3.1.6:
   dependencies:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
-
-esprima@^2.6.0:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -1082,10 +963,6 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatten@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
-
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1161,10 +1038,6 @@ fstream@^1.0.0, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
-
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1392,19 +1265,9 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
-  dependencies:
-    function-bind "^1.1.1"
-
 hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
-
-html-comment-regex@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -1463,10 +1326,6 @@ indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
-indexes-of@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1507,10 +1366,6 @@ inquirer@^0.12.0:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
-
-is-absolute-url@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -1694,10 +1549,6 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -1731,12 +1582,6 @@ is-resolvable@^1.0.0:
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-svg@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
-  dependencies:
-    html-comment-regex "^1.1.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1795,13 +1640,6 @@ js-yaml@^3.4.3, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.9.0:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@~3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -2015,17 +1853,9 @@ lodash.kebabcase@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
-lodash.memoize@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
 lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
-
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
 lodash@^3.5.0:
   version "3.10.1"
@@ -2089,10 +1919,6 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
-
-math-expression-evaluator@^1.2.14:
-  version "1.2.17"
-  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
 
 math-random@^1.0.1:
   version "1.0.1"
@@ -2218,7 +2044,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2355,15 +2181,6 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
 normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
-
-normalize-url@^1.4.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
-  dependencies:
-    object-assign "^4.0.1"
-    prepend-http "^1.0.0"
-    query-string "^4.1.0"
-    sort-keys "^1.0.0"
 
 npm-bundled@^1.0.1:
   version "1.0.5"
@@ -2657,14 +2474,6 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-postcss-calc@^5.2.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-5.3.1.tgz#77bae7ca928ad85716e2fda42f261bf7c1d65b5e"
-  dependencies:
-    postcss "^5.0.2"
-    postcss-message-helpers "^2.0.0"
-    reduce-css-calc "^1.2.6"
-
 postcss-cli@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/postcss-cli/-/postcss-cli-4.1.1.tgz#b94bd8fffbb7ac1f62f2607e78fc9397f7f63a5d"
@@ -2682,58 +2491,6 @@ postcss-cli@^4.1.0:
     pretty-hrtime "^1.0.3"
     read-cache "^1.0.0"
     yargs "^8.0.1"
-
-postcss-colormin@^2.1.8:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-2.2.2.tgz#6631417d5f0e909a3d7ec26b24c8a8d1e4f96e4b"
-  dependencies:
-    colormin "^1.0.5"
-    postcss "^5.0.13"
-    postcss-value-parser "^3.2.3"
-
-postcss-convert-values@^2.3.4:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz#bbd8593c5c1fd2e3d1c322bb925dcae8dae4d62d"
-  dependencies:
-    postcss "^5.0.11"
-    postcss-value-parser "^3.1.2"
-
-postcss-discard-comments@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d"
-  dependencies:
-    postcss "^5.0.14"
-
-postcss-discard-duplicates@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz#b9abf27b88ac188158a5eb12abcae20263b91932"
-  dependencies:
-    postcss "^5.0.4"
-
-postcss-discard-empty@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz#d2b4bd9d5ced5ebd8dcade7640c7d7cd7f4f92b5"
-  dependencies:
-    postcss "^5.0.14"
-
-postcss-discard-overridden@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz#8b1eaf554f686fb288cd874c55667b0aa3668d58"
-  dependencies:
-    postcss "^5.0.16"
-
-postcss-discard-unused@^2.2.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz#bce30b2cc591ffc634322b5fb3464b6d934f4433"
-  dependencies:
-    postcss "^5.0.14"
-    uniqs "^2.0.0"
-
-postcss-filter-plugins@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz#82245fdf82337041645e477114d8e593aa18b8ec"
-  dependencies:
-    postcss "^5.0.4"
 
 postcss-load-config@^1.1.0:
   version "1.2.0"
@@ -2758,110 +2515,6 @@ postcss-load-plugins@^2.3.0:
     cosmiconfig "^2.1.1"
     object-assign "^4.1.0"
 
-postcss-merge-idents@^2.1.5:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz#4c5530313c08e1d5b3bbf3d2bbc747e278eea270"
-  dependencies:
-    has "^1.0.1"
-    postcss "^5.0.10"
-    postcss-value-parser "^3.1.1"
-
-postcss-merge-longhand@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz#23d90cd127b0a77994915332739034a1a4f3d658"
-  dependencies:
-    postcss "^5.0.4"
-
-postcss-merge-rules@^2.0.3:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz#d1df5dfaa7b1acc3be553f0e9e10e87c61b5f721"
-  dependencies:
-    browserslist "^1.5.2"
-    caniuse-api "^1.5.2"
-    postcss "^5.0.4"
-    postcss-selector-parser "^2.2.2"
-    vendors "^1.0.0"
-
-postcss-message-helpers@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz#a4f2f4fab6e4fe002f0aed000478cdf52f9ba60e"
-
-postcss-minify-font-values@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz#4b58edb56641eba7c8474ab3526cafd7bbdecb69"
-  dependencies:
-    object-assign "^4.0.1"
-    postcss "^5.0.4"
-    postcss-value-parser "^3.0.2"
-
-postcss-minify-gradients@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz#5dbda11373703f83cfb4a3ea3881d8d75ff5e6e1"
-  dependencies:
-    postcss "^5.0.12"
-    postcss-value-parser "^3.3.0"
-
-postcss-minify-params@^1.0.4:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz#ad2ce071373b943b3d930a3fa59a358c28d6f1f3"
-  dependencies:
-    alphanum-sort "^1.0.1"
-    postcss "^5.0.2"
-    postcss-value-parser "^3.0.2"
-    uniqs "^2.0.0"
-
-postcss-minify-selectors@^2.0.4:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz#b2c6a98c0072cf91b932d1a496508114311735bf"
-  dependencies:
-    alphanum-sort "^1.0.2"
-    has "^1.0.1"
-    postcss "^5.0.14"
-    postcss-selector-parser "^2.0.0"
-
-postcss-normalize-charset@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz#ef9ee71212d7fe759c78ed162f61ed62b5cb93f1"
-  dependencies:
-    postcss "^5.0.5"
-
-postcss-normalize-url@^3.0.7:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz#108f74b3f2fcdaf891a2ffa3ea4592279fc78222"
-  dependencies:
-    is-absolute-url "^2.0.0"
-    normalize-url "^1.4.0"
-    postcss "^5.0.14"
-    postcss-value-parser "^3.2.3"
-
-postcss-ordered-values@^2.1.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz#eec6c2a67b6c412a8db2042e77fe8da43f95c11d"
-  dependencies:
-    postcss "^5.0.4"
-    postcss-value-parser "^3.0.1"
-
-postcss-reduce-idents@^2.2.2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz#c2c6d20cc958284f6abfbe63f7609bf409059ad3"
-  dependencies:
-    postcss "^5.0.4"
-    postcss-value-parser "^3.0.2"
-
-postcss-reduce-initial@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz#68f80695f045d08263a879ad240df8dd64f644ea"
-  dependencies:
-    postcss "^5.0.4"
-
-postcss-reduce-transforms@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz#ff76f4d8212437b31c298a42d2e1444025771ae1"
-  dependencies:
-    has "^1.0.1"
-    postcss "^5.0.8"
-    postcss-value-parser "^3.0.1"
-
 postcss-reporter@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-5.0.0.tgz#a14177fd1342829d291653f2786efd67110332c3"
@@ -2871,44 +2524,11 @@ postcss-reporter@^5.0.0:
     log-symbols "^2.0.0"
     postcss "^6.0.8"
 
-postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
-  dependencies:
-    flatten "^1.0.2"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
-
-postcss-svgo@^2.1.1:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-2.1.6.tgz#b6df18aa613b666e133f08adb5219c2684ac108d"
-  dependencies:
-    is-svg "^2.0.0"
-    postcss "^5.0.14"
-    postcss-value-parser "^3.2.3"
-    svgo "^0.7.0"
-
-postcss-unique-selectors@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz#981d57d29ddcb33e7b1dfe1fd43b8649f933ca1d"
-  dependencies:
-    alphanum-sort "^1.0.1"
-    postcss "^5.0.4"
-    uniqs "^2.0.0"
-
-postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
+postcss-value-parser@^3.2.3:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
 
-postcss-zindex@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-zindex/-/postcss-zindex-2.2.0.tgz#d2109ddc055b91af67fc4cb3b025946639d2af22"
-  dependencies:
-    has "^1.0.1"
-    postcss "^5.0.4"
-    uniqs "^2.0.0"
-
-postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.8, postcss@^5.2.16:
+postcss@^5.2.16:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
   dependencies:
@@ -2928,10 +2548,6 @@ postcss@^6.0.1, postcss@^6.0.8:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-
-prepend-http@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -2968,20 +2584,9 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-q@^1.1.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-
-query-string@^4.1.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
-  dependencies:
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
 
 randomatic@^3.0.0:
   version "3.1.1"
@@ -3078,20 +2683,6 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
-
-reduce-css-calc@^1.2.6:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
-  dependencies:
-    balanced-match "^0.4.2"
-    math-expression-evaluator "^1.2.14"
-    reduce-function-call "^1.0.1"
-
-reduce-function-call@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
-  dependencies:
-    balanced-match "^0.4.2"
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -3262,7 +2853,7 @@ sass-lint@^1.10.2:
     path-is-absolute "^1.0.0"
     util "^0.10.3"
 
-sax@^1.2.4, sax@~1.2.1:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -3364,12 +2955,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sort-keys@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
-  dependencies:
-    is-plain-obj "^1.0.0"
-
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
@@ -3390,7 +2975,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6:
+source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -3460,10 +3045,6 @@ stdout-stream@^1.4.0:
   resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.1.tgz#5ac174cdd5cd726104aa0c0b2bd83815d8d535de"
   dependencies:
     readable-stream "^2.0.1"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-argv@^0.0.2:
   version "0.0.2"
@@ -3563,18 +3144,6 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
-
-svgo@^0.7.0:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
-  dependencies:
-    coa "~1.0.1"
-    colors "~1.1.2"
-    csso "~2.3.1"
-    js-yaml "~3.7.0"
-    mkdirp "~0.5.1"
-    sax "~1.2.1"
-    whet.extend "~0.9.9"
 
 symbol-observable@^1.1.0:
   version "1.2.0"
@@ -3691,14 +3260,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-uniq@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
-
-uniqs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
-
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -3749,10 +3310,6 @@ vanilla-framework@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.0.tgz#b5aacc3ce60a521b8de8f160cb505807aadc7869"
 
-vendors@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
-
 verbalize@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/verbalize/-/verbalize-0.1.2.tgz#165fda4640331548f8e990b1d7e14395eb720207"
@@ -3776,10 +3333,6 @@ watch-cli@^0.2.2:
     minimist "^1.1.1"
     supports-color "^4.0.0"
     verbalize "^0.1.2"
-
-whet.extend@~0.9.9:
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Done
Created the [general form](https://docs.google.com/document/d/1JRwDbIk9NzOiUuZvWfcmkXtWxr0An6tpvS6Yt1WPVI0/edit#) and added it to all the contact us buttons/links. 
Split the contact-model styles into its own file.
Click when modal back drop is clicked.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go sections of the site other then core and iot and click the contact buttons/links
- See that the modal opens
- Step through it and submit

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4607
