### PR TITLE
French ESM takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,4 +30,5 @@
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
+  {% include "takeovers/_french_14-04-esm.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_french_14-04-esm.html
+++ b/templates/takeovers/_french_14-04-esm.html
@@ -1,7 +1,7 @@
 <section lang="fr" class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance">
   <div class="row u-vertically-center">
     <div class="col-7 u-fade-left--medium">
-      <h1>Votre entreprise utilise toujours Ubuntu 14.04?</h1>
+      <h1>Votre entreprise utilise toujours Ubuntu 14.04 ?</h1>
       <p class="u-no-padding--top p-heading--four">Gardez vos systèmes en sécurité après la fin de support officiel en avril 2019.</p>
       <p class="u-hide--large u-hide--medium u-align--center">
         <img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up">

--- a/templates/takeovers/_french_14-04-esm.html
+++ b/templates/takeovers/_french_14-04-esm.html
@@ -1,0 +1,29 @@
+<section lang="fr" class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance">
+  <div class="row u-vertically-center">
+    <div class="col-7 u-fade-left--medium">
+      <h1>Votre entreprise utilise toujours Ubuntu 14.04?</h1>
+      <p class="u-no-padding--top p-heading--four">Gardez vos systèmes en sécurité après la fin de support officiel en avril 2019.</p>
+      <p class="u-hide--large u-hide--medium u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up">
+      </p>
+      <p>
+        <a href="/engage/fr/esm?utm_source=takeover&utm_campaign=CY19_DC_UA_GenConForm_ESM14-04" class="p-button--positive">
+          Découvrez l'Extension Sécurité et Maintenance
+        </a>
+      </p>
+    </div>
+    <div class="col-4 u-hide--small prefix-1">
+      <img src="{{ ASSET_SERVER_URL }}2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon u-fade-up">
+    </div>
+  </div>
+  <style>
+    .p-takeover--compliance {
+      background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    }
+
+    .p-compliance-icon {
+      height: 154px;
+      width: 154px;
+    }
+  </style>
+</section>


### PR DESCRIPTION
## Done

* French version of the ESM takeover linking to an existing french ESM landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- If it's not already the case, switch your browser language preferences to French first.
- Refresh the homepage until you see the takeover.

## Screenshots

![screenshot_2019-02-19 the leading operating system for pcs iot devices servers and the cloud ubuntu](https://user-images.githubusercontent.com/18480003/53020087-82ee5500-3456-11e9-9062-7d970cce2fcd.png)

