### PR TITLE
Fix 404s caused by moving assets

### DIFF
--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -237,5 +237,5 @@ juju status kibana --format yaml| grep public-address
 [quickstart]: /kubernetes/docs/quickstart
 [nagios]: https://www.nagios.org/
 [elastic]: https://www.elastic.co/
-[download-scraper]: https://github.com/conjure-up/spells/blob/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
+[download-scraper]: https://raw.githubusercontent.com/conjure-up/spells/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
 [download-dashboard]: https://raw.githubusercontent.com/conjure-up/spells/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/grafana-k8s.json

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -125,7 +125,7 @@ Once logged in, check out the cluster metric dashboard by clicking the `Home` dr
 
 ![grafana dashboard image](https://assets.ubuntu.com/v1/e6934269-grafana-1.png)
 
-You can also check out the system metrics of the cluster by switching the drop-down box to `Node Metrics (via Telegraf):
+You can also check out the system metrics of the cluster by switching the drop-down box to `Node Metrics (via Telegraf)`:
 
 ![grafana dashboard image](https://assets.ubuntu.com/v1/45b87639-grafana-2.png)
 

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -5,17 +5,28 @@ markdown_includes:
 context:
   title: "Monitoring"
   description: How to create monitoring solution that runs whether the cluster itself is running or not. It may also be useful to integrate monitoring into existing setups.
+keywords: juju, monitor, grafana, prometheus
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: monitoring.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
-The Charmed Distribution of Kubernetes<sup>&reg;</sup> includes the standard Kubernetes dashboard for monitoring your cluster. However, it is often advisable to have a monitoring solution which will run whether the cluster itself is running or not. It may also be useful to integrate monitoring into existing setups.
+The **Charmed Distribution of Kubernetes**<sup>&reg;</sup> includes the standard
+**Kubernetes** dashboard for monitoring your cluster. However, it is often advisable to
+have a monitoring solution which will run whether the cluster itself is running or not. It
+may also be useful to integrate monitoring into existing setups.
 
-Prometheus is the recommended way to monitor your deployment - instructions are provided below. There are also instructions for setting up other monitoring solutions, or connecting to existing monitoring setups.
+**Prometheus** is the recommended way to monitor your deployment - instructions are
+provided below. There are also instructions for setting up other monitoring solutions, or
+connecting to existing monitoring setups.
 
 ## Monitoring with Prometheus
 
-The recommended way to monitor your cluster is to use a combination of Prometheus, Grafana and Telegraf. The fastest, easiest way to install and configure this is via conjure-up when installing the Charmed Distribution of Kubernetes<sup>&reg;</sup>, by selecting the box next to Prometheus from the `Add-on` menu. You can then log in to the dashboard as [described below](#retrieve-credentials-and-login). See the [quickstart guide][quickstart] for more details on installing CDK with conjure-up.
+The recommended way to monitor your cluster is to use a combination of **Prometheus**, **Grafana** and **Telegraf**. The fastest, easiest way to install and configure this is via **conjure-up** when installing the **Canonical Distribution of Kubernetes**<sup>&reg;</sup>, by selecting the box next to Prometheus from the `Add-on` menu. You can then log in to the dashboard as [described below](#retrieve-credentials-and-login). See the [quickstart guide][quickstart] for more details on installing **CDK** with **conjure-up**.
 
-If you have already installed your cluster, you will be able to add and configure the extra applications using Juju as described here:
+If you have already installed your cluster, you will be able to add and configure the extra applications using **Juju** as described here:
 
 ### Install the required applications
 
@@ -42,14 +53,13 @@ juju add-relation kubernetes-worker:juju-info telegraf:juju-info
 
 ### Adding a scraper for Prometheus
 
-Prometheus will also need an appropriate scraper to collect metrics relevant to the cluster. A useful default is installed when using conjure-up (the template for this can be [downloaded here][download-scraper]), but you can also configure it manually by following the steps outlined here:
+Prometheus will also need an appropriate scraper to collect metrics relevant to the cluster. A useful default is installed when using **conjure-up** (the template for this can be [downloaded here][download-scraper]), but you can also configure it manually by following the steps outlined here:
 
 #### 1. Download the scraper file
 
 ```bash
 curl -O  https://raw.githubusercontent.com/conjure-up/spells/master/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
 ```
-
 This is the template, but it needs some specific information for your cluster.
 
 #### 2. Get the relevant address and password
@@ -58,7 +68,6 @@ This is the template, but it needs some specific information for your cluster.
 api=$(juju run  --unit kubeapi-load-balancer/0 'network-get website --format yaml --ingress-address' | head -1)
 pass=$(juju run --unit kubernetes-master/0 'grep "password:" /home/ubuntu/config' | awk '{ print $2 }')
 ```
-
 This will fetch the relevant info from your cluster and store in temporary environment variables for convenience.
 
 #### 4. Substitute in the variables
@@ -75,20 +84,20 @@ juju config prometheus scrape-jobs="$(<myscraper.yaml)"
 
 ### Add the dashboards
 
-As with the scraper, there is a [sample dashboard available for download here][download-dashboard]. You can download and configure grafana to use it by following these steps:
+As with the scraper, there is a [sample dashboard available for download here][download-dashboard]. You can download and configure **grafana** to use it by following these steps:
 
 #### 1. Download the sample dashboard configuration
 
 ```bash
 curl -O https://raw.githubusercontent.com/conjure-up/spells/master/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/grafana-k8s.json
 ```
-
 #### 2. Upload this to grafana
 
-`bash juju run-action --wait grafana/0 import-dashboard dashboard="$(base64 grafana-k8s.json)"`
+```bash
+juju run-action --wait grafana/0 import-dashboard dashboard="$(base64 grafana-k8s.json)"
+```
 
 There is also a default Telegraf dashboard. If you wish to install this, it can be done in a similar way:
-
 ```bash
 curl -O https://raw.githubusercontent.com/conjure-up/spells/master/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/grafana-telegraf.json
 juju run-action --wait grafana/0 import-dashboard  dashboard="$(base64 grafana-telegraf.json)"
@@ -96,7 +105,7 @@ juju run-action --wait grafana/0 import-dashboard  dashboard="$(base64 grafana-t
 
 ### Retrieve credentials and login
 
-To open the dashboard in your browser you will need to know the IP address for grafana and the admin password. These can be retrieved with the following commands:
+To open the dashboard in your browser you will need to know the IP address for **grafana** and the admin password. These can be retrieved with the following commands:
 
 ```bash
 juju status --format yaml grafana/0 | grep public-address
@@ -116,13 +125,13 @@ Once logged in, check out the cluster metric dashboard by clicking the `Home` dr
 
 ![grafana dashboard image](https://assets.ubuntu.com/v1/e6934269-grafana-1.png)
 
-You can also check out the system metrics of the cluster by switching the drop-down box to Node Metrics (via Telegraf):
+You can also check out the system metrics of the cluster by switching the drop-down box to `Node Metrics (via Telegraf):
 
 ![grafana dashboard image](https://assets.ubuntu.com/v1/45b87639-grafana-2.png)
 
 ## Monitoring with Nagios
 
-Nagios ([https://www.nagios.org/][nagios]) is widely used for monitoring networks, servers and applications. Using the Nagios Remote Plugin Executor (NRPE) on each node, it can monitor your cluster with machine-level detail.
+**Nagios** ([https://www.nagios.org/][nagios]) is widely used for monitoring networks, servers and applications. Using the Nagios Remote Plugin Executor (NRPE) on each node, it can monitor your cluster with machine-level detail.
 
 To start, deploy the latest version of the Nagios and NRPE Juju charms:
 
@@ -132,7 +141,7 @@ juju deploy nrpe --series=xenial
 juju expose nagios
 ```
 
-Connect Nagios to NRPE:
+Connect **Nagios** to NRPE:
 
 ```bash
 juju add-relation nagios nrpe
@@ -160,11 +169,11 @@ The default username is `nagiosadmin`. The password is randomly generated at ins
 juju ssh nagios/0 sudo cat /var/lib/juju/nagios.passwd
 ```
 
-![nagios dashboard image](https://assets.ubuntu.com/v1/4b109895-CDK-nagios.png)
+![nagios dashboard image][https://assets.ubuntu.com/v1/4b109895-cdk-nagios.png]
 
 ### Using an existing Nagios service
 
-If you already have an existing Nagios installation, the `nrpe-external-master` charm can be used instead.
+If you already have an existing **Nagios** installation, the `nrpe-external-master` charm can be used instead.
 
 ```bash
 juju deploy nrpe-external-master --series=xenial
@@ -173,10 +182,10 @@ juju configure nrpe-external-master nagios_master= <ip-address-of-nagios>
 
 Once configured, add relations to `nrpe-external-master` as outlined above.
 
-## Monitoring with Elasticsearch
+## Monitoring with **Elasticsearch**
 
 Elasticsearch ([https://www.elastic.co/][elastic]) is a popular monitoring application which
-can be used in conjunction with CDK.
+can be used in conjunction with **CDK**.
 
 ### Deploy the required applications
 
@@ -198,6 +207,7 @@ You now need to relate the elasticsearch applications together, and connect the 
 juju add-relation elasticsearch kibana
 juju add-relation elasticsearch topbeat
 juju add-relation elasticsearch filebeat
+
 juju add-relation  topbeat kubernetes-master
 juju add-relation filebeat kubernetes-master
 juju add-relation topbeat kubernetes-worker
@@ -210,15 +220,15 @@ juju add-relation filebeat etcd
 
 ### Initialise the dashboard
 
-A sample dashboard is included in kabana for monitoring the beat services. You can deploy it by running the following:
+A sample dashboard is included in kibana for monitoring the beat services. You can deploy it by running the following:
 
-```bash
+```
 juju run-action --wait kibana/0 load-dashboard dashboard=beats
 ```
 
-You can find the dashboard at the public IP address of your kibana application
+You can find the dashboard at the public IP address of your **kibana** application
 
-```bash
+```
 juju status kibana --format yaml| grep public-address
 ```
 
@@ -227,5 +237,5 @@ juju status kibana --format yaml| grep public-address
 [quickstart]: /kubernetes/docs/quickstart
 [nagios]: https://www.nagios.org/
 [elastic]: https://www.elastic.co/
-[download-scraper]: https://raw.githubusercontent.com/conjure-up/spells/master/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
-[download-dashboard]: https://raw.githubusercontent.com/conjure-up/spells/master/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/grafana-k8s.json
+[download-scraper]: https://github.com/conjure-up/spells/blob/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
+[download-dashboard]: https://raw.githubusercontent.com/conjure-up/spells/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/grafana-k8s.json

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -62,6 +62,14 @@ public registries. Full instructions on using this feature are in the [documenta
 The keepalived charm can be used to run multiple kube-api-loadbalancers behind a
 virtual IP. For more details, please see the [documentation][docs-keepalived].
 
+- Nginx update
+
+Nginx was updated to v0.21.0, which brings a few changes of which to be aware. The first
+is that nginx is now in a namespace by itself, which is derived from the application name.
+By default this will be `ingress-nginx-kubernetes-worker`. The second change relates to
+custom configmaps. The name has changed to `nginx-configuration` and the configmap needs to
+reside in the same namespace as the nginx deployment.
+
 ## Fixes
 
  - Added post deployment script for jaas/jujushell ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/pull/697))
@@ -89,9 +97,9 @@ virtual IP. For more details, please see the [documentation][docs-keepalived].
  - Fixed an issue where the calico-node service failed to start ([Issue](https://github.com/juju-solutions/layer-canal/pull/24))
  - Fixed updating policy definitions during upgrade-charm on AWS integrator ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/30))
  - Fixed parsing credentials config value ([Issue](https://github.com/juju-solutions/charm-azure-integrator/pull/18))
- - Fixed pvc stuck in pending ([Issue](https://github.com/juju-solutions/charm-azure-integrator/issues/16))
- - Fixed updating properties of the openstack integrator charm do not propagate automatically ([Issue](https://github.com/juju-solutions/charm-openstack-integrator/issues/10))
- - Fixed flannel error during install hook due to incorrect resource ([Issue](https://github.com/juju-solutions/charm-flannel/issues/52))
+ - Fixed pvc stuck in pending (azure-integrator)
+ - Fixed updating properties of the openstack integrator charm do not propagate automatically (openstack-integrator)
+ - Fixed flannel error during install hook due to incorrect resource (flannel)
  - Updated master and worker to handle upstream changes from OpenStack Integrator ([Issue](https://github.com/juju-solutions/kubernetes/pull/176))
  - Updated to CNI 0.7.4 ([Issue](https://github.com/juju-solutions/kubernetes/pull/194))
  - Updated to Flannel v0.10.0 ([Issue](https://github.com/juju-solutions/charm-flannel/pull/50))

--- a/templates/kubernetes/docs/using-vault.md
+++ b/templates/kubernetes/docs/using-vault.md
@@ -122,8 +122,8 @@ More details can be found [in the guide][vault-guide-ha].
 [certs-doc]: /kubernetes/docs/certs-and-trust
 [encryption-doc]: /kubernetes/docs/encryption-at-rest
 [vault]: https://www.vaultproject.io
-[expose]: https://docs.jujucharms.com/stable/en/charms-exposing
-[hacluster]: https://jujucharms.com/stable/en/hacluster
+[expose]: https://docs.jujucharms.com/stable/en/charms-deploying#exposing-deployed-applications
+[hacluster]: https://jujucharms.com/hacluster/
 [vault-guide-csr]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-certificate-management.html
 [vault-guide-unseal]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-vault.html#initialize-and-unseal-vault
 [vault-guide-ha]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-vault.html#enabling-ha


### PR DESCRIPTION
## Done

Fixes a lot of links - 
 - broken links in using-vault caused by new version of Juju docs
 - broken links in release notes caused by moving issues to LP
 - broken links in monitoring caused by renaming CDK assets

Apologies for the reflowed text in the monitoring page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)

The link-checker should confirm these are okay, but you can visit the pages mentioned to check yourself


## Issue / Card

Fixes #4655 

