### PR TITLE
Create /engage/fr/vmware-to-openstack page

### DIFF
--- a/templates/engage/_heading-help.html
+++ b/templates/engage/_heading-help.html
@@ -13,41 +13,41 @@
 
 <section class="p-strip">
   <div class="row">
-    <p>These headers have several options with only one required field and can be used for case studies and webinars.  These include the title, a subtitle (optional), a date (optional), a cta with a url  (optional) and a class (optional).</p>
+    <p>These headers have several options with only one required field and can be used for case studies and webinars.  These include the title, a subtitle (optional), a date (optional), a cta with a url  (optional), a class (optional) and a lang(uage) (optional).</p>
 
     <h3>Everything - title, subtitle, date, cta and url, class</h3>
 
     <h4>Include tag</h4>
-    <pre><code>&#123;% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar" class="test-class" %}
+    <pre><code>&#123;% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar" class="test-class" lang="en" %}
     </code></pre>
     <h4>Output</h4>
   </div>
 </section>
-{% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar" class="test-class" %}
+{% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar" class="test-class"  lang="en" %}
 <hr />
 
 <section class="p-strip">
   <div class="row">
     <h3>No date</h3>
     <h4>Include tag</h4>
-    <pre><code>&#123;% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" url="#register-section" cta="Watch the webinar" %}
+    <pre><code>&#123;% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" url="#register-section" cta="Watch the webinar"  lang="en" %}
     </code></pre>
     <h4>Output</h4>
   </div>
 </section>
-{% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" url="#register-section" cta="Watch the webinar" %}
+{% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  image="d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" url="#register-section" cta="Watch the webinar"  lang="en" %}
 <hr />
 
 <section class="p-strip">
   <div class="row">
     <h3>No image, no class</h3>
     <h4>Include tag</h4>
-    <pre><code>&#123;% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar" %}
+    <pre><code>&#123;% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar"  lang="en" %}
     </code></pre>
     <h4>Output</h4>
   </div>
 </section>
-{% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar"  %}
+{% include "engage/shared/_header.html" with title="What's New in Ubuntu 18.10"  subtitle="Canonical product managers discuss the new Ubuntu 18.10 release features in this on-demand webinar" date="Webinar is live on 3 December 2018 at 8pm GMT" url="#register-section" cta="Watch the webinar"  lang="en"  %}
 <hr />
 
 <section class="p-strip">

--- a/templates/engage/fr/vmware-to-openstack.html
+++ b/templates/engage/fr/vmware-to-openstack.html
@@ -6,21 +6,12 @@
 
 {% block content %}
 
-<section lang="fr" class="p-strip p-takeover--vmware-to-os">
-  <div class="row u-equal-height">
-    <div class="col-9">
-        <h1 class="p-takeover__title">Migrer de VMware à Openstack</h1>
-        <p class="p-takeover__text">
-            <a href="#register-section">S'inscrire au webinar&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</section>
+
+{% include "engage/shared/_header.html" with title="Migrer de VMware à Openstack"  subtitle="Apprenez comment migrer d'un environnement traditionnelle et propriétaire à un cloud OpenStack" url="#register-section" cta="S'inscrire au webinar&nbsp;&rsaquo;" lang="fr" %}
+
 
 <section lang="fr" class="p-strip is-bordered">
   <div class="row">
-    <div class="col-12">
-      <h2 id="register-section">Apprenez comment migrer d'un environnement traditionnelle et propriétaire à un cloud OpenStack</h2>
-    </div>
     <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 17466, "language": "fr", "commId" : 352419, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
   </div>
 </section>

--- a/templates/engage/fr/vmware-to-openstack.html
+++ b/templates/engage/fr/vmware-to-openstack.html
@@ -2,12 +2,12 @@
 
 {% block title %}Migrer de VMware à Openstack{% endblock %}
 
-{% block meta_description %}OpenStack est souvent présenté comme une alternative aux environnements de virtualisation propriétaires traditionnels.{% endblock %}
+{% block meta_description %}Quels sont les différences entre VMWare et OpenStack et les bénéfices d'une migration de l'un vers l'autre. Un webinar gratuit pour mieux comprendre les technologies du cloud privé.{% endblock %}
 
 {% block content %}
 
 
-{% include "engage/shared/_header.html" with title="Migrer de VMware à Openstack"  subtitle="Apprenez comment migrer d'un environnement traditionnelle et propriétaire à un cloud OpenStack" url="#register-section" cta="S'inscrire au webinar&nbsp;&rsaquo;" lang="fr" %}
+{% include "engage/shared/_header.html" with title="Migrer de VMware à Openstack"  subtitle="Apprenez comment migrer d'un environnement traditionnel et propriétaire à un cloud OpenStack" url="#register-section" cta="S'inscrire au webinar&nbsp;&rsaquo;" lang="fr" %}
 
 
 <section lang="fr" class="p-strip is-bordered">

--- a/templates/engage/fr/vmware-to-openstack.html
+++ b/templates/engage/fr/vmware-to-openstack.html
@@ -10,7 +10,7 @@
 {% include "engage/shared/_header.html" with title="Migrer de VMware à Openstack"  subtitle="Apprenez comment migrer d'un environnement traditionnel et propriétaire à un cloud OpenStack" url="#register-section" cta="S'inscrire au webinar&nbsp;&rsaquo;" lang="fr" %}
 
 
-<section lang="fr" class="p-strip is-bordered">
+<section lang="fr" class="p-strip is-bordered" id="register-section">
   <div class="row">
     <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 17466, "language": "fr", "commId" : 352419, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
   </div>

--- a/templates/engage/fr/vmware-to-openstack.html
+++ b/templates/engage/fr/vmware-to-openstack.html
@@ -5,20 +5,21 @@
 {% block meta_description %}OpenStack est souvent présenté comme une alternative aux environnements de virtualisation propriétaires traditionnels.{% endblock %}
 
 {% block content %}
-<section class="p-strip p-takeover--vmware-to-os">
+
+<section lang="fr" class="p-strip p-takeover--vmware-to-os">
   <div class="row u-equal-height">
     <div class="col-9">
         <h1 class="p-takeover__title">Migrer de VMware à Openstack</h1>
         <p class="p-takeover__text">
-            <a href="#register-section">Regarder le webinaire&nbsp;&rsaquo;</a></p>
+            <a href="#register-section">S'inscrire au webinar&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section lang="fr" class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 id="register-section">Regardez notre vidéo de démonstration sur les coûts et la migration</h2>
+      <h2 id="register-section">Apprenez comment migrer d'un environnement traditionnelle et propriétaire à un cloud OpenStack</h2>
     </div>
     <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 17466, "language": "fr", "commId" : 352419, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
   </div>

--- a/templates/engage/fr/vmware-to-openstack.html
+++ b/templates/engage/fr/vmware-to-openstack.html
@@ -1,0 +1,29 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Migrer de VMware à Openstack{% endblock %}
+
+{% block meta_description %}OpenStack est souvent présenté comme une alternative aux environnements de virtualisation propriétaires traditionnels.{% endblock %}
+
+{% block content %}
+<section class="p-strip p-takeover--vmware-to-os">
+  <div class="row u-equal-height">
+    <div class="col-9">
+        <h1 class="p-takeover__title">Migrer de VMware à Openstack</h1>
+        <p class="p-takeover__text">
+            <a href="#register-section">Regarder le webinaire&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 id="register-section">Regardez notre vidéo de démonstration sur les coûts et la migration</h2>
+    </div>
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 17466, "language": "fr", "commId" : 352419, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_newsletter" third_item="_telco_further_reading" %}
+{% endblock content %}

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -1,4 +1,4 @@
-<section class="{% if class %}p-strip {{ class }}{% else %}p-strip--light{% endif %}">
+<section {% if lang %}lang="{{ lang }}"{% endif %} class="{% if class %}p-strip {{ class }}{% else %}p-strip--light{% endif %}">
   <div class="row u-equal-height">
     <div class="{% if image %}col-7{% else %}col-8{% endif %} u-vertically-center">
       <div>


### PR DESCRIPTION
## Done

- Created the french landing page for the vmware to openstack webinar

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/engage/fr/vmware-to-openstack](http://0.0.0.0:8001/engage/fr/vmware-to-openstack)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the copy in the [brief](https://docs.google.com/document/d/14Lzlydn9YNjTm-x-ACuKSE5xJaBe3xyHzFakQ1oRIVY/edit?ts=5c90d017#)

## Issue / Card

Fixes #4839 	

## Screenshots

![image](https://user-images.githubusercontent.com/441217/54683289-33f51780-4b09-11e9-8174-5e6270857efa.png)
![image](https://user-images.githubusercontent.com/441217/54683308-40797000-4b09-11e9-9413-d11bb424b3b1.png)
