### PR TITLE
Control the interative form via hash

### DIFF
--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -93,35 +93,23 @@
   function close() {
     setState(1);
     contactModal.classList.add('u-hide');
-    removeHash();
+    updateHash('');
   }
 
   // Open the contact us modal
   function open() {
     contactModal.classList.remove('u-hide');
-    addHash();
+    updateHash(triggeringHash);
   }
 
   // Removes the triggering hash
-  function removeHash() {
+  function updateHash(hash) {
     var location = window.location;
-    if (location.hash === triggeringHash) {
+    if (location.hash !== hash || hash === '') {
       if ("pushState" in history) {
-        history.pushState('', document.title, location.pathname + location.search);
+        history.pushState('', document.title, location.pathname + location.search + hash);
       } else {
-        location.hash = '';
-      }
-    }
-  }
-
-  // Adds the triggering hash
-  function addHash() {
-    var location = window.location;
-    if (location.hash !== triggeringHash) {
-      if ("pushState" in history) {
-        history.pushState('', document.title, location.pathname + location.search + triggeringHash);
-      } else {
-        location.hash = triggeringHash;
+        location.hash = hash;
       }
     }
   }

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -1,4 +1,5 @@
 (function () {
+  var triggeringHash = '#get-in-touch';
   var contactIndex = 1;
   var contactModal = document.getElementById("contact-modal");
   var contactButtons = document.querySelectorAll('.js-invoke-modal');
@@ -17,10 +18,6 @@
       open();
     });
   });
-
-  if (window.location.hash == '#get-in-touch') {
-    open();
-  }
 
   document.onkeydown = function(evt) {
     evt = evt || window.event;
@@ -96,11 +93,37 @@
   function close() {
     setState(1);
     contactModal.classList.add('u-hide');
+    removeHash();
   }
 
   // Open the contact us modal
   function open() {
     contactModal.classList.remove('u-hide');
+    addHash();
+  }
+
+  // Removes the triggering hash
+  function removeHash() {
+    var location = window.location;
+    if (location.hash === triggeringHash) {
+      if ("pushState" in history) {
+        history.pushState('', document.title, location.pathname + location.search);
+      } else {
+        location.hash = '';
+      }
+    }
+  }
+
+  // Adds the triggering hash
+  function addHash() {
+    var location = window.location;
+    if (location.hash !== triggeringHash) {
+      if ("pushState" in history) {
+        history.pushState('', document.title, location.pathname + location.search + triggeringHash);
+      } else {
+        location.hash = triggeringHash;
+      }
+    }
   }
 
   // Update the content of the modal based on the current index
@@ -145,4 +168,18 @@
     });
     return message;
   }
+
+  // Opens the form when the initial hash matches the trigger
+  if (window.location.hash === triggeringHash) {
+    open();
+  }
+
+
+  // Listens for hash changes and opens the form if it matches the trigger
+  function locationHashChanged() {
+    if (window.location.hash === triggeringHash) {
+      open();
+    }
+  }
+  window.onhashchange = locationHashChanged;
 })()

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -18,6 +18,10 @@
     });
   });
 
+  if (window.location.hash == '#get-in-touch') {
+    open();
+  }
+
   document.onkeydown = function(evt) {
     evt = evt || window.event;
     if (evt.keyCode == 27) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,3 +29,4 @@
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
 {% endblock takeover_content %}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,4 +29,3 @@
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
 {% endblock takeover_content %}
-


### PR DESCRIPTION
## Done
Add controls for adding and removing the triggering hash (get-in-touch). Also listens for hash changes.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /core
- See there is no modal
- Add `#get-in-touch` to the URL and see the modal loads
- Close the modal and see the hash is removed
- Now click the green "Get to market faster" button
- See the modal opens and the hash is added

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4610
