### PR TITLE
Update 12.04 to 14.04 on security page

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -87,13 +87,13 @@
         <li class="p-matrix__item">
           <div>
             <h3 class="p-matrix__title p-heading--four">5 years of support guaranteed</h3>
-            <p class="p-matrix__desc">A new LTS (Long Term Support) version of Ubuntu is released every two years, for desktop and for server. Both versions are supported for five years.</p>
+            <p class="p-matrix__desc">A new LTS (Long Term Support) version of Ubuntu is released every two years, for desktop and server. Both versions are supported for five years.</p>
           </div>
         </li>
         <li class="p-matrix__item">
           <div>
             <h3 class="p-matrix__title p-heading--four">Extended security</h3>
-            <p class="p-matrix__desc">For users of Ubuntu 12.04 LTS, Canonical offers Extended Security Maintenance (ESM) to provide ongoing kernel security fixes through a secure and private archive.</p>
+            <p class="p-matrix__desc">For users of Ubuntu 14.04 LTS, Canonical offers Extended Security Maintenance (ESM) to provide ongoing kernel security fixes through a secure and private archive.</p>
           </div>
         </li>
         <li class="p-matrix__item">
@@ -248,8 +248,8 @@
       <p><a class="p-link--external" href="https://landscape.canonical.com">Get Landscape</a></p>
     </div>
     <div class="col-6 p-card">
-      <h3>Extend your Ubuntu 12.04 LTS security maintenance</h3>
-      <p>Following the end-of-life of Ubuntu 12.04 LTS in April 2017, Canonical began offering Ubuntu 12.04 ESM (Extended Security Maintenance), to Ubuntu Advantage customers to provide important security fixes for the kernel and essential user space packages. These updates are delivered via a secure, private archive exclusively available to Ubuntu Advantage customers.</p>
+      <h3>Extend your Ubuntu 14.04 LTS security maintenance</h3>
+      <p>Following the end-of-life of Ubuntu 14.04 LTS in April 2017, Canonical began offering Ubuntu 14.04 ESM (Extended Security Maintenance), to Ubuntu Advantage customers to provide important security fixes for the kernel and essential user space packages. These updates are delivered via a secure, private archive exclusively available to Ubuntu Advantage customers.</p>
       <p><a class="p-link--external" href="https://pages.ubuntu.com/01.Howtoupgradefrom12.04webinar_LPOn-demandwebinar.html?utm_source=insights&amp;utm_medium=blog&amp;utm_campaign=On-demand%20webinar%20--%20How%20to%20ensure%20the%20ongoing%20security%20compliance%20of%2012.04&amp;">Watch our security compliance webinar now</a></p>
     </div>
   </div>

--- a/templates/shared/contextual_footers/_security_esm.html
+++ b/templates/shared/contextual_footers/_security_esm.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Canonical is offering Extended Security Maintenance</h3>
-  <p>Canonical is offering Ubuntu 12.04 Extended Security Maintenance (ESM) for security fixes and essential packages.</p>
+  <p>Canonical is offering Ubuntu 14.04 Extended Security Maintenance (ESM) for security fixes and essential packages.</p>
   <p><a href="/esm" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Support - ESM', 'eventLabel' : 'Find out more about ESM', 'eventValue' : undefined });">Find out more about ESM</a></p>
 </div>


### PR DESCRIPTION
## Done

- Minor text updates on the security page 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/security](http://0.0.0.0:8001/security)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit#)

## Issue / Card

Fixes #4860 

