### PR TITLE
Fixed k8s cert image size to 200px

### DIFF
--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -16,7 +16,7 @@
       <p><a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us?product=kubernetes-features">Talk to us</a></p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}96d35aa4-certified-kubernetes-logo.svg?w=300" width="300" alt="Kubernetes Certified Service Provider" />
+      <img src="{{ ASSET_SERVER_URL }}96d35aa4-certified-kubernetes-logo.svg" width="200" alt="Kubernetes Certified Service Provider" />
     </div>
   </div>
 </section>

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -13,7 +13,7 @@
       <p>Ubuntu is the standard platform for Kubernetes &mdash; from development to production, on bare metal, on public cloud, on VMware and on OpenStack. All major clouds offer Ubuntu as the worker node for their Kubernetes SAAS offerings.</p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}96d35aa4-certified-kubernetes-logo.svg?w=300" width="300" alt="Kubernetes Certified Service Provider" />
+      <img src="{{ ASSET_SERVER_URL }}96d35aa4-certified-kubernetes-logo.svg" width="200" alt="Kubernetes Certified Service Provider" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- k8s cert logo was 300px, should be 200px

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/kubernetes/install](http://0.0.0.0:8001/kubernetes/install) and [/kubernetes/managed](http://0.0.0.0:8001/kubernetes/managed)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the logo is 200px

## Issue / Card

Fixes #4622 
