### PR TITLE
New IoT board: Intel IEI Tank 870

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -294,6 +294,9 @@ download:
       path: /download/iot
 
       children:
+        - title: Intel IEI TANK 870
+          path: /download/iot/intel-iei-tank-870
+          hidden: True
         - title: Raspberry Pi 2 or 3
           path: /download/iot/raspberry-pi-2-3
           hidden: True

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -16,26 +16,34 @@
 
 <section class="p-strip--light">
   <div class="row">
-    <h3>Featured boards</h3>
+    <h3>Install Ubuntu Core</h3>
   </div>
   <div class="row u-equal-height">
-    <div class="p-card--highlighted col-4">
+    <div class="p-card--highlighted col-6">
       <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=115" width="115" alt="Raspberry Pi">
       <hr class="u-sv1">
       <p class="p-card__content">Ubuntu Core 18 allows you to install apps on your board in just a few clicks for Raspberry Pi 2 or 3.</p>
-      <p class="u-no-margin--bottom"><a href="/download/iot/raspberry-pi-2-3" class="p-button--neutral is-wide">Install Ubuntu Core 18</a></p>
+      <p class="u-no-margin--bottom"><a href="/download/iot/raspberry-pi-2-3" class="p-button--neutral is-wide">Install on Raspberry Pi 3 or 2</a></p>
     </div>
-    <div class="p-card--highlighted col-4">
+    <div class="p-card--highlighted col-6">
       <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}d9ccf84b-qualcoom.png?w=132" width="132" alt="Qualcomm Snapdragon">
       <hr class="u-sv1">
       <p class="p-card__content">Ubuntu Core 18 helps you harness the power of boards tailored for the IoT ecosystem, like the Dragonboard 410c.</p>
-      <p class="u-no-margin--bottom"><a href="/download/iot/qualcomm-dragonboard-410c" class="p-button--neutral is-wide">Install Ubuntu Core 18</a></p>
+      <p class="u-no-margin--bottom"><a href="/download/iot/qualcomm-dragonboard-410c" class="p-button--neutral is-wide">Install on Dragonboard 410c</a></p>
     </div>
-    <div class="p-card--highlighted col-4">
+  </div>
+  <div class="row u-equal-height">
+    <div class="p-card--highlighted col-6">
       <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg" width="85" alt="Intel NUC">
       <hr class="u-sv1">
       <p class="p-card__content">Ubuntu Desktop and Ubuntu Core 18 can be easily installed on other architectures like Intel® 64 bits.</p>
-      <p class="u-no-margin--bottom"><a href="/download/iot/intel-nuc" class="p-button--neutral is-wide">Install Ubuntu Core 18</a></p>
+      <p class="u-no-margin--bottom"><a href="/download/iot/intel-nuc" class="p-button--neutral is-wide">Install on Intel NUC</a></p>
+    </div>
+    <div class="p-card--highlighted col-6">
+      <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}ff8c23f4-logo-pic.png" width="85" alt="Intel IEI TANK 870">
+      <hr class="u-sv1">
+      <p class="p-card__content">Ubuntu Core 18 brings enterprise-grade security to industrial AIoT kits such as the Intel IEI TANK 870.</p>
+      <p class="u-no-margin--bottom"><a href="/download/iot/intel-iei-tank-870" class="p-button--neutral is-wide">Install on Intel IEI TANK 870</a></p>
     </div>
   </div>
   <div class="row">

