### PR TITLE
Update on Intel NUC and Rasp Pi CM4 to use Ubuntu Core 18

### DIFF
--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -113,7 +113,7 @@
               </li>
               <li>If there is any directory mounted on the internal eMMC storage, unmount it. For instance, if you see an occurence of <code>/dev/mmcblk0p3</code> on <code>/media/ubuntu/writable type ext4 (rw,relatime,data=ordered)</code>, run <code>sudo umount /media/ubuntu/writabl</code>.</li>
               <li>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:
-                  <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/ubuntu-core-16-amd64.img.xz | sudo dd of=/dev/mmcblk0 bs=32M status=progress; sync</code></pre>
+                  <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/ubuntu-core-18-amd64.img.xz | sudo dd of=/dev/mmcblk0 bs=32M status=progress; sync</code></pre>
               </li>
               <li>Reboot the system and remove the flash drives when prompted, it will then reboot from the internal memory where Ubuntu Core has been flashed.</li>
             </ol>

--- a/templates/download/iot/raspberry-pi-compute-module-3.html
+++ b/templates/download/iot/raspberry-pi-compute-module-3.html
@@ -96,7 +96,7 @@ sudo ./rpiboot</code></pre>
                 <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4"></p>
               </li>
               <li>
-                <p>With the first micro USB to USB cable, plug the hose machine into the IO Board USB slave port (<code>J15</code>).</p>
+                <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
                 <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15"></p>
               </li>
               <li>With the second micro USB to USB cable, power on the IO board.</li>

--- a/templates/download/iot/raspberry-pi-compute-module-3.html
+++ b/templates/download/iot/raspberry-pi-compute-module-3.html
@@ -53,8 +53,8 @@
           <div class="p-list-step__content">
             <p>Get the correct Ubuntu Core image for your board:</p>
             <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/ubuntu-core-16-cm3.img.xz">Ubuntu Core 16 image for Compute Module 3</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+cm3.img.xz">Ubuntu Core 18 image for Compute Module 3</a></li>
+              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
             </ul>
           </div>
         </li>
@@ -119,7 +119,7 @@ sudo ./rpiboot</code></pre>
                   <li>If the partition is mounted, unmount it by clicking the square icon below the partition diagram or the eject icon in a file manager</li>
                 </ul>
               </li>
-              <li>Download the <a href="#step2">Ubuntu Core image</a>. When this is done you should have an <code>ubuntu-core-16-cm3.img.xz</code> file in your <code>~/Downloads</code> directory</li>
+              <li>Download the <a href="#step2">Ubuntu Core image</a>. When this is done you should have an <code>ubuntu-core-18-armhf+cm3.img.xz</code> file in your <code>~/Downloads</code> directory</li>
               <li>
                 <p>Flash Ubuntu Core on the EMMC partition with:</p>
                 <pre><code>xzcat ~/Downloads/&lt;image file .xz&gt; | sudo dd of=&lt;device address&gt; bs=32M; sync</code></pre>


### PR DESCRIPTION
## Done

- Updated these two pages to use the official Ubuntu core 18 isos

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot/intel-nuc](http://0.0.0.0:8001/download/iot/intel-nuc) and [/download/iot/raspberry-pi-compute-module-3](http://0.0.0.0:8001/download/iot/raspberry-pi-compute-module-3)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Test the links and compare to the copy docs [NUC](https://docs.google.com/document/d/1e2aWvVEEXvxDWSbxDzs-_tqKbKbW9sapjCjIRiuAdMg/edit) and PI CM3](https://docs.google.com/document/d/1BO8UI7BNDbyLhLcRSbxzhhaAj-dO6AbYPJUJ0A36vCQ/edit#)

## Issue / Card

Fixes #4587

