### PR TITLE
Point release update to 16.04.6 LTS

### DIFF
--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -20,7 +20,7 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/16.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '16.04.5', 'eventValue' : undefined });">16.04.5 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ previous_lts_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ previous_lts_release_with_point }}', 'eventValue' : undefined });">{{ previous_lts_release_with_point }} <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
@@ -29,7 +29,7 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">16.04.5 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ previous_lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">{{ previous_lts_release_with_point }} <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
         </ul>
       </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -9,7 +9,7 @@
 <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.5" previous_lts_release_full_with_point='16.04.5 <abbr title="Long-term support">LTS</abbr>' %}
+{% with latest_release_name="CosmicCuttlefish" latest_release='18.10' latest_release_with_point="18.10" latest_release_eol='July 2019' lts_release_name="BionicBeaver" lts_release="18.04" lts_release_full='18.04 LTS' lts_release_with_point="18.04.2" lts_release_full_with_point='18.04.2 <abbr title="Long-term support">LTS</abbr>' lts_release_eol='April 2023' lts_openstack_version="Queens" latest_openstack_version="Rocky" previous_lts_release="16.04" previous_lts_release_full='16.04 LTS' previous_lts_release_with_point="16.04.6" previous_lts_release_full_with_point='16.04.6 <abbr title="Long-term support">LTS</abbr>' %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

- Updating from 5 to 6 for 16.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads) and [/download/server/power](http://0.0.0.0:8001/download/server/power)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check the pages and downloads say 16.04.6

## Issue / Card

Fixes #4742