### PR TITLE
Add fine grain formIDs to each interactive form

### DIFF
--- a/templates/ai/base_ai.html
+++ b/templates/ai/base_ai.html
@@ -4,5 +4,4 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -182,5 +182,6 @@
   </div>
 </section>
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_general.html" with formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-features' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -205,4 +205,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_general.html" with formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
 {% endblock content %}

--- a/templates/ai/install.html
+++ b/templates/ai/install.html
@@ -110,6 +110,6 @@
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
-
+{% include "shared/forms/interactive/_general.html" with  formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/containers/base_containers.html
+++ b/templates/containers/base_containers.html
@@ -4,5 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+  {% include "shared/forms/interactive/_general.html" with formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 {% endblock %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -568,7 +568,7 @@ store for access to all the standard apps, or curate your own collection.</p>
 </style>
 <script src="{% versioned_static 'js/stickyNav.js' %}"></script>
 
-{% include "shared/forms/interactive/_embedded.html" with lpId="2166" formid="1266" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/core/thank-you" %}
+{% include "shared/forms/interactive/_embedded.html" with formid="1266" lpId="2166"  returnURL="https://www.ubuntu.com/core/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 

--- a/templates/desktop/base_desktop.html
+++ b/templates/desktop/base_desktop.html
@@ -4,5 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+    {% include "shared/forms/interactive/_general.html" with formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 {% endblock %}

--- a/templates/esm/base_esm.html
+++ b/templates/esm/base_esm.html
@@ -4,5 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+  {% include "shared/forms/interactive/_general.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 {% endblock %}

--- a/templates/internet-of-things/base_things.html
+++ b/templates/internet-of-things/base_things.html
@@ -4,5 +4,4 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/kubernetes/base_kubernetes.html
+++ b/templates/kubernetes/base_kubernetes.html
@@ -4,5 +4,4 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_kubernetes.html" with lpId="6274" formid="3230" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/kubernetes/thank-you" %}
 {% endblock %}

--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -14,7 +14,7 @@
   {% elif product == 'multicloud' %}
       {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about multicloud" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=multicloud' %}
   {% elif product == 'kubernetes-install' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install' %}
   {% elif product == 'kubernetes-features' %}
       {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features' %}
   {% elif product == 'kubernetes-explorer' %}

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -174,5 +174,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
 
 {% endblock content %}

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -312,5 +312,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
 
 {% endblock content %}

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -163,5 +163,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
 
 {% endblock content %}

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -403,5 +403,6 @@
   </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
 
 {% endblock content %}

--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -66,5 +66,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
 
 {% endblock content %}

--- a/templates/livepatch/base_livepatch.html
+++ b/templates/livepatch/base_livepatch.html
@@ -4,5 +4,5 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+  {% include "shared/forms/interactive/_general.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 {% endblock %}

--- a/templates/openstack/_base_openstack.html
+++ b/templates/openstack/_base_openstack.html
@@ -4,5 +4,4 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_openstack.html" with lpId="2086" formid="1251" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% endblock %}

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -232,4 +232,6 @@
   </section>
 
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_rfp" third_item="_cloud_further_reading" %}
+  {% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
 {% endblock content %}

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -360,4 +360,6 @@
 
 
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_rfp" third_item="_cloud_further_reading" %}
+  {% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
 {% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -291,5 +291,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_ubuntu_advantage" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -404,6 +404,7 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_cloud_bootstack" second_item="_download_cloud_buy_landscape" third_item="_download_documentation" %}
+{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 
 {% endblock content %}

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -542,4 +542,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_openstack.html" with formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
 {% endblock content %}

--- a/templates/openstack/partners.html
+++ b/templates/openstack/partners.html
@@ -70,5 +70,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -142,5 +142,6 @@
           </section>
 
           {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_rfp" third_item="_cloud_further_reading" %}
+          {% include "shared/forms/interactive/_openstack.html" with formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
           {% endblock content %}

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -137,6 +137,7 @@
     </div>
   </div>
 </section>
+{% include "shared/forms/interactive/_openstack.html" with formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}
 {% endblock outer_content %}

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -116,5 +116,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_ubuntu_advantage" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/server/base_server.html
+++ b/templates/server/base_server.html
@@ -4,5 +4,4 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    {% include "shared/forms/interactive/_support.html" with lpId="2152" formid="1254" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/server/thank-you" %}
 {% endblock %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -224,5 +224,6 @@
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_support.html" with formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -395,5 +395,6 @@
   </div>
 
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
+  {% include "shared/forms/interactive/_support.html" with formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
   {% endblock content %}

--- a/templates/support/base_support.html
+++ b/templates/support/base_support.html
@@ -4,5 +4,4 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_support.html" with lpId="2065" formid="1240" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/support/thank-you" %}
 {% endblock %}

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -44,6 +44,7 @@
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}
+{% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}
 {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -213,5 +213,6 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}
+{% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -256,6 +256,7 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}
+{% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}
 {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}


### PR DESCRIPTION
## Done
Updated the formIDs used and scoped them to a page by page instead of section by section.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check that the formIDs in the contact us file for each section matches the formID included to the interactive form module
- Check a few pages with the interactive form installed and check they load ok