### PR TITLE
Remove nextaedge and swiftstack from the  /openstack/storage page

### DIFF
--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Ubuntu Advantage Storage | OpenStack{% endblock %}
-{% block meta_description %}Canonical includes proven software-defined storage - Ceph and Swift, in a 24x7 supported OpenStack with pay-for-what-you-use metered pricing options.{% endblock meta_description %}
+{% block meta_description %}Canonical includes proven software-defined storage - Ceph and Swift - in a 24x7 supported OpenStack with pay-for-what-you-use metered pricing options.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1iw2SWNmoj4GZ2pUh0yB8gbtVXK0oXfyEaXT44bQbPlI/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Ubuntu Advantage Storage | OpenStack{% endblock %}
-{% block meta_description %}Canonical includes proven software-defined storage - Ceph, NexentaEdge, Swift and SwiftStack, in a 24x7 supported OpenStack with pay-for-what-you-use metered pricing options.{% endblock meta_description %}
+{% block meta_description %}Canonical includes proven software-defined storage - Ceph and Swift, in a 24x7 supported OpenStack with pay-for-what-you-use metered pricing options.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1iw2SWNmoj4GZ2pUh0yB8gbtVXK0oXfyEaXT44bQbPlI/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -80,26 +80,6 @@
       <div class="p-card__content">
         <h3 class="p-card__title">Ceph</h3>
         <p class="p-card__desc">A converged storage framework that has been designed to present object, block, and file storage from a single distributed computer cluster.</p>
-      </div>
-    </div>
-  </div>
-
-  <div class="row u-equal-height">
-    <div class="p-card col-6">
-      <img src="{{ ASSET_SERVER_URL }}888cd4eb-nexenta-logo.png?w=100" width="100" alt="NexentaEdge icon">
-      <hr class="u-sv2">
-      <div class="p-card__content">
-        <h3 class="p-card__title">NexentaEdge</h3>
-        <p class="p-card__desc">Block and object storage offering inline de-duplication and compression, low latency block services, instant snapshots, and enterprise grade, end-to-end data integrity.</p>
-      </div>
-    </div>
-
-    <div class="p-card col-6">
-      <img src="{{ ASSET_SERVER_URL }}d5950d6c-swiftstack.png?w=100" width="100" alt="SwiftStack icon">
-      <hr class="u-sv2">
-      <div class="p-card__content">
-        <h3 class="p-card__title">SwiftStack</h3>
-        <p class="p-card__desc">An object storage system built on OpenStack Swift, with an innovative storage controller for global management and NFS and SMB/CIFS file gateways.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Remove nextaedge and swiftstack from the  /openstack/storage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/storage](http://0.0.0.0:8001/openstack/storage)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1iw2SWNmoj4GZ2pUh0yB8gbtVXK0oXfyEaXT44bQbPlI/edit#)

## Issue / Card

Fixes #4761

