### PR TITLE
Add interactive forms to the bootstack section

### DIFF
--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -40,6 +40,16 @@
       }
 
       @media only screen and (min-width: $breakpoint-medium) {
+        .u-align {
+          padding-bottom: 70px;
+
+          &--bottom {
+            bottom: 0;
+            margin-top: 1rem;
+            position: absolute;
+          }
+        }
+
         .pagination__link--next,
         .pagination__link--previous {
           margin-bottom: 0;

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -139,6 +139,8 @@
 </section>
 {% include "shared/forms/interactive/_openstack.html" with formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
+{% include "shared/forms/interactive/_openstack.html" with lpId="2086" formid="1251" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+
 {% endblock content %}
 {% endblock outer_content %}
 

--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -60,8 +60,6 @@
             <label for="priority-workloads-Messaging">Messaging</label>
             <input type="checkbox" id="priority-workloads-Web-apps">
             <label for="priority-workloads-Web-apps">Web apps</label>
-            <input type="checkbox" id="priority-workloads-Databases">
-            <label for="priority-workloads-Databases">Databases</label>
             <input type="checkbox" id="priority-workloads-Service-catalog">
             <label for="priority-workloads-Service-catalog">Service catalog</label>
           </div>

--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -1,0 +1,367 @@
+{% load versioned_static  %}
+
+<div class="p-modal u-hide" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title" id="modal-title">Fully managed OpenStack</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <h3 class="p-heading--five">Where do you want your OpenStack?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="radio" id="where-Own-data-center" name="openstack-where" value="Our own data center">
+          <label for="where-Own-data-center">Our own data center</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="radio" id="where-My-hosting-company" name="openstack-where" value="My hosting company">
+          <label for="where-My-hosting-company">My hosting company</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="radio" id="where-Any-hosting-company" name="openstack-where" value="Any hosting company">
+          <label for="where-Any-hosting-company">Any hosting company</label>
+        </div>
+      </div>
+      <div class="row u-no-padding">
+        <h3 class="p-heading--five">What are priority workloads and use cases?</h3>
+        <div class="row u-no-padding u-equal-height">
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="priority-workloads-High-availability">
+            <label for="priority-workloads-High-availability">High availability</label>
+            <input type="checkbox" id="priority-workloads-High-performance">
+            <label for="priority-workloads-High-performance">High performance</label>
+            <input type="checkbox" id="priority-workloads-Multi-region">
+            <label for="priority-workloads-Multi-region">Multi-region</label>
+            <input type="checkbox" id="priority-workloads-Multi-cloud">
+            <label for="priority-workloads-Multi-cloud">Multi-cloud</label>
+            <input type="checkbox" id="priority-workloads-Disaster-recovery">
+            <label for="priority-workloads-Disaster-recovery">Disaster recovery</label>
+            <input type="checkbox" id="priority-workloads-Encryption-at-rest">
+            <label for="priority-workloads-Encryption-at-rest">Encryption at rest</label>
+            <input type="checkbox" id="priority-workloads-FedRAMP">
+            <label for="priority-workloads-FedRAMP">FedRAMP</label>
+            <input type="checkbox" id="priority-workloads-PCI-DSS">
+            <label for="priority-workloads-PCI-DSS">PCI-DSS</label>
+            <input type="checkbox" id="priority-workloads-FIPS">
+            <label for="priority-workloads-FIPS">FIPS</label>
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="priority-workloads-Kubernetes">
+            <label for="priority-workloads-Kubernetes">Kubernetes</label>
+            <input type="checkbox" id="priority-workloads-Enterprise-Apps">
+            <label for="priority-workloads-Enterprise-Apps">Enterprise Apps</label>
+            <input type="checkbox" id="priority-workloads-Telco-NFV">
+            <label for="priority-workloads-Telco-NFV">Telco NFV</label>
+            <input type="checkbox" id="priority-workloads-Databases">
+            <label for="priority-workloads-Databases">Databases</label>
+            <input type="checkbox" id="priority-workloads-HPC">
+            <label for="priority-workloads-HPC">HPC</label>
+            <input type="checkbox" id="priority-workloads-Messaging">
+            <label for="priority-workloads-Messaging">Messaging</label>
+            <input type="checkbox" id="priority-workloads-Web-apps">
+            <label for="priority-workloads-Web-apps">Web apps</label>
+            <input type="checkbox" id="priority-workloads-Databases">
+            <label for="priority-workloads-Databases">Databases</label>
+            <input type="checkbox" id="priority-workloads-Service-catalog">
+            <label for="priority-workloads-Service-catalog">Service catalog</label>
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="priority-workloads-Dev-and-test">
+            <label for="priority-workloads-Dev-and-test">Dev and test</label>
+            <input type="checkbox" id="priority-workloads-CI-CD">
+            <label for="priority-workloads-CI-CD">CI/CD</label>
+            <input type="checkbox" id="priority-workloads-Build-farm">
+            <label for="priority-workloads-Build-farm">Build farm</label>
+            <input type="checkbox" id="priority-workloads-Containers">
+            <label for="priority-workloads-Containers">Containers</label>
+            <input type="checkbox" id="priority-workloads-VDI">
+            <label for="priority-workloads-VDI">VDI</label>
+            <input type="checkbox" id="priority-workloads-LDAP">
+            <label for="priority-workloads-LDAP">LDAP</label>
+            <input type="checkbox" id="priority-workloads-AD">
+            <label for="priority-workloads-AD">AD</label>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <input type="checkbox" id="priority-workloads-AI-ML">
+            <label for="priority-workloads-AI-ML">AI / ML</label>
+            <input type="checkbox" id="priority-workloads-Data-lake">
+            <label for="priority-workloads-Data-lake">Data lake</label>
+            <input type="checkbox" id="priority-workloads-Hadoop">
+            <label for="priority-workloads-Hadoop">Hadoop</label>
+            <input type="checkbox" id="priority-workloads-Spark">
+            <label for="priority-workloads-Spark">Spark</label>
+            <input type="checkbox" id="priority-workloads-Analytics">
+            <label for="priority-workloads-Analytics">Analytics</label>
+            <input type="checkbox" id="priority-workloads-ETL">
+            <label for="priority-workloads-ETL">ETL</label>
+            <div class="js-other-container u-align--bottom">
+              <input type="checkbox" class="js-other-container__checkbox" id="priority-workloads-other">
+              <label for="priority-workloads-other">Other</label>
+              <input type="text" id="priority-workloads-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other Board">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row u-no-padding">
+        <h3 class="p-heading--five">What are your platform preferences?</h3>
+        <div class="row u-no-padding u-equal-height">
+          <div class="col-3 u-sv3 u-align">
+            <p>Architecture</p>
+            <input type="checkbox" id="platform-preferences-Architecture-Intel">
+            <label for="platform-preferences-Architecture-Intel">Intel</label>
+            <input type="checkbox" id="platform-preferences-Architecture-ARM">
+            <label for="platform-preferences-Architecture-ARM">ARM</label>
+            <input type="checkbox" id="platform-preferences-Architecture-POWER">
+            <label for="platform-preferences-Architecture-POWER">POWER</label>
+            <input type="checkbox" id="platform-preferences-Architecture-Z">
+            <label for="platform-preferences-Architecture-Z">Z</label>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <p>Servers</p>
+            <input type="checkbox" id="platform-preferences-Servers-Undecided">
+            <label for="platform-preferences-Servers-Undecided">Undecided</label>
+            <input type="checkbox" id="platform-preferences-Servers-Dell">
+            <label for="platform-preferences-Servers-Dell">Dell</label>
+            <input type="checkbox" id="platform-preferences-Servers-HP">
+            <label for="platform-preferences-Servers-HP">HP</label>
+            <input type="checkbox" id="platform-preferences-Servers-Lenovo">
+            <label for="platform-preferences-Servers-Lenovo">Lenovo</label>
+            <input type="checkbox" id="platform-preferences-Servers-Supermicro">
+            <label for="platform-preferences-Servers-Supermicro">Supermicro</label>
+            <input type="checkbox" id="platform-preferences-Servers-Intel-Select">
+            <label for="platform-preferences-Servers-Intel-Select">Intel Select</label>
+            <input type="checkbox" id="platform-preferences-Servers-Cisco">
+            <label for="platform-preferences-Servers-Cisco">Cisco</label>
+            <div class="js-other-container u-align--bottom">
+              <input type="checkbox" class="js-other-container__checkbox" id="platform-preferences-Servers-other">
+              <label for="platform-preferences-Servers-other">Other</label>
+              <input type="text" id="platform-preferences-Servers-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other Board">
+            </div>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <p>Networking</p>
+            <input type="checkbox" id="platform-preferences-Networking-Cisco">
+            <label for="platform-preferences-Networking-Cisco">Cisco</label>
+            <input type="checkbox" id="platform-preferences-Networking-Juniper">
+            <label for="platform-preferences-Networking-Juniper">Juniper</label>
+            <input type="checkbox" id="platform-preferences-Networking-Arista">
+            <label for="platform-preferences-Networking-Arista">Arista</label>
+            <input type="checkbox" id="platform-preferences-Networking-Dell">
+            <label for="platform-preferences-Networking-Dell">Dell</label>
+            <input type="checkbox" id="platform-preferences-Networking-Mellanox">
+            <label for="platform-preferences-Networking-Mellanox">Mellanox</label>
+            <input type="checkbox" id="platform-preferences-Networking-Whitebox">
+            <label for="platform-preferences-Networking-Whitebox">Whitebox</label>
+            <div class="js-other-container u-align--bottom">
+              <input type="checkbox" class="js-other-container__checkbox" id="platform-preferences-Networking-other">
+              <label for="platform-preferences-Networking-other">Other</label>
+              <input type="text" id="platform-preferences-Networking-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other Board">
+            </div>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <p>Storage</p>
+            <input type="checkbox" id="platform-preferences-Storage-Commodity">
+            <label for="platform-preferences-Storage-Commodity">Commodity</label>
+            <input type="checkbox" id="platform-preferences-Storage-NetApp">
+            <label for="platform-preferences-Storage-NetApp">NetApp</label>
+            <input type="checkbox" id="platform-preferences-Storage-EMC">
+            <label for="platform-preferences-Storage-EMC">EMC</label>
+            <input type="checkbox" id="platform-preferences-Storage-PureStorage">
+            <label for="platform-preferences-Storage-PureStorage">PureStorage</label>
+            <div class="js-other-container u-align--bottom">
+              <input type="checkbox" class="js-other-container__checkbox" id="platform-preferences-Storage-other">
+              <label for="platform-preferences-Storage-other">Other</label>
+              <input type="text" id="platform-preferences-Storage-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other Board">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <h3 class="p-heading--five">Which OpenStack capabilities matter to you?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="openstack-capabilities-KVM">
+          <label for="openstack-capabilities-KVM">KVM</label>
+          <input type="checkbox" id="openstack-capabilities-LXD">
+          <label for="openstack-capabilities-LXD">LXD</label>
+          <input type="checkbox" id="openstack-capabilities-Ceph">
+          <label for="openstack-capabilities-Ceph">Ceph</label>
+          <input type="checkbox" id="openstack-capabilities-Swift">
+          <label for="openstack-capabilities-Swift">Swift</label>
+          <input type="checkbox" id="openstack-capabilities-SAN-integration">
+          <label for="openstack-capabilities-SAN-integration">SAN integration</label>
+          <input type="checkbox" id="openstack-capabilities-SDN">
+          <label for="openstack-capabilities-SDN">SDN</label>
+          <input type="checkbox" id="openstack-capabilities-OVS">
+          <label for="openstack-capabilities-OVS">OVS</label>
+          <input type="checkbox" id="openstack-capabilities-OVN">
+          <label for="openstack-capabilities-OVN">OVN</label>
+          <input type="checkbox" id="openstack-capabilities-Contrail">
+          <label for="openstack-capabilities-Contrail">Contrail</label>
+          <input type="checkbox" id="openstack-capabilities-ACI">
+          <label for="openstack-capabilities-ACI">ACI</label>
+          <input type="checkbox" id="openstack-capabilities-Nuage">
+          <label for="openstack-capabilities-Nuage">Nuage</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="openstack-capabilities-Keystone">
+          <label for="openstack-capabilities-Keystone">Keystone</label>
+          <input type="checkbox" id="openstack-capabilities-Designate">
+          <label for="openstack-capabilities-Designate">Designate</label>
+          <input type="checkbox" id="openstack-capabilities-Barbican">
+          <label for="openstack-capabilities-Barbican">Barbican</label>
+          <input type="checkbox" id="openstack-capabilities-Octavia">
+          <label for="openstack-capabilities-Octavia">Octavia</label>
+          <input type="checkbox" id="openstack-capabilities-Gnocchi">
+          <label for="openstack-capabilities-Gnocchi">Gnocchi</label>
+          <input type="checkbox" id="openstack-capabilities-HSM">
+          <label for="openstack-capabilities-HSM">HSM</label>
+          <input type="checkbox" id="openstack-capabilities-Manila">
+          <label for="openstack-capabilities-Manila">Manila</label>
+          <input type="checkbox" id="openstack-capabilities-Vault">
+          <label for="openstack-capabilities-Vault">Vault</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="openstack-capabilities-SR-IOV">
+          <label for="openstack-capabilities-SR-IOV">SR-IOV</label>
+          <input type="checkbox" id="openstack-capabilities-DPDK">
+          <label for="openstack-capabilities-DPDK">DPDK</label>
+          <input type="checkbox" id="openstack-capabilities-EPA">
+          <label for="openstack-capabilities-EPA">EPA</label>
+          <input type="checkbox" id="openstack-capabilities-NUMA">
+          <label for="openstack-capabilities-NUMA">NUMA</label>
+          <input type="checkbox" id="openstack-capabilities-FPGA">
+          <label for="openstack-capabilities-FPGA">FPGA</label>
+          <input type="checkbox" id="openstack-capabilities-SmartNICs">
+          <label for="openstack-capabilities-SmartNICs">SmartNICs</label>
+          <input type="checkbox" id="openstack-capabilities-GPGPU">
+          <label for="openstack-capabilities-GPGPU">GPGPU</label>
+        </div>
+      </div>
+      <div class="row u-no-padding">
+        <h3 class="p-heading--five">Tell us about your project and team</h3>
+        <textarea id="tell-us-about-your-project" aria-label="Tell us about your project and team" rows="3" placeholder="Where are you located? Do you already have OpenStack? Is this initiative for a specific workload or for the business as a whole? Do you have particular regulatory constraints or priorities?"></textarea>
+      </div>
+      <h3 class="p-heading--five">What would be most helpful?</h3>
+      <div class="row u-no-padding">
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="most-helpful-Architecture-design">
+          <label for="most-helpful-Architecture-design">Architecture design</label>
+          <input type="checkbox" id="most-helpful-Performance-tuning">
+          <label for="most-helpful-Performance-tuning">Performance tuning</label>
+          <input type="checkbox" id="most-helpful-Conformance-testing">
+          <label for="most-helpful-Conformance-testing">Conformance testing</label>
+          <input type="checkbox" id="most-helpful-Workload-migration">
+          <label for="most-helpful-Workload-migration">Workload migration</label>
+          <input type="checkbox" id="most-helpful-Integration">
+          <label for="most-helpful-Integration">Integration</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="most-helpful-Version-upgrades">
+          <label for="most-helpful-Version-upgrades">Version upgrades</label>
+          <input type="checkbox" id="most-helpful-Upstream-enhancement">
+          <label for="most-helpful-Upstream-enhancement">Upstream enhancement</label>
+          <input type="checkbox" id="most-helpful-Training">
+          <label for="most-helpful-Training">Training</label>
+          <input type="checkbox" id="most-helpful-Skills-certification">
+          <label for="most-helpful-Skills-certification">Skills certification</label>
+        </div>
+        <div class="col-4 u-sv3">
+          <input type="checkbox" id="most-helpful-Hardware-selection">
+          <label for="most-helpful-Hardware-selection">Hardware selection</label>
+          <input type="checkbox" id="most-helpful-Data-replication">
+          <label for="most-helpful-Data-replication">Data replication</label>
+          <input type="checkbox" id="most-helpful-Backup-and-recovery">
+          <label for="most-helpful-Backup-and-recovery">Backup and recovery</label>
+          <input type="checkbox" id="most-helpful-Logging-and-monitoring">
+          <label for="most-helpful-Logging-and-monitoring">Logging and monitoring</label>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+        <a class="pagination__link--next p-button--positive" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Email address:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--4 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about Ubuntu core</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>
+
+<script src="{% versioned_static 'js/dynamic-contact-form.js' %}"></script>


### PR DESCRIPTION
## Done
Add interactive forms to the bootstack section. Set up the form on the page. Added some styling to align Other inputs.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /openstack/managed
- Click the contact button
- Check that the contact form matches the [copy docs](https://docs.google.com/document/d/14dJOH-eHQTQcw-eA7dxLaYYqxZofcumVpW4A7ShzB-s/edit#heading=h.tk4y6g6el1tm)

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4591
