### PR TITLE
Remove the bespoke suru background strip

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -86,19 +86,6 @@
   width: 100;
 }
 
-// XXX Applies suru background to the site
-// Candidate for moving to the vanilla-brochure-theme
-.has-background {
-  background-color: $color-light;
-  background-image: url("#{$assets-path}f8a323a7-image-background-paper.png?w=768");
-  background-position: center top;
-  background-repeat: repeat-y;
-
-  @media (min-width: $breakpoint-medium) {
-    background-image: url("#{$assets-path}f8a323a7-image-background-paper.png");
-  }
-}
-
 /// XXX fix nested bullets to use default styles
 .p-list .p-list {
   list-style-type: circle;

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<section class="p-strip has-background is-deep">
+<section class="p-strip--light is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>An IoT app store for all your devices</h1>
@@ -63,7 +63,7 @@
   </div>
 </section>
 
-<section class="p-strip has-background is-bordered is-deep">
+<section class="p-strip is-bordered is-deep">
   <div class="row">
     <div class="col-8">
       <h2>Features</h2>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip has-background is-deep is-bordered">
+<section class="p-strip is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Ubuntu Advantage commercial support</h1>
@@ -199,7 +199,7 @@
 
 {% include "shared/_case-study-itstrategen.html" %}
 
-<section id="community-support" class="p-strip--light has-background is-deep">
+<section id="community-support" class="p-strip--light is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Community support</h2>


### PR DESCRIPTION
## Done
Removed the styling and use on /support and /internet-of-things/appstore

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /support and check the suru background has been replaced with basic strips
- Same on /internet-of-things/appstore

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4456

