### PR TITLE
Remove IE conditionals

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -4,11 +4,7 @@
 {# Release versions - update as appropriate #}
 {% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}
 
-<!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
-<!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->
-<!--[if IE 8]>    <html class="no-js lt-ie10 lt-ie9" lang="en" dir="ltr"> <![endif]-->
-<!--[if IE 9]>    <html class="no-js lt-ie10" lang="en" dir="ltr"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js{% block extra_html_class %}{% endblock %}" lang="en" dir="ltr"> <!--<![endif]-->
+<html class="no-js{% block extra_html_class %}{% endblock %}" lang="en" dir="ltr">
   <head>
     {% block content-experiment %}{% endblock %}
 
@@ -25,10 +21,6 @@
 
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
 
-    <!--[if IE]>
-    <meta http-equiv="X-UA-Compatible" content="IE=8">
-    <![endif]-->
-
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
     <link rel="canonical" href="{% block canonical_url %}https://www.ubuntu.com{{ request.get_full_path }}{% endblock %}" />
@@ -44,9 +36,7 @@
 
     <!-- stylesheets -->
 
-    <!--[if !lte IE 9]> -->
     <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/styles.css' %}" />
-    <!-- <![endif]-->
 
     <link rel="stylesheet" type="text/css" media="print" href="{% versioned_static 'css/print.css' %}" />
 

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -1,11 +1,7 @@
 {% load versioned_static  %}
 <!doctype html>
 
-<!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
-<!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->
-<!--[if IE 8]>    <html class="no-js lt-ie10 lt-ie9" lang="en" dir="ltr"> <![endif]-->
-<!--[if IE 9]>    <html class="no-js lt-ie10" lang="en" dir="ltr"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js{% block extra_html_class %}{% endblock %}" lang="en" dir="ltr"> <!--<![endif]-->
+<html class="no-js{% block extra_html_class %}{% endblock %}" lang="en" dir="ltr">
   <head>
 
     {% include "templates/_tag_manager.html" %}
@@ -19,10 +15,6 @@
     <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
     <meta name="theme-color" content="#E95420" />
 
-    <!--[if IE]>
-    <meta http-equiv="X-UA-Compatible" content="IE=8">
-    <![endif]-->
-
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
@@ -35,10 +27,7 @@
     <link type="text/plain" rel="author" href="{% versioned_static 'files/humans.txt' %}" />
 
     <!-- stylesheets -->
-
-    <!--[if !lte IE 9]> -->
     <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/styles.css' %}" />
-    <!-- <![endif]-->
 
     <link rel="stylesheet" type="text/css" media="print" href="{% versioned_static 'css/print.css' %}" />
 


### PR DESCRIPTION
## Done

We no longer support any of these legacy IE browsers and even if we did, we don't do anything with the classes they add.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Ensure no errors.