### PR TITLE
Updated Ubuntu core 18 takeover copy

### DIFF
--- a/templates/takeovers/_ubuntu-core-18-takeover.html
+++ b/templates/takeovers/_ubuntu-core-18-takeover.html
@@ -8,7 +8,7 @@
         <img src="{{ ASSET_SERVER_URL }}635ce124-IOT_core_infographic+light.svg" alt="Ubuntu Core 18" />
       </p>
       <p class="u-no-margin--top u-no-margin--bottom"><a href="https://www.brighttalk.com/webcast/6793/339167?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_IOT_UbuntuCore_WBN_Core 18"
-          class="p-button--positive">Register for the webinar</a></p>
+          class="p-button--positive">Watch the webinar</a></p>
       <p class="u-no-margin--top"><a href="/download/iot" class="p-link--inverted">Download Ubuntu Core 18 now&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-hide--small">


### PR DESCRIPTION
## Done

- Updated ubuntu core 18 takeover copy via marketing request, as the webinar is now live. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check copy makes sense and goes to correct place. 

