### PR TITLE
Fix release-cycle kernel versions Fixes: 4691

### DIFF
--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -161,7 +161,7 @@ var kernelReleases = [
   {
     startDate: new Date('2016-07-01T00:00:00'),
     endDate: new Date('2018-07-01T00:00:00'),
-    taskName: 'Ubuntu 14.04.5 LTS',
+    taskName: 'Ubuntu 14.04.5 LTS (v4.4)',
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
@@ -203,7 +203,7 @@ var kernelReleases = [
   {
     startDate: new Date('2018-10-01T00:00:00'),
     endDate: new Date('2019-10-01T00:00:00'),
-    taskName: 'Ubuntu 18.10',
+    taskName: 'Ubuntu 18.10 (v4.18)',
     status: 'STANDARD_RELEASE'
   },
   {

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -310,7 +310,7 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 18.10</td>
+            <td>Ubuntu 18.10 (v4.18)</td>
             <td>October 2018</td>
             <td>July 2019</td>
             <td>&nbsp;</td>
@@ -352,7 +352,7 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 14.04.5 LTS LTS (v3.13)</strong></td>
+            <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
             <td>August 2016</td>
             <td>April 2019</td>
             <td>&nbsp;</td>


### PR DESCRIPTION
## Done

- Fixes double LTS typo
- Fixes 14.04.5 kernel version in text
- Adds 14.04.5 kernel version on chart
- Adds 18.10 kernel version on chart

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)

See [14.04.x Ubuntu Kernel Support Schedule](https://wiki.ubuntu.com/Kernel/RollingLTSEnablementStack) for 14.04.5 fixes
See [18.10 Linux Kernel release notes](https://wiki.ubuntu.com/CosmicCuttlefish/ReleaseNotes#Linux_kernel_.2B2D3cJw-) for 18.10 updates


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
