### PR TITLE
Snap delta takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,6 @@
   {# ALL #}
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}
-  {% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
+  {% include "takeovers/_snap-deltas-takeover.html" %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_snap-deltas-takeover.html
+++ b/templates/takeovers/_snap-deltas-takeover.html
@@ -3,13 +3,11 @@
     <div class="row u-vertically-center">
       <div class="col-7">
         <h1>Optimising IoT bandwidth with delta updates</h1>
-        <h4>
-          Efficient over the air updates with snaps.
-        </h4>
+        <h4>Efficient over the air updates with snaps.</h4>
         <p class="col-7 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}b511e965-Delta+updates.svg" width="250" height="134" alt="b511e965-Delta+updates.svg" style="margin: 2rem 0;" /></p>
-        <p><a itemprop="url" href="/engage/snap-deltas?utm_source=takeover&utm_campaign=CY19_IOT_Snap_Deltas" class="p-button--positive">Download the whitepaper</a></p>
+        <p><a itemprop="url" href="/engage/snap-deltas?utm_source=takeover&utm_medium=takeover&utm_campaign=CY19_IOT_UbuntuCore_Whitepaper_SnapDeltas_Takeover" class="p-button--positive">Download the whitepaper</a></p>
       </div>
-      <div class="col-7 u-hide--small u-align--center">
+      <div class="col-5 u-hide--small u-align--center">
         <img src="{{ ASSET_SERVER_URL }}b511e965-Delta+updates.svg" alt="snap delta updates" />
       </div>
     </div>

--- a/templates/takeovers/_snap-deltas-takeover.html
+++ b/templates/takeovers/_snap-deltas-takeover.html
@@ -1,0 +1,30 @@
+<section class="js-takeover is-bordered p-takeover--snap-deltas">
+  <div class="p-strip--image is-dark is-deep p-takeover__suru">
+    <div class="row u-vertically-center">
+      <div class="col-7">
+        <h1>Optimising IoT bandwidth with delta updates</h1>
+        <h4>
+          Efficient over the air updates with snaps.
+        </h4>
+        <p class="col-7 u-hide--large u-hide--medium u-align--center"><img src="{{ ASSET_SERVER_URL }}b511e965-Delta+updates.svg" width="250" height="134" alt="b511e965-Delta+updates.svg" style="margin: 2rem 0;" /></p>
+        <p><a itemprop="url" href="/engage/snap-deltas?utm_source=takeover&utm_campaign=CY19_IOT_Snap_Deltas" class="p-button--positive">Download the whitepaper</a></p>
+      </div>
+      <div class="col-7 u-hide--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}b511e965-Delta+updates.svg" alt="snap delta updates" />
+      </div>
+    </div>
+    <style>
+      .p-takeover--snap-deltas {
+        background-blend-mode: color;
+        background-image: linear-gradient(-181deg, #106363 12%, #083333 100%);
+      }
+
+      @media only screen and (min-width: 768px) {
+        .p-takeover__suru {
+          background-image: url('{{ ASSET_SERVER_URL }}57c3b829-suru+-+snapcraft+-+left.svg');
+          background-size: auto 100% ;
+        }
+      }
+    </style>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Added a new snap delta takeover
- Removed the full disc encryption takeover per the content calendar

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that it matches the designs in the issue for small and large screens

## Issue / Card

Fixes #4832

