### PR TITLE
Add the interactive contact us form to the footers

### DIFF
--- a/templates/shared/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared/contextual_footers/_cloud_contact_us.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Talk to us</h3>
   <p>Let our cloud experts help you get started in the right direction with OpenStack, with consulting, training or outsourced operations.</p>
-  <p><a class="p-button--neutral" href="/openstack/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us</a></p>
+  <p><a class="p-button--neutral js-invoke-modal" href="/openstack/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us</a></p>
 </div>

--- a/templates/shared/contextual_footers/_cloud_ubuntu_advantage.html
+++ b/templates/shared/contextual_footers/_cloud_ubuntu_advantage.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Growing your cloud?</h3>
   <p>Ubuntu Advantage enterprise support agreements include Canonical OpenStack at no extra charge.</p>
-  <p><a class="p-button--positive" href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud Ubuntu Advantage', 'eventLabel' : 'Buy now', 'eventValue' : undefined });">Buy now</a> or <a href="/support/contact-us">contact us&nbsp;&rsaquo;</a></p>
+  <p><a class="p-button--positive" href="https://buy.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud Ubuntu Advantage', 'eventLabel' : 'Buy now', 'eventValue' : undefined });">Buy now</a> or <a class="js-invoke-modal" href="/support/contact-us">contact us&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_desktop_contact_us.html
+++ b/templates/shared/contextual_footers/_desktop_contact_us.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Talk to us today</h3>
   <p>Ready to discuss how Ubuntu could benefit your organisation?</p>
-  <p><a class="p-button--neutral" href="/desktop/contact-us?product=contextual-footer-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Desktop contact-us', 'eventLabel' : 'Talk to us today', 'eventValue' : undefined });">Get in touch</a></p>
+  <p><a class="p-button--neutral js-invoke-modal" href="/desktop/contact-us?product=contextual-footer-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Desktop contact-us', 'eventLabel' : 'Talk to us today', 'eventValue' : undefined });">Get in touch</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
+++ b/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
@@ -11,7 +11,7 @@
     </a>
   </p>
   <p>Or,
-    <a href="/management/contact-us?product=contextual-footer-landscape"
+    <a href="/management/contact-us?product=contextual-footer-landscape" class="js-invoke-modal"
       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Contact our sales team', 'eventLabel' : 'Need help?', 'eventValue' : undefined });">
       contact our sales team&nbsp;&rsaquo;
     </a>

--- a/templates/shared/contextual_footers/_iot_contact.html
+++ b/templates/shared/contextual_footers/_iot_contact.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Get in touch</h3>
   <p>Contact us for more information or to discuss your specific needs.</p>
-  <p><a class="p-button--neutral" href="/internet-of-things/contact-us?product={{level_2}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'iot digitalsignage contact-us, 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us</a></p>
+  <p><a class="p-button--neutral js-invoke-modal" href="/internet-of-things/contact-us?product={{level_2}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'iot digitalsignage contact-us, 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Contact us</a></p>
 </div>

--- a/templates/shared/contextual_footers/_maas_experts.html
+++ b/templates/shared/contextual_footers/_maas_experts.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Talk to our experts</h3>
   <p>Canonical makes MAAS amazing and we help people run critical infrastructure at scale with it. Contact us for more information or to discuss your specific&nbsp;needs.</p>
-  <p><a href="/server/contact-us?product=contextual-footer-server-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'download server provisioning page', 'eventLabel' : 'contact us', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
+  <p><a href="/server/contact-us?product=contextual-footer-server-maas" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'download server provisioning page', 'eventLabel' : 'contact us', 'eventValue' : undefined });">Contact us&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_server_contact_us.html
+++ b/templates/shared/contextual_footers/_server_contact_us.html
@@ -2,5 +2,5 @@
   <h3 class="p-heading--four">Ubuntu Advantage for business</h3>
   <p>Get professional support {% if level_2 == 'management' %}with Ubuntu Advantage{% else %}for Ubuntu Server{% endif %} from Canonical.</p>
   <p><a href="https://buy.ubuntu.com" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'Ubuntu Advantage store', 'eventValue' : undefined });"><span class="p-link--external">Visit the store</span></a></p>
-  <p><a href="/server/contact-us?product=contextual-footer-ua" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'For business', 'eventValue' : undefined });">Get in touch&nbsp;&rsaquo;</a></p>
+  <p><a href="/server/contact-us?product=contextual-footer-ua" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'For business', 'eventValue' : undefined });">Get in touch&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_support_contact_us.html
+++ b/templates/shared/contextual_footers/_support_contact_us.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Contact us today</h3>
   <p>Landscape is part of the Ubuntu Advantage service package, delivered by Canonical. To talk to a member of our team about the benefits it could bring to your organisation.</p>
-  <p><a href="/support/contact-us?product=contextual-footer-landscape" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'support contact-us', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us today</a></p>
+  <p><a href="/support/contact-us?product=contextual-footer-landscape" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'support contact-us', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us today</a></p>
 </div>


### PR DESCRIPTION
## Done
Added the invoke class to the contact links/buttons in the contextual footer.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /openstack
- Scroll to the contextual footer
- Click contact us and see the interactive form appears