### PR TITLE
Updated to 18.04.2 LTS

### DIFF
--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -80,7 +80,7 @@
           <div class="p-list-step__content">
             <ol class="u-no-margin--left">
               <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
-              <li>Insert the first USB flash drive, containing Ubuntu Desktop 18.04.1 LTS.</li>
+              <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ lts_release_full_with_point }}.</li>
               <li>Connect the USB hub, keyboard, mouse and the monitor to the NUC.</li>
               <li>Insert the Live USB Ubuntu Desktop flash drive in the NUC.</li>
             </ol>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.1" lts_release_full_with_point='18.04.1 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}
+{% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

- **NOTE - WAIT FOR RELEASE TEAM TO CONFIRM THIS RELEASE - SCHEDULED FOR 14 FEB 2019**
- Updated the template variables to point to the .2 release of 18.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/desktop](http://0.0.0.0:8001/download/desktop), [/download/server](http://0.0.0.0:8001/download/server) and [/download/iot/intel-nuc](http://0.0.0.0:8001/download/iot/intel-nuc) - which now uses the variable
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the download section referes to and points to the 18.04.2 release over the 18.04.1 release

## Issue / Card

Fixes #4683

