### PR TITLE
Update to the iot download next steps strip and contibute footer

### DIFF
--- a/templates/download/iot/_install-snaps-strip.html
+++ b/templates/download/iot/_install-snaps-strip.html
@@ -4,9 +4,9 @@
       <img src="{{ ASSET_SERVER_URL }}0c16085c-network-equipment_2px.svg" alt="" width="150">
     </div>
     <div class="col-8">
-      <h3>Install and develop snaps</h3>
-      <p>Your {{ board|default:"board" }} is now ready to have snaps installed — <a class="p-link--external" href="http://snapcraft.io/docs/core/usage">get started with the <code>snap</code> command</a></p>
-      <p>You can install a classic Ubuntu environment on top of Ubuntu Core to have a fully-fledged development environment and <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/developer-setup">develop snaps on target</a></p>
+      <h3>Get started with snaps</h3>
+      <p>Your {{ board|default:"board" }} is now ready to have snaps installed, it's time to use the <code>snap</code> command to <a class="p-link--external" href="https://docs.snapcraft.io/getting-started/3876">install your first snap</a>.</p>
+      <p>The Snap Store is where you can find <a class="p-link--external" href="https://snapcraft.io/store">the best Linux apps</a> packaged as snaps to install on your Ubuntu Core device and get started with your secure IoT journey.</p>
     </div>
   </div>
 </section>

--- a/templates/shared/contextual_footers/_core_contribute.html
+++ b/templates/shared/contextual_footers/_core_contribute.html
@@ -1,6 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Contribute</h3>
   <p>Add to Ubuntu Core.</p>
-  <p><a href="http://snapcraft.io/docs/build-snaps/your-first-snap" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'snapcraft.io/docs/build-snaps/your-first-snap', 'eventLabel' : 'Contribute to Ubuntu Core', 'eventValue' : undefined });">Learn how to create a snap</a></p>
+  <p><a href="https://snapcraft.io/first-snap" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'snapcraft.io/docs/build-snaps/your-first-snap', 'eventLabel' : 'Contribute to Ubuntu Core', 'eventValue' : undefined });">Learn how to create a snap</a></p>
   <p><a href="https://github.com/snapcore/snapd" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'github.com/snapcore/snapd', 'eventLabel' : 'Contribute to Ubuntu Core', 'eventValue' : undefined });">Check out the project on GitHub</a></p>
 </div>


### PR DESCRIPTION
## Done

* Update and optimise copy on /iot/download/<board> next step strip
* Update tutorial link in iot contribute footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]
