### PR TITLE
Sync updated k8s release-notes into website

### DIFF
--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,7 +13,18 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-# CVE-2018-18264 - January 10, 2019
+# 1.13 Bugfix Release
+
+### February 21, 2019 - [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-435/archive/bundle.yaml)
+
+## Fixes
+
+- Fixed docker does not start when docker_runtime is set to nvidia ([Issue](https://bugs.launchpad.net/charm-layer-docker/+bug/1816471))
+- Fixed snapd_refresh charm option conflict ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/657))
+
+# CVE-2018-18264
+
+### January 10, 2019
 
 ## What happened
 


### PR DESCRIPTION
## Done

Updated the release notes for kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/docs/release-notes](http://0.0.0.0:8001/kubernetes/docs/release-notes)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
