### PR TITLE
Fix use of everyday vs every day

### DIFF
--- a/templates/legal/font-licence/index.html
+++ b/templates/legal/font-licence/index.html
@@ -70,7 +70,7 @@
     <div class="col-8">
       <h2>Ubuntu Font Licence &mdash; Further information</h2>
       <p>The Ubuntu Font Family is presently distributed under the Ubuntu Font Licence.  This means you can use the font in much the same way as you would use any other font (open or proprietary).  The <em>open</em> means that in the long run, the font can continue to be expanded, because the raw source code (design files) for the font itself are available to those who are interested.</p>
-      <p>You are most welcome to use the Ubuntu Font Family, in your documents, graphic designs, logos, or company stationary.  We'd like as many people as possible to have a better quality reading experience everyday.</p>
+      <p>You are most welcome to use the Ubuntu Font Family, in your documents, graphic designs, logos, or company stationary.  We'd like as many people as possible to have a better quality reading experience every day.</p>
 
       <h2>For those wishing to alter or expand the font itself</h2>
       <p>The present Ubuntu Font Licence 1.0 is loosely inspired from the <a href="http://scripts.sil.org/OFL" class="p-link--external">SIL Open Font Licence (OFL)</a> version 1.1. Using the Ubuntu Font Licence 1.0 is an interim solution and the choice of licence will likely change as alternative licences become available in the future.</p>

--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -42,8 +42,8 @@
           <td>Phone and web ticket support</td>
           <td class="u-align--center">None</td>
           <td class="p-table__cell--highlight u-align--center">8am &ndash; 6pm on weekdays</td>
-          <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
-          <td class="p-table__cell--highlight u-align--center">24 hours a day, everyday</td>
+          <td class="p-table__cell--highlight u-align--center">24 hours a day, every day</td>
+          <td class="p-table__cell--highlight u-align--center">24 hours a day, every day</td>
         </tr>
         <tr>
           <td>Industry-leading cloud operations tooling (Ubuntu, MAAS, Juju, LXD)</td>
@@ -95,7 +95,7 @@
           <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
         </tr>
         <tr>
-          <td>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day, everyday</td>
+          <td>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day, every day</td>
           <td>&nbsp;</td>
           <td class="p-table__cell--highlight">&nbsp;</td>
           <td class="p-table__cell--highlight">&nbsp;</td>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -19,7 +19,7 @@
     </tr>
     <tr>
       <th>Phone and web ticket support</th>
-      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />every day</td>
     </tr>
     <tr>
       <th>Industry-leading cloud operations tooling<br />

--- a/templates/shared/pricing/_landscape.html
+++ b/templates/shared/pricing/_landscape.html
@@ -43,7 +43,7 @@
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
     </tr>
     <tr>
-      <td>Phone and ticket support for Landscape 24 hours a day, everyday</td>
+      <td>Phone and ticket support for Landscape 24 hours a day, every day</td>
       <td class="p-table__cell--highlight u-align--center"><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
     </tr>
   </tbody>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -36,7 +36,7 @@
         <td>Phone and ticket support</td>
         <td class="u-align--center">None</td>
         <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
-        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
+        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />every day</td>
       </tr>
 
       <tr>

--- a/templates/shared/pricing/_storage-support.html
+++ b/templates/shared/pricing/_storage-support.html
@@ -28,7 +28,7 @@
     </tr>
     <tr>
       <td>Phone and web ticket support</td>
-      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
+      <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />every day</td>
     </tr>
     <tr>
       <td>Industry-leading cloud operations tooling (Ubuntu, MAAS, Juju)</td>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -25,7 +25,7 @@
           <td>Phone and ticket support</td>
           <td class="u-align--center">None</td>
           <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
-          <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
+          <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />every day</td>
         </tr>
         <tr>
           <td>Download, install, run, use, update, secure, upgrade</td>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -34,7 +34,7 @@
         <td class="u-align--center">None</td>
         <td class="p-table__cell--highlight u-align--center">None</td>
         <td class="p-table__cell--highlight u-align--center">8am - 6pm<br />on weekdays</td>
-        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />everyday</td>
+        <td class="p-table__cell--highlight u-align--center">24 hours a day,<br />every day</td>
       </tr>
       <tr>
         <td>Download, install, run, use,<br />update, secure, upgrade</td>


### PR DESCRIPTION
## Done

- Fixed the use of 'everyday' and 'every day' across the site - see https://www.grammarly.com/blog/everyday-every-day/ for more info
- Fixed the font-license copy doc, left the pricing ones as the UA for Infrastructure project will kill all these.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/legal/font-licence/
    - http://0.0.0.0:8001/pricing/
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that you agree with my changes

## Issue / Card

Fixes #4755
