### PR TITLE
Add french vmware to os takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,14 +23,18 @@
 #}
 
 {% block takeover_content %}
-  {% include "takeovers/_ci-cd-webinar.html" %}
-  {% include "takeovers/_14-04-esm.html" %}
-  {% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
-  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
+  {# GERMAN #}
   {% include "takeovers/_german_ai_webinar.html" %}
   {% include "takeovers/_german-compliance-webinar.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
+  {# FRENCH #}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
+  {% include "takeovers/_french_vmware-to-os.html" %}
+  {# ALL #}
+  {% include "takeovers/_ci-cd-webinar.html" %}
+  {% include "takeovers/_14-04-esm.html" %}
+  {% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
+  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_french_vmware-to-os.html
+++ b/templates/takeovers/_french_vmware-to-os.html
@@ -1,0 +1,37 @@
+<section lang="fr" data-lang="fr" class="p-strip is-deep p-takeover--vmware-to-os js-takeover">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1 class="p-takeover__title">Migrer de VMWare à Openstack</h1>
+      <p class="p-heading--four">Apprenez comment migrer d'un environnement traditionnelle et propriétaire à un cloud OpenStack</p>
+      <div class="u-hide--small">
+        <a href="/engage/fr/vmware-to-openstack?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack" class="p-button--positive">S'inscrire au webinar</a>
+      </div>
+    </div>
+    <div class="col-5 suffix-1 u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
+    </div>
+    <div class="u-hide--medium u-hide--large">
+      <a href="/engage/fr/vmware-to-openstack?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack" class="p-button--positive">S'inscrire au webinar</a>
+    </div>
+  </div>
+  <style>
+    .p-takeover--vmware-to-os {
+      background-color: #f7f7f7;
+    }
+
+    .p-takeover--vmware-to-os .p-takeover__title {
+      color: 	#111;
+      font-weight: 100;
+    }
+
+    @media  (min-width: 768px) {
+      .p-takeover--vmware-to-os {
+        background-color: #f7f7f7;
+        background-image: url('{{ ASSET_SERVER_URL }}d3edfcd5-left.png'), url('{{ ASSET_SERVER_URL }}17508275-right.png');
+        background-position: bottom left, bottom right;
+        background-repeat: no-repeat;
+        background-size: contain;
+      }
+    }
+  </style>
+</section>


### PR DESCRIPTION
## Done

- Added a takeover for the french version of the VMware to OpenStack

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Change your browser to use french
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare the text to the [brief](https://docs.google.com/document/d/14Lzlydn9YNjTm-x-ACuKSE5xJaBe3xyHzFakQ1oRIVY/edit)


## Issue / Card

Fixes #4839

## Screenshots

![image](https://user-images.githubusercontent.com/441217/54479844-56d9b000-4819-11e9-8aab-f25992186762.png)
