### PR TITLE
Updated all typos 'premise' to 'premises'

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -38,7 +38,7 @@
 <section class="p-strip">
   <div class="row">
     <h2>Kubeflow &mdash; AI on Kubernetes &mdash; anywhere</h2>
-    <p>Google and Canonical collaborate on Kubeflow, a standardised machine learning solution for on-premise and on-cloud training. Leveraging Ubuntu, you benefit from perfect multi-cloud portability of AI/ML workloads.</p>
+    <p>Google and Canonical collaborate on Kubeflow, a standardised machine learning solution for on-premises and on-cloud training. Leveraging Ubuntu, you benefit from perfect multi-cloud portability of AI/ML workloads.</p>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
@@ -59,7 +59,7 @@
       <p>Kubernetes on bare metal with NVIDIA GPGPU acceleration</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Highest performance</li>
-        <li class="p-list__item is-ticked">On-premise with local data</li>
+        <li class="p-list__item is-ticked">On-premises with local data</li>
         <li class="p-list__item is-ticked">Hardware recommendations</li>
         <li class="p-list__item is-ticked">Fully managed options</li>
       </ul>
@@ -82,7 +82,7 @@
       <p>Kubeflow on Kubernetes on Openstack with NVIDIA GPGPU acceleration</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Maximize benefits of OpenStack</li>
-        <li class="p-list__item is-ticked">On-premise with local data</li>
+        <li class="p-list__item is-ticked">On-premises with local data</li>
         <li class="p-list__item is-ticked">Hardware recommendations</li>
         <li class="p-list__item is-ticked">Fully managed options</li>
       </ul>
@@ -111,7 +111,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <blockquote class="p-pull-quote">
-        <p>Canonical has provided both a familiar and highly performant operating system that works everywhere. Whether on-premise or in the cloud, software engineers and data scientists can use tools they are already familiar with, such as Ubuntu, Kubernetes and Kubeflow, and greatly accelerate their ability to deliver value for their customers.</p>
+        <p>Canonical has provided both a familiar and highly performant operating system that works everywhere. Whether on-premises or in the cloud, software engineers and data scientists can use tools they are already familiar with, such as Ubuntu, Kubernetes and Kubeflow, and greatly accelerate their ability to deliver value for their customers.</p>
         <cite class="p-pull-quote__citation">David Aronchick, Google Product Manager for Kubeflow</cite>
       </blockquote>
     </div>

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -10,7 +10,7 @@
     <div class="col-10">
       <div>
         <h1>Get Metal as a Service</h1>
-        <p>Metal as a Service (MAAS) gives you automated server provisioning and easy network setup for your physical servers for amazing data centre operational efficiency &mdash; on premise, open source and supported.</p>
+        <p>Metal as a Service (MAAS) gives you automated server provisioning and easy network setup for your physical servers for amazing data centre operational efficiency &mdash; on premises, open source and supported.</p>
       </div>
     </div>
   </div>

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -50,7 +50,7 @@
       <h3 class="p-card__title">Managed Kubernetes</h3>
       <hr>
       <p>Predictable OpEx for organisations looking to adopt production-ready Kubernetes. Focus on your business while we take care of your Kubernetes cluster.</p>
-      <p>Canonical provides managed services for Kubernetes at great economics on-premise or on public clouds.</p>
+      <p>Canonical provides managed services for Kubernetes at great economics on-premises or on public clouds.</p>
       <p><a class="p-button--positive" href="/kubernetes/managed">Learn more</a></p>
     </div>
   </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -141,7 +141,7 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <h2>The default platform for Kubernetes</h2>
-    <p>All leading cloud providers, such as Google, Microsoft, Amazon, Cisco and IBM run cloud Kubernetes services on Ubuntu because we focus on the latest container capabilities in modern kernels. This focus is why Ubuntu is also the top choice for on-premise enterprise Kubernetes, with MicroK8s, kubeadm and Charmed Kubernetes all supported by Canonical.</p>
+    <p>All leading cloud providers, such as Google, Microsoft, Amazon, Cisco and IBM run cloud Kubernetes services on Ubuntu because we focus on the latest container capabilities in modern kernels. This focus is why Ubuntu is also the top choice for on-premises enterprise Kubernetes, with MicroK8s, kubeadm and Charmed Kubernetes all supported by Canonical.</p>
   </div>
   <div class="row">
     <div class="col-12">
@@ -179,7 +179,7 @@
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title p-heading--four">Fully managed</h3>
-            <p class="p-matrix__desc">At your request, Canonical’s remote operations team can build and operate Kubernetes for you, on premise or on your choice of public cloud. We will transfer control of the cluster to your ops team any time you want to take over</p>
+            <p class="p-matrix__desc">At your request, Canonical’s remote operations team can build and operate Kubernetes for you, on premises or on your choice of public cloud. We will transfer control of the cluster to your ops team any time you want to take over</p>
             <p class="p-matrix__desc"><a href="/kubernetes/managed">Learn more about managed kubernetes&nbsp;&rsaquo;</a></p>
           </div>
         </li>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -11,7 +11,7 @@
         <h1>
           Fully managed private Kubernetes clusters. Cost effective. Pure upstream.
         </h1>
-        <p>Focus on your business while Canonical builds and manages your Kubernetes clusters. Take advantage of your on-premise assets and leverage public clouds for your multi-cloud strategy.</p>
+        <p>Focus on your business while Canonical builds and manages your Kubernetes clusters. Take advantage of your on-premises assets and leverage public clouds for your multi-cloud strategy.</p>
         <p>Canonical will set-up and operate your Kubernetes cluster for you, with in-house experts available at all times to stand-up and scale your cluster. And, when you're ready, we will hand over operational control.</p>
         <ul>
           <li>Fully managed Kubernetes on your bare metal, VMWare, OpenStack or any public cloud</li>
@@ -48,7 +48,7 @@
       </div>
       <div class="col-4 p-divider__block">
         <h2 class="p-heading--three">Pure upstream</h2>
-        <p>We work directly with Google and the community to provide a pure Kubernetes experience on-premise and maximise compatibility across all public Kubernetes services such as Google GKE, Amazon EKS and Azure AKS.</p>
+        <p>We work directly with Google and the community to provide a pure Kubernetes experience on-premises and maximise compatibility across all public Kubernetes services such as Google GKE, Amazon EKS and Azure AKS.</p>
       </div>
     </div>
   </section>
@@ -336,7 +336,7 @@
             <li class="p-matrix__item">
               <div class="p-matrix__content">
                 <h3 class="p-matrix__title p-heading--four">Transfer support</h3>
-                <p class="p-matrix__desc">Canonical offers training and on-premise Cloud Reliability Engineers to smooth your transition to internal operations when requested. Trust us to get you started in the best possible way.</p>
+                <p class="p-matrix__desc">Canonical offers training and on-premises Cloud Reliability Engineers to smooth your transition to internal operations when requested. Trust us to get you started in the best possible way.</p>
               </div>
             </li>
           </ul>

--- a/templates/legal/managed-services/2015-07-01.html
+++ b/templates/legal/managed-services/2015-07-01.html
@@ -346,7 +346,7 @@
             <p>Should customer choose to discontinue the Services, customer will choose one of the following options:</p>
             <ul>
               <li class="p-list__item">Canonical will transfer the ownership of the hosts to customer. In this case, customer assumes the responsibility of paying the Cloud service provider (if any) for any use of such services after the transfer. Unless otherwise licensed, the licence for the LDS Product terminates at such time.</li>
-              <li class="p-list__item">If the servers are within the premise of customer&rsquo;s data center, Canonical will hand over all control of the hosts and management software to customer. Unless otherwise licensed, the licence for the LDS Product shall terminate at such time.
+              <li class="p-list__item">If the servers are within the premises of customer&rsquo;s data center, Canonical will hand over all control of the hosts and management software to customer. Unless otherwise licensed, the licence for the LDS Product shall terminate at such time.
               </li>
               <li class="p-list__item">Optional training is offered to customer at the recommended list price for such service prior to the transfer of the Cloud or at any mutually agreeable time.</li>
             </ul>

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -394,7 +394,7 @@
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title p-heading--four">Transfer support</h3>
-            <p class="p-matrix__desc">Canonical offers training and on-premise Cloud Reliability Engineers to smooth your transition to internal operations when requested. Trust us to get you started in the best possible way.</p>
+            <p class="p-matrix__desc">Canonical offers training and on-premises Cloud Reliability Engineers to smooth your transition to internal operations when requested. Trust us to get you started in the best possible way.</p>
           </div>
         </li>
       </ul>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -212,7 +212,7 @@
               </a>
               <div class="p-matrix__content">
                 <h4 class="p-matrix__title"><a class="p-link" href="https://jujucharms.com/">Juju&nbsp;&rsaquo;</a></h4>
-                <p class="p-matrix__desc">Model-driven multi-cloud operations for applications. On-premise or on-cloud SAAS app store, with big data, k8s and openstack solutions</p>
+                <p class="p-matrix__desc">Model-driven multi-cloud operations for applications. On-premises or on-cloud SAAS app store, with big data, k8s and openstack solutions</p>
               </div>
             </li>
             <li class="p-matrix__item">


### PR DESCRIPTION
## Done

Fixed all instances of "premise", replacing them with "premises"

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