--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -1,0 +1,84 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Install Ubuntu Core on an Intel IEI TANK 870{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <div>
+        <h1>Install Ubuntu Core on an Intel IEI TANK 870</h1>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 p-card">
+      <div class="u-equal-height p-divider">
+        <div class="col-6 p-divider__block">
+          <h2>Install Ubuntu Core</h2>
+          <p>We will walk you through the steps of flashing Ubuntu Core on an Intel IEI TANK 870. At the end of this process, you will have a board ready for production or testing snaps.</p>
+        </div>
+        <div class="col-6 p-divider__block">
+          <h3>Minimum requirements</h3>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">An Intel IEI TANK 870</li>
+            <li class="p-list__item is-ticked">A USB flash drive</li>
+            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
+            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
+            <li class="p-list__item is-ticked">An HDMI cable</li>
+            <li class="p-list__item is-ticked">A USB keyboard</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Installation instructions</h2>
+      <ol class="p-stepped-list--detailed">
+        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Download Ubuntu Core
+          </h3>
+          <div class="p-list-step__content">
+            <p>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
+              
+              <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://people.canonical.com/~chih/intel_kassel/kassel-uc18-m6-20190121.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+            </ul>
+          </div>
+        </li>
+        {% include "./_flash-image.html" with card="USB flash drive" number=3 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Install Ubuntu Core
+          </h3>
+          <div class="p-list-step__content">
+            <ol class="u-no-margin--left">
+              <li>Attach the monitor and keyboard to the board.</li>
+              <li>Insert the USB flash drive card and power on the board.</li>
+            </ol>
+          </div>
+        </li>
+        {% include "./_first-boot-setup.html" with number=5 %}
+        {% include "./_login.html" with number=6 %}
+      </ol>
+    </div>
+  </div>
+</section>
+
+{% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
+
+{% include "./_install-snaps-strip.html" %}
+
+{% include "download/shared/_get-ebook-security.html"%}
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+{% endblock content %}

--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -46,7 +46,7 @@
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
-            <p>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
+            <p>Download the <a class="p-link--external" href="http://people.canonical.com/~chih/intel_kassel/kassel-uc18-m6-20190121.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
             <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://people.canonical.com/~chih/intel_kassel/kassel-uc18-m6-20190121.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
             </ul>
           </div>

--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -22,12 +22,11 @@
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">An Intel IEI TANK 870</li>
-            <li class="p-list__item is-ticked">A USB flash drive</li>
-            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
-            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-            <li class="p-list__item is-ticked">An HDMI cable</li>
+            <li class="p-list__item is-ticked">An Intel® IEI TANK 870 with BIOS updated to the latest version (<a class="p-link--external" href="https://download.ieiworld.com/?model=TANK-870-Q170">update instructions</a>)</li>
+            <li class="p-list__item is-ticked">2 USB 2.0 or 3.0 flash drives (2GB minimum)</li>
+            <li class="p-list__item is-ticked">A monitor with D-sub interface</li>
             <li class="p-list__item is-ticked">A USB keyboard</li>
+            <li class="p-list__item is-ticked">A network connection with Internet access</li>
           </ul>
         </div>
       </div>
@@ -48,26 +47,55 @@
           </h3>
           <div class="p-list-step__content">
             <p>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
-              
-              <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://people.canonical.com/~chih/intel_kassel/kassel-uc18-m6-20190121.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://people.canonical.com/~chih/intel_kassel/kassel-uc18-m6-20190121.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
             </ul>
           </div>
         </li>
-        {% include "./_flash-image.html" with card="USB flash drive" number=3 %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
-            Install Ubuntu Core
+            <span class="p-list-step__bullet">3</span>
+            Prepare the two USB flash drives
           </h3>
           <div class="p-list-step__content">
             <ol class="u-no-margin--left">
-              <li>Attach the monitor and keyboard to the board.</li>
-              <li>Insert the USB flash drive card and power on the board.</li>
+              <li>Download and flash an <a href="/download/desktop">Ubuntu Desktop {{ lts_release_full_with_point }}</a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a>.</li>
+              <li>Copy the Ubuntu Core image file to the second USB flash drive.</li>
             </ol>
           </div>
         </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Boot the live Ubuntu Desktop image
+          </h3>
+          <div class="p-list-step__content">
+            <ol class="u-no-margin--left">
+              <li>Connect the keyboard and monitor to the Intel IEI TANK 870.</li>
+              <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ lts_release_full_with_point }}.</li>
+              <li>Start the device and press F7 to enter the boot menu.</li>
+              <li>Select the USB flash drive as a boot option.</li>
+              <li>Select "Try Ubuntu without installing”.</li>
+            </ol>
+          </div>
+        </li>
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">5</span>
+            Flash Ubuntu Core to the internal memory
+          </h3>
+          <div class="p-list-step__content">
+            <ol class="u-no-margin--left">
+              <li>Once the Ubuntu session has started, insert the second USB flash drive containing the Ubuntu Core image file.</li>
+              <li><p>Open a terminal and use the following command to find out the target disk device to install the Ubuntu Core image to:</p>
+              <pre><code>sudo fdisk -l</code></pre></li>
+              <li><p>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:</p>
+              <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/&lt;name of the image&gt;.img.xz | sudo dd of=/dev/&lt;target disk device&gt; bs=32M status=progress; sync</code></pre></li>
+              <li>Reboot the system and remove the flash drives when prompted. It will then boot from the internal memory where Ubuntu Core has been flashed.</li>
+            </ol>
+          </div>
+        </li>
+        {% include "./_first-boot-setup.html" with number=6 %}
+        {% include "./_login.html" with number=7 %}
       </ol>
     </div>
   </div>

--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -54,6 +54,9 @@
             <li class='p-list__item'><a class='p-link' href='/download/iot/up-squared-iot-grove-server'>
               UP<sup>2</sup> IoT Grove
             </a></li>
+            <li class='p-list__item'><a class='p-link' href='/download/iot/intel-iei-tank-870'>
+              Intel IEI TANK 870
+            </a></li>
           </ul>
         </div>
         <div class="col-3">


### PR DESCRIPTION
## Done

* New iot board in `/download/iot/intel-iei-tank-870`
* Some copy changes to `/download/iot`
* Don't merge: needs review from the SE team, needs copydoc update/creation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]

