### PR TITLE
Build the Financial Services whitepaper takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,12 +23,12 @@
 #}
 
 {% block takeover_content %}
-{% comment %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
-{% endcomment %}
+  {% comment %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
   {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
+  {% endcomment %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,11 +24,9 @@
 
 {% block takeover_content %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
-  {% comment %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
   {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
-  {% endcomment %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,9 @@
 #}
 
 {% block takeover_content %}
+{% comment %}
+  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
+{% endcomment %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
   {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}

--- a/templates/takeovers/_fin-serv-whitepaper-takeover.html
+++ b/templates/takeovers/_fin-serv-whitepaper-takeover.html
@@ -7,7 +7,7 @@
           Cloud technologies are sparking a revolution within financial services operations.
         </h4>
         <p class="col-5 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}c52bcce2-financial-takeover-infographic.svg" alt="Financial Services" /></p>
-        <p><a itemprop="url" href="" class="p-button--positive">Download the whitepaper now</a></p>
+        <p><a itemprop="url" href="/engage/finserv-multi-cloud" class="p-button--positive">Download the whitepaper now</a></p>
       </div>
       <div class="col-5 u-hide--small u-align--center">
         <img src="{{ ASSET_SERVER_URL }}c52bcce2-financial-takeover-infographic.svg" alt="Financial serivices" />
@@ -26,7 +26,6 @@
           background-size: auto 100%;
         }
       }
-
     </style>
   </div>
 </section>

--- a/templates/takeovers/_fin-serv-whitepaper-takeover.html
+++ b/templates/takeovers/_fin-serv-whitepaper-takeover.html
@@ -7,7 +7,7 @@
           Cloud technologies are sparking a revolution within financial services operations.
         </h4>
         <p class="col-5 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}c52bcce2-financial-takeover-infographic.svg" alt="Financial Services" /></p>
-        <p><a itemprop="url" href="/engage/finserv-multi-cloud" class="p-button--positive">Download the whitepaper now</a></p>
+        <p><a itemprop="url" href="/engage/finserv-multi-cloud?utm_source=takeover&utm_campaign=CY19_DC_Finance_eBook_451" class="p-button--positive">Download the whitepaper now</a></p>
       </div>
       <div class="col-5 u-hide--small u-align--center">
         <img src="{{ ASSET_SERVER_URL }}c52bcce2-financial-takeover-infographic.svg" alt="Financial serivices" />

--- a/templates/takeovers/_fin-serv-whitepaper-takeover.html
+++ b/templates/takeovers/_fin-serv-whitepaper-takeover.html
@@ -3,9 +3,9 @@
     <div class="row u-vertically-center">
       <div class="col-7">
         <h1>Transforming financial services with multi-cloud</h1>
-        <p class="u-no-padding--top">
+        <h4>
           Cloud technologies are sparking a revolution within financial services operations.
-        </p>
+        </h4>
         <p class="col-5 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}c52bcce2-financial-takeover-infographic.svg" alt="Financial Services" /></p>
         <p><a itemprop="url" href="" class="p-button--positive">Download the whitepaper now</a></p>
       </div>
@@ -16,7 +16,7 @@
     <style>
       .p-takeover--fin-serv-whitepaper {
         background-blend-mode: color;
-        background-image: linear-gradient(-45deg, #2C001E 0%, #5E2750 100%);
+        background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);
       }
 
       @media only screen and (min-width: 768px) {

--- a/templates/takeovers/_fin-serv-whitepaper-takeover.html
+++ b/templates/takeovers/_fin-serv-whitepaper-takeover.html
@@ -1,0 +1,32 @@
+<section lang="en" class="js-takeover is-bordered p-takeover--fin-serv-whitepaper">
+  <div class="p-strip--image is-dark is-deep p-takeover__suru">
+    <div class="row u-vertically-center">
+      <div class="col-7">
+        <h1>Transforming financial services with multi-cloud</h1>
+        <p class="u-no-padding--top">
+          Cloud technologies are sparking a revolution within financial services operations.
+        </p>
+        <p class="col-5 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}c52bcce2-financial-takeover-infographic.svg" alt="Financial Services" /></p>
+        <p><a itemprop="url" href="" class="p-button--positive">Download the whitepaper now</a></p>
+      </div>
+      <div class="col-5 u-hide--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}c52bcce2-financial-takeover-infographic.svg" alt="Financial serivices" />
+      </div>
+    </div>
+    <style>
+      .p-takeover--fin-serv-whitepaper {
+        background-blend-mode: color;
+        background-image: linear-gradient(-45deg, #2C001E 0%, #5E2750 100%);
+      }
+
+      @media only screen and (min-width: 768px) {
+        .p-takeover__suru {
+          background-image: url('{{ ASSET_SERVER_URL }}75a8bada-suru-fold-right.svg');
+          background-position: top right;
+          background-size: auto 100%;
+        }
+      }
+
+    </style>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Build the takeover
- MISSING 
    - the URL to the whitepaper
    - turning it on in the index.html
    - the timing of the release

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the design in https://github.com/ubuntudesign/web-squad/issues/961 and the [copy in the brief](https://docs.google.com/document/d/1HmSgOcUhqEbrCNe0YenuFlDvVa7mDuqbdJOkyvo1GIQ/edit)


## Issue / Card

961 - in web-squad

## Screenshots

large
![image](https://user-images.githubusercontent.com/441217/52220121-12600980-2896-11e9-9ae1-8185d639b550.png)

small
![image](https://user-images.githubusercontent.com/441217/52220172-2e63ab00-2896-11e9-9301-075faeaa69ee.png)
