### PR TITLE
Remove the .0 from the server torrent download link

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -53,7 +53,7 @@
       <h3 class="p-link--external p-heading--four"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-desktop-amd64.iso.torrent">Ubuntu {{ lts_release_with_point }} Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}.0-live-server-amd64.iso.torrent">Ubuntu {{ lts_release_with_point }} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-live-server-amd64.iso.torrent">Ubuntu {{ lts_release_with_point }} Server (64-bit)</a></li>
       </ul>
     </div>
     <div class="col-3">


### PR DESCRIPTION
## Done
Remove the .0 from the server torrent download link

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /download/alternative-downloads#bittorrents
- Check that the 18.04.02 server links does not link to `18.04.02.1`