### PR TITLE
add checksum links to download thank-you page

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -47,6 +47,19 @@ Thank you for your contribution
         <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download now</a>.
         {% endif %}
       </p>
+      <p>
+         You can <a href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu">verify</a>
+         your image using the
+         {% if architecture == 'amd64+mac' %}
+         <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256 checksum</a>
+         and
+         <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS.gpg">signature</a>.
+         {% else %}
+         <a href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS">SHA256 checksum</a>
+         and
+         <a href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS.gpg">signature</a>.
+         {% endif %}
+      </p>
       {% else %}
       <h1>Thank you for your contribution</h1>
       <p>It will help further the open source development of Ubuntu.</p>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -23,6 +23,13 @@
         <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-{{ architecture }}.iso">
           download now</a>.
       </p>
+      <p>
+         You can <a href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu">verify</a>
+         your image using the
+         <a href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS">SHA256 checksum</a>
+         and
+         <a href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS.gpg">signature</a>.
+      </p>
       {% else %}
       <p>
         You didn&rsquo;t pick a version or architecture, please


### PR DESCRIPTION
## Done

I added links to the checksum and signature files on the download thank you page.

For now I've just done it for server and desktop. 
If you guys are happy with this, I can try adding it to all the other download pages too.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

#4723 

## Screenshots

![Screenshot from 2019-03-09 13-37-37](https://user-images.githubusercontent.com/7035647/54065165-9da33500-4270-11e9-90bc-376e687090b5.png)

![Screenshot from 2019-03-09 13-37-51](https://user-images.githubusercontent.com/7035647/54065168-a3991600-4270-11e9-8063-ba04a53b721b.png)

