### PR TITLE
Update IBM Z download page

### DIFF
--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -1,122 +1,138 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Ubuntu Server for IBM LinuxONE and z Systems | Download{% endblock %}
-{% block meta_description %}Ubuntu for IBM Z and z Systems brings the Ubuntu Server and Ubuntu Server for cloud with the OpenStack, KVM and LXD ecosystem to IBM’s premium platform.{% endblock meta_description %}
+{% block title %}Ubuntu Server for IBM LinuxONE and IBM Z | Download{% endblock %}
+{% block meta_description %}Ubuntu for IBM LinuxONE and IBM Z brings the Ubuntu Server and Ubuntu Server for cloud with the OpenStack, KVM and LXD ecosystem to IBM’s premium platform.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit{% endblock meta_copydoc %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
 <div class="p-strip is-deep">
-  <div class="row">
-    <div class="col-12">
-      <h1>Ubuntu Server for IBM LinuxONE and z Systems</h1>
+    <div class="row">
+        <div class="col-12">
+            <h1>Ubuntu Server for IBM LinuxONE and IBM Z</h1>
+        </div>
     </div>
-  </div>
 
-  <div class="row">
-    <div class="col-12">
-      <div class="col-6">
-        <h2>Ubuntu Server</h2>
-        <p>IBM Z and LinuxONE systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, flexibility, security and resiliency. Ubuntu Server LTS are released every two years in April and can now be downloaded by all IBM Z and LinuxONE system customers.</p>
-        <p>Ubuntu Server for IBM Z and LinuxONE is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
-        <p>Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p>
-        <p>For questions about Ubuntu Advantage for IBM Z and LinuxONE, please call us <tel href="+442036565291">+44&nbsp;(0)&nbsp;203&nbsp;656&nbsp;5291</tel> or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
-      </div>
-      <div class="col-6">
+    <div class="row">
+        <div class="col-12">
+            <div class="col-6">
+                <h2>Ubuntu Server</h2>
+                <p>IBM Z and LinuxONE systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, flexibility, security and resiliency. Ubuntu Server LTS are released every two years in April and can now be downloaded by all IBM Z and LinuxONE system customers.</p>
+                <p>Ubuntu Server for IBM Z and LinuxONE is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
+                <p>Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p>
+                <p>For questions about Ubuntu Advantage for IBM Z and LinuxONE, please call us <tel href="+442036565291">+44&nbsp;(0)&nbsp;203&nbsp;656&nbsp;5291</tel> or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
+            </div>
+            <div class="col-6">
 
-        <!-- MARKETO FORM -->
-        <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
-        <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+                <!-- MARKETO FORM -->
+                <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
+                <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
 
-        <form class="p-form u-no-margin--top" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
-          <fieldset style="border: 1px solid #c0c0c0;">
-            <ul class="p-list u-no-margin--bottom">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name: <span>*</span></label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
-              </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name: <span>*</span></label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
-              </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="Company" class="mktoLabel">Company name: <span>*</span></label>
-                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
-              </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address: <span>*</span></label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
-              </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel">Phone number: <span>*</span></label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
-              </li>
-              <li class="mktField p-list__item">
-                <label for="NumUbuntuServers__c" class="mktoLabel">Number of drawers you are purchasing support for:</label>
-                <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField"><option value="">Select...</option>
-                  <option value="zBC12" disabled>zBC12</option>
-                  <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
-                  <option value="zEC12" disabled>zEC12</option>
-                  <option value="zEC12 - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
-                  <option value="zEC12 - 2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
-                  <option value="zEC12 - 3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
-                  <option value="zEC12 - 4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
-                  <option value="Z13s/Rockhopper" disabled> Z13s/Rockhopper</option>
-                  <option value="Z13s/Rockhopper - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
-                  <option value="Z13/Emperor" disabled>Z13/Emperor</option>
-                  <option value="Z13/Emperor - 1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
-                  <option value="Z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
-                  <option value="Z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
-                  <option value="Z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option></select>
-              </li>
-              <li class="mktField p-list__item">
-                <label for="Comments_from_Contact__c" class="mktoLabel">Serial number(s)</label>
-                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000"></textarea>
-              </li>
-              <li class="mktField p-list__item">
-                <label for="purchaseordernumber" class="mktoLabel">Purchase order number:</label>
-                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField ">
-              </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox"> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
-              </li>
-              <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
-              <li class="mktField p-list__item">
-                <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
-                <input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
-                  name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
-                <input
-                  type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
-              </li>
-            </ul>
-          </fieldset>
-          <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
-          <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
-        </form>
-        <script>
-          $("#mktoForm_1400").validate({
-            errorElement: "span",
-            errorClass: "mktFormMsg mktError",
-            onkeyup: false,
-            onclick: false,
-            onblur: false
-          });
-          $(function() {
-            $("#comments").hide()
-          });
-          $('#Ubuntu_User__c').on('change', function() {
-            var selection = $(this).val();
-            if (selection == 'Commercially only') {
-              $('#comments').show();
-            } else {
-              $('#comments').hide();
-            }
-          });
-        </script>
-        <!-- /MARKETO FORM -->
-      </div>
+                <form class="p-form u-no-margin--top" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
+                    <fieldset style="border: 1px solid #c0c0c0;">
+                        <ul class="p-list u-no-margin--bottom">
+                            <li class="mktFormReq mktField p-list__item">
+                                <label for="FirstName" class="mktoLabel">First name: <span>*</span></label>
+                                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+                            </li>
+                            <li class="mktFormReq mktField p-list__item">
+                                <label for="LastName" class="mktoLabel">Last name: <span>*</span></label>
+                                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
+                            </li>
+                            <li class="mktFormReq mktField p-list__item">
+                                <label for="Company" class="mktoLabel">Company name: <span>*</span></label>
+                                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+                            </li>
+                            <li class="mktFormReq mktField p-list__item">
+                                <label for="Email" class="mktoLabel">Email address: <span>*</span></label>
+                                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+                            </li>
+                            <li class="mktFormReq mktField p-list__item">
+                                <label for="Phone" class="mktoLabel">Phone number: <span>*</span></label>
+                                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+                            </li>
+                            <li class="mktField p-list__item">
+                                <label for="NumUbuntuServers__c" class="mktoLabel">Number of drawers you are purchasing support for:</label>
+                                <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField">
+                                    <option value="">Select...</option>
+
+                                    <option value="zBC12" disabled>zBC12</option>
+                                    <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
+
+                                    <option value="zEC12" disabled>zEC12</option>
+                                    <option value="zEC12 - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                                    <option value="zEC12 - 2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
+                                    <option value="zEC12 - 3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
+                                    <option value="zEC12 - 4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
+
+                                    <option value="z13s/Rockhopper" disabled> z13s/Rockhopper</option>
+                                    <option value="z13s/Rockhopper - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+
+                                    <option value="z13/Emperor" disabled>z13/Emperor</option>
+                                    <option value="z13/Emperor - 1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
+                                    <option value="z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
+                                    <option value="z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
+                                    <option value="z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option>
+
+                                    <option value="z14 ZR1/Rockhopper II" disabled> z14 ZR1/Rockhopper II</option>
+                                    <option value="z14 ZR1/Rockhopper II - 1/2 drawer (up to 30 cores)"> - 1/2 drawer (up to 30 cores)</option>
+
+                                    <option value="z14/Emperor II" disabled>z14/Emperor II</option>
+                                    <option value="z14/Emperor II - 1 drawer (up to 33 cores)"> - 1 drawer (up to 33 cores)</option>
+                                    <option value="z14/Emperor II - 2 drawers (up to 69 cores)"> - 2 drawers (up to 69 cores)</option>
+                                    <option value="z14/Emperor II - 3 drawers (up to 105 cores)"> - 3 drawers (up to 105 cores)</option>
+                                    <option value="z14/Emperor II - 4 drawer (up to 170 cores)"> - 4 drawer (up to 170 cores)</option>
+
+                                </select>
+                            </li>
+                            <li class="mktField p-list__item">
+                                <label for="Comments_from_Contact__c" class="mktoLabel">Serial number(s)</label>
+                                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000"></textarea>
+                            </li>
+                            <li class="mktField p-list__item">
+                                <label for="purchaseordernumber" class="mktoLabel">Purchase order number:</label>
+                                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField ">
+                            </li>
+                            <li class="mktField p-list__item">
+                                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox"> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+                            </li>
+                            <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
+                            <li class="mktField p-list__item">
+                                <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
+                                <input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
+                                name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
+                                <input
+                                type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+                            </li>
+                        </ul>
+                    </fieldset>
+                    <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
+                    <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
+                </form>
+                <script>
+                    $("#mktoForm_1400").validate({
+                        errorElement: "span",
+                        errorClass: "mktFormMsg mktError",
+                        onkeyup: false,
+                        onclick: false,
+                        onblur: false
+                    });
+                    $(function() {
+                        $("#comments").hide()
+                    });
+                    $('#Ubuntu_User__c').on('change', function() {
+                        var selection = $(this).val();
+                        if (selection == 'Commercially only') {
+                            $('#comments').show();
+                        } else {
+                            $('#comments').hide();
+                        }
+                    });
+                </script>
+                <!-- /MARKETO FORM -->
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -7,132 +7,132 @@
 
 {% block content %}
 <div class="p-strip is-deep">
-    <div class="row">
-        <div class="col-12">
-            <h1>Ubuntu Server for IBM LinuxONE and IBM Z</h1>
-        </div>
+  <div class="row">
+    <div class="col-12">
+      <h1>Ubuntu Server for IBM LinuxONE and IBM Z</h1>
     </div>
+  </div>
 
-    <div class="row">
-        <div class="col-12">
-            <div class="col-6">
-                <h2>Ubuntu Server</h2>
-                <p>IBM Z and LinuxONE systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, flexibility, security and resiliency. Ubuntu Server LTS are released every two years in April and can now be downloaded by all IBM Z and LinuxONE system customers.</p>
-                <p>Ubuntu Server for IBM Z and LinuxONE is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
-                <p>Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p>
-                <p>For questions about Ubuntu Advantage for IBM Z and LinuxONE, please call us <tel href="+442036565291">+44&nbsp;(0)&nbsp;203&nbsp;656&nbsp;5291</tel> or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
-            </div>
-            <div class="col-6">
+  <div class="row">
+    <div class="col-12">
+      <div class="col-6">
+        <h2>Ubuntu Server</h2>
+        <p>IBM Z and LinuxONE systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, flexibility, security and resiliency. Ubuntu Server LTS are released every two years in April and can now be downloaded by all IBM Z and LinuxONE system customers.</p>
+        <p>Ubuntu Server for IBM Z and LinuxONE is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
+        <p>Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p>
+        <p>For questions about Ubuntu Advantage for IBM Z and LinuxONE, please call us <tel href="+442036565291">+44&nbsp;(0)&nbsp;203&nbsp;656&nbsp;5291</tel> or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
+      </div>
+      <div class="col-6">
 
-                <!-- MARKETO FORM -->
-                <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
-                <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+        <!-- MARKETO FORM -->
+        <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
+        <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
 
-                <form class="p-form u-no-margin--top" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
-                    <fieldset style="border: 1px solid #c0c0c0;">
-                        <ul class="p-list u-no-margin--bottom">
-                            <li class="mktFormReq mktField p-list__item">
-                                <label for="FirstName" class="mktoLabel">First name: <span>*</span></label>
-                                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
-                            </li>
-                            <li class="mktFormReq mktField p-list__item">
-                                <label for="LastName" class="mktoLabel">Last name: <span>*</span></label>
-                                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
-                            </li>
-                            <li class="mktFormReq mktField p-list__item">
-                                <label for="Company" class="mktoLabel">Company name: <span>*</span></label>
-                                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
-                            </li>
-                            <li class="mktFormReq mktField p-list__item">
-                                <label for="Email" class="mktoLabel">Email address: <span>*</span></label>
-                                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
-                            </li>
-                            <li class="mktFormReq mktField p-list__item">
-                                <label for="Phone" class="mktoLabel">Phone number: <span>*</span></label>
-                                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
-                            </li>
-                            <li class="mktField p-list__item">
-                                <label for="NumUbuntuServers__c" class="mktoLabel">Number of drawers you are purchasing support for:</label>
-                                <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField">
-                                    <option value="">Select...</option>
+        <form class="p-form u-no-margin--top" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
+          <fieldset style="border: 1px solid #c0c0c0;">
+            <ul class="p-list u-no-margin--bottom">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" aria-label="FirstName" class="mktoLabel">First name: <span>*</span></label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" aria-label="LastName" class="mktoLabel">Last name: <span>*</span></label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Company" aria-label="Company" class="mktoLabel">Company name: <span>*</span></label>
+                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" aria-label="Email" class="mktoLabel">Email address: <span>*</span></label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" aria-label="Phone" class="mktoLabel">Phone number: <span>*</span></label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+              </li>
+              <li class="mktField p-list__item">
+                <label for="NumUbuntuServers__c" aria-label="NumUbuntuServers__c" class="mktoLabel">Number of drawers you are purchasing support for:</label>
+                <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField">
+                  <option value="">Select...</option>
 
-                                    <option value="zBC12" disabled>zBC12</option>
-                                    <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
+                  <option value="zBC12" disabled>zBC12</option>
+                  <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
 
-                                    <option value="zEC12" disabled>zEC12</option>
-                                    <option value="zEC12 - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
-                                    <option value="zEC12 - 2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
-                                    <option value="zEC12 - 3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
-                                    <option value="zEC12 - 4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
+                  <option value="zEC12" disabled>zEC12</option>
+                  <option value="zEC12 - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                  <option value="zEC12 - 2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
+                  <option value="zEC12 - 3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
+                  <option value="zEC12 - 4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
 
-                                    <option value="z13s/Rockhopper" disabled> z13s/Rockhopper</option>
-                                    <option value="z13s/Rockhopper - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                  <option value="z13s/Rockhopper" disabled> z13s/Rockhopper</option>
+                  <option value="z13s/Rockhopper - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
 
-                                    <option value="z13/Emperor" disabled>z13/Emperor</option>
-                                    <option value="z13/Emperor - 1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
-                                    <option value="z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
-                                    <option value="z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
-                                    <option value="z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option>
+                  <option value="z13/Emperor" disabled>z13/Emperor</option>
+                  <option value="z13/Emperor - 1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
+                  <option value="z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
+                  <option value="z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
+                  <option value="z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option>
 
-                                    <option value="z14 ZR1/Rockhopper II" disabled> z14 ZR1/Rockhopper II</option>
-                                    <option value="z14 ZR1/Rockhopper II - 1/2 drawer (up to 30 cores)"> - 1/2 drawer (up to 30 cores)</option>
+                  <option value="z14 ZR1/Rockhopper II" disabled> z14 ZR1/Rockhopper II</option>
+                  <option value="z14 ZR1/Rockhopper II - 1/2 drawer (up to 30 cores)"> - 1/2 drawer (up to 30 cores)</option>
 
-                                    <option value="z14/Emperor II" disabled>z14/Emperor II</option>
-                                    <option value="z14/Emperor II - 1 drawer (up to 33 cores)"> - 1 drawer (up to 33 cores)</option>
-                                    <option value="z14/Emperor II - 2 drawers (up to 69 cores)"> - 2 drawers (up to 69 cores)</option>
-                                    <option value="z14/Emperor II - 3 drawers (up to 105 cores)"> - 3 drawers (up to 105 cores)</option>
-                                    <option value="z14/Emperor II - 4 drawer (up to 170 cores)"> - 4 drawer (up to 170 cores)</option>
+                  <option value="z14/Emperor II" disabled>z14/Emperor II</option>
+                  <option value="z14/Emperor II - 1 drawer (up to 33 cores)"> - 1 drawer (up to 33 cores)</option>
+                  <option value="z14/Emperor II - 2 drawers (up to 69 cores)"> - 2 drawers (up to 69 cores)</option>
+                  <option value="z14/Emperor II - 3 drawers (up to 105 cores)"> - 3 drawers (up to 105 cores)</option>
+                  <option value="z14/Emperor II - 4 drawer (up to 170 cores)"> - 4 drawer (up to 170 cores)</option>
 
-                                </select>
-                            </li>
-                            <li class="mktField p-list__item">
-                                <label for="Comments_from_Contact__c" class="mktoLabel">Serial number(s)</label>
-                                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000"></textarea>
-                            </li>
-                            <li class="mktField p-list__item">
-                                <label for="purchaseordernumber" class="mktoLabel">Purchase order number:</label>
-                                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField ">
-                            </li>
-                            <li class="mktField p-list__item">
-                                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox"> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
-                            </li>
-                            <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
-                            <li class="mktField p-list__item">
-                                <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
-                                <input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
-                                name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
-                                <input
-                                type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
-                            </li>
-                        </ul>
-                    </fieldset>
-                    <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
-                    <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
-                </form>
-                <script>
-                    $("#mktoForm_1400").validate({
-                        errorElement: "span",
-                        errorClass: "mktFormMsg mktError",
-                        onkeyup: false,
-                        onclick: false,
-                        onblur: false
-                    });
-                    $(function() {
-                        $("#comments").hide()
-                    });
-                    $('#Ubuntu_User__c').on('change', function() {
-                        var selection = $(this).val();
-                        if (selection == 'Commercially only') {
-                            $('#comments').show();
-                        } else {
-                            $('#comments').hide();
-                        }
-                    });
-                </script>
-                <!-- /MARKETO FORM -->
-            </div>
-        </div>
+                </select>
+              </li>
+              <li class="mktField p-list__item">
+                <label for="Comments_from_Contact__c" aria-label="Comments_from_Contact__c" class="mktoLabel">Serial number(s)</label>
+                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000"></textarea>
+              </li>
+              <li class="mktField p-list__item">
+                <label for="purchaseordernumber" aria-label="purchaseordernumber" class="mktoLabel">Purchase order number:</label>
+                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField ">
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox"> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+              </li>
+              <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
+              <li class="mktField p-list__item">
+                <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
+                <input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden"
+                name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
+                <input
+                type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+              </li>
+            </ul>
+          </fieldset>
+          <input type="hidden" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
+          <input type="hidden" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
+        </form>
+        <script>
+          $("#mktoForm_1400").validate({
+            errorElement: "span",
+            errorClass: "mktFormMsg mktError",
+            onkeyup: false,
+            onclick: false,
+            onblur: false
+          });
+          $(function() {
+            $("#comments").hide()
+          });
+          $('#Ubuntu_User__c').on('change', function() {
+            var selection = $(this).val();
+            if (selection == 'Commercially only') {
+              $('#comments').show();
+            } else {
+              $('#comments').hide();
+            }
+          });
+        </script>
+        <!-- /MARKETO FORM -->
+      </div>
     </div>
+  </div>
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}


### PR DESCRIPTION
## Done

- Updated the list of drawers
- Updated the case on Z13 to z13
- Removed z systems to IBM Z
- Updated the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/server/s390x](http://0.0.0.0:8001/download/server/s390x)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit#)

## Issue / Card

Fixes #4664
