### PR TITLE
Update Intel NUC desktop image link copy

### DIFF
--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -49,10 +49,8 @@
           <div class="p-list-step__content">
             <p>Download the correct Ubuntu image for your device:</p>
             <ul class="u-no-margin--left u-no-margin--top">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
-              <br>Certified for these models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE and NUC7i3DNBE</li>
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
-                <br>Certified for these models: NUC7PJYH and NUC7CJYH</li>
+              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon and June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
+              <br>Certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE, NUC7i3DNBE and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH.</li>
             </ul>
           </div>
         </li>


### PR DESCRIPTION
## Done

* Update Intel NUC desktop image link copy

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure the content matches [the copy doc](https://docs.google.com/document/d/1hDkrBqpJXWaENYZMSxd8P-XLFQ2LQqS1wNe4o2MGLho/edit)

## Issue / Card

Fixes #4067 
