### PR TITLE
Fix server download link

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -21,7 +21,7 @@
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ lts_release }} LTS release notes</a></p>
         </div>
         <div class="col-4">
-          <p class="p-card__content"><a href="/download/server/thank-you?version={{ lts_release_with_point }}.0&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
+          <p class="p-card__content"><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
           <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
         </div>
       </div>


### PR DESCRIPTION
## Done
Remove the trailing `.0` from the server download page.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to `/download/server` check the top download buttons link is to /download/server/thank-you?version=18.04.2&architecture=amd64 not /download/server/thank-you?version=18.04.2**.0**&architecture=amd64
