### PR TITLE
Remove an FAQ from the ESM page

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -147,9 +147,6 @@ background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
       <h4 class="u-no-max-width">Is it possible to purchase Ubuntu ESM months down the road when needed, with or without backdating the cost, or does it need to be in place in advance?</h4>
       <p>You can purchase Ubuntu Advantage support at any time. It does not need to be in place in advance, although we strongly recommend you eliminate the gap between when Ubuntu ESM is enabled on your system(s), to avoid exposing your systems to security vulnerabilities. Ubuntu Advantage is priced year-over-year so there is no backdating.</p>
 
-      <h4 class="u-no-max-width">Any plans to offer Ubuntu ESM a la carte without the other features of Advantage?</h4>
-      <p>Yes, in quantities of 1,000 machines or above, at $50/node/year. <br /><a href="/support/contact-us?product=server-esm">Contact Canonical Sales</a>.</p>
-
       <h4 class="u-no-max-width">We're mirroring the repository on our internal Landscape Server. Is there a guide on how to get Ubuntu ESM if using Landscape?</h4>
       <p>ESM is just a regular Ubuntu archive, but authenticated and served over HTTPS. Archive mirroring is already available in Landscape, and is the only supported mechanism for mirroring the ESM archive.</p>
 


### PR DESCRIPTION
## Done
Remove an FAQ from the ESM page.
Removed it from [the copy doc](https://docs.google.com/document/d/1BK-XXECYJJllG8jIe3WN3X8EMo_3wBBa03nlzYDP8xE/edit#heading=h.ubrgxqbmql1c)

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /esm
- Check that the FAQ item is missing
