### PR TITLE
UA for Infrastructure - Add registry bullet on /kubernetes

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -50,6 +50,7 @@
         <li class="p-list__item is-ticked">Bare metal, VMware infrastructure</li>
         <li class="p-list__item is-ticked">AWS, Azure, Google, OpenStack, Oracle, Rackspace clouds</li>
         <li class="p-list__item is-ticked">Public cloud LBAAS, storage, networking integrations</li>
+        <li class="p-list__item is-ticked">Built-in registry</li>
         <li class="p-list__item is-ticked">Built-in high availability</li>
         <li class="p-list__item is-ticked">Built-in Istio registry</li>
         <li class="p-list__item is-ticked">In place upgrades</li>


### PR DESCRIPTION
## Done

* Add registry bullet on /kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit?ts=5c7017c2#)

## Issue / Card

Fixes #4759

