### PR TITLE
Preconnect to google-analytics.com

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,5 +1,6 @@
 {% load versioned_static  %}
 <!doctype html>
+<link rel="preconnect" href="https://www.google-analytics.com">
 
 {# Release versions - update as appropriate #}
 {% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}


### PR DESCRIPTION
Fixes #4746

## Done

Added `<link rel="preconnect" href="https://www.google-analytics.com">` to the base template. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run a local performance audit with Lighthouse in Chrome dev tools.
- Verify that "Preconnect to required origins" has a green tick

## Issue / Card

#4746

## Screenshots

<img width="522" alt="screenshot 2019-02-25 at 16 27 36" src="https://user-images.githubusercontent.com/505570/53347949-6f416380-391a-11e9-8dac-37f76e92304a.png">
