### PR TITLE
Remove lang class from 3 takeovers

### DIFF
--- a/templates/takeovers/_ci-cd-webinar.html
+++ b/templates/takeovers/_ci-cd-webinar.html
@@ -1,4 +1,4 @@
-<section lang="en" class="js-takeover is-bordered p-takeover p-strip--image is-deep is-dark">
+<section class="js-takeover is-bordered p-takeover p-strip--image is-deep is-dark">
   <div class="row u-vertically-center">
     <div class="col-8">
       <h1>Learn DevOps best practices</h1>

--- a/templates/takeovers/_fin-serv-whitepaper-takeover.html
+++ b/templates/takeovers/_fin-serv-whitepaper-takeover.html
@@ -1,4 +1,4 @@
-<section lang="en" class="js-takeover is-bordered p-takeover--fin-serv-whitepaper">
+<section class="js-takeover is-bordered p-takeover--fin-serv-whitepaper">
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="row u-vertically-center">
       <div class="col-7">

--- a/templates/takeovers/_ubuntu-core-full-disk-encryption.html
+++ b/templates/takeovers/_ubuntu-core-full-disk-encryption.html
@@ -1,4 +1,4 @@
-<section lang="en" class="js-takeover is-bordered p-takeover p-strip--image is-deep">
+<section class="js-takeover is-bordered p-takeover p-strip--image is-deep">
   <div class="row u-vertically-center">
     <div class="col-8">
       <h1>Secure your IoT device’s data</h1>


### PR DESCRIPTION
## Done

* These takeovers should be on the global rotation and not on an "en" specific one

## QA

- **On prod:**
  - Change your browser language to something else than 'en*', 'fr*' or 'de*'. Refresh www.ubuntu.com.
  - **Notice you only see one takeover**.
- **Check out this feature branch**
  - Run the site using the command `./run serve`
  - View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
  - Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
  - Ensure your browser language is set to something else than 'en*', 'fr*' or 'de*'.
  - **Ensure you are seeing a loop of 4 takeovers.**
