### PR TITLE
Remove hidden ebook forms

### DIFF
--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -34,9 +34,7 @@
   </div>
 </div>
 
-{% include "download/shared/_get_ebook_v1.html" with return_url="https://www.ubuntu.com/download/server/thank-you" default="true" %}
-{% include "download/shared/_get_ebook_v2.html" with return_url="https://www.ubuntu.com/download/server/thank-you" %}
-{% include "download/shared/_get_ebook_v3.html" with return_url="https://www.ubuntu.com/download/server/thank-you" %}
+{% include "download/shared/_get_ebook_v1.html" with return_url="https://www.ubuntu.com/download/server/thank-you" %}
 
 <!-- dependencies -->
 <script src="{{ ASSET_SERVER_URL }}ec520d10-XMLHttpRequest.min.js"></script>

--- a/templates/download/shared/_get_ebook_v1.html
+++ b/templates/download/shared/_get_ebook_v1.html
@@ -1,4 +1,4 @@
-<div class="p-strip--accent is-deep {% if not default == 'true' %}u-hide{% endif %}" id="ebook-1">
+<div class="p-strip--accent is-deep" id="ebook-1">
   <div class="row">
     <div class="col-12">
       <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>
@@ -31,6 +31,11 @@
             <li class="mktFormReq mktField p-list__item">
               <label for="1-Company" class="mktoLabel">Company name:</label>
               <input required id="1-Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+            </li>
+
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Title" class="mktoLabel">Job title:</label>
+              <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
 
             <li class="mktFormReq mktField p-list__item">


### PR DESCRIPTION
## Done

- Removed the old AB test remnants which was causing duplicates in Marketo
- Added Job title field 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/server/thank-you](http://0.0.0.0:8001/download/server/thank-you)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that there is only one ebook form in the source

## Issue / Card

Fixes #4620

