### PR TITLE
ESM landing page in french

### DIFF
--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<section class="p-strip is-deep p-takeover--private-cloud-economics">
+<section class="p-strip is-deep p-takeover--private-cloud-economics" lang="fr">
   <div class="row u-equal-height">
     <div class="col-8">
       <h1 class="p-takeover__title">Extension Sécurité et Maintenance pour Ubuntu 14.04</h1>

--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -44,7 +44,7 @@
       <p>Contactez ci-dessous les équipes de vente de Canonical pour commencer à planifier la fin de vie d’Ubuntu 14.04 ou pour parler de vos systèmes sous Ubuntu 12.04: l’ESM facilitera votre processus de migration, tout en assurant votre conformité aux normes et votre sécurité.</p>
   
     </div>
-    <div class="col-4 u-hide--small u-align--left">
+    <div class="col-4 u-hide--small u-align--center">
       <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="" class="u-hide--small">
     </div>
   </div>

--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -1,0 +1,117 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Canonical annonce l’Extension Sécurité et Maintenance pour Ubuntu 14.04.{% endblock %}
+{% block meta_description %}Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019.{% endblock %}
+
+{% block content %}
+
+<section class="p-strip is-deep p-takeover--private-cloud-economics">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h1 class="p-takeover__title">Extension Sécurité et Maintenance pour Ubuntu 14.04</h1>
+      <h3>Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019.</h3>
+      <p class="p-takeover__text">
+      Aujourd’hui, Ubuntu est le point de départ pour la majorité des applications cloud. Avec plus de 450 million d’instances clouds publiques déployées depuis la sortie d’Ubuntu 16.04 LTS, on constate que la plupart des déploiements les plus larges - à l’échelle du web - utilisent Ubuntu.</p>
+
+      <p>Ce sont notamment des applications financières, de big data et de distribution de contenu, qui dépendent de la stabilité et de la continuité du système d’exploitation sous-jacent pour fournir les services essentiels dont leurs clients dépendent.</p>
+ 
+      <p>L’Extension Sécurité et Maintenance (ESM) a été initialement créée pour Ubuntu 12.04 LTS afin de prolonger la disponibilité des patchs de sécurité essentiels après la date de fin de vie initialement prévue de la version.</p>
+      
+      <p>Par exemple, des institutions utilisent l’ESM pour répondre à leurs problématiques de sécurité et de conformité aux régulations, en attendant d’être en mesure de mettre à jour leurs systèmes vers une version d’Ubuntu supportée et plus récente.</p>
+      
+      <p>La capacité à pouvoir planifier et contrôler les mises à jour des applications dans un environnement sécurisé est cité comme comme la raison principale d’adoption de l’ESM. Avec la fin de vie d’Ubuntu 14.04 LTS prévue pour avril 2019, et pour soutenir les efforts de planification des développeurs du monde entier, Canonical annonce la disponibilité de l’ESM pour Ubuntu 14.04.</p>
+
+      <h3>L’Extension Sécurité et Maintenance: retours d’expérience</h3>
+
+      <p>Ubuntu 12.04 a été la première version d’Ubuntu à avoir une Extension Sécurité et Maintenance. Sa création est tombée à point nommé, car depuis l’année dernière les départements informatiques ont eu à traiter des problèmes majeurs de sécurité et de conformité aux normes: RGPD, Spectre, Meltdown, Stack Clash, Blueborne, Dirty Cow, SegmentSmack ou FragmentSmack pour n’en nommer que quelques uns.</p>
+      
+      <p><b>En tout, l’ESM a fourni plus de 120 mises à jour, comprenant les corrections pour plus de 60 vulnérabilités à haute priorité ou critiques pour les utilisateurs d’Ubuntu 12.04.</b></p>
+      
+      <p>L’Extension Securité et Maintenance a donné l’opportunité aux équipes IT, DevOps et de Sécurité d’avoir une nouvelle approche pour leur stratégie de mise à jour de système d’exploitation. Quelques exemples:</p>
+      
+      <p>Commerctools a réduit ses risques opérationnels et augmenté la conformité RGPD de ses anciens systèmes.</p>
+      
+      <p>ITstrategen a utilisé l’Extension Sécurité et Maintenance pour garantir la sécurité continue de ses serveurs et a fait économiser à ses clients des mises à jours très coûteuses.  </p>
+
+      <h3>En savoir plus sur l’Extension Sécurité et Maintenance</h3>
+      
+      <p>L’ESM pour Ubuntu 14.04 LTS sera disponible lorsque Ubuntu 14.04 LTS arrivera en fin de vie le 30 Avril 2019.
+      
+      <p>Elle est en option dans le pack de support technique commercial de Canonical: <a href="/support">Ubuntu Advantage</a>, mais elle peut aussi être achetée de façon indépendante.</p>
+      
+      <p>Contactez ci-dessous les équipes de vente de Canonical pour commencer à planifier la fin de vie d’Ubuntu 14.04 ou pour parler de vos systèmes sous Ubuntu 12.04: l’ESM facilitera votre processus de migration, tout en assurant votre conformité aux normes et votre sécurité.</p>
+  
+    </div>
+    <div class="col-4 u-hide--small u-align--left">
+      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="" class="u-hide--small">
+    </div>
+  </div>
+  <div class="row">
+
+
+    <div class="col-8">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
+        <fieldset>
+          <h3>Prenons contact</h3>
+          <ul class="p-list u-no-margin--bottom">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel">Prénom :</label>
+              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="LastName" class="mktoLabel">Nom :</label>
+              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Email" class="mktoLabel">Adresse électronique professionnelle :</label>
+              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Phone" class="mktoLabel">N° de téléphone professionnel :</label>
+              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Company" class="mktoLabel">Société :</label>
+              <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Title" class="mktoLabel">Votre fonction ou poste:</label>
+              <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Comments_from_lead__c" class="mktoLabel">Décrivez vos besoins de support :</label>
+              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" class="mktoField mktoRequired" maxlength="2000"></textarea>
+            </li>
+
+            <li class="mktField p-list__item">
+              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label for="canonicalUpdatesOptIn" class="mktoLabel">J'accepte de recevoir des informations sur les produits et services de Canonical.</label>
+            </li>
+            <li class="p-list__item">
+              <p>En soumettant ce formulaire, je confirme que j'ai lu et que j'accepte les conditions suivantes : <a href="/legal/data-privacy" target="_blank" class="mchNoDecorate">Politique de confidentialité</a></p>
+            </li>
+            <li class="mktField p-list__item">
+              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'server-esm', 'eventValue' : undefined });">Planifiez votre passage à l'ESM</button>
+            </li>
+          </ul>
+          <!-- hidden fields -->
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="1240" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="2065" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://www.ubuntu.com/support/thank-you" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="https://www.ubuntu.com/support/thank-you" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+        </fieldset>
+      </form>
+    </div>
+
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -2,6 +2,8 @@
 
 {% block title %}Canonical annonce l’Extension Sécurité et Maintenance pour Ubuntu 14.04.{% endblock %}
 {% block meta_description %}Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/14owLexmd5yn9g9Opq2oYAw-oxG2k2YKLgEi9bGqzzMg/edit{% endblock meta_copydoc %}
+
 
 {% block content %}
 

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<section class="p-strip is-deep p-takeover--private-cloud-economics">
+<section class="p-strip is-deep p-takeover--private-cloud-economics" lang="fr">
   <div class="row u-equal-height">
     <div class="col-8">
       <h1 class="p-takeover__title">Installez et mettez OpenStack à l'échelle en toute simplicité</h1>


### PR DESCRIPTION
## Done

* ESM landing page in French
* [Copy doc](https://docs.google.com/document/d/14owLexmd5yn9g9Opq2oYAw-oxG2k2YKLgEi9bGqzzMg/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure the page at https://www-ubuntu-com-canonical-websites-pr-4623.run.demo.haus/engage/fr/esm looks right and matches the [copy doc](https://docs.google.com/document/d/14owLexmd5yn9g9Opq2oYAw-oxG2k2YKLgEi9bGqzzMg/edit)