### PR TITLE
Add GA events to the interactive form

### DIFF
--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -8,7 +8,7 @@
     var closeModalButton = document.querySelector('.js-close');
     var modalPaginationButtons = contactModal.querySelectorAll('.pagination a');
     var paginationContent = contactModal.querySelectorAll('.js-pagination');
-    var submitButton = contactModal.querySelector('button.pagination__link--next');
+    var submitButton = contactModal.querySelector('.mktoButton');
     var inputs = contactModal.querySelectorAll('input, textarea');
     var comment = contactModal.querySelector('#Comments_from_lead__c');
     var otherContainers = document.querySelectorAll('.js-other-container');
@@ -27,6 +27,12 @@
         close();
       }
     };
+
+    if (submitButton) {
+      closeModal.addEventListener('click', function(e) {
+        ga('send', 'event', 'interactive-forms', 'submitted', window.location.pathname);
+      });
+    }
 
     if (closeModal) {
       closeModal.addEventListener('click', function(e) {
@@ -55,10 +61,15 @@
       modalPaginationButton.addEventListener('click', function(e) {
         e.preventDefault();
         var button = e.target.closest('a');
+        var index = contactIndex;
         if (button.classList.contains('pagination__link--previous')) {
-          setState(contactIndex - 1);
+          index = index - 1;
+          setState(index);
+          ga('send', 'event', 'interactive-forms', 'goto:'+index, window.location.pathname);
         } else {
-          setState(contactIndex + 1);
+          index = index + 1;
+          setState(index);
+          ga('send', 'event', 'interactive-forms', 'goto:'+index, window.location.pathname);
         }
       });
     });
@@ -97,12 +108,14 @@
       setState(1);
       contactModal.classList.add('u-hide');
       updateHash('');
+      ga('send', 'event', 'interactive-forms', 'close', window.location.pathname);
     }
 
     // Open the contact us modal
     function open() {
       contactModal.classList.remove('u-hide');
       updateHash(triggeringHash);
+      ga('send', 'event', 'interactive-forms', 'open', window.location.pathname);
     }
 
     // Removes the triggering hash


### PR DESCRIPTION
## Done
Add GA events to the interactive form script

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to the homepage
- Add `#get-in-touch` to the address bar
- Open the inspector and switch to the network tab
- Click next and close it and see it triggers ga pings
