### PR TITLE
Stop postcss from inlining the source maps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lint-scss": "sass-lint 'static/sass/**/*.scss' --verbose --no-exit -i static/sass/prism.scss",
     "test-python": "python3 manage.py test",
     "test-links": "python3 manage.py runserver && sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --no-warnings http://127.0.0.1:8000",
-    "build": "cp node_modules/global-nav/dist/index.js static/js/global-nav.js && node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css'",
+    "build": "cp node_modules/global-nav/dist/index.js static/js/global-nav.js && node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'node_modules/vanilla-framework/scss/*.scss' -c 'yarn run build'",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "serve": "./entrypoint 0.0.0.0:${PORT}"


### PR DESCRIPTION
## Done

- Set the postcss option to not include the source maps. This reduces the css from 313kb to 230kb.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Open the network tab and see that styles.css is about 230kb. You could also open the file and check that it does not contain the sourcemaps.