### PR TITLE
Remove the Ubuntu Core 18 takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,6 @@
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
-  {% include "takeovers/_ubuntu-core-18-takeover.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}


### PR DESCRIPTION
## Done
Remove the Ubuntu Core 18 takeover

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Load the homepage and check there is no Ubuntu Core 18 takeover
