### PR TITLE
Add user surveys data privacy page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -444,6 +444,8 @@ legal:
         - title: Online purchase privacy
           path: /legal/data-privacy/online-purchase
         - title: Snap store privacy notice
+          path: /legal/data-privacy/maas-user-survey
+        - title: Usabilla privacy notice
           path: /legal/data-privacy/snap-store
         - title: Snapcraft NPS privacy notice
           path: /legal/data-privacy/snapcraft-nps

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -437,19 +437,19 @@ legal:
       children:
         - title: Data protection enquiry
           path: /legal/data-privacy/enquiry
-        - title: Newsletter privacy notice
+        - title: Newsletter
           path: /legal/data-privacy/newsletter
-        - title: Webinar privacy notice
+        - title: Webinar
           path: /legal/data-privacy/webinar
-        - title: Online purchase privacy
+        - title: Online purchase
           path: /legal/data-privacy/online-purchase
-        - title: Snap store privacy notice
-          path: /legal/data-privacy/maas-user-survey
-        - title: Usabilla privacy notice
+        - title: User surveys
+          path: /legal/data-privacy/user-survey
+        - title: Snap store
           path: /legal/data-privacy/snap-store
-        - title: Snapcraft NPS privacy notice
+        - title: Snapcraft NPS
           path: /legal/data-privacy/snapcraft-nps
-        - title: SSO privacy notice
+        - title: SSO
           path: /legal/data-privacy/sso
         - title: Contact us
           path: /legal/data-privacy/contact

--- a/templates/legal/data-privacy/maas-user-survey.md
+++ b/templates/legal/data-privacy/maas-user-survey.md
@@ -1,0 +1,93 @@
+---
+wrapper_template: "../_base_legal_markdown.html"
+context:
+  title: "Privacy Notice – MAAS User Survey"
+  description: This privacy notice tells you about the information collected from you when you take part in a MAAS user survey on Canonical’s MAAS webpage, hosted by Usabilla.
+  copydoc: https://docs.google.com/document/d/1XKWK3VvJe0Z_soJqO3F0BrrXwlP9ZObYYKxA1hym7QU/edit
+---
+
+# Privacy Notice – Snapcraft NPS Survey  
+
+Version -  December 2018
+
+This privacy notice tells you about the information collected from you when you take part in a MAAS user survey on Canonical’s MAAS webpage, hosted by Usabilla. Usabilla is a third party software provider that enables live user feedback. In collecting this information, Usabilla are acting as a data controller and details of their terms can be found on [their website](https://usabilla.com/terms/). Usabilla will be sharing your data with us and by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
+
+## Who are we?
+
+We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of “Legal”.
+
+We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
+
+## What personal data do we collect?
+
+When you submit live feedback on the MAAS webpages, we invite you to leave your your email address and related information via Usabilla’s software platform. You may be shown different surveys depending on user features and usage. Usabilla will share this information with us.
+
+## Why do we collect this information?
+
+We will use your information for MAAS user research. We ask for your consent to do this and will only contact you for this purpose for as long as you continue to consent. This may involve inviting you to talk to us about how you use MAAS and to test new MAAS features.
+
+## What do we do with your information?
+
+Your information is stored in our database and may be processed outside of the European Economic Area. It is shared with the third parties only as reasonably required for Canonical to process and store your data in accordance with this notice.
+
+Such countries do not have the same data protection laws as the United Kingdom and EEA. Where the European Commission has not given a formal decision that such countries provide an adequate level of data protection similar to those which apply to the United Kingdom and EEA, any transfer of your personal information will be subject to approved contract terms designed to help safeguard your privacy rights and give you remedies in the unlikely event of misuse of you personal information. If you would like further information please contact us (see “Your right to complain” below). We will not otherwise transfer your personal data outside of the EEA.
+
+## How long do we keep your information for?
+
+We keep your information for as long as you continue to consent to participate in MAAS user research and thereafter for so long as reasonably required in accordance with our record retention policy.
+
+## Your rights over your information
+
+You have a number of important rights under data protection laws. In summary, those include rights to:
+
+- fair processing of information and transparency over how we use your personal information;
+- access to your personal information and to certain other supplementary information that this Privacy Notice is already designed to address;
+- require us to correct any mistakes in your information which we hold;
+- require the erasure of personal information concerning you in certain situations;
+- receive the personal information concerning you which you have provided to us, in a structured, commonly used and machine-readable format and have the right to transmit that data to a third party in certain situations;
+- object at any time to processing of personal information concerning you for direct marketing;
+- object to decisions being taken by automated means which produce legal effects concerning you or similarly significantly affect you;
+- object in certain other situations to our continued processing of your personal information;
+- otherwise restrict our processing of your personal information in certain circumstances;
+- claim compensation for damages caused by out breach of any data protection laws.
+
+For further information on each of those rights, including the circumstances in which they apply, see the Guidance from the UK Information Commissioner’s Office (ICO) on individuals rights under the General Data Protection Regulation.
+
+If you would like to exercise any of those rights, please:
+
+- email, call or write to us, please see “Your right to complain” section below;
+- let us have enough information to identify you;
+- let us have proof of your identity and address (a copy of your driving licence or passport and a recent utility or credit card bill); and
+- let us know the information to which your request relates.
+
+If you would like to unsubscribe from any email you can also click on the “unsubscribe” button at the bottom of the email. Please note that this is not automatic, but will be implemented once confirmed.
+
+## Keeping your personal information secure
+
+We have appropriate security measures in place to prevent personal information from being accidentally lost, or used or accessed in an unauthorised way. We limit access to your personal information to those who have a genuine business need to know it. Those processing your information will do so only in an authorised manner and are subject to a duty of confidentiality.
+
+We also have procedures in place to deal with any suspected data security breach. We will notify you and any applicable regulator of a suspected data breach where we are legally required to do so.
+
+## Changes to this Privacy Notice
+
+This Privacy Notice will be reviewed from time to time. If we decide to change this Privacy Notice we will post the changes here. However, if we intend to make material changes to the way we use your personal information we will notify you before doing do. Any personal information held will be governed by our most current notice.
+
+## Your right to complain
+
+We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) or to the address below:
+
+Legal, Canonical<br />
+5th Floor, Blue Fin Building<br />
+110 Southwark Street<br />
+London, SE1 0SU
+
+Alternatively, you can use the relevant contact us form.
+
+If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at [ico.org.uk/make-a-complaint](https://ico.org.uk/make-a-complaint/) or write to them at:
+
+Information Commissioner's Office<br />
+Wycliffe House<br />
+Water Lane<br />
+Wilmslow<br />
+Cheshire<br />
+SK9 5AF

--- a/templates/legal/data-privacy/maas-user-survey.md
+++ b/templates/legal/data-privacy/maas-user-survey.md
@@ -20,7 +20,7 @@ We are not required to have a data protection officer, so any enquiries about ou
 
 ## What personal data do we collect?
 
-When you submit live feedback on the MAAS webpages, we invite you to leave your your email address and related information via Usabilla’s software platform. You may be shown different surveys depending on user features and usage. Usabilla will share this information with us.
+When you submit live feedback on the MAAS webpages, we invite you to leave your email address and related information via Usabilla’s software platform. You may be shown different surveys depending on user features and usage. Usabilla will share this information with us.
 
 ## Why do we collect this information?
 

--- a/templates/legal/data-privacy/snapcraft-nps.md
+++ b/templates/legal/data-privacy/snapcraft-nps.md
@@ -5,10 +5,10 @@ context:
   description: This Privacy Notice tells you about the information collected from you when you participate in the Snapcraft Net Promoter Score (NPS) survey.
   copydoc: https://docs.google.com/document/d/1JODNGJQ0G-aSrycKTv4XOGmJVWw98Fqk2gLfHmQqgB4/edit
 ---
+<h4 class="p-muted-heading">Version - December 2018</h4>
+<hr style="margin-bottom: 2rem;" />
 
 # Privacy Notice – Snapcraft NPS Survey  
-
-Version -  December 2018
 
 This Privacy Notice tells you about the information collected from you when you participate in the Snapcraft Net Promoter Score (NPS) survey. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
 
@@ -75,18 +75,24 @@ This Privacy Notice will be reviewed from time to time. If we decide to change t
 
 We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) or to the address below:
 
+<div style="margin:2rem;">
 Legal, Canonical<br />
 5th Floor, Blue Fin Building<br />
 110 Southwark Street<br />
-London, SE1 0SU
+London, SE1 0SU<br />
+United Kingdom
+</div>
 
 Alternatively, you can use the relevant contact us form.
 
 If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at [ico.org.uk/make-a-complaint](https://ico.org.uk/make-a-complaint/) or write to them at:
 
+<div style="margin:2rem;">
 Information Commissioner's Office<br />
 Wycliffe House<br />
 Water Lane<br />
 Wilmslow<br />
 Cheshire<br />
-SK9 5AF
+SK9 5AF<br />
+United Kingdom
+</div>

--- a/templates/legal/data-privacy/user-survey.md
+++ b/templates/legal/data-privacy/user-survey.md
@@ -20,7 +20,7 @@ We are not required to have a data protection officer, so any enquiries about ou
 
 ## What personal data do we collect?
 
-When you submit live feedback on the webpage, we may invite you to leave your your email address and related information via Usabilla’s software platform. You may be shown different surveys depending on user features and usage. Usabilla will share this information with us.
+When you submit live feedback on the webpage, we may invite you to leave your email address and related information via Usabilla’s software platform. You may be shown different surveys depending on user features and usage. Usabilla will share this information with us.
 
 ## Why do we collect this information?
 

--- a/templates/legal/data-privacy/user-survey.md
+++ b/templates/legal/data-privacy/user-survey.md
@@ -1,30 +1,30 @@
 ---
 wrapper_template: "../_base_legal_markdown.html"
 context:
-  title: "Privacy Notice – MAAS User Survey"
-  description: This privacy notice tells you about the information collected from you when you take part in a MAAS user survey on Canonical’s MAAS webpage, hosted by Usabilla.
+  title: "Privacy Notice – User Survey"
+  description: This privacy notice tells you about the information collected from you when you take part in a user survey on a Canonical webpage, hosted by Usabilla.
   copydoc: https://docs.google.com/document/d/1XKWK3VvJe0Z_soJqO3F0BrrXwlP9ZObYYKxA1hym7QU/edit
 ---
+<h4 class="p-muted-heading">Version - February 2019</h4>
+<hr style="margin-bottom: 2rem;" />
 
-# Privacy Notice – Snapcraft NPS Survey  
+# Privacy Notice – User Survey  
 
-Version -  December 2018
-
-This privacy notice tells you about the information collected from you when you take part in a MAAS user survey on Canonical’s MAAS webpage, hosted by Usabilla. Usabilla is a third party software provider that enables live user feedback. In collecting this information, Usabilla are acting as a data controller and details of their terms can be found on [their website](https://usabilla.com/terms/). Usabilla will be sharing your data with us and by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
+This privacy notice tells you about the information collected from you when you take part in a user survey on a Canonical webpage, hosted by Usabilla. Usabilla is a third party software provider that enables live user feedback. In collecting this information, Usabilla are acting as a data controller and details of their terms can be found on their website here: [usabilla.com/terms/](https://usabilla.com/terms/)  and the Usabilla Privacy Notice. Usabilla will be sharing your data with us and by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of “Legal”.
+We are Canonical Group Limited. Our address is 5<sup>th</sup>, Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of “Legal”.
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 
 ## What personal data do we collect?
 
-When you submit live feedback on the MAAS webpages, we invite you to leave your email address and related information via Usabilla’s software platform. You may be shown different surveys depending on user features and usage. Usabilla will share this information with us.
+When you submit live feedback on the webpage, we may invite you to leave your your email address and related information via Usabilla’s software platform. You may be shown different surveys depending on user features and usage. Usabilla will share this information with us.
 
 ## Why do we collect this information?
 
-We will use your information for MAAS user research. We ask for your consent to do this and will only contact you for this purpose for as long as you continue to consent. This may involve inviting you to talk to us about how you use MAAS and to test new MAAS features.
+We will use your information for user research. We ask for your consent to do this and will only contact you for this purpose for as long as you continue to consent. This may involve inviting you to talk to us about how you use Canonical products and to test new features.
 
 ## What do we do with your information?
 
@@ -34,7 +34,7 @@ Such countries do not have the same data protection laws as the United Kingdom a
 
 ## How long do we keep your information for?
 
-We keep your information for as long as you continue to consent to participate in MAAS user research and thereafter for so long as reasonably required in accordance with our record retention policy.
+We keep your information for as long as you continue to consent to participate in user research and thereafter for so long as reasonably required in accordance with our record retention policy.
 
 ## Your rights over your information
 
@@ -55,7 +55,7 @@ For further information on each of those rights, including the circumstances in 
 
 If you would like to exercise any of those rights, please:
 
-- email, call or write to us, please see “Your right to complain” section below;
+- email or write to us, please see “Your right to complain” section below;
 - let us have enough information to identify you;
 - let us have proof of your identity and address (a copy of your driving licence or passport and a recent utility or credit card bill); and
 - let us know the information to which your request relates.
@@ -76,18 +76,23 @@ This Privacy Notice will be reviewed from time to time. If we decide to change t
 
 We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) or to the address below:
 
+<div style="margin:2rem;">
 Legal, Canonical<br />
 5th Floor, Blue Fin Building<br />
 110 Southwark Street<br />
-London, SE1 0SU
+London, SE1 0SU<br />
+United Kingdom
+</div>
 
 Alternatively, you can use the relevant contact us form.
 
 If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at [ico.org.uk/make-a-complaint](https://ico.org.uk/make-a-complaint/) or write to them at:
 
+<div style="margin:2rem;">
 Information Commissioner's Office<br />
 Wycliffe House<br />
-Water Lane<br />
-Wilmslow<br />
+Water Lane<br />Wilmslow<br />
 Cheshire<br />
-SK9 5AF
+SK9 5AF<br />
+United Kingdom
+</div>


### PR DESCRIPTION
## Done

- **Asking legal if this shouldn't be made more generic**
- Add MAAS user survey data privacy page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/data-privacy/snap-store](http://0.0.0.0:8001/legal/data-privacy/snap-store)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1XKWK3VvJe0Z_soJqO3F0BrrXwlP9ZObYYKxA1hym7QU/edit)


## Issue / Card

Fixes #4666

