### PR TITLE
K8s integration docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -116,6 +116,12 @@ kubernetes:
         - title: Manual install
           path: /kubernetes/docs/install-manual
           hidden: True
+        - title: GCP integration
+          path: /kubernetes/docs/gcp-integration
+          hidden: True
+        - title: AWS integration
+          path: /kubernetes/docs/aws-integration
+          hidden: True
         - title: Logging
           path: /kubernetes/docs/logging
           hidden: True

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -279,6 +279,6 @@ juju debug-log --replay --include aws-integrator/0
 [quickstart]: /kubernetes/docs/quickstart
 [storage]: /kubernetes/docs/storage
 [ebs-info]: https://aws.amazon.com/ebs/features/
-[cloudtrail]: console.aws.amazon.com/cloudtrail/
+[cloudtrail]: https://console.aws.amazon.com/cloudtrail/
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes
 [aws-integrator-readme]: https://jujucharms.com/u/containers/aws-integrator/

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -1,0 +1,284 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "CDK on AWS"
+  description: Running CDK on AWS using the aws-integrator.
+keywords: aws, integrator, ebs, elb
+tags: [install]
+sidebar: k8smain-sidebar
+permalink: aws-integration.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** will run seamlessly on
+AWS.  With the addition of the `aws-integrator`, your cluster will also be able to directly
+use AWS native features.
+
+
+## AWS integrator
+
+The `aws-integrator` charm simplifies working with **CDK** on AWS. Using the
+credentials provided to Juju, it acts as a proxy between CDK and the underlying cloud,
+granting permissions to dynamically create, for example, EBS volumes.
+
+### Installing
+
+If you use the [recommended install method][quickstart] with `conjure-up`, the
+integrator charm will be installed by default, and trust granted automatically.
+
+If you install **CDK** using the Juju bundle, you can add the aws-integrator at
+the same time by using the following overlay file
+([download it here][asset-aws-overlay]):
+
+```yaml
+applications:
+  aws-integrator:
+    charm: cs:~containers/aws-integrator
+    num_units: 1
+relations:
+  - ['aws-integrator', 'kubernetes-master']
+  - ['aws-integrator', 'kubernetes-worker']
+  ```
+
+To use this overlay with the **CDK** bundle, it is specified during deploy like this:
+
+```bash
+juju deploy canonical-kubernetes  --overlay ~/path/aws-overlay.yaml
+```
+
+Then run the command to share credentials with this charm:
+
+```bash
+juju trust aws-integrator
+```
+
+... and remember to fetch the configuration file!
+
+```bash
+juju scp kubernetes-master/0:config ~/.kube/config
+```
+
+For more configuration options and details of the permissions which the integrator uses,
+please see the [charm readme][aws-integrator-readme].
+
+### Using EBS volumes
+
+Many  pods you may wish to deploy will require storage. Although you can use any type
+of storage supported by Kubernetes (see the [storage documentation][storage]), you
+also have the option to use the native AWS storage, Elastic Block Store (EBS).
+
+First we need to create a storage class which can be used by Kubernetes.  To start with,
+we will create one for the 'General Purpose SSD' type of EBS storage:
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-gp2
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+EOY
+```
+
+You can confirm this has been added by running:
+
+```bash
+kubectl get sc
+```
+
+which should return:
+```bash
+NAME      PROVISIONER             AGE
+ebs-gp2   kubernetes.io/aws-ebs   39s
+```
+
+You can create additional storage classes for the other types of EBS storage if
+needed, simply give them a different name and replace the 'type: gp2' with a
+different type (See the [AWS website][ebs-info] for more information on the
+available types).
+
+To actually create storage using this new class, you can make a Persistent Volume Claim:
+
+```bash
+kubectl create -f - <<EOY
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: ebs-gp2
+EOY
+```
+
+This should finish with a confirmation. You can check the current PVCs with:
+
+```bash
+kubectl get pvc
+```
+
+...which should return something similar to:
+
+```bash
+NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+testclaim   Bound    pvc-54a94dfa-3128-11e9-9c54-028fdae42a8c   1Gi        RWO            ebs-gp2        9s
+```
+
+This PVC can then be used by pods operating in the cluster. As an example, the following
+deploys a `busybox` pod:
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+      volumeMounts:
+        - mountPath: "/pv"
+          name: testvolume
+  restartPolicy: Always
+  volumes:
+    - name: testvolume
+      persistentVolumeClaim:
+        claimName: testclaim
+EOY
+```
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+If you create EBS volumes and subsequently tear down the cluster, check
+with the AWS console to make sure all the associated resources have also been released.
+  </p>
+</div>
+
+### Using ELB Loadbalancers
+
+With the aws-integrator charm in place, actions which invoke a loadbalancer in
+Kubernetes  will automatically generate an AWS Elastic Load Balancer.  This can
+be demonstrated with a simple application. Here we will create a simple
+application running in five pods:
+
+```bash
+kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+```
+
+You can verify that the application and replicas have been created with:
+
+```bash
+ kubectl get deployments hello-world
+ ```
+
+ Which should return output similar to:
+
+ ```bash
+ NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+ hello-world      5/5               5                            5             2m38s
+```
+
+To create a LoadBalancer, the application should now be exposed as a service:
+
+```bash
+ kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+ ```
+
+To check that the service is running correctly:
+
+```bash
+kubectl describe service hello
+```
+
+...which should return output similar to:
+
+```yaml
+Name:                     hello
+Namespace:                default
+Labels:                   run=load-balancer-example
+Annotations:              <none>
+Selector:                 run=load-balancer-example
+Type:                     LoadBalancer
+IP:                       10.152.183.134
+LoadBalancer Ingress:     ad5fc7750350611e99768068a686bb67-239702253.eu-west-1.elb.amazonaws.com
+Port:                     <unset>  8080/TCP
+TargetPort:               8080/TCP
+NodePort:                 <unset>  31203/TCP
+Endpoints:                10.1.13.4:8080,10.1.13.5:8080,10.1.35.8:8080 + 2 more...
+Session Affinity:         None
+External Traffic Policy:  Cluster
+Events:                   <none>
+```
+
+You can see that the LoadBalancer Ingress is now associated with an ELB address in front
+of the five endpoints of the  example deployment. Leaving a while for DNS propagation, you
+can test the ingress address:
+
+```bash
+curl  http://ad5fc7750350611e99768068a686bb67-239702253.eu-west-1.elb.amazonaws.com:8080
+```
+```
+Hello Kubernetes!
+```
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+If you create ELBs and subsequently tear down the cluster, check with the AWS console
+to make sure all the associated resources have also been released.
+  </p>
+</div>
+Note that if you subsequently decommission this service, it is useful to check through
+the AWS console that the ELB resources are also released.
+
+### Upgrading the integrator-charm
+
+The aws-integrator is not specifically tied to the version of CDK installed and may
+generally be upgraded at any time with the following command:
+
+```bash
+juju upgrade-charm aws-integrator
+```
+
+### Troubleshooting
+
+If you have any specific problems with the aws-integrator, you can report bugs on
+[Launchpad][bugs].
+
+The aws-integrator charm makes use of IAM accounts in AWS to perform actions, so
+useful information can be obtained from [Amazon's CloudTrail][cloudtrail], which logs
+such activity.
+
+For logs of what the charm itself believes the world to look like, you can use Juju to replay
+the log history for that specific unit:
+
+```bash
+juju debug-log --replay --include aws-integrator/0
+```
+
+
+<!-- LINKS -->
+
+[asset-aws-overlay]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/aws-overlay.yaml
+[quickstart]: /kubernetes/docs/quickstart
+[storage]: /kubernetes/docs/storage
+[ebs-info]: https://aws.amazon.com/ebs/features/
+[cloudtrail]: console.aws.amazon.com/cloudtrail/
+[bugs]: https://bugs.launchpad.net/charmed-kubernetes
+[aws-integrator-readme]: https://jujucharms.com/u/containers/aws-integrator/

--- a/templates/kubernetes/docs/gcp-integration.md
+++ b/templates/kubernetes/docs/gcp-integration.md
@@ -1,0 +1,317 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "CDK on GCP"
+  description: Running CDK on Google Cloud Platform using the gcp-integrator.
+keywords: gcp, integrator, LoadBalancer
+tags: [install]
+sidebar: k8smain-sidebar
+permalink: gcp-integration.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** will run seamlessly on
+**Google Cloud Platform**(GCP).  With the addition of the `gcp-integrator`, your cluster
+will also be able to use GCP native features directly.
+
+## GCP Credentials
+
+If you have set up a service account with IAM roles as your credential for Juju, there may
+be some additional authorisations you will need to make to access all features of GCP
+with **CDK**.
+
+If you have a GCP project set up specifically for **CDK**, the quickest route is to simply
+add the service account as an `Owner` of that project in the [GCP console][owner].
+
+If you chose a more fine-grained approach to role administration, the service account
+should have at least:
+
+  - roles/compute.loadBalancerAdmin
+  - roles/compute.instanceAdmin.v1
+  - roles/compute.securityAdmin
+  - roles/iam.serviceAccountUser
+
+A full description of the various pre-defined roles is available in the
+[GCP Documentation][iam-roles].
+
+## GCP integrator
+
+The `gcp-integrator` charm simplifies working with **CDK** on GCP. Using the
+credentials provided to Juju, it acts as a proxy between **CDK** and the underlying
+cloud, granting permissions to dynamically create, for example, storage volumes.
+
+### Installing
+
+If you use the [recommended install method][quickstart] with `conjure-up`, the
+integrator charm will be installed by default, and trust granted automatically.
+
+If you install **CDK** using the Juju bundle, you can add the gcp-integrator at
+the same time by using the following overlay file
+([download it here][asset-gcp-overlay]):
+
+```yaml
+applications:
+  gcp-integrator:
+    charm: cs:~containers/gcp-integrator
+    num_units: 1
+relations:
+  - ['gcp-integrator', 'kubernetes-master']
+  - ['gcp-integrator', 'kubernetes-worker']
+  ```
+
+To use this overlay with the **CDK** bundle, it is specified during deploy like this:
+
+```bash
+juju deploy canonical-kubernetes --overlay ~/path/gcp-overlay.yaml
+```
+
+Then run the command to share credentials with this charm:
+
+```bash
+juju trust gcp-integrator
+```
+
+... and remember to fetch the configuration file!
+
+```bash
+juju scp kubernetes-master/0:config ~/.kube/config
+```
+
+For more configuration options and details of the permissions which the integrator uses,
+please see the [charm readme][gcp-integrator-readme].
+
+### Using persistent storage
+
+Many pods you may wish to deploy will require storage. Although you can use any type
+of storage supported by Kubernetes (see the [storage documentation][storage]), you
+also have the option to use the native GCP storage types.
+
+GCP storage currently comes in two types - SSD (pd-ssd) or 'standard'(pd-standard). To
+use these, we need to create a storage classes in Kubernetes.  
+
+For the standard disks:
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gcp-standard
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+EOY
+```
+
+Or for SSD:
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gcp-ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+EOY
+```
+
+You can confirm this has been added by running:
+
+```bash
+kubectl get sc
+```
+
+which should return:
+```bash
+NAME           PROVISIONER            AGE
+gcp-ssd        kubernetes.io/gce-pd   9s
+gcp-standard   kubernetes.io/gce-pd   45s
+```
+
+To actually create storage using this new class, you can make a Persistent Volume Claim:
+
+```bash
+kubectl create -f - <<EOY
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: gcp-standard
+EOY
+```
+
+This should finish with a confirmation. You can check the current PVCs with:
+
+```bash
+kubectl get pvc
+```
+
+...which should return something similar to:
+
+```bash
+NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+testclaim   Bound    pvc-e1d42bae-44e6-11e9-8dff-42010a840007   1Gi        RWO            gcp-standard   15s
+```
+
+This PVC can then be used by pods operating in the cluster. As an example, the following
+deploys a `busybox` pod:
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+      volumeMounts:
+        - mountPath: "/pv"
+          name: testvolume
+  restartPolicy: Always
+  volumes:
+    - name: testvolume
+      persistentVolumeClaim:
+        claimName: testclaim
+EOY
+```
+
+To set this type of storage as the default, you can use the command:
+
+```bash
+kubectl patch storageclass gcp-standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+If you create persistent disks and subsequently tear down the cluster, check
+with the GCP console to make sure all the associated resources have also been released.
+  </p>
+</div>
+
+### Using GCP Loadbalancers
+
+With the gcp-integrator charm in place, actions which invoke a loadbalancer in
+Kubernetes  will automatically generate a GCP [Target Pool][target-pool] and the
+relevant forwarding rules.  This can be demonstrated with a simple application. Here we
+will create an application running in five pods:
+
+```bash
+kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+```
+
+You can verify that the application and replicas have been created with:
+
+```bash
+ kubectl get deployments hello-world
+ ```
+
+ Which should return output similar to:
+
+ ```bash
+ NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+ hello-world      5/5               5                            5             2m38s
+```
+
+To create a target pool load balancer, the application should now be exposed as a service:
+
+```bash
+ kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+ ```
+
+To check that the service is running correctly:
+
+```bash
+kubectl describe service hello
+```
+
+...which should return output similar to:
+
+```yaml
+Name:                     hello
+Namespace:                default
+Labels:                   run=load-balancer-example
+Annotations:              <none>
+Selector:                 run=load-balancer-example
+Type:                     LoadBalancer
+IP:                       10.152.183.63
+LoadBalancer Ingress:     34.76.144.215
+Port:                     <unset>  8080/TCP
+TargetPort:               8080/TCP
+NodePort:                 <unset>  31864/TCP
+Endpoints:                10.1.54.11:8080,10.1.54.12:8080,10.1.54.13:8080 + 2 more...
+Session Affinity:         None
+External Traffic Policy:  Cluster
+Events:
+  Type    Reason                Age    From                Message
+  ----    ------                ----   ----                -------
+  Normal  EnsuringLoadBalancer  9m21s  service-controller  Ensuring load balancer
+  Normal  EnsuredLoadBalancer   7m37s  service-controller  Ensured load balancer
+
+```
+
+You can see that the `LoadBalancer Ingress` is now associated with a new ingress address
+in front of the five endpoints of the  example deployment. You can test this address:
+
+```bash
+curl 34.76.144.215:8080
+```
+```
+Hello Kubernetes!
+```
+
+### Upgrading the integrator-charm
+
+The gcp-integrator is not specifically tied to the version of **CDK** installed and may
+generally be upgraded at any time with the following command:
+
+```bash
+juju upgrade-charm gcp-integrator
+```
+
+### Troubleshooting
+
+If you have any specific problems with the gcp-integrator, you can report bugs on
+[Launchpad][bugs].
+
+Any activity in GCP can be monitored from the [Operations][operations] console. If you
+are using a service account with IAM roles, it is relatively easy to see the actions that
+particular account is responsible for.
+
+For logs of what the charm itself believes the world to look like, you can use Juju to replay
+the log history for that specific unit:
+
+```bash
+juju debug-log --replay --include gcp-integrator/0
+```
+
+
+<!-- LINKS -->
+
+[quickstart]: /kubernetes/docs/quickstart
+[owner]: https://console.cloud.google.com/iam-admin/iam
+[iam-roles]: https://cloud.google.com/compute/docs/access/iam
+[asset-gcp-overlay]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/gcp-overlay.yaml
+[operations]: https://console.cloud.google.com/compute/operations
+[storage]: /kubernetes/docs/storage
+[bugs]: https://bugs.launchpad.net/charmed-kubernetes
+[gcp-integrator-readme]: https://jujucharms.com/u/containers/gcp-integrator/
+[target-pool]: https://cloud.google.com/load-balancing/docs/target-pools

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -188,9 +188,9 @@ used:
 
 | Cloud     | Integrator charm   |  Juju deploy command  | Notes/docs  |
 |------------|----------------------|-------------------------------------------------|-----------------------------------------------------------|
-| AWS        | aws-integrator       | juju deploy cs:~containers/aws-integrator       | [docs](https://jujucharms.com/u/containers/aws-integrator/)       |
+| AWS        | aws-integrator       | juju deploy cs:~containers/aws-integrator       | [docs][aws-docs]      |
 | Azure      | azure-integrator     | juju deploy cs:~containers/azure-integrator     | [docs](https://jujucharms.com/u/containers/azure-integrator/)     |
-| Google     | gcp-integrator       | juju deploy cs:~containers/gcp-integrator       | [docs](https://jujucharms.com/u/containers/gcp-integrator/)       |
+| Google     | gcp-integrator       | juju deploy cs:~containers/gcp-integrator       | [docs][gcp-docs]      |
 | Local      | N/A                  | N/A                                             |                                                           |
 | OpenStack  | openstack-integrator | juju deploy cs:~containers/openstack-integrator | [docs](https://jujucharms.com/u/containers/openstack-integrator/) |
 | Rackspace  | openstack-integrator | juju deploy cs:~containers/openstack-integrator | [docs](https://jujucharms.com/u/containers/openstack-integrator/) |
@@ -398,3 +398,5 @@ For more information on the Juju GUI, see the [Juju documentation][juju-gui].
 [charm-kworker]: https://jujucharms.com/u/containers/kubernetes-worker/#configuration
 [snaps]: https://docs.snapcraft.io/snap-documentation
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[aws-docs]: /kubernetes/docs/aws-integration
+[gcp-docs]: /kubernetes/docs/gcp-integration

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -5,6 +5,9 @@
   - [Quickstart](/kubernetes/docs/quickstart)
   - [Local install](/kubernetes/docs/install-local)
   - [Manual install](/kubernetes/docs/install-manual)
+- **Cloud Integration**
+  - [AWS integration](/kubernetes/docs/aws-integration)
+  - [GCP integration](/kubernetes/docs/gcp-integration)
 - **Operations**
   - [Logging](/kubernetes/docs/logging)
   - [Monitoring](/kubernetes/docs/monitoring)
@@ -22,5 +25,5 @@
 - **Reference**
   - [Release notes](/kubernetes/docs/release-notes)
   - [Upgrade notes](/kubernetes/docs/upgrade-notes)
-  - [Certificates and Trust](/kubernetes/docs/certs-and-trust)
+  - [Certificates and trust](/kubernetes/docs/certs-and-trust)
   - [Get in touch](/kubernetes/docs/get-in-touch)


### PR DESCRIPTION
## Done

Added aws integration page
Added gcp integration page 
Added Cloud integration as a navigation section
added new pages to navigation.yaml

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/docs/](http://0.0.0.0:8001/kubernetes/docs/])
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)