### PR TITLE
Revert the http package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.django_views==1.3.3
 canonicalwebteam.yaml-responses[django]==1.1.0
 canonicalwebteam.get-feeds==0.2.4
-canonicalwebteam.http==1.0.0
+canonicalwebteam.http==0.1.6
 whitenoise==3.3.1
 gunicorn[gevent]
 statsd==3.3.0


### PR DESCRIPTION
## Done
Revert the http package

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- This requires msgpack which is breaking the build
