### PR TITLE
Rerun VMware to OpenStack takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,6 @@
 #}
 
 {% block takeover_content %}
-  {% include "takeovers/_vmware-to-os.html" %}
   {% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
 #}
 
 {% block takeover_content %}
+  {% include "takeovers/_vmware-to-os.html" %}
   {% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
   {% include "takeovers/_ubuntu-core-18-takeover.html" %}

--- a/templates/takeovers/_vmware-to-os.html
+++ b/templates/takeovers/_vmware-to-os.html
@@ -1,17 +1,17 @@
-<section lang="de" data-lang="de" class="p-strip is-deep p-takeover--vmware-to-os js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section class="p-strip is-deep p-takeover--vmware-to-os js-takeover">
   <div class="row u-equal-height">
     <div class="col-7">
-      <h1 class="p-takeover__title">Von VMware zu Canonical OpenStack</h1>
-      <p class="p-heading--four">Sehen Sie sich unser Demonstrationsvideo zu Kosten und Migration an!</p>
+      <h1 class="p-takeover__title">From VMware to Canonical Openstack</h1>
+      <p class="p-heading--four">Watch this webinar to learn about the efficiency of the public cloud on-prem.</p>
       <div class="u-hide--small">
-        <a href="/engage/de/vmware-to-openstack?utm_source=takeover&utm_campaign=FY19_Cloud_OpenStack_WBN_VMWareToOpenStackDE" class="p-button--positive">Registrieren zum webinar</a>
+        <a href="/engage/vmware-to-openstack?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_VMwaretoOpenstack_Takeover" class="p-button--positive">Watch for webinar</a>
       </div>
     </div>
     <div class="col-5 suffix-1 u-align--center u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
     </div>
     <div class="u-hide--medium u-hide--large">
-      <a href="/engage/de/vmware-to-openstack?utm_source=takeover&utm_campaign=FY19_Cloud_OpenStack_WBN_VMWareToOpenStackDE" class="p-button--positive">Registrieren zum webinar</a>
+      <a href="/engage/vmware-to-openstack?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_VMwaretoOpenstack_Takeover" class="p-button--positive">Watch for webinar</a>
     </div>
   </div>
   <style>
@@ -24,7 +24,7 @@
       font-weight: 100;
     }
 
-    @media  (min-width: 768px) {
+    @media (min-width: 768px) {
       .p-takeover--vmware-to-os {
         background-color: #f7f7f7;
         background-image: url('{{ ASSET_SERVER_URL }}d3edfcd5-left.png'), url('{{ ASSET_SERVER_URL }}17508275-right.png');

--- a/templates/takeovers/_vmware-to-os.html
+++ b/templates/takeovers/_vmware-to-os.html
@@ -2,16 +2,16 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1 class="p-takeover__title">From VMware to Canonical Openstack</h1>
-      <p class="p-heading--four">Watch this webinar to learn about the efficiency of the public cloud on-prem.</p>
+      <p class="p-heading--four">Learn about the efficiency of the public cloud on-prem.</p>
       <div class="u-hide--small">
-        <a href="/engage/vmware-to-openstack?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_VMwaretoOpenstack_Takeover" class="p-button--positive">Watch for webinar</a>
+        <a href="/engage/vmware-to-openstack?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_VMwaretoOpenstack_Takeover" class="p-button--positive">Watch the webinar</a>
       </div>
     </div>
     <div class="col-5 suffix-1 u-align--center u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
     </div>
     <div class="u-hide--medium u-hide--large">
-      <a href="/engage/vmware-to-openstack?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_VMwaretoOpenstack_Takeover" class="p-button--positive">Watch for webinar</a>
+      <a href="/engage/vmware-to-openstack?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_VMwaretoOpenstack_Takeover" class="p-button--positive">Watch the webinar</a>
     </div>
   </div>
   <style>


### PR DESCRIPTION
## Done
Rerun VMware to OpenStack takeover in English

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh the homepage until you see the "From VMware to Canonical Openstack" takeover
- Make sure it matches [the design](https://github.com/canonical-websites/www.ubuntu.com/issues/4700#issuecomment-464798175)
- Make sure [the copy](https://docs.google.com/document/d/14Lzlydn9YNjTm-x-ACuKSE5xJaBe3xyHzFakQ1oRIVY/edit?ts=5c6e9927#) is correct.

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4700