### PR TITLE
Fix app icons that were either not appearing or wrong

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -207,7 +207,7 @@ abbr[title] {
   margin-bottom: 0;
 }
 
-img[src*="svg"] {
-  width: 100%;
-  height: auto;
+.p-matrix__img[src*="svg"] {
+  height: auto !important;
+  width: 100% !important;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -206,3 +206,8 @@ abbr[title] {
 [class^="p-strip"].is-bordered {
   margin-bottom: 0;
 }
+
+img[src*="svg"] {
+  width: 100%;
+  height: auto;
+}

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -76,7 +76,7 @@
         </li>
         <li class="p-matrix__item last-row">
           <a href="https://snapcraft.io/vlc">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}3c8c6a92-VLC_Icon.svg" width="48" alt="VLC icon" />
+            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}33f5e395-vlc.svg" width="48" alt="VLC icon" />
           </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/vlc">VLC player</a></h3>
@@ -84,18 +84,14 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://snapcraft.io/firefox">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}a45d30aa-vf.io-firefox.svg" width="48" alt="Firefox icon" />
-          </a>
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}a45d30aa-vf.io-firefox.svg" width="48" alt="Firefox icon" />
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/firefox">Firefox</a></h3>
             <p class="p-matrix__desc">Firefox Quantum is now 2x faster and 30% lighter than Chrome.</p>
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://snapcraft.io/slack">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="Slack icon" />
-          </a>
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="Slack">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/slack">Slack</a></h3>
             <p class="p-matrix__desc">Team communication and collaboration in one place so you can get more done.</p>

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -2,29 +2,29 @@
 
 {% block head_extra %}
 <style type="text/css">
-@-webkit-keyframes flash-sign {
-  22%, 28%, 98%, 100% {
-    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
-    opacity: 0;
+  @-webkit-keyframes flash-sign {
+    22%, 28%, 98%, 100% {
+      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+      opacity: 0;
+    }
+
+    27%, 99% {
+      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+      opacity: 1;
+    }
   }
 
-  27%, 99% {
-    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
-    opacity: 1;
-  }
-}
+  @keyframes flash-sign {
+    22%, 28%, 98%, 100% {
+      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+      opacity: 0;
+    }
 
-@keyframes flash-sign {
-  22%, 28%, 98%, 100% {
-    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
-    opacity: 0;
+    27%, 99% {
+      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+      opacity: 1;
+    }
   }
-
-  27%, 99% {
-    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
-    opacity: 1;
-  }
-}
 </style>
 {% endblock %}
 {% block title %}Desktop features{% endblock %}
@@ -84,14 +84,18 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}a45d30aa-vf.io-firefox.svg" width="48" alt="Firefox icon" />
+          <a href="https://snapcraft.io/firefox">
+            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}a45d30aa-vf.io-firefox.svg" width="48" alt="Firefox icon" />
+          </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/firefox">Firefox</a></h3>
             <p class="p-matrix__desc">Firefox Quantum is now 2x faster and 30% lighter than Chrome.</p>
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="Slack">
+          <a href="https://snapcraft.io/slack">
+            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="Slack">
+          </a>
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a href="https://snapcraft.io/slack">Slack</a></h3>
             <p class="p-matrix__desc">Team communication and collaboration in one place so you can get more done.</p>
@@ -266,18 +270,18 @@
 {% endblock content %}
 {% block footer_extra %}
 <script>
-var photoRow = document.querySelector('.p-strip-photos');
-var caption = photoRow.querySelector('.p-strip-photos__credit');
-var credits = {'photo-1': 'Photo by community member Tomáš Kijas',
-'photo-2': 'Photo by community member Life Nomadic',
-'photo-3': 'Photo by community member Martin Wagner'};
-if (photoRow) {
-  var n = Math.floor((Math.random() * 3) + 1);
-  if (!credits['photo-' + n]) {
-    n = 1;
+  var photoRow = document.querySelector('.p-strip-photos');
+  var caption = photoRow.querySelector('.p-strip-photos__credit');
+  var credits = {'photo-1': 'Photo by community member Tomáš Kijas',
+  'photo-2': 'Photo by community member Life Nomadic',
+  'photo-3': 'Photo by community member Martin Wagner'};
+  if (photoRow) {
+    var n = Math.floor((Math.random() * 3) + 1);
+    if (!credits['photo-' + n]) {
+      n = 1;
+    }
+    photoRow.classList.add('photo-' + n);
+    caption.innerHTML = credits["photo-" + n];
   }
-  photoRow.classList.add('photo-' + n);
-  caption.innerHTML = credits["photo-" + n];
-}
 </script>
 {% endblock footer_extra %}

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -67,7 +67,7 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}c9be8d47-Spotify_logo_without_text.svg" width="48" alt="">
+          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">Slack</h3>
             <p class="p-matrix__desc">Team communication for the 21st century.</p>


### PR DESCRIPTION
## Done

- fixed non-appearing firefox, slack and vlc logos... some svg corruption on assets?

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/desktop/organisations](http://0.0.0.0:8001/desktop/organisations) and [/desktop/features](http://0.0.0.0:8001/desktop/features)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the correct logos appear
- Not that if you add a link around slack or firefox, the svg resizes to 0x0????!!!!???

## Issue / Card

Fixes #4619