### PR TITLE
Language skipping for takeovers

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -159,11 +159,11 @@
         // For browsers that support <template> (all but IE), grab the template's ".content"
         takeovers = 'content' in takeovers ? takeovers.content: takeovers;
 
-        // First, select takeovers that don't specify a language
-        var takeoverSelectors = [".js-takeover:not([lang])"]
-
         // get the users language and remove any extra detail suffix (e.g. -gb)
         var language = getPrimaryParentLanguage();
+
+        // First, select takeovers that don't specify a language and don't exclude the users language
+        var takeoverSelectors = [".js-takeover:not([lang]).js-takeover:not([lang-skip*=" + language + "])"]
 
         // Add selectors to find takeovers for any of the user's languages
         takeoverSelectors.push(".js-takeover[lang=" + language + "]");

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,9 @@
 
   To designate a takeover to display for a specific language parent group, specify
   the "lang" attribute on the <section> container. For takeovers that should appear
-  for all languages, simply omit the "lang" attribute.
+  for all languages, simply omit the "lang" attribute. For takeovers you don't want to
+  be displayed in specific languages, you can use the "lang-skip" attribute
+  (eg. lang-skip="fr" or lang-skip="fr de").
 
   NB: Only specify parent language groups (e.g. "en", "de"), *not* derivatives (e.g. "en-GB").
 

--- a/templates/takeovers/_14-04-esm.html
+++ b/templates/takeovers/_14-04-esm.html
@@ -1,4 +1,4 @@
-<section class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance">
+<section class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance" lang-skip="fr">
   <div class="row u-vertically-center">
     <div class="col-7 u-fade-left--medium">
       <h1>Still running Ubuntu 14.04 LTS?</h1>


### PR DESCRIPTION
## Done

In order to give more display time to localized takeovers, a new "`lang-skip`" attribute allows skipping displaying a global takeover in specific languages, for example: skipping the global ESM takeover when a localized one exists, or when a topic is less relevant to a specific region.

Usage: `lang-skip="fr de"`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- If it's not already the case :eyes:, switch your default browser language to French
- Ensure you don't see the english version of the ESM takeover.

