### PR TITLE
Preconnect to assets server and preload Vanilla fonts

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -3,6 +3,11 @@
 <link rel="preconnect" href="https://www.google-analytics.com">
 <link rel="preconnect" href="https://assets.ubuntu.com">
 
+<link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2" crossorigin>
+<link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2" crossorigin>
+<link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
+<link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
+
 {# Release versions - update as appropriate #}
 {% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,6 +1,7 @@
 {% load versioned_static  %}
 <!doctype html>
 <link rel="preconnect" href="https://www.google-analytics.com">
+<link rel="preconnect" href="https://assets.ubuntu.com">
 
 {# Release versions - update as appropriate #}
 {% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,5 +1,6 @@
 {% load versioned_static  %}
 <!doctype html>
+<link rel="preconnect" href="https://www.google-analytics.com">
 
 {# Release versions - update as appropriate #}
 {% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}


### PR DESCRIPTION
Blocked by https://github.com/canonical-websites/www.ubuntu.com/pull/4747

## Done

Preconnect to assets server and preload Vanilla fonts

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure no errors