### PR TITLE
Update terms-and-policies with partner portal

### DIFF
--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -1,6 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Terms and policies{% endblock %}
+{% block meta_description %}Ubuntu and Canonical Legal - legal terms and policies{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1p3ZWroZ3nkw8XJJdPvPxSlWGYcLZLT8UbUVuppBcyHk/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -105,6 +106,15 @@
         <h3>Systems information notice</h3>
         <p>Find out about the information we may collect during installation of Ubuntu.</p>
         <p><a href="/legal/systems-information-notice">View systems information notice&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="u-equal-height">
+      <div class="col-6 p-card">
+        <h3>Partner Portal terms and conditions</h3>
+        <p>Terms and conditions governing use of Canonical's Partner Portal.</p>
+        <p><a href="/legal/partner-portal-terms">View Partner Portal terms&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Added the partner portal terms to the overview page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1p3ZWroZ3nkw8XJJdPvPxSlWGYcLZLT8UbUVuppBcyHk/edit#)


## Issue / Card

Fixes #4843

## Screenshots

![image](https://user-images.githubusercontent.com/441217/54481213-b2ac3500-4829-11e9-9898-36c722126eed.png)

