### PR TITLE
Exclude jp lang posts from blog feed requests

### DIFF
--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -1,18 +1,18 @@
 {% if topic_id %}
-  {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=true&per_page=1&topic="|add:topic_id as spotlight_articles %}
+  {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=true&per_page=1&tags_exclude=3184&topic="|add:topic_id as spotlight_articles %}
 
   {% if spotlight_articles %}
-    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&per_page=3&topic="|add:topic_id as articles %}
+    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&per_page=3&tags_exclude=3184&topic="|add:topic_id as articles %}
   {% else %}
-    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&per_page=4&topic="|add:topic_id as articles %}
+    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&per_page=4&tags_exclude=3184&topic="|add:topic_id as articles %}
   {% endif %}
 {% else %}
-  {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=true&per_page=1" as spotlight_articles %}
+  {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=true&tags_exclude=3184&per_page=1" as spotlight_articles %}
 
   {% if spotlight_articles %}
-    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&per_page=3" as articles %}
+    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&tags_exclude=3184&per_page=3" as articles %}
   {% else %}
-    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&per_page=4" as articles %}
+    {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?sticky=false&tags_exclude=3184&per_page=4" as articles %}
   {% endif %}
 {% endif %}
 

--- a/templates/shared/contextual_footers/_cloud_further_reading.html
+++ b/templates/shared/contextual_footers/_cloud_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1833&per_page=5" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1833&tags_exclude=3184&per_page=5" %}
 </div>

--- a/templates/shared/contextual_footers/_desktop_further_reading.html
+++ b/templates/shared/contextual_footers/_desktop_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1479&per_page=5" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1479&tags_exclude=3184&per_page=5" %}
 </div>

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=5" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=5&tags_exclude=3184" %}
 </div>

--- a/templates/shared/contextual_footers/_iot_further_reading.html
+++ b/templates/shared/contextual_footers/_iot_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1666&per_page=4" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?group=1666&tags_exclude=3184&per_page=4" %}
 </div>

--- a/templates/shared/contextual_footers/_security_further_reading.html
+++ b/templates/shared/contextual_footers/_security_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1364&per_page=4" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1364&tags_exclude=3184&per_page=4" %}
 </div>

--- a/templates/shared/contextual_footers/_telco_further_reading.html
+++ b/templates/shared/contextual_footers/_telco_further_reading.html
@@ -1,4 +1,4 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
-  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1500&per_page=5" %}
+  {% include "templates/_further_reading_links.html" with insights_news_url="https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1500&tags_exclude=3184&per_page=5" %}
 </div>


### PR DESCRIPTION
## Done

* Exclude jp lang posts from blog feed requests

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure no jp post is present in the homepage feed
