### PR TITLE
Remove some options for livepatch

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -49,26 +49,6 @@
   <div class="row">
     <div class="col-4">
       <p>
-        <a class="p-button--positive row"  href="https://aws.amazon.com/marketplace/seller-profile?id=565feec9-3d43-413e-9760-c651546613f2"><span class="p-link--external">AWS Marketplace</span></a>
-      </p>
-    </div>
-    <div class="col-8">
-      <p>Part of Ubuntu Advantage for AWS.</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <p>
-        <a class="p-button--positive row"  href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuAdvantageSupport?src=blogazure&tab=Overview"><span class="p-link--external">Azure Marketplace</span></a>
-      </p>
-    </div>
-    <div class="col-8">
-      <p> Part of Ubuntu Advantage for Azure.</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <p>
         <a class="p-button--positive row"  href="https://buy.ubuntu.com"><span class="p-link--external">Buy direct</span></a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- removed aws and azure versions, doesn't work with custom kernels

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/livepatch](http://0.0.0.0:8001/livepatch)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that AWS and Azure options are removed

## Issue / Card

Fixes #4820
