### PR TITLE
Add /legal/partner-portal-terms page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -420,6 +420,8 @@ legal:
           path: /legal/systems-information-notice
         - title: Ubuntu font
           path: /legal/font-licence
+        - title: Partner Portal
+          path: /legal/partner-portal-terms
 
           children:
             - title: FAQ

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -402,19 +402,19 @@ legal:
         - title: Intellectual property - 14th May 2013
           path: /legal/intellectual-property-policy/2013-05-14
           hidden: True
-        - title: Online account terms
+        - title: Online accounts
           path: /legal/online-account-terms
         - title: U1 Terms of Service
           path: /legal/terms-of-service
         - title: Confidentiality agreement
           path: /legal/confidentiality-agreement
-        - title: Developer terms
+        - title: Developers
           path: /legal/developer-terms-and-conditions
-        - title: Launchpad terms
+        - title: Launchpad
           path: /legal/launchpad-terms-of-service
-        - title: Livepatch terms
+        - title: Livepatch
           path: /legal/livepatch-terms-of-service
-        - title: JAAS terms
+        - title: JAAS
           path: /legal/jaas-beta-terms-of-service
         - title: System Information
           path: /legal/systems-information-notice

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -418,10 +418,10 @@ legal:
           path: /legal/jaas-beta-terms-of-service
         - title: System Information
           path: /legal/systems-information-notice
-        - title: Ubuntu font
-          path: /legal/font-licence
         - title: Partner Portal
           path: /legal/partner-portal-terms
+        - title: Ubuntu font
+          path: /legal/font-licence
 
           children:
             - title: FAQ

--- a/templates/legal/_base_legal_markdown.html
+++ b/templates/legal/_base_legal_markdown.html
@@ -9,6 +9,14 @@
 
     {% block content %}
     <div class="p-strip is-deep">
+{% if update_date %}
+      <div class="row">
+        <div class="col-12">
+          <h4 class="p-muted-heading">{{ update_date | safe }}</h4>
+          <hr style="margin-bottom: 2rem;" />
+        </div>
+      </div>
+{% endif %}
       <div class="row" id="service-description">
         <div class="col-8 l-legal-pages">
 {{ html_content | safe }}

--- a/templates/legal/partner-portal-terms.md
+++ b/templates/legal/partner-portal-terms.md
@@ -3,11 +3,9 @@ wrapper_template: "./_base_legal_markdown.html"
 context:
   title: "Partner Portal terms and conditions"
   description: "This privacy notice tells you about the information we collect from you when you submit your information to us via an enquiry or contact us form on our website."
+  update_date: "Version - February 2019"
   copydoc: https://docs.google.com/document/d/1CqJbwC3KpEJeJaCUVjAIN0y6ZLmoc7gVlFyc-BeFMYw/edit#
 ---
-<h4 class="p-muted-heading">Version - February 2019</h4>
-<hr style="margin-bottom: 2rem;" />
-
 # Partner Portal terms and conditions
 
 ## Intellectual property

--- a/templates/legal/partner-portal-terms.md
+++ b/templates/legal/partner-portal-terms.md
@@ -1,0 +1,50 @@
+---
+wrapper_template: "./_base_legal_markdown.html"
+context:
+  title: "Partner Portal terms and conditions"
+  description: "This privacy notice tells you about the information we collect from you when you submit your information to us via an enquiry or contact us form on our website."
+  copydoc: https://docs.google.com/document/d/1CqJbwC3KpEJeJaCUVjAIN0y6ZLmoc7gVlFyc-BeFMYw/edit#
+---
+<h4 class="p-muted-heading">Version - February 2019</h4>
+<hr style="margin-bottom: 2rem;" />
+
+# Partner Portal terms and conditions
+
+## Intellectual property
+
+[Canonical's intellectual property rights policy](/legal/intellectual-property-policy) governs your use of Canonical's intellectual property.
+
+## Copyright
+
+The website HTML, text, images audio, video, software or other content that is made available on Canonical's Partner Platform or otherwise hosted by Canonical are the property of someone - the author in the case of content produced elsewhere and reproduced here with permission of Canonical, the platform provider or content suppliers (e.g. Gorilla Toolz, Inc. and Vartopia, LLC.). Before you use this content in some way please take care to ensure that you have the relevant rights and permissions from the copyright holder.
+
+You are welcome to display on your computer, download and print pages from Canonical's Partner Platform for internal use only. You must retain copyright, trademark and other notices unaltered on any copies or printouts you make. Certain materials available on this site are "open source" materials subject to the GNU General Public Licence ("GPL") or other open-source licence and are so marked. Use of those materials is governed by the individual applicable licence.
+
+## Trademarks
+
+Any trademarks, logos and service marks displayed on Canonical's Partner Platform are the property of their owners, whether Canonical or third parties. For example, the Gorilla Toolz logo is a registered trademark of Gorilla Toolz, Inc.
+
+## Privacy policy
+
+Our collection and use of your personal information is governed by the Partner Portal Privacy Notice and [Canonical privacy policy](/legal/data-privacy).
+
+## Links and third-party content
+
+This and any other sites hosted by Canonical may contain links to other websites and resources and third party content, for example, useful background information. Canonical is not responsible for such content, or that of any linked websites. You will not remove or alter any third party's copyright or trademark notices or other identifier, except as allowed by the third-party's licence of that content. Should you reasonably believe that any third-party content you access through our site is in breach of any law, regulation or third party's rights, you should notify Canonical in writing at the address below. In doing so, please:
+
+- identify the material which you believe to be infringing;
+- identify what you believe this material infringes and why;
+- provide your name, email address, address and telephone number;
+- confirm that you believe in good faith that this material is infringing a law or third party's rights and that, to the best of your knowledge, the information you are providing is correct;
+- identify if you are acting on behalf of the third party whose rights may have been infringed;
+- provide your physical or electronic signature.
+
+## Disclaimer
+
+The Canonical Partner Portal and any other sites hosted by Canonical and all information, products and services on them are provided on an "as is" basis, without warranty of any kind, either express or implied. Your use of this and any other sites hosted by Canonical is at your own risk. Canonical disclaims all warranties, express or implied, including without limitation, warranties of merchantability and fitness for a particular purpose.
+
+Canonical disclaims liability for any direct, indirect, incidental, special, consequential, exemplary, punitive or other damages, or lost profits, that may result directly or indirectly from the use of this and any other websites hosted by Canonical and any material that is downloaded or obtained through them.
+
+This includes, without limitation, any damage to computer systems, hardware or software, loss of data, or any other performance failures, any errors, bugs, viruses or other defects that result from, or are associated with the use of this and any other websites hosted by Canonical.
+
+Yes, it gives most of us a headache to read all of this, but it's important so thank you for your patience and now, enjoy the Partner Portal!


### PR DESCRIPTION
## Done

- Added a new t&c page for the partner portal
- Created a copy doc
- Added the page to the navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/partner-portal-terms](http://0.0.0.0:8001/legal/partner-portal-terms)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare it to the [copy doc](https://docs.google.com/document/d/1CqJbwC3KpEJeJaCUVjAIN0y6ZLmoc7gVlFyc-BeFMYw/edit#)


## Issue / Card

Fixes #4841 