### PR TITLE
Add interactive forms to the support and server section

### DIFF
--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -8,6 +8,7 @@
 
       input[type="checkbox"] + label {
         margin-bottom: 0;
+        margin-top: 0;
       }
 
       .p-modal__dialog {

--- a/templates/server/base_server.html
+++ b/templates/server/base_server.html
@@ -4,5 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+    {% include "shared/forms/interactive/_support.html" with lpId="2152" formid="1254" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/server/thank-you" %}
 {% endblock %}

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -4,7 +4,7 @@
       <img src="{{ ASSET_SERVER_URL }}00d6e773-contact_orange_phone.svg" width="28" alt="" />
     </div>
     <div class="col-11 u-no-margin--left u-no-margin--bottom">
-      <p class="p-heading--four u-no-margin--bottom">Any questions? Call us <tel href="+17372040291">+1 737 204 0291</tel> (Americas), <tel href="+442036565291">+44 203 656 5291</tel> (RoW) or <a href="/support/contact-us">contact us online</a>.</p>
+      <p class="p-heading--four u-no-margin--bottom">Any questions? Call us <tel href="+17372040291">+1 737 204 0291</tel> (Americas), <tel href="+442036565291">+44 203 656 5291</tel> (RoW) or <a href="/support/contact-us" class="js-invoke-modal">contact us online</a>.</p>
     </div>
   </div>
 </div>

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -1,0 +1,222 @@
+{% load versioned_static  %}
+
+<div class="p-modal u-hide" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title" id="modal-title">Unleash open source in your business</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <h3 class="p-heading--five">Where would you like to go faster?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="where-would-you-like-infrastructure">
+          <label for="where-would-you-like-infrastructure">Infrastructure</label>
+          <input type="checkbox" id="where-would-you-like-applications">
+          <label for="where-would-you-like-applications">Applications</label>
+          <input type="checkbox" id="where-would-you-like-development">
+          <label for="where-would-you-like-development">Development</label>
+          <input type="checkbox" id="where-would-you-like-operations">
+          <label for="where-would-you-like-operations">Operations</label>
+          <input type="checkbox" id="where-would-you-like-managed-services">
+          <label for="where-would-you-like-managed-services">Managed services</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="where-would-you-like-multi-cloud">
+          <label for="where-would-you-like-multi-cloud">Multi cloud</label>
+          <input type="checkbox" id="where-would-you-like-on-premises">
+          <label for="where-would-you-like-on-premises">On premises</label>
+          <input type="checkbox" id="where-would-you-like-edge">
+          <label for="where-would-you-like-edge">Edge</label>
+          <input type="checkbox" id="where-would-you-like-hpc">
+          <label for="where-would-you-like-hpc">HPC</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="where-would-you-like-servers">
+          <label for="where-would-you-like-servers">Servers</label>
+          <input type="checkbox" id="where-would-you-like-virtual-machines">
+          <label for="where-would-you-like-virtual-machines">Virtual machines</label>
+          <input type="checkbox" id="where-would-you-like-desktops">
+          <label for="where-would-you-like-desktops">Desktops</label>
+          <input type="checkbox" id="where-would-you-like-appliances">
+          <label for="where-would-you-like-appliances">Appliances</label>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <h3 class="p-heading--five">Should we bring a particular expert to the discussion?</h3>
+      <div class="row u-no-padding">
+        <div class="col-3 u-sv3">
+          <input type="checkbox" id="expert-to-the-discussion-Kubernetes">
+          <label for="expert-to-the-discussion-Kubernetes">Kubernetes</label>
+          <input type="checkbox" id="expert-to-the-discussion-Openstack">
+          <label for="expert-to-the-discussion-Openstack">Openstack</label>
+          <input type="checkbox" id="expert-to-the-discussion-Kernel">
+          <label for="expert-to-the-discussion-Kernel">Kernel</label>
+          <input type="checkbox" id="expert-to-the-discussion-DevSecOps">
+          <label for="expert-to-the-discussion-DevSecOps">DevSecOps</label>
+          <input type="checkbox" id="expert-to-the-discussion-High-availability">
+          <label for="expert-to-the-discussion-High-availability">High availability</label>
+          <input type="checkbox" id="expert-to-the-discussion-Service-catalog">
+          <label for="expert-to-the-discussion-Service-catalog">Service catalog</label>
+          <input type="checkbox" id="expert-to-the-discussion-Scale">
+          <label for="expert-to-the-discussion-Scale">Scale</label>
+          <input type="checkbox" id="expert-to-the-discussion-Performance">
+          <label for="expert-to-the-discussion-Performance">Performance</label>
+          <input type="checkbox" id="expert-to-the-discussion-VMware">
+          <label for="expert-to-the-discussion-VMware">VMware</label>
+          <input type="checkbox" id="expert-to-the-discussion-Docker">
+          <label for="expert-to-the-discussion-Docker">Docker</label>
+          <input type="checkbox" id="expert-to-the-discussion-Snaps">
+          <label for="expert-to-the-discussion-Snaps">Snaps</label>
+        </div>
+        <div class="col-3 u-sv3">
+          <input type="checkbox" id="expert-to-the-discussion-Storage">
+          <label for="expert-to-the-discussion-Storage">Storage</label>
+          <input type="checkbox" id="expert-to-the-discussion-Networking">
+          <label for="expert-to-the-discussion-Networking">Networking</label>
+          <input type="checkbox" id="expert-to-the-discussion-Databases">
+          <label for="expert-to-the-discussion-Databases">Databases</label>
+          <input type="checkbox" id="expert-to-the-discussion-Message-queues">
+          <label for="expert-to-the-discussion-Message-queues">Message queues</label>
+          <input type="checkbox" id="expert-to-the-discussion-Web-applications">
+          <label for="expert-to-the-discussion-Web-applications">Web applications</label>
+          <input type="checkbox" id="expert-to-the-discussion-Big-data">
+          <label for="expert-to-the-discussion-Big-data">Big data</label>
+          <input type="checkbox" id="expert-to-the-discussion-Event-streams">
+          <label for="expert-to-the-discussion-Event-streams">Event streams</label>
+          <input type="checkbox" id="expert-to-the-discussion-Logging">
+          <label for="expert-to-the-discussion-Logging">Logging</label>
+          <input type="checkbox" id="expert-to-the-discussion-Monitoring">
+          <label for="expert-to-the-discussion-Monitoring">Monitoring</label>
+          <input type="checkbox" id="expert-to-the-discussion-Alerting">
+          <label for="expert-to-the-discussion-Alerting">Alerting</label>
+        </div>
+        <div class="col-3 u-sv3">
+          <input type="checkbox" id="expert-to-the-discussion-AI-ML">
+          <label for="expert-to-the-discussion-AI-ML">AI / ML</label>
+          <input type="checkbox" id="expert-to-the-discussion-Tensorflow">
+          <label for="expert-to-the-discussion-Tensorflow">Tensorflow</label>
+          <input type="checkbox" id="expert-to-the-discussion-Kubeflow">
+          <label for="expert-to-the-discussion-Kubeflow">Kubeflow</label>
+          <input type="checkbox" id="expert-to-the-discussion-PyTorch">
+          <label for="expert-to-the-discussion-PyTorch">PyTorch</label>
+          <input type="checkbox" id="expert-to-the-discussion-NumPy">
+          <label for="expert-to-the-discussion-NumPy">NumPy</label>
+          <input type="checkbox" id="expert-to-the-discussion-ElasticSearch">
+          <label for="expert-to-the-discussion-ElasticSearch">ElasticSearch</label>
+          <input type="checkbox" id="expert-to-the-discussion-Kafka">
+          <label for="expert-to-the-discussion-Kafka">Kafka</label>
+          <input type="checkbox" id="expert-to-the-discussion-Graylog">
+          <label for="expert-to-the-discussion-Graylog">Graylog</label>
+          <input type="checkbox" id="expert-to-the-discussion-Ceph">
+          <label for="expert-to-the-discussion-Ceph">Ceph</label>
+        </div>
+        <div class="col-3 u-sv3">
+          <input type="checkbox" id="expert-to-the-discussion-Compliance">
+          <label for="expert-to-the-discussion-Compliance">Compliance</label>
+          <input type="checkbox" id="expert-to-the-discussion-Licensing">
+          <label for="expert-to-the-discussion-Licensing">Licensing</label>
+          <input type="checkbox" id="expert-to-the-discussion-PCI-DSS">
+          <label for="expert-to-the-discussion-PCI-DSS">PCI-DSS</label>
+          <input type="checkbox" id="expert-to-the-discussion-Outsourcing">
+          <label for="expert-to-the-discussion-Outsourcing">Outsourcing</label>
+          <input type="checkbox" id="expert-to-the-discussion-Orchestration">
+          <label for="expert-to-the-discussion-Orchestration">Orchestration</label>
+          <input type="checkbox" id="expert-to-the-discussion-Integration">
+          <label for="expert-to-the-discussion-Integration">Integration</label>
+          <input type="checkbox" id="expert-to-the-discussion-Packaging">
+          <label for="expert-to-the-discussion-Packaging">Packaging</label>
+        </div>
+      </div>
+      <div class="u-sv3">
+        <h3 class="p-heading--five">Tell us about your project or interest</h3>
+        <textarea id="about-your-project-or-interest" name="sector-specific-requirements" aria-label="Tell us about your project or interest" rows="3"></textarea>
+      </div>
+      <div class="pagination">
+        <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Email address:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--4 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about Ubuntu core</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>
+
+<script src="{% versioned_static 'js/dynamic-contact-form.js' %}"></script>

--- a/templates/support/base_support.html
+++ b/templates/support/base_support.html
@@ -4,5 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+  {% include "shared/forms/interactive/_support.html" with lpId="2065" formid="1240" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/support/thank-you" %}
 {% endblock %}

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -115,7 +115,7 @@
     <div class="col-4 p-divider__block">
       <h4>Talk to a member of our team</h4>
       <p>We can recommend a support package that best suits the needs of your organisation. </p>
-      <p><a class="p-button--neutral" href="/support/contact-us?product=support-overview">Contact us</a></p>
+      <p><a class="p-button--neutral js-invoke-modal" href="/support/contact-us?product=support-overview">Contact us</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Add interactive forms to the support and server section. Including a small drive by to help the checkbox from over lapping.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /server and click a contact us button/link
- Check it shows the interactive form
- Go to /support and click a contact us button/link
- Check it shows the interactive form
- Check the form matches [the copy doc](https://docs.google.com/document/d/1_cn1wgMQdpVLPpQjkKMfnoduI6vbNpIyTpjb7BfTvC0/edit#heading=h.wpzmuhi8p0jp)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4595
