### PR TITLE
🚧 Add Instant Pages snippet before <body>

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -101,6 +101,8 @@
 
     <script src="/static/js/global-nav.js"></script>
     <script>canonicalGlobalNav.createNav();</script>
+    <script src="https://instant.page/1.2.0" type="module"
+      integrity="sha384-0xWpXpkOUkAVETH+RMYJlSFIDNGlnPHgmqv2rP3uZS1BM48EMcxAZGW09n4pTGV4"></script>
   </body>
 </html>
 


### PR DESCRIPTION
## Done

Added https://instant.page/ script to page body (Recommended by Harry Roberts)

This script will prefetch a link as soon as it's hovered.


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
