### PR TITLE
Fix broken links

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -85,7 +85,6 @@
           </div>
           <h3 class="p-card__title">HP Moonshot</h3>
           <ul class="p-list--divided">
-            <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty-updates/main/installer-armhf/current/images/keystone/netboot/">m800 ARMv7 netboot image (14.04 LTS)</a></li>
             <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty-updates/main/installer-arm64/current/images/generic/netboot/xgene/">m400 ARMv8 netboot image (14.04 LTS)</a></li>
             <li class="p-list__item"><a class="p-link--external" href="http://h20564.www2.hp.com/hpsc/doc/public/display?docId=c03933547">HP ProLiant Moonshot user guide</a></li>
           </ul>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -7,9 +7,12 @@
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-<noscript>
-  <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-{{ architecture }}.iso">
-</noscript>
+
+{% if version and architecture %}
+  <noscript>
+    <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-{{ architecture }}.iso">
+  </noscript>
+{% endif %}
 
 <div class="p-strip is-deep">
   <div class="row u-equal-height">

--- a/templates/legal/data-privacy/2013-03-25/index.html
+++ b/templates/legal/data-privacy/2013-03-25/index.html
@@ -123,7 +123,7 @@
             <td headers="cookie" scope="row">Marketo Munchkin</td>
             <td headers="cookie_name">_mkto_trk</td>
             <td headers="cookie_purpose">Marketo&#39;s cookie allows us to track repeated visits to the website, and link each visit to the information voluntarily provided by the visitor. For example, if the visitor is asked to provide us with their name, company name and email address, we will know the identity of the visitor when they visit the site at a later date, or when we send them email.</td>
-            <td headers="cookie_info">For Marketo&#39;s complete Privacy Policy please visit <a href="http://uk.marketo.com/trust/privacy.php">uk.marketo.com/trust/privacy.php</a></td>
+            <td headers="cookie_info">For Marketo&#39;s complete Privacy Policy please visit <a href="https://documents.marketo.com/legal/privacy/">uk.marketo.com/trust/privacy.php</a></td>
           </tr>
         </tbody>
       </table>

--- a/templates/legal/data-privacy/2016-02-08/index.html
+++ b/templates/legal/data-privacy/2016-02-08/index.html
@@ -121,7 +121,7 @@
       <h4>Marketo Munchkin</h4>
       <p><code>_mkto_trk</code></p>
       <p>Marketo&#39;s cookie allows us to track repeated visits to the website, and link each visit to the information voluntarily provided by the visitor. For example, if the visitor is asked to provide us with their name, company name and email address, we will know the identity of the visitor when they visit the site at a later date, or when we send them email.</p>
-      <p><a class="p-link--external" href="http://uk.marketo.com/trust/privacy.php">Marketo&#39;s complete Privacy Policy</a></p>
+      <p><a class="p-link--external" href="https://documents.marketo.com/legal/privacy/">Marketo&#39;s complete Privacy Policy</a></p>
     </div>
   </div>
   <div class="row">

--- a/templates/legal/data-privacy/third-parties.html
+++ b/templates/legal/data-privacy/third-parties.html
@@ -13,17 +13,17 @@
   <div class="row">
     <ul class="inline-list">
       <li class="p-list__item"><a href="http://www.3sat.de/page/?source=/service/140014/index.html">3sat Mediathek</a></li>
-      <li class="p-list__item"><a href="http://about.7digital.com/terms-and-conditions-use">7Digital</a></li>
+      <li class="p-list__item"><a href="http://about.7digital.com/legal-0">7Digital</a></li>
       <li class="p-list__item"><a href="http://www.abc.net.au/privacy.htm">ABC iView</a></li>
       <li class="p-list__item"><a href="http://www.amazon.co.uk/gp/help/customer/display.html/ref=hp_left_cn?ie=UTF8&nodeId=502584">Amazon</a></li>
       <li class="p-list__item"><a href="http://stackexchange.com/legal/privacy-policy">Ask Ubuntu</a></li>
       <li class="p-list__item"><a href="http://www.bbc.co.uk/privacy/">BBC iPlayer</a></li>
-      <li class="p-list__item"><a href="http://privacy.microsoft.com/en-gb/bing.mspx">Bing Video</a></li>
+      <li class="p-list__item"><a href="https://privacy.microsoft.com/en-gb/privacystatement">Bing Video</a></li>
       <li class="p-list__item"><a href="http://cleardarksky.com/csk/admin.html#Privacy">Clear Sky Chart</a></li>
       <li class="p-list__item"><a href="http://www.colourlovers.com/privacy">COLOURlovers</a></li>
       <li class="p-list__item"><a href="http://www.dailymotion.com/us/legal/privacy">Dailymotion</a></li>
       <li class="p-list__item"><a href="http://about.deviantart.com/policy/privacy/">deviantArt</a></li>
-      <li class="p-list__item"><a href="http://dribbble.com/site/privacy">Dribbble</a></li>
+      <li class="p-list__item"><a href="https://dribbble.com/privacy">Dribbble</a></li>
       <li class="p-list__item"><a href="http://pages.ebay.co.uk/help/policies/privacy-policy.html">eBay</a></li>
       <li class="p-list__item"><a href="http://www.encuentro.gov.ar/sitios/encuentro/condiciones/index">Encuentro</a></li>
       <li class="p-list__item"><a href="http://www.etsy.com/help/article/480?ref=ft_privacy">Etsy</a></li>
@@ -34,7 +34,7 @@
       <li class="p-list__item"><a href="https://help.github.com/articles/github-privacy-policy">GitHub</a></li>
       <li class="p-list__item"><a href="http://www.google.com/intl/en/policies/privacy/">Google docs (Google)</a></li>
       <li class="p-list__item"><a href="https://www.google.com/intl/en_uk/policies/privacy/">Google News</a></li>
-      <li class="p-list__item"><a href="http://www.headweb.com/en/100234/integrity-policy">Headweb</a></li>
+      <li class="p-list__item"><a href="https://www.hardweb.com.au/privacypolicy.html">Headweb</a></li>
       <li class="p-list__item"><a href="http://www.imdb.com/privacy">IMDb</a></li>
       <li class="p-list__item"><a href="http://is.gd/privacy.php">is.gd</a></li>
       <li class="p-list__item"><a href="http://www.jstor.org/page/info/about/policies/privacy.jsp">JSTOR</a></li>
@@ -58,7 +58,7 @@
       <li class="p-list__item"><a href="http://vodo.net/terms">VODO</a></li>
       <li class="p-list__item"><a href="http://www.wunderground.com/weather/api/d/terms.html#privacy">Weather Underground</a></li>
       <li class="p-list__item"><a href="http://wikimediafoundation.org/wiki/Wikimedia:Privacy_policy">Wikipedia</a></li>
-      <li class="p-list__item"><a href="http://helloreverb.com/privacy/">Wordnik</a></li>
+      <li class="p-list__item"><a href="https://www.wordnik.com/privacy">Wordnik</a></li>
       <li class="p-list__item"><a href="http://info.yahoo.com/privacy/uk/yahoo/details.html">Yahoo! Finance</a></li>
       <li class="p-list__item"><a href="http://www.yelp.co.uk/static?p=privacy&country=GB">Yelp</a></li>
       <li class="p-list__item"><a href="http://www.google.co.uk/intl/en/policies/privacy/">YouTube Education</a></li>

--- a/templates/legal/developer-terms-and-conditions/2016-04-06.html
+++ b/templates/legal/developer-terms-and-conditions/2016-04-06.html
@@ -23,7 +23,7 @@
         <li class="p-list__item">Client Software: any utilities in Ubuntu, such as the Ubuntu Software Centre, which enable end users to discover, install, and remove software including Apps.</li>
         <li class="p-list__item">Developer Account: Your account on the Developer Site.</li>
         <li class="p-list__item">Developer Site: Canonical&#39;s websites for uploading and managing Apps at <a href="https://myapps.developer.ubuntu.com/dev/click-apps/">myapps.developer.ubuntu.com/dev/click-apps</a></li>
-        <li class="p-list__item">Publishing Policy: the Developer Site policy for accepting Apps for publishing at <a href="https://developer.ubuntu.com/en/publish/">developer.ubuntu.com/en/publish</a>, as updated from time to time.</li>
+        <li class="p-list__item">Publishing Policy: the Developer Site policy for accepting Apps for publishing at developer.ubuntu.com, as updated from time to time.</li>
         <li class="p-list__item">Services: Canonical&#39;s services for distributing, publishing, discovery, installation, and removal of your Apps and payment collection.</li>
         <li class="p-list__item">Term: the term of this Agreement, as set out in Clause 10.</li>
         <li class="p-list__item">Ubuntu: any desktop versions of the Linux-based operating system known as Ubuntu.</li>

--- a/templates/legal/font-licence/faq.html
+++ b/templates/legal/font-licence/faq.html
@@ -24,7 +24,7 @@
         <li><a href="http://scripts.sil.org/" class="p-link--external">SIL International</a></li>
         <li><a href="http://openfontlibrary.org/" class="p-link--external">Open Font Library</a></li>
         <li><a href="http://www.softwarefreedom.org/" class="p-link--external">Software Freedom Law Center</a></li>
-        <li><a href="http://code.google.com/webfonts" class="p-link--external">Google Font API</a></li>
+        <li><a href="https://developers.google.com/fonts/" class="p-link--external">Google Font API</a></li>
       </ul>
       <h2 id="embedding">Document embedding</h2>
       <p>One issue highlighted early on in the survey of existing font licences is that of document embedding. Almost all font licences, both free and unfree, permit embedding a font into a document to a certain degree.</p>

--- a/templates/templates/_navigation-community-h.html
+++ b/templates/templates/_navigation-community-h.html
@@ -41,7 +41,7 @@
           <h4 class="p-muted-heading u-hide--medium u-hide--large">Meet</h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu &mdash; our StackExchange</a></li>
-            <li class="p-list__item"><a href="https://loco.ubuntu.com/events/">Join your Local Community team</a></li>
+            <li class="p-list__item"><a href="http://loco.ubuntu.com/events/">Join your Local Community team</a></li>
             <li class="p-list__item"><a href="https://ubuntuforums.org/">Meet up in the Ubuntu Forums</a></li>
             <li class="p-list__item"><a href="https://help.ubuntu.com/community/InternetRelayChat">Chat on IRC</a></li>
           </ul>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -39,7 +39,7 @@
     <link rel="apple-touch-icon" sizes="144x144" href="{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png" />
     <link rel="apple-touch-icon" sizes="114x114" href="{{ ASSET_SERVER_URL }}5fe4d3c8-apple-touch-icon-114x114-precomposed.png" />
     <link rel="apple-touch-icon" sizes="72x72" href="{{ ASSET_SERVER_URL }}09460d9a-apple-touch-icon-72x72-precomposed.png" />
-    <link rel="apple-touch-icon" href="{{ ASSET_SERVER_URL }}cc66da65-apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="{{ ASSET_SERVER_URL }}c39e0fed-apple-touch-icon.png" />
     <link type="text/plain" rel="author" href="{% versioned_static 'files/humans.txt' %}" />
 
     <!-- stylesheets -->

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -31,7 +31,7 @@
     <link rel="apple-touch-icon" sizes="144x144" href="{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png" />
     <link rel="apple-touch-icon" sizes="114x114" href="{{ ASSET_SERVER_URL }}5fe4d3c8-apple-touch-icon-114x114-precomposed.png" />
     <link rel="apple-touch-icon" sizes="72x72" href="{{ ASSET_SERVER_URL }}09460d9a-apple-touch-icon-72x72-precomposed.png" />
-    <link rel="apple-touch-icon" href="{{ ASSET_SERVER_URL }}cc66da65-apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="{{ ASSET_SERVER_URL }}c39e0fed-apple-touch-icon.png" />
     <link type="text/plain" rel="author" href="{% versioned_static 'files/humans.txt' %}" />
 
     <!-- stylesheets -->


### PR DESCRIPTION
- Fix link to apple-touch-icon in `<head>`
- Remove link to non-existent image
- Fix link to http://loco.ubuntu.com
- Only show `<noscript><meta refresh...` on server download page when we have the correct parameters
- Fix links in legal

Fixes #4656
Fixes #4665

Please read my changes carefully. I've done some weird things - removed a link in one place, changed the domain in another.

And I haven't updated the copy docs at this point.

QA
--

`./run` and look at the pages I've changed.