### PR TITLE
Add interactive forms to the k8s section

### DIFF
--- a/templates/kubernetes/base_kubernetes.html
+++ b/templates/kubernetes/base_kubernetes.html
@@ -4,5 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+  {% include "shared/forms/interactive/_kubernetes.html" with lpId="6274" formid="3230" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/kubernetes/thank-you" %}
 {% endblock %}

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -72,7 +72,7 @@
         <li class="p-list__item is-ticked">For hand-built clusters with custom operations regimes</li>
       </ul>
       <p><a href="https://kubernetes.io/docs/setup/independent/install-kubeadm/" class="p-link--external">Install instructions</a></p>
-      <p><a href="/kubernetes/contact-us?product=kubernetes-kubeadm">Get support for kubeadm&nbsp;&rsaquo;</a></p>
+      <p><a href="/kubernetes/contact-us?product=kubernetes-kubeadm" class="js-invoke-modal">Get support for kubeadm&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/templates/shared/forms/interactive/_embedded.html
+++ b/templates/shared/forms/interactive/_embedded.html
@@ -21,7 +21,7 @@
       </div>
       <div class="u-sv3">
         <h3 class="p-heading--five">What sector(s) are you important to you?</h3>
-        <textarea id="particular-sectors" aria-label="Are there particular sectors which are important to you" rows="3" placeholder="Are there particular sectors which are important to you such as industrial, automotive, display, retail, home, office, data center, networking, robotics?"></textarea>
+        <textarea id="particular-sectors" aria-label="Are there particular sectors which are important to you" rows="3" placeholder="Anything extra you’d like to communicate about your needs or interests?"></textarea>
       </div>
       <div class="pagination">
         <a class="p-button--positive pagination__link--next" href="">Next</a>

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -9,7 +9,7 @@
     <div class="js-pagination js-pagination--1">
       <h3 class="p-heading--five">Where do you want to use K8s?</h3>
       <div class="row u-no-padding">
-        <div class="col-4 u-sv3">
+        <div class="col-4">
           <input type="checkbox" id="on-prem-k8s-VMware">
           <label for="on-prem-k8s-VMware">VMware</label>
           <input type="checkbox" id="on-prem-k8s-Bare-metal">
@@ -28,7 +28,7 @@
             <input type="text" id="on-prem-k8s-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other architecture">
           </div>
         </div>
-        <div class="col-4 u-sv3">
+        <div class="col-4">
           <input type="checkbox" id="cloud-k8s-AWS">
           <label for="cloud-k8s-AWS">Amazon Web Services</label>
           <input type="checkbox" id="cloud-k8s-GCP">
@@ -45,7 +45,7 @@
             <input type="text" id="cloud-k8s-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other architecture">
           </div>
         </div>
-        <div class="col-4 u-sv3">
+        <div class="col-4">
           <input type="checkbox" id="architecture-k8s-x86">
           <label for="architecture-k8s-x86">x86</label>
           <input type="checkbox" id="architecture-k8s-ARM">

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -1,0 +1,278 @@
+{% load versioned_static  %}
+
+<div class="p-modal u-hide" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title" id="modal-title">Get your kubernetes clusters running</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <h3 class="p-heading--five">Where do you want to use K8s?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="on-prem-k8s-VMware">
+          <label for="on-prem-k8s-VMware">VMware</label>
+          <input type="checkbox" id="on-prem-k8s-Bare-metal">
+          <label for="on-prem-k8s-Bare-metal">Bare metal</label>
+          <input type="checkbox" id="on-prem-k8s-OpenStack">
+          <label for="on-prem-k8s-OpenStack">OpenStack</label>
+          <input type="checkbox" id="on-prem-k8s-Workstations">
+          <label for="on-prem-k8s-Workstations">Workstations</label>
+          <input type="checkbox" id="on-prem-k8s-Embedded">
+          <label for="on-prem-k8s-Embedded">Embedded</label>
+          <input type="checkbox" id="on-prem-k8s-Edge">
+          <label for="on-prem-k8s-Edge">Edge</label>
+          <div class="js-other-container">
+            <input type="checkbox" class="js-other-container__checkbox" id="on-prem-k8s-other">
+            <label for="on-prem-k8s-other">Other</label>
+            <input type="text" id="on-prem-k8s-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other architecture">
+          </div>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="cloud-k8s-AWS">
+          <label for="cloud-k8s-AWS">Amazon Web Services</label>
+          <input type="checkbox" id="cloud-k8s-GCP">
+          <label for="cloud-k8s-GCP">Google Cloud Platform</label>
+          <input type="checkbox" id="cloud-k8s-IBM-Cloud">
+          <label for="cloud-k8s-IBM-Cloud">IBM Cloud</label>
+          <input type="checkbox" id="cloud-k8s-Microsoft-Azure">
+          <label for="cloud-k8s-Microsoft-Azure">Microsoft Azure</label>
+          <input type="checkbox" id="cloud-k8s-Oracle-Cloud">
+          <label for="cloud-k8s-Oracle-Cloud">Oracle Cloud</label>
+          <div class="js-other-container">
+            <input type="checkbox" class="js-other-container__checkbox" id="cloud-k8s-other">
+            <label for="cloud-k8s-other">Other</label>
+            <input type="text" id="cloud-k8s-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other architecture">
+          </div>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="architecture-k8s-x86">
+          <label for="architecture-k8s-x86">x86</label>
+          <input type="checkbox" id="architecture-k8s-ARM">
+          <label for="architecture-k8s-ARM">ARM</label>
+          <input type="checkbox" id="architecture-k8s-POWER">
+          <label for="architecture-k8s-POWER">POWER</label>
+          <input type="checkbox" id="architecture-k8s-Z">
+          <label for="architecture-k8s-Z">Z</label>
+        </div>
+      </div>
+      <h3 class="p-heading--five">Are any of these relevant for your operations?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="relevant-for-operations-Multi-cloud">
+          <label for="relevant-for-operations-Multi-cloud">Multi-cloud</label>
+          <input type="checkbox" id="relevant-for-operations-Upgrades">
+          <label for="relevant-for-operations-Upgrades">Upgrades</label>
+          <input type="checkbox" id="relevant-for-operations-Monitoring">
+          <label for="relevant-for-operations-Monitoring">Monitoring</label>
+          <input type="checkbox" id="relevant-for-operations-Training">
+          <label for="relevant-for-operations-Training">Training</label>
+          <input type="checkbox" id="relevant-for-operations-RBAC">
+          <label for="relevant-for-operations-RBAC">RBAC</label>
+          <input type="checkbox" id="relevant-for-operations-GPGPU">
+          <label for="relevant-for-operations-GPGPU">GPGPU</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="relevant-for-operations-Security">
+          <label for="relevant-for-operations-Security">Security</label>
+          <input type="checkbox" id="relevant-for-operations-Compliance">
+          <label for="relevant-for-operations-Compliance">Compliance</label>
+          <input type="checkbox" id="relevant-for-operations-Certification">
+          <label for="relevant-for-operations-Certification">Certification</label>
+          <input type="checkbox" id="relevant-for-operations-Federation">
+          <label for="relevant-for-operations-Federation">Federation</label>
+          <input type="checkbox" id="relevant-for-operations-LDAP-integration">
+          <label for="relevant-for-operations-LDAP-integration">LDAP integration</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="relevant-for-operations-Multi-tenancy">
+          <label for="relevant-for-operations-Multi-tenancy">Multi-tenancy</label>
+          <input type="checkbox" id="relevant-for-operations-Interoperability">
+          <label for="relevant-for-operations-Interoperability">Interoperability</label>
+          <input type="checkbox" id="relevant-for-operations-Performance">
+          <label for="relevant-for-operations-Performance">Performance</label>
+          <input type="checkbox" id="relevant-for-operations-Observability">
+          <label for="relevant-for-operations-Observability">Observability</label>
+          <input type="checkbox" id="relevant-for-operations-Tracing">
+          <label for="relevant-for-operations-Tracing">Tracing</label>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <h3 class="p-heading--five">Which use cases are important to you?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="important-to-you-CI-CD">
+          <label for="important-to-you-CI-CD">CI/CD</label>
+          <input type="checkbox" id="important-to-you-Re-platforming">
+          <label for="important-to-you-Re-platforming">Re-platforming</label>
+          <input type="checkbox" id="important-to-you-12-factor-apps">
+          <label for="important-to-you-12-factor-apps">12 factor apps</label>
+          <input type="checkbox" id="important-to-you-Microservices">
+          <label for="important-to-you-Microservices">Microservices</label>
+          <input type="checkbox" id="important-to-you-Stateful-Applications">
+          <label for="important-to-you-Stateful-Applications">Stateful Applications</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="important-to-you-AI-ML">
+          <label for="important-to-you-AI-ML">AI/ML</label>
+          <input type="checkbox" id="important-to-you-Auto-scaling">
+          <label for="important-to-you-Auto-scaling">Auto-scaling</label>
+          <input type="checkbox" id="important-to-you-Docker-Migration">
+          <label for="important-to-you-Docker-Migration">Docker Migration</label>
+          <input type="checkbox" id="important-to-you-Mesos-Migration">
+          <label for="important-to-you-Mesos-Migration">Mesos Migration</label>
+          <input type="checkbox" id="important-to-you-OpenShift-Migration">
+          <label for="important-to-you-OpenShift-Migration">OpenShift Migration</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="important-to-you-Big-Data">
+          <label for="important-to-you-Big-Data">Big Data</label>
+          <input type="checkbox" id="important-to-you-Multi-cloud-ingress">
+          <label for="important-to-you-Multi-cloud-ingress">Multi-cloud ingress</label>
+          <input type="checkbox" id="important-to-you-Enterprise-Java">
+          <label for="important-to-you-Enterprise-Java">Enterprise Java</label>
+          <input type="checkbox" id="important-to-you-SOA">
+          <label for="important-to-you-SOA">SOA</label>
+          <div class="js-other-container">
+            <input type="checkbox" class="js-other-container__checkbox" id="important-to-you-other">
+            <label for="important-to-you-other">Other</label>
+            <input type="text" id="important-to-you-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other architecture">
+          </div>
+        </div>
+      </div>
+      <h3 class="p-heading--five">Which cloud native projects are important to you?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="cloud-native-projects-Prometheus">
+          <label for="cloud-native-projects-Prometheus">Prometheus</label>
+          <input type="checkbox" id="cloud-native-projects-Istio">
+          <label for="cloud-native-projects-Istio">Istio</label>
+          <input type="checkbox" id="cloud-native-projects-Envoy">
+          <label for="cloud-native-projects-Envoy">Envoy</label>
+          <input type="checkbox" id="cloud-native-projects-gRPC">
+          <label for="cloud-native-projects-gRPC">gRPC</label>
+          <input type="checkbox" id="cloud-native-projects-Knative">
+          <label for="cloud-native-projects-Knative">Knative</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="cloud-native-projects-Linkerd">
+          <label for="cloud-native-projects-Linkerd">Linkerd</label>
+          <input type="checkbox" id="cloud-native-projects-Fluentd">
+          <label for="cloud-native-projects-Fluentd">Fluentd</label>
+          <input type="checkbox" id="cloud-native-projects-Jaeger">
+          <label for="cloud-native-projects-Jaeger">Jaeger</label>
+          <input type="checkbox" id="cloud-native-projects-OpenTracing">
+          <label for="cloud-native-projects-OpenTracing">OpenTracing</label>
+          <input type="checkbox" id="cloud-native-projects-NATS">
+          <label for="cloud-native-projects-NATS">NATS</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="cloud-native-projects-Rook">
+          <label for="cloud-native-projects-Rook">Rook</label>
+          <input type="checkbox" id="cloud-native-projects-Vitess">
+          <label for="cloud-native-projects-Vitess">Vitess</label>
+          <input type="checkbox" id="cloud-native-projects-etcd">
+          <label for="cloud-native-projects-etcd">etcd</label>
+          <input type="checkbox" id="cloud-native-projects-Notary">
+          <label for="cloud-native-projects-Notary">Notary</label>
+          <input type="checkbox" id="cloud-native-projects-Helm">
+          <label for="cloud-native-projects-Helm">Helm</label>
+          <div class="js-other-container">
+            <input type="checkbox" class="js-other-container__checkbox" id="cloud-native-projects-other">
+            <label for="cloud-native-projects-other">Other</label>
+            <input type="text" id="cloud-native-projects-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other architecture">
+          </div>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+        <a class="pagination__link--next p-button--positive" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <div class="u-sv3">
+        <h3 class="p-heading--five">Have we missed something?</h3>
+        <textarea id="particular-sectors" aria-label="Have we missed something?" rows="3" placeholder="Are there particular sectors which are important to you such as industrial, automotive, display, retail, home, office, data center, networking, robotics?"></textarea>
+      </div>
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Email address:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--4 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about Ubuntu core</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>
+
+<script src="{% versioned_static 'js/dynamic-contact-form.js' %}"></script>

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -24,6 +24,6 @@
         </ul>
       </div>
     </div>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us&nbsp;&rsaquo;</a></p>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -15,7 +15,7 @@
       <li class="p-list__item is-ticked">Lifecycle management</li>
       <li class="p-list__item is-ticked">Backup and recovery</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-explorer">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-explorer" class="js-invoke-modal">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
@@ -31,7 +31,7 @@
       <li class="p-list__item is-ticked">3 days on-site in-person Canonical Kubernetes training</li>
       <li class="p-list__item is-ticked">Optional add-on: AI/ML $40,000 one-off fee</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer" class="js-invoke-modal">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
@@ -52,6 +52,6 @@
       <li class="p-list__item is-ticked">Application Catalog</li>
       <li class="p-list__item is-ticked">2 days on-site in-person Knowledge Transfer to Kubernetes Operators</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer-plus">Contact us about Kubernetes Discoverer Plus&nbsp;&rsaquo;</a></p>
+    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer-plus" class="js-invoke-modal">Contact us about Kubernetes Discoverer Plus&nbsp;&rsaquo;</a></p>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -115,7 +115,7 @@
     <div class="col-12">
       <p><small><sup>*</sup> Minimums apply</small></p>
       <p><small><sup>**</sup> <a href="/openstack/managed">BootStack</a> pricing is in addition to the managed Kubernetes price of $2,190. You can run an unlimited number of virtual Kubernetes nodes on top of each OpenStack physical node. Ubuntu Advantage for Kubernetes is provided at no additional charge if UA for OpenStack has already been purchased for the physical node.</small></p>
-      <p><a href="/kubernetes/contact-us?product=kubernetes-support">For more information about Kubernetes support, contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/kubernetes/contact-us?product=kubernetes-support" class="js-invoke-modal">For more information about Kubernetes support, contact us&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -86,8 +86,8 @@
       <tr>
         <td>&nbsp;</td>
         <td class="u-align--center"><a class="p-link--external" href="https://maas.io/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Install MAAS', 'eventLabel' : 'Install MAAS - MAAS support table' : undefined });">Install MAAS</a></td>
-        <td class="p-table__cell--highlight u-align--center"><a href="/server/contact-us?product=server-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - standard - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
-        <td class="p-table__cell--highlight u-align--center"><a href="/server/contact-us?product=server-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - advanced - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
+        <td class="p-table__cell--highlight u-align--center"><a href="/server/contact-us?product=server-maas" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - standard - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
+        <td class="p-table__cell--highlight u-align--center"><a href="/server/contact-us?product=server-maas" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Contact us - advanced - MAAS support table' : undefined });">Contact us&nbsp;&rsaquo;</a></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Done
Add interactive forms to the k8s section. Added a contact us button in the hero section.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /kubernetes
- Click the contact us button
- Check the form matches the [copy doc](https://docs.google.com/document/d/1F2DrXEU_XtnxsTkSbBIRf2l0vAsTHOY-HYu2Ry_693c/edit#)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4590
