### PR TITLE
Update to 14.04.6 from 14.04.5

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -66,12 +66,12 @@
       </ul>
     </div>
     <div class="col-3">
-      <h3 class="p-link--external p-heading--four"><span>Ubuntu 14.04.5 LTS</span></h3>
+      <h3 class="p-link--external p-heading--four"><span>Ubuntu 14.04.6 LTS</span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-amd64.iso.torrent">Ubuntu 14.04.5 Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-i386.iso.torrent">Ubuntu 14.04.5 Desktop (32-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso.torrent">Ubuntu 14.04.5 Server (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-i386.iso.torrent">Ubuntu 14.04.5 Server (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso.torrent">Ubuntu 14.04.6 Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-i386.iso.torrent">Ubuntu 14.04.6 Desktop (32-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-server-amd64.iso.torrent">Ubuntu 14.04.6 Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-server-i386.iso.torrent">Ubuntu 14.04.6 Server (32-bit)</a></li>
       </ul>
     </div>
   </div>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -21,7 +21,7 @@
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ previous_lts_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ previous_lts_release_with_point }}', 'eventValue' : undefined });">{{ previous_lts_release_with_point }} <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.6/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '14.04.6', 'eventValue' : undefined });">14.04.6&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
       <div class="col-6">
@@ -30,7 +30,7 @@
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ previous_lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">{{ previous_lts_release_with_point }} <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.6/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04.6', 'eventValue' : undefined });">14.04.6&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updated bittorrents and power links for 14.04.6

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/server/power](http://0.0.0.0:8001/download/server/power) and [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads#bittorrents)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that these pages point to 14.04.6 and not 14.04.5

## Issue / Card

Fixes #4743

