### PR TITLE
[ua4i] Remove azure and aws livepatch options from /livepatch

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -49,28 +49,18 @@
     <div class="col-10">
       <h2>Subscribe to Livepatch</h2>
     </div>
-  </div>    
+  </div>
   <div class="row p-divider u-equal-height">
-    <div class="col-3 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h4>Free for 3 machines</h4>
       <p>All you need is an Ubuntu One account.</p>
       <p> <a class="p-button--positive row"  href="https://auth.livepatch.canonical.com/"><span class="p-link--external">Get yours now</span></a></p>
     </div>
-    <div class="col-3 p-divider__block">
-      <h4>On Amazon</h4>
-      <p>Part of Ubuntu Advantage for AWS.</p>
-      <p> <a class="p-button--positive row"  href="https://aws.amazon.com/marketplace/seller-profile?id=565feec9-3d43-413e-9760-c651546613f2"><span class="p-link--external">Visit AWS Marketplace</span></a></p>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h4>On Azure</h4>
-      <p>Part of Ubuntu Advantage for Azure.</p>
-      <p><a class="p-button--positive row"  href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuAdvantageSupport?src=blogazure&tab=Overview"><span class="p-link--external">Visit Azure Marketplace</span></a></p>
-    </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h4>Buy online</h4>
       <p>Buy as part of Ubuntu Advantage from Canonical.</p>
       <p><a class="p-button--positive row"  href="https://buy.ubuntu.com"><span class="p-link--external">Visit buy.ubuntu.com</span></a></p>
-    </div>    
+    </div>
   </div>
 </section>
 
@@ -160,7 +150,7 @@
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
         <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="140" alt="" />
-    </div>  
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- removed aws and azure versions, doesn't work with custom kernels

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/livepatch](http://0.0.0.0:8001/livepatch)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that AWS and Azure options are removed

## Issue / Card

Fixes #4822 	