### PR TITLE
Update datasheet on /livepatch

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -160,7 +160,7 @@
           <li class="p-list__item is-ticked">Answers to frequently asked questions</li>
         </ul>
         <p>
-          <a class="p-button" href="{{ ASSET_SERVER_URL }}ac3aa269-DS_Canonical_Livepatch_Service_screen-AW_08.17.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/livepatch', 'eventValue' : undefined });"><span class="p-link--external">Download the datasheet</span></a>
+          <a class="p-button" href="{{ ASSET_SERVER_URL }}ef19ede0-Datasheet_Livepatch_AW_Web_30.07.18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/livepatch', 'eventValue' : undefined });"><span class="p-link--external">Download the datasheet</span></a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- update the pdf in the page to one with a typo fixed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/livepatch](http://0.0.0.0:8001/livepatch)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the datasheet says 'physical machines' not 'pnysical machines'

## Issue / Card

Fixes #3925
