### PR TITLE
Build the ESM 14.04 takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,10 +23,10 @@
 #}
 
 {% block takeover_content %}
+  {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}
-  {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}

--- a/templates/takeovers/_14-04-esm.html
+++ b/templates/takeovers/_14-04-esm.html
@@ -1,0 +1,29 @@
+<section class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance">
+  <div class="row u-vertically-center">
+    <div class="col-7 u-fade-left--medium">
+      <h1>Still running Ubuntu 14.04 LTS?</h1>
+      <p class="u-no-padding--top p-heading--four">Learn how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.</p>
+      <p class="u-hide--large u-hide--medium u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up">
+      </p>
+      <p>
+        <a href="/engage/14-04-esm?utm_source=takeover&utm_campaign=CY19_DC_UA_WBN_ESM14-04" class="p-button--positive">
+          Register for the webinar
+        </a>
+      </p>
+    </div>
+    <div class="col-4 u-hide--small prefix-1">
+      <img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up">
+    </div>
+  </div>
+  <style>
+    .p-takeover--compliance {
+      background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    }
+
+    .p-compliance-icon {
+      height: 154px;
+      width: 154px;
+    }
+  </style>
+</section>

--- a/templates/takeovers/_snapcraft-brand-store_takeover.html
+++ b/templates/takeovers/_snapcraft-brand-store_takeover.html
@@ -6,7 +6,7 @@
         <p class="p-heading--four">Curate your own customised store for a fully managed device software portfolio.</p>
         <p class="u-hide--small">
           <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral u-no-margin--bottom">
-            <span class="p-link--external">Register for the webinar</span>
+            <span class="p-link--external">Watch the webinar</span>
           </a>
         </p>
       </div>
@@ -16,7 +16,7 @@
         </div>
         <p class="u-no-margin--bottom u-hide--large u-hide--medium">
           <a href="https://www.brighttalk.com/webcast/6793/346324?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_BrandStore_WBN_BrandStoreIntro" class="p-button--neutral">
-            <span class="p-link--external">Register for the webinar</span>
+            <span class="p-link--external">Watch the webinar</span>
           </a>
         </p>
       </div>


### PR DESCRIPTION
## Done
Build the ESM 14.04 takeover and the engage page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh the homepage until the you see the ESM takeover titled (Still running Ubuntu 14.04?)
- Check the takeover matches [the design](https://github.com/canonical-websites/www.ubuntu.com/issues/4695)
- Check the content matches [the copy doc](https://docs.google.com/document/d/1OY1C3rJeIlv4I_P6SmwWev5mx7d_gX0oZ22w9u1HgwY/edit#)
- Check the link works and the engage page has the right content

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4697
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4699