### PR TITLE
Swap the core landing page takeover

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-{% include "takeovers/_snapcraft-brand-store_takeover.html" %}
+{% include "takeovers/_ubuntu-core-18-takeover.html" %}
 
 <nav class="p-tabs p-sticky-nav">
   <ul class="p-tabs__list" role="tablist">


### PR DESCRIPTION
## Done
Swap the core landing page takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /core and check the takeover is core 18.
