### PR TITLE
Use django-views 1.3.4, for python2 compatability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.18
 django-prometheus==1.0.15
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
-canonicalwebteam.django_views==1.3.3
+canonicalwebteam.django_views==1.3.4
 canonicalwebteam.yaml-responses[django]==1.1.0
 canonicalwebteam.get-feeds==0.2.4
 canonicalwebteam.http==0.1.6


### PR DESCRIPTION
1.3.4 no longer errors on missing NotADirectoryError.

This should fix the release errors: https://jenkins.canonical.com/webteam/job/www.ubuntu.com-deploy-to-staging/694/console

QA
--

```
./run build
virtualenv env2
source env2/bin/activate
pip install -r requirements.txt
python manage.py runserver
```

Go to http://localhost:8000 - check it doesn't error.