### PR TITLE
1.14 updates for Kubernetes Docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -101,32 +101,8 @@ kubernetes:
       path: /kubernetes/docs
 
       children:
-        - title: Backups
-          path: /kubernetes/docs/backups
-          hidden: True
-        - title: Ceph
-          path: /kubernetes/docs/ceph
-          hidden: True
-        - title: Decommissioning
-          path: /kubernetes/docs/decommissioning
-          hidden: True
-        - title: Install local
-          path: /kubernetes/docs/install-local
-          hidden: True
-        - title: Manual install
-          path: /kubernetes/docs/install-manual
-          hidden: True
-        - title: GCP integration
-          path: /kubernetes/docs/gcp-integration
-          hidden: True
-        - title: AWS integration
-          path: /kubernetes/docs/aws-integration
-          hidden: True
-        - title: Logging
-          path: /kubernetes/docs/logging
-          hidden: True
-        - title: Monitoring
-          path: /kubernetes/docs/monitoring
+        - title: Home
+          path: /kubernetes/docs
           hidden: True
         - title: Overview
           path: /kubernetes/docs/overview
@@ -134,26 +110,83 @@ kubernetes:
         - title: Quickstart
           path: /kubernetes/docs/quickstart
           hidden: True
-        - title: Release notes
-          path: /kubernetes/docs/release-notes
+        - title: Local install
+          path: /kubernetes/docs/install-local
           hidden: True
-        - title: Scaling
-          path: /kubernetes/docs/scaling
+        - title: Manual install
+          path: /kubernetes/docs/install-manual
           hidden: True
-        - title: Storage
-          path: /kubernetes/docs/storage
+        - title: AWS integration
+          path: /kubernetes/docs/aws-integration
           hidden: True
-        - title: Troubleshooting
-          path: /kubernetes/docs/troubleshooting
+        - title: GCP integration
+          path: /kubernetes/docs/gcp-integration
           hidden: True
-        - title: Upgrade notes
-          path: /kubernetes/docs/upgrade-notes
+        - title: Logging
+          path: /kubernetes/docs/logging
+          hidden: True
+        - title: Monitoring
+          path: /kubernetes/docs/monitoring
           hidden: True
         - title: Upgrading
           path: /kubernetes/docs/upgrading
           hidden: True
+        - title: Storage
+          path: /kubernetes/docs/storage
+          hidden: True
+        - title: Scaling
+          path: /kubernetes/docs/scaling
+          hidden: True
         - title: Validation
           path: /kubernetes/docs/validation
+          hidden: True
+        - title: Decommissioning
+          path: /kubernetes/docs/decommissioning
+          hidden: True
+        - title: Authentication with LDAP
+          path: /kubernetes/docs/ldap
+          hidden: True
+        - title: Using Vault as a CA
+          path: /kubernetes/docs/using-vault
+          hidden: True
+        - title: Encryption at rest
+          path: /kubernetes/docs/encryption-at-rest
+          hidden: True
+        - title: Private Docker Registry
+          path: /kubernetes/docs/docker-registry
+          hidden: True
+        - title: Using GPU workers
+          path: /kubernetes/docs/gpu-workers
+          hidden: True
+        - title: Audit Logging
+          path: /kubernetes/docs/audit-logging
+          hidden: True
+        - title: Using Tigera Secure EE
+          path: /kubernetes/docs/tigera-secure-ee
+          hidden: True
+        - title: Troubleshooting
+          path: /kubernetes/docs/troubleshooting
+          hidden: True
+        - title: Overview
+          path: /kubernetes/docs/high-availability
+          hidden: True
+        - title: keepalived
+          path: /kubernetes/docs/keepalived
+          hidden: True
+        - title: HAcluster
+          path: /kubernetes/docs/hacluster
+          hidden: True
+        - title: MetalLB
+          path: /kubernetes/docs/metallb
+          hidden: True
+        - title: Release notes
+          path: /kubernetes/docs/release-notes
+          hidden: True
+        - title: Upgrade notes
+          path: /kubernetes/docs/upgrade-notes
+          hidden: True
+        - title: Certificates and trust
+          path: /kubernetes/docs/certs-and-trust
           hidden: True
         - title: Get in touch
           path: /kubernetes/docs/get-in-touch

--- a/templates/kubernetes/docs/audit-logging.md
+++ b/templates/kubernetes/docs/audit-logging.md
@@ -1,0 +1,161 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "Audit logging"
+  description: Accessing and configuring the Kubernetes audit logs with CDK
+keywords: log, audit, config
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: audit-logging.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+Kubernetes auditing provides a security-relevant chronological set of records
+documenting the sequence of activities that have affected the system by individual
+users, administrators or other components of the system. This documentation
+covers the configuration and usage of these audit logs in the
+**Charmed Distribution of Kubernetes<sup>&reg;</sup>**. For a more detailed
+description of the motives and methodology behind audit logging in Kubernetes, see
+the [Kubernetes Auditing documentation][k8s-audit].
+
+
+## Viewing the log
+
+By default, CDK enables audit logging to files on the kubernetes-master units. The log
+file is located at `/root/cdk/audit/audit.log` and is owned by the nominal `root` user. You
+can view the log directly by using Juju's credentials to make an SSH connection:
+
+```
+juju ssh kubernetes-master/0 sudo cat /root/cdk/audit/audit.log
+```
+
+Note that this log is replicated on all kubernetes-master units.
+
+## Audit policy configuration
+
+Audit policy defines rules about what events should be recorded and what data
+they should include.  For **CDK** this is configurable on the kubernetes-master charm
+using the `audit-policy` setting.
+
+To view the current policy:
+
+```bash
+juju config kubernetes-master audit-policy
+```
+
+To set a new audit policy, it is easiest to write the policy to a file. Assuming you have a file
+named `audit-policy.yaml` with the following contents:
+
+```yaml
+# Log all requests at the Metadata level.
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+- level: Metadata
+```
+
+You can set the new audit policy like so:
+
+```bash
+juju config kubernetes-master audit-policy="$(cat audit-policy.yaml)"
+```
+
+For more information about audit policy definitions, please refer to the
+upstream [Kubernetes Audit Policy documentation][k8s-audit-policy].
+
+## Audit log backend configuration
+
+The audit log backend writes audit events to a file in JSON format. It is configurable in
+**CDK**  through the use of the `api-extra-args` config on kubernetes-master.
+
+By default, the log backend is enabled in CDK with the following configuration:
+
+| kube-apiserver config | value |
+| --------------------------------- | ----- |
+| audit-log-path                | /root/cdk/audit/audit.log |
+| audit-log-maxsize          | 100 |
+| audit-log-maxbackup   | 9 |
+
+You can override the defaults by using `api-extra-args`. For example:
+
+```bash
+juju config kubernetes-master api-extra-args="audit-log-path=/root/cdk/my-audit-location audit-log-maxage=30 audit-log-maxsize=200 audit-log-maxbackup=5"
+```
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+    The <code>audit-log-path</code> must be a directory that is writeable by the
+     kube-apiserver snap.
+     Any non-hidden folders in <code>/root</code>, <code>/var/snap/kube-apiserver/current</code>, or
+     <code>/var/snap/kube-apiserver/common</code> should work.
+  </p>
+</div>
+
+
+Please refer to the upstream
+[Kubernetes Audit Log Backend documentation][k8s-audit-log]
+for more information about the available options.
+
+## Audit webhook backend configuration
+
+The audit webhook backend sends audit events to a remote API, which is assumed to be
+the same API that the kube-apiserver exposes. This backend is disabled by default in
+**CDK**, and is configurable on the kubernetes-master charm via the
+`audit-webhook-config` option.
+
+To view the current audit webhook configuration:
+
+```bash
+juju config kubernetes-master audit-webhook-config
+```
+
+To set a new audit webhook config, it is easiest to write the config to a file.
+Assuming you have a file named `audit-webhook-config.yaml` with the following contents:
+
+```yaml
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+- name: example-cluster
+  cluster:
+    server: http://10.1.35.4
+users:
+- name: example-user
+  user:
+    username: some-user
+    password: some-password
+contexts:
+- name: example-context
+  context:
+    cluster: example-cluster
+    user: example-user
+current-context: example-context
+```
+
+You can set the new audit webhook config with:
+
+```bash
+juju config kubernetes-master audit-webhook-config=”$(cat audit-webhook-config.yaml)”
+```
+
+Additional options for the webhook backend can be set by using `api-extra-args`.
+For example:
+
+```bash
+juju config kubernetes-master api-extra-args="audit-webhook-initial-backoff=20s"
+```
+
+Please refer to the upstream
+[Kubernetes Audit Webhook Backend documentation][k8s-audit-backend] for more
+information about the audit webhook config format and related options.
+
+<!-- LINKS -->
+[k8s-audit]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/
+[k8s-audit-policy]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#policy
+[k8s-audit-log]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-backend
+[k8s-audit-backend]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#webhook-backend

--- a/templates/kubernetes/docs/decommissioning.md
+++ b/templates/kubernetes/docs/decommissioning.md
@@ -5,6 +5,12 @@ markdown_includes:
 context:
   title: "Decommissioning"
   description: Decommissioning a cluster requires only a few commands, but beware that it will irretrievably destroy the cluster.
+keywords: juju, decommissioning, destroy-model, destroy-controller, config
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: decommissioning.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
 Decommissioning a cluster requires only a few commands, but beware that it will irretrievably destroy the cluster, its workloads and any information that was stored within. Before proceeding, it is important to verify that you:
@@ -24,7 +30,7 @@ juju models
 
 This will list all the models running on the current controller, for example:
 
-```
+```no-highlight
 Controller: k8s-controller
 
 Model           Cloud/Region   Status     Machines  Cores  Access  Last connection
@@ -43,7 +49,7 @@ To proceed, use the `juju destroy-model` command to target the model you wish to
 
 You will see a warning, and be required to confirm the action. **Juju** will then continue to free up the resources, giving feedback on the process. It may take some minutes to complete depending on the size of the deployed model and the nature of the cloud it is running on.
 
-```no-highlight
+```
 WARNING! This command will destroy the "k8s-testing" model.
 This includes all machines, applications, data and other resources.
 

--- a/templates/kubernetes/docs/get-in-touch.md
+++ b/templates/kubernetes/docs/get-in-touch.md
@@ -3,12 +3,12 @@ wrapper_template: "base_docs.html"
 markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
-  title: "Contacts"
+  title: "Get in Touch"
   description: How to contact the CDK team
 keywords: help, contact, support
 tags: [contact]
 sidebar: k8smain-sidebar
-permalink: contact.html
+permalink: get-in-touch.html
 layout: [base, ubuntu-com]
 toc: False
 ---

--- a/templates/kubernetes/docs/gpu-workers.md
+++ b/templates/kubernetes/docs/gpu-workers.md
@@ -1,0 +1,170 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "Using GPU workers"
+  description: How to run workloads with GPU support.
+keywords: gpu, nvidia, cuda
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: gpu-workers.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+The **Charmed Distribution of Kubernetes**<sup>&reg;</sup> supports GPU-enabled
+instances for applications which can use them. The kubernetes-worker charm will
+automatically detect NVIDIA hardware and enable the appropriate support.
+However, the implementation of GPU-enabled instances differs greatly between
+public clouds. This page outlines the recommended methods for running GPU
+enabled hardware for different public clouds.
+
+### Deploying CDK with GPU workers on AWS
+
+Using the recommended install method detailed in the [quickstart
+documentation][quickstart], you can select "CDK with NVIDIA GPU workers" at the
+first step, if you are using AWS. All the workers will then be deployed to
+machines with GPUs enabled. There is nothing further to do, enjoy!
+
+If you are installing CDK using a bundle, you can use constraints to specify
+that the worker units are deployed on GPU-enabled machines. Because GPU support
+varies considerably depending on the underlying cloud, this requires specifying
+a particular instance type.
+
+This can be done with a YAML overlay file. For example, when deploying CDK on
+AWS, you may decide you wish to use AWS's 'p2.xlarge' instances (you can check
+the AWS instance definitions on the  [AWS website][aws-instance]). A YAML
+overlay file can be constructed like this:
+
+```yaml
+#gpu-overlay.yaml
+applications:
+  kubernetes-worker:
+    constraints: instance-type=p2.xlarge
+```
+
+And then deployed with CDK like this:
+
+```bash
+juju deploy canonical-kubernetes --overlay ~/path/aws-overlay.yaml --overlay ~/path/gpu-overlay.yaml
+```
+
+As demonstrated here, you can use multiple overlay files when deploying, so you
+can combine GPU support with an integrator charm or other custom configuration.
+
+You may then want to [test a GPU workload](#test)
+
+### Adding GPU workers with AWS
+
+It isn't necessary for all the worker units to have GPU support. You can simply
+add GPU-enabled workers to a running cluster. The recommended way to do this is
+to first create a new constraint for the kubernetes-worker:
+
+```bash
+juju set-constraints kubernetes-worker instance-type=p2.xlarge
+```
+
+Then you can add as many new worker units as required. For example, to add two
+new units.
+
+```bash
+juju add-unit kubernetes-worker -n2
+```
+
+### Adding GPU workers with GCP
+
+Google supports GPUs slightly differently to most clouds. There are no GPUs
+included in any of the default instance templates, and therefore they have
+to be added manually.
+
+To begin, add a new machine with Juju. Include any desired constraints for
+memory,cores,etc :
+
+```bash
+juju add-machine --constraints cores=2
+```
+
+The command will return, telling you the number of the machine that was
+created - keep a note of this number.
+
+Next you will need to use the gcloud tool or the GCP console to stop the
+instance, edit its configuration and then restart the machine.
+
+Once it is up and running, you can then add it as a worker:
+
+```bash
+juju add-unit kubernetes-worker --to 10
+```
+
+...replacing '10' in the above with the number of the machine you created.
+
+As the charm installs, the GPU will be detected and the relevant drivers will
+also be installed.
+<a  id="test"> </a>
+
+## Testing
+
+As GPU instances can be costly, it is useful to test that they can actually be
+used. A simple test job can be created to run NVIDIA's hardware reporting tool.
+
+This can also be [downloaded here][asset-nvidia].
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nvidia-smi
+spec:
+  template:
+    metadata:
+      name: nvidia-smi
+    spec:
+      restartPolicy: Never
+      containers:
+      - image: nvidia/cuda
+        name: nvidia-smi
+        args:
+          - nvidia-smi
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+          requests:
+            nvidia.com/gpu: 1
+        volumeMounts:
+        - mountPath: /usr/bin/
+          name: binaries
+        - mountPath: /usr/lib/x86_64-linux-gnu
+          name: libraries
+      volumes:
+      - name: binaries
+        hostPath:
+          path: /usr/bin/
+      - name: libraries
+        hostPath:
+          path: /usr/lib/x86_64-linux-gnu
+
+```
+
+Download the file and run it with:
+
+```bash
+kubectl create -f nvidia-test.yaml
+```
+
+If you then check the Kubernetes dashboard, you can inspect the logs to
+find the hardware report.
+
+![dashboard image][img-log]
+
+
+<!-- IMAGES -->
+
+[img-log]: https://assets.ubuntu.com/v1/2ba88cee-nvidia.png
+
+
+<!-- LINKS -->
+[asset-nvidia]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/nvidia-test.yaml
+[quickstart]: /kubernetes/docs/quickstart
+[aws-instance]: https://aws.amazon.com/ec2/instance-types/
+[azure-instance]: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu

--- a/templates/kubernetes/docs/hacluster.md
+++ b/templates/kubernetes/docs/hacluster.md
@@ -1,0 +1,63 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "HAcluster"
+  description: How to configure your Kubernetes cluster to use HAcluster.
+keywords: high availability, hacluster, vip, load balancer
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: hacluster.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+**HAcluster** is a **Juju** subordinate charm that encapsulates **corosync** and
+**pacemaker** for floating virtual IP or DNS addresses and is similar to
+[keepalived][keepalived]. It differentiates itself in that it allows servers to span subnets
+via the DNS option, which communicates directly with [MAAS][maas]. It also has the
+ability to shoot the other node in the head(STONITH) via **MAAS** to prevent issues in
+a split-brain scenario.
+
+**CDK** supports **HAcluster** via a relation and the configuration options
+`ha-cluster-vips` and `ha-cluster-dns`. Relations to the kubernetes-master and
+kubeapi-load-balancer charms are supported. These options are mutually exclusive.
+
+## Deploying
+In order to use HAcluster, the first decision is if a load balancer is desired. This depends
+on the size of the cluster and the expected control plane load. Note that HAcluster
+requires a minimum of 3 units for a quorum, so you will need 3 kubeapi-load-balancer or 3 kubernetes-master units to use HAcluster.
+
+### With Load Balancer
+
+```bash
+juju deploy canonical-kubernetes
+juju add-unit -n 2 kubeapi-load-balancer
+juju deploy hacluster
+juju config kubeapi-load-balancer ha-cluster-vips=”192.168.0.1 192.168.0.2”
+juju relate kubeapi-load-balancer hacluster
+```
+
+### Without Load Balancer
+
+```bash
+juju deploy kubernetes-core
+juju add-unit -n 2 kubernetes-master
+juju deploy hacluster
+juju config kubernetes-master ha-cluster-vips=”192.168.0.1 192.168.0.2”
+juju relate kubernetes-master hacluster
+```
+
+## Validation
+
+Once things settle, the virtual IP addresses should be pingable. A new kubeconfig file will be created containing the virtual IP addresses. You will need to replace your kubeconfig with the new one:
+
+```bash
+juju scp kubernetes-master/0:config ~/.kube/config
+```
+
+<!-- LINKS -->
+
+[keepalived]: /kubernetes/docs/keepalived
+[maas]: https://maas.io

--- a/templates/kubernetes/docs/high-availability.md
+++ b/templates/kubernetes/docs/high-availability.md
@@ -1,0 +1,108 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "High Availability"
+  description: How to configure your Kubernetes cluster for high availability.
+keywords: high availability, hacluster, vip, load balancer
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: high-availability.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+It is desirable to have a **CDK** cluster that is resilient to failure and highly available. For
+clusters operating in public cloud environments the options and the methodology are
+usually straightforward - cloud providers have HA solutions which will work well in these 
+environments, and these should be used for **CDK**.
+
+For 'on-premises' or private cloud deployments, there are a number of options. This
+documentation will present the strategies and methodology for software solutions only -
+if you have a hardware load-balancer, that would obviously be a better option.
+
+ We start with the two basic components of a **CDK** cluster: 
+ 
+ - your control plane, the `kubernetes-master` charm
+ - the worker units, the `kubernetes-worker` charm
+
+## Control Plane
+
+An initial plan to make the control plane more resilient might be to simply add more 
+master nodes with  `juju add-unit kubernetes-master`:
+
+![multi-master worker image][img-multi-master]
+
+While this will add more machines, it doesn’t work as may be expected. What
+happens is that the workers will randomly pick a master to communicate with and
+always use that master unit. This means if that master fails in a way that
+doesn’t remove it from **Juju**, those workers are simply unable to communicate
+with the control plane. If workers arbitrarily pick the same master, they can
+also overload the master with traffic, making the additional units redundant.
+
+Load balancing the masters is the next logical step:
+
+![single load balancer image][img-single-load-balancer]
+
+The workers now all use the load balancer to talk to the control plane. This will
+balance the load to the master units, but we have just moved the single point of
+failure to the load balancer. Floating a virtual IP address in front of the master
+units works in a similar manner but without any load balancing. If your cluster
+won’t generate enough traffic to saturate a single master, but you want high
+availability on the control plane, multiple masters floating a virtual IP address
+is a solid choice.
+
+The next thought is to add multiple load balancers to add resiliency there:
+
+![multi-load balancer image][img-multi-load-balancer]
+
+We’re now back to the problem where the workers are talking to a random
+load balancer and if that balancer fails they will fail. We can float a virtual IP address in
+front of these load balancers to solve that.
+
+The way to handle a highly available control plane is to add virtual IP addresses in front
+of either the master units or load balancers depending on load balance requirements.
+If the desire is simply to avoid a node failing from compromising the cluster, a virtual
+IP on the master nodes will handle that. Note that multiple virtual IP addresses can
+be used if load exceeds a single machine, but realise that without proper load
+balancing the load on the master units will not necessarily be even due to the random
+IP selection in the Kubernetes worker charms.
+
+## Worker units
+
+Worker ingress is a very similar problem to the control plane, with the
+exception that the random selection of IP for the API server isn’t relevant to worker ingress.
+There are a few ways to get traffic into Kubernetes. Two common ways are to forward
+incoming traffic to the service IP and route that to any worker. It will get routed
+by kube-proxy to a pod that will service it. The other option is to forward incoming traffic to a
+node port on any worker to be proxied.
+
+Multiple virtual IPs would be a good choice in front of the workers. This allows a
+bit of load balancing with round-robin DNS and also allows individual workers to fail.
+A more robust option would be to add load balancers in front of the workers and
+float virtual IPs on those. Note a downside here is the increase in internal traffic as it may
+need to be routed due to load or just to find a worker with the correct destination pod. 
+This problem is under active development with projects that are Kubernetes-aware such
+as MetalLB.
+
+## Solutions
+
+The pages linked below give practical details on how to use the currently supported
+software to enable HA
+
+  - [Keepalived][keepalived]
+  - [HAcluster][hacluster]
+  - [MetalLB][metallb]
+
+<!-- IMAGES -->
+
+[img-single-load-balancer]: https://assets.ubuntu.com/v1/b47ac644-single-loadbalancer.png
+[img-multi-load-balancer]: https://assets.ubuntu.com/v1/21062012-multi-load-balancer.png
+[img-multi-master]: https://assets.ubuntu.com/v1/dd44ab17-multi-master.png
+
+<!-- LINKS -->
+
+[keepalived]: /kubernetes/docs/keepalived
+[hacluster]: /kubernetes/docs/hacluster
+[metallb]: /kubernetes/docs/metallb

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -5,21 +5,27 @@ markdown_includes:
 context:
   title: "Installing to a local machine"
   description: How to install the Charmed Distribution of Kubernetes on a single machine for easy testing and development.
+keywords: lxd, conjure-up, requirements,developer
+tags: [install]
+sidebar: k8smain-sidebar
+permalink: install-local.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
-Installing the Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)
+Installing the **Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)**
 on a single machine is possible for the purposes of testing and development.
 
-Be aware that the full deployment of CDK has system requirements which may exceed a standard laptop or desktop machine. It is only recommended for a machine with 32GB RAM and 250GB of SSD storage.
+Be aware that the full deployment of **CDK** has system requirements which may exceed a standard laptop or desktop machine. It is only recommended for a machine with 32GB RAM and 250GB of SSD storage.
 
 <div class="p-notification--positive"><p markdown="1" class="p-notification__response">
 <span class="p-notification__status">Note:</span>
 If you don't meet these requirements or want a lightweight way to develop on pure Kubernetes, we recommend  <a href="https://microk8s.io/">microk8s</a>
 </p></div>
 
-The main requirement for a local install is a local cloud to run CDK on. This is achieved by using lightweight containers managed by [LXD][lxd-home]. LXD version 3.0 or better is required for the default installer, and there are some specific profile requirements as detailed below.
+The main requirement for a local install is a local cloud to run **CDK** on. This is achieved by using lightweight containers managed by [LXD][lxd-home]. **LXD** version 3.0 or better is required for the default installer, and there are some specific profile requirements as detailed below.
 
-## If LXD is already installed
+## If **LXD** is already installed
 
 The **conjure-up** installer requires a specific LXD version, profile and storage options which may conflict with any existing version of LXD.
 To avoid problems, migrate from the _deb_ LXD packaging after installing the snap version:
@@ -35,13 +41,13 @@ You can now proceed using the main installer. Follow the [install instructions][
 
 ## Ubuntu Server
 
-### 1. Install LXD
+### 1. Install **LXD**
 
 ```bash
 sudo snap install lxd
 ```
 
-### 2. Run the LXD init script
+### 2. Run the **LXD** init script
 
 ```bash
 /snap/bin/lxd init
@@ -58,7 +64,7 @@ You can now proceed using the main installer. Follow the [install instructions][
 
 ## Ubuntu Desktop
 
-### 1. Install LXD
+### 1. Install **LXD**
 
 ```bash
 sudo snap install lxd
@@ -66,14 +72,14 @@ sudo snap install lxd
 
 ### 2. Create users
 
-In order to access the LXD service your user will need to be apart of the `lxd` group. Run the following:
+In order to access the **LXD** service your user will need to be apart of the `lxd` group. Run the following:
 
 ```bash
 sudo usermod -a -G lxd $USER
 newgrp lxd
 ```
 
-### 3. Run the LXD init script
+### 3. Run the **LXD** init script
 
 ```bash
 /snap/bin/lxd init
@@ -90,9 +96,11 @@ You can now proceed using the main installer. Follow the [install instructions][
 
 ## Other platforms (ArchLinux, Debian, Fedora, OpenSUSE )
 
-1.  Install LXD using the [instructions for your OS][lxd-install]
-2.  Install Conjure up using the [instructions for your OS][conjure-up-install]
-3.  Proceed with the relevant steps from the [install instructions][quickstart] and choose `localhost` in the `CHOOSE A CLOUD` step.
+1.  Install **LXD** using the [instructions for your OS][lxd-install]
+
+1.  Install Conjure up using the [instructions for your OS][conjure-up-install]
+
+1.  Proceed with the relevant steps from the [install instructions][quickstart] and choose `localhost` in the `CHOOSE A CLOUD` step.
 
 <!-- LINKS -->
 

--- a/templates/kubernetes/docs/keepalived.md
+++ b/templates/kubernetes/docs/keepalived.md
@@ -16,7 +16,7 @@ toc: False
 The standard deployment of the
 **Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)** includes a single
 instance of the kube-api-loadbalancer.  For many use cases this is perfectly adequate,
-but in a production environment, you should be keen to eliminate any single point of
+but in a production environment you should be keen to eliminate any single point of
 failure.
 
 The recommended way to provide a failover for the kube-api-loadbalancer is by using
@@ -64,6 +64,7 @@ into your **CDK** model and configured as follows:
 1. Remove unneeded relations:
     ```bash
     juju remove-relation kubernetes-worker:kube-api-endpoint kubeapi-load-balancer:website
+    juju remove-relation kubernetes-master:loadbalancer kubeapi-load-balancer:loadbalancer
     ```
 
 1. Scale up the `kubeapi-load-balancer`. You can specify as many units as your situation requires.

--- a/templates/kubernetes/docs/ldap.md
+++ b/templates/kubernetes/docs/ldap.md
@@ -200,7 +200,9 @@ The [default policy may be downloaded][policy] for easy editing.
 ## Troubleshooting
 
 As with any application configuration, it is easy to make simple mistakes when entering
-different values or editing config files. If you are having problems, please [read the troubleshooting guide][trouble] for specific tips and information on configuring Keystone/LDAP.
+different values or editing config files. If you are having problems, please
+[read the troubleshooting guide][trouble] for specific tips and information on
+configuring Keystone/LDAP.
 
 <!--LINKS-->
 [install]: /kubernetes/docs/quickstart

--- a/templates/kubernetes/docs/logging.md
+++ b/templates/kubernetes/docs/logging.md
@@ -5,6 +5,12 @@ markdown_includes:
 context:
   title: "Logging"
   description: Learn about the tools and techniques to examine cluster logs as described in the Kubernetes documentation.
+keywords: juju, logging, debug-log
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: logging.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
 <div class="p-notification--information">
@@ -14,9 +20,15 @@ This documentation assumes you are using version 2.4.0 or later of <strong>Juju<
   </p>
 </div>
 
-Broadly, there are two types of logs you may be interested in. On cluster or node level; for the applications you are running inside your cluster, and at an infrastructure level, the applications which are responsible for running the cluster itself. As the **Charmed Distribution of Kubernetes<sup>&reg;</sup>** is pure Kubernetes, you can use any of the tools and techniques to examine cluster logs as [described in the Kubernetes documentation][k8-logs].
+Broadly, there are two types of logs you may be interested in. On cluster or node level;
+for the applications you are running inside your cluster, and at an infrastructure level, the
+applications which are responsible for running the cluster itself. As the
+**Charmed Distribution of Kubernetes<sup>®</sup>** is pure Kubernetes, you can
+use any of the tools and techniques to examine cluster logs as
+[described in the Kubernetes documentation][k8-logs].
 
-For the infrastructure, your CDK deployment has centralised logging set up as default. Each unit in your cluster automatically sends logging information to the controller based on the current logging level. You can use the **Juju** command line to easily inspect these logs and to change the logging level, as explained below.
+For the infrastructure, your **CDK** deployment has centralised logging set up as default. Each unit in your cluster automatically sends logging information to the controller based on the current logging level. You can use the **Juju**
+command line to easily inspect these logs and to change the logging level, as explained below.
 
 ## Viewing logs
 
@@ -40,7 +52,8 @@ unit-kubernetes-master-0: 18:04:11 INFO juju.cmd running jujud [2.4.2 gc go1.10]
 
 The entity is the unit, machine or application the message originates from (in this case _kubernetes-master/0_). It can be very useful to filter the output based on the entity or log level, and the `debug-log` command has many options.
 
-For a full description, run the command `juju help debug-log` or see the [**Juju** documentation][juju-logging]. Some useful examples are outlined below.
+For a full description, run the command `juju help debug-log` or see the
+[**Juju** documentation][juju-logging]. Some useful examples are outlined below.
 
 ### Useful examples
 

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -1,0 +1,50 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "MetalLB"
+  description: How to configure your Kubernetes cluster to use MetalLB.
+keywords: high availability, metallb, vip, load balancer
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: metallb.html
+layout: [base, ubuntu-com]
+toc: False
+---
+# About
+
+[MetalLB][metallb] is a Kubernetes-aware solution that will monitor for services with
+the type `LoadBalancer` and assign them an IP address from a virtual pool. 
+
+It uses BGP([Border Gateway Protocol][bgp]) or ARP([Address Resolution Protocol][arp])
+to expose services. 
+
+MetalLB has support for local traffic, meaning that the machine that receives the
+data will be the machine that services the request. It is not suggested to use a
+virtual IP with high traffic workloads because only one machine will receive the
+traffic for a service - the other machines are solely used for failover. 
+
+BGP does not have this limitation but does see nodes as the atomic unit. This means
+if the service is running on two of five nodes then only those two nodes will receive
+traffic, but they will each receive 50% of the traffic even if one of the nodes has
+three pods and the other only has one pod running on it. It is recommended to use node
+anti-affinity to prevent Kubernetes pods from stacking on a single node. 
+
+MetalLB is not currently available as a Juju CaaS charm, so the best way to install
+it is with a helm chart:
+
+```bash
+helm install --name metallb stable/metallb
+```
+Further configuration can be performed by using a [MetalLB configmap][configmap].
+
+See also the [Helm with CDK documentation][helm] for using Helm with CDK
+
+<!-- LINKS -->
+
+[metallb]: https://metallb.universe.tf
+[arp]: https://tools.ietf.org/html/rfc826
+[bgp]: https://tools.ietf.org/html/rfc1105
+[helm]: /kubernetes/docs/helm
+[configmap]: https://metallb.universe.tf/configuration/

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -39,8 +39,6 @@ helm install --name metallb stable/metallb
 ```
 Further configuration can be performed by using a [MetalLB configmap][configmap].
 
-See also the [Helm with CDK documentation][helm] for using Helm with CDK
-
 <!-- LINKS -->
 
 [metallb]: https://metallb.universe.tf

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -125,7 +125,7 @@ Once logged in, check out the cluster metric dashboard by clicking the `Home` dr
 
 ![grafana dashboard image](https://assets.ubuntu.com/v1/e6934269-grafana-1.png)
 
-You can also check out the system metrics of the cluster by switching the drop-down box to `Node Metrics (via Telegraf)`:
+You can also check out the system metrics of the cluster by switching the drop-down box to `Node Metrics (via Telegraf):
 
 ![grafana dashboard image](https://assets.ubuntu.com/v1/45b87639-grafana-2.png)
 
@@ -237,5 +237,5 @@ juju status kibana --format yaml| grep public-address
 [quickstart]: /kubernetes/docs/quickstart
 [nagios]: https://www.nagios.org/
 [elastic]: https://www.elastic.co/
-[download-scraper]: https://raw.githubusercontent.com/conjure-up/spells/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
+[download-scraper]: https://github.com/conjure-up/spells/blob/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
 [download-dashboard]: https://raw.githubusercontent.com/conjure-up/spells/master/charmed-kubernetes/addons/prometheus/steps/01_install-prometheus/grafana-k8s.json

--- a/templates/kubernetes/docs/release-notes-historic.md
+++ b/templates/kubernetes/docs/release-notes-historic.md
@@ -1,0 +1,186 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "Release notes"
+  description: Release notes for CDK
+keywords: kubernetes, news, release, notes
+tags: [news]
+sidebar: k8smain-sidebar
+permalink: release-notes-historic.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+# 1.13 Bugfix Release
+
+### February 21, 2019 - [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-435/archive/bundle.yaml)
+
+## Fixes
+
+- Fixed docker does not start when docker_runtime is set to nvidia ([Issue](https://bugs.launchpad.net/charm-layer-docker/+bug/1816471))
+- Fixed snapd_refresh charm option conflict ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/657))
+
+# CVE-2018-18264
+
+### January 10, 2019
+
+## What happened
+
+- A security vulnerability was found in the Kubernetes dashboard that affected all
+versions of the dashboard.
+
+A new dashboard version, v1.10.1, was released to address this vulnerability. This
+includes an important change to logging in to the dashboard. The Skip button is now
+missing from the login page and a user and password is now required. The easiest way
+to log in to the dashboard is to select your ~/.kube/config file and use credentials
+from there.
+
+# 1.13 Release Notes
+
+### December 10, 2018
+
+## What's new
+
+- LDAP and Keystone support
+
+Added support for LDAP-based authentication and authorisation via Keystone. Please
+read the [documentation][docs-ldap] for details on how to enable this.
+
+- Vault PKI support
+
+Added support for using [Vault](https://jujucharms.com/u/openstack-charmers/vault/)
+for PKI in place of EasyRSA. Vault is more secure and robust than EasyRSA and supports
+more advanced features for certificate management. See the
+[documentation][docs-vault] for details of how to add Vault to CDK and configure it as a
+root or intermediary CA.
+
+- Encryption-at-rest support using Vault
+
+Added support for encryption-at-rest for cluster secrets, leveraging
+[Vault](https://jujucharms.com/u/openstack-charmers/vault/) for data protection. This
+ensures that even the keys used to encrypt the data are protected at rest, unlike many
+configurations of encryption-at-rest for Kubernetes. Please see the
+[documentation][docs-ear] for further details.
+
+- Private Docker registry support
+
+Added support for the [Docker Registry](https://jujucharms.com/u/containers/docker-registry)
+charm to provide Docker images to cluster components without requiring access to
+public registries. Full instructions on using this feature are in the [documentation][docs-registry].
+
+- Keepalived support
+
+The keepalived charm can be used to run multiple kube-api-loadbalancers behind a
+virtual IP. For more details, please see the [documentation][docs-keepalived].
+
+- Nginx update
+
+Nginx was updated to v0.21.0, which brings a few changes of which to be aware. The first
+is that nginx is now in a namespace by itself, which is derived from the application name.
+By default this will be `ingress-nginx-kubernetes-worker`. The second change relates to
+custom configmaps. The name has changed to `nginx-configuration` and the configmap needs to
+reside in the same namespace as the nginx deployment.
+
+## Fixes
+
+ - Added post deployment script for jaas/jujushell ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/pull/697))
+ - Added support for load-balancer failover ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/453))
+ - Added always restart for etcd ([Issue](https://github.com/juju-solutions/layer-etcd/pull/145))
+ - Added Xenial support to Azure integrator ([Issue](https://github.com/juju-solutions/charm-azure-integrator/pull/17))
+ - Added Bionic support to Openstack integrator ([Issue](https://github.com/juju-solutions/charm-openstack-integrator/pull/13))
+ - Added support for ELB service-linked role ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/29))
+ - Added ability to configure Docker install source ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/621))
+ - Fixed EasyRSA does not run as an LXD container on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/654))
+ - Fixed ceph volumes cannot be attached to the pods after 1.12 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/662))
+ - Fixed ceph volumes fail to attach with "node has no NodeID annotation" ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/675))
+ - Fixed ceph-xfs volumes failing to format due to "executable file not found in $PATH" ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/668))
+ - Fixed ceph volumes not detaching properly ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/669))
+ - Fixed ceph-csi addons not getting cleaned up properly ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/680))
+ - Fixed Calico/Canal not working with kube-proxy on master ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/660))
+ - Fixed issue with Canal charm not populating the kubeconfig option in 10-canal.conflist ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/671))
+ - Fixed cannot access logs after enabling RBAC ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/642))
+ - Fixed RBAC breaking prometheus/grafana metric collection ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/635))
+ - Fixed upstream Docker charm config option using wrong package source ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/620))
+ - Fixed a timing issue where ceph can appear broken when it's not ([Issue](https://github.com/juju-solutions/kubernetes/pull/173))
+ - Fixed status when cni is not ready ([Issue](https://github.com/juju-solutions/kubernetes/pull/174))
+ - Fixed an issue with calico-node service failures not surfacing ([Issue](https://github.com/juju-solutions/layer-calico/pull/28))
+ - Fixed empty configuration due to timing issue with cni. ([Issue](https://github.com/juju-solutions/layer-canal/pull/22))
+ - Fixed an issue where the calico-node service failed to start ([Issue](https://github.com/juju-solutions/layer-canal/pull/24))
+ - Fixed updating policy definitions during upgrade-charm on AWS integrator ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/30))
+ - Fixed parsing credentials config value ([Issue](https://github.com/juju-solutions/charm-azure-integrator/pull/18))
+ - Fixed pvc stuck in pending (azure-integrator)
+ - Fixed updating properties of the openstack integrator charm do not propagate automatically (openstack-integrator)
+ - Fixed flannel error during install hook due to incorrect resource (flannel)
+ - Updated master and worker to handle upstream changes from OpenStack Integrator ([Issue](https://github.com/juju-solutions/kubernetes/pull/176))
+ - Updated to CNI 0.7.4 ([Issue](https://github.com/juju-solutions/kubernetes/pull/194))
+ - Updated to Flannel v0.10.0 ([Issue](https://github.com/juju-solutions/charm-flannel/pull/50))
+ - Updated Calico and Canal charms to Calico v2.6.12 ([Issue](https://github.com/juju-solutions/layer-calico/pull/30), [Issue](https://github.com/juju-solutions/layer-canal/pull/27))
+ - Updated to latest CUDA and removed version pins of nvidia-docker stack ([Issue](https://github.com/juju-solutions/layer-docker/pull/123))
+ - Updated to nginx-ingress-controller v0.21.0 ([Issue](https://github.com/juju-solutions/kubernetes/pull/195))
+ - Removed portmap from Calico resource ([Issue](https://github.com/juju-solutions/layer-calico/pull/29))
+ - Removed CNI bins from flannel resource ([Issue](https://github.com/juju-solutions/layer-canal/pull/25))
+
+## Known issues
+
+ - A [current bug](https://github.com/kubernetes/kubernetes/issues/70044) in Kubernetes could prevent the upgrade from properly deleting old pods. `kubectl delete pod <pod_name> --force --grace-period=0` can be used to clean them up.
+
+
+## 1.12 Release Notes
+
+- Added support for Ubuntu 18.04 (Bionic)
+
+New deployments will get Ubuntu 18.04 machines by default. We will also continue to support CDK on Ubuntu 16.04 (Xenial) machines for existing deployments.
+
+- Added kube-proxy to kubernetes-master
+
+The kubernetes-master charm now installs and runs kube-proxy along with the other master services. This makes it possible for the master services to reach Service IPs within the cluster, making it easier to enable certain integrations that depend on this functionality (e.g. Keystone).
+
+For operators of offline deployments, please note that this change may require you to attach a kube-proxy resource to kubernetes-master.
+
+- New kubernetes-worker charm config: kubelet-extra-config
+
+In Kubernetes 1.10, a new KubeletConfiguration file was introduced, and many of Kubelet's command line options were moved there and marked as deprecated. In order to accomodate this change, we've introduced a new charm config to kubernetes-worker: `kubelet-extra-config`.
+
+This config can be used to override KubeletConfiguration values provided by the charm, and is usable on any Canonical cluster running Kubernetes 1.10+.
+
+The value for this config must be a YAML mapping that can be safely merged with a KubeletConfiguration file. For example:
+
+```
+juju config kubernetes-worker kubelet-extra-config="{evictionHard: {memory.available: 200Mi}}"
+```
+
+For more information about KubeletConfiguration, see upstream docs:
+https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+
+- Added support for Dynamic Kubelet Configuration
+
+While we recommend `kubelet-extra-config` as a more robust and approachable way to configure Kubelet, we've also made it possible to configure kubelet using the Dynamic Kubelet Configuration feature that comes with Kubernetes 1.11+. You can read about that here:
+https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
+
+- New etcd charm config: bind_to_all_interfaces ([PR](https://github.com/juju-solutions/layer-etcd/pull/137))
+
+Default `true`, which retains the old behavior of binding to 0.0.0.0. Setting this to `false` makes etcd bind only to the addresses it expects traffic on, as determined by the configuration of [Juju endpoint bindings](https://docs.jujucharms.com/2.4/en/charms-deploying-advanced#deploying-to-network-spaces).
+
+Special thanks to [@rmescandon](https://github.com/rmescandon) for this contribution!
+
+- Updated proxy configuration
+
+For operators who currently use the `http-proxy`, `https-proxy` and `no-proxy` Juju model configs, we recommend using the newer `juju-http-proxy`, `juju-https-proxy` and `juju-no-proxy` model configs instead. See the [Proxy configuration](https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Proxy-configuration) page for details.
+
+## Fixes
+
+- Fixed kube-dns constantly restarting on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/655))
+- Fixed LXD machines not working on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/654))
+- Fixed kubernetes-worker unable to restart services after kubernetes-master leader is removed ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/627))
+- Fixed kubeapi-load-balancer default timeout might be too low ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/650))
+- Fixed unable to deploy on NVidia hardware ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/664))
+
+<!--LINKS-->
+
+[docs-ldap]: /kubernetes/docs/ldap
+[docs-vault]: /kubernetes/docs/using-vault
+[docs-ear]: /kubernetes/docs/encryption-at-rest
+[docs-keepalived]: /kubernetes/docs/keepalived
+[docs-registry]: /kubernetes/docs/docker-registry

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -5,7 +5,7 @@ markdown_includes:
 context:
   title: "Release notes"
   description: Release notes for CDK
-keywords: kubernetes, news, release, notes
+keywords: kubernetes,  release, notes
 tags: [news]
 sidebar: k8smain-sidebar
 permalink: release-notes.html
@@ -13,188 +13,98 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-# 1.13 Bugfix Release
-
-### February 21, 2019 - [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-435/archive/bundle.yaml)
-
-## Fixes
-
-- Fixed docker does not start when docker_runtime is set to nvidia ([Issue](https://bugs.launchpad.net/charm-layer-docker/+bug/1816471))
-- Fixed snapd_refresh charm option conflict ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/657))
-
-# CVE-2018-18264
-
-### January 10, 2019
-
-## What happened
-
-- A security vulnerability was found in the Kubernetes dashboard that affected all
-versions of the dashboard.
-
-A new dashboard version, v1.10.1, was released to address this vulnerability. This
-includes an important change to logging in to the dashboard. The Skip button is now
-missing from the login page and a user and password is now required. The easiest way
-to log in to the dashboard is to select your ~/.kube/config file and use credentials
-from there.
-
-# 1.13 Release Notes
+# 1.14
 
 ## What's new
 
-- LDAP and Keystone support
+- Tigera Secure EE support
 
-Added support for LDAP-based authentication and authorisation via Keystone. Please
-read the [documentation][docs-ldap] for details on how to enable this.
+**CDK** extends its support for CNI solutions by adding the option of using
+[**Tigera Secure EE**][tigera-home], the enterprise-ready alternative to Calico. Users are now able
+to deploy **CDK** with **Tigera Secure EE** installed and subsequently configure additional
+features such as ElasticSearch and the CNX secure connectivity manager. For further
+details, please see the [**CDK** CNI documentation][tigera-docs]
 
-- Vault PKI support
+- Additional options for High Availability
 
-Added support for using [Vault](https://jujucharms.com/u/openstack-charmers/vault/)
-for PKI in place of EasyRSA. Vault is more secure and robust than EasyRSA and supports
-more advanced features for certificate management. See the
-[documentation][docs-vault] for details of how to add Vault to CDK and configure it as a
-root or intermediary CA.
+Version 1.13 of **CDK** introduced support for **keepalived** to provide HA for the 
+api-loadbalancer. This new release adds support for both **HAcluster** and **MetalLB**. See 
+the relevant [HAcluster][hacluster-docs] and [MetalLB][metallb-docs] pages in the
+documentation, as well as the [HA overview][haoverview] for more information. 
 
-- Encryption-at-rest support using Vault
+- Added CoreDNS support
 
-Added support for encryption-at-rest for cluster secrets, leveraging
-[Vault](https://jujucharms.com/u/openstack-charmers/vault/) for data protection. This
-ensures that even the keys used to encrypt the data are protected at rest, unlike many
-configurations of encryption-at-rest for Kubernetes. Please see the
-[documentation][docs-ear] for further details.
+All new deployments of **CDK 1.14** will install **CoreDNS 1.4.0** by
+default instead of **KubeDNS**.
 
-- Private Docker registry support
+Existing deployments that are upgraded to **CDK 1.14** will
+continue to use **KubeDNS** until the operator chooses to upgrade to
+**CoreDNS**. See the [upgrade notes][upgrade-notes] for details.
 
-Added support for the [Docker Registry](https://jujucharms.com/u/containers/docker-registry)
-charm to provide Docker images to cluster components without requiring access to
-public registries. Full instructions on using this feature are in the [documentation][docs-registry].
+ - Docker upgrades: Docker 18.09.2 is the new default in Ubuntu. CDK now includes a charm action to simplify [upgrading Docker across a set of worker nodes][upgrading-docker].
+ 
+- Registry enhancements: Read-only mode, frontend support, and additional TLS configuration options have been added to the [Docker registry charm](https://jujucharms.com/u/containers/docker-registry/114).
 
-- Keepalived support
+- Cloud integrations: New configuration options have been added to the
+[vSphere](https://jujucharms.com/u/containers/vsphere-integrator/) (`folder` and `respool_path`) and 
+[OpenStack]( https://jujucharms.com/u/containers/openstack-integrator/) (`ignore-volume-az`, `bs-version`, `trust-device-path`) integrator charms.
 
-The keepalived charm can be used to run multiple kube-api-loadbalancers behind a
-virtual IP. For more details, please see the [documentation][docs-keepalived].
-
-- Nginx update
-
-Nginx was updated to v0.21.0, which brings a few changes of which to be aware. The first
-is that nginx is now in a namespace by itself, which is derived from the application name.
-By default this will be `ingress-nginx-kubernetes-worker`. The second change relates to
-custom configmaps. The name has changed to `nginx-configuration` and the configmap needs to
-reside in the same namespace as the nginx deployment.
 
 ## Fixes
 
- - Added post deployment script for jaas/jujushell ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/pull/697))
- - Added support for load-balancer failover ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/453))
- - Added always restart for etcd ([Issue](https://github.com/juju-solutions/layer-etcd/pull/145))
- - Added Xenial support to Azure integrator ([Issue](https://github.com/juju-solutions/charm-azure-integrator/pull/17))
- - Added Bionic support to Openstack integrator ([Issue](https://github.com/juju-solutions/charm-openstack-integrator/pull/13))
- - Added support for ELB service-linked role ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/29))
- - Added ability to configure Docker install source ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/621))
- - Fixed EasyRSA does not run as an LXD container on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/654))
- - Fixed ceph volumes cannot be attached to the pods after 1.12 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/662))
- - Fixed ceph volumes fail to attach with "node has no NodeID annotation" ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/675))
- - Fixed ceph-xfs volumes failing to format due to "executable file not found in $PATH" ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/668))
- - Fixed ceph volumes not detaching properly ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/669))
- - Fixed ceph-csi addons not getting cleaned up properly ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/680))
- - Fixed Calico/Canal not working with kube-proxy on master ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/660))
- - Fixed issue with Canal charm not populating the kubeconfig option in 10-canal.conflist ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/671))
- - Fixed cannot access logs after enabling RBAC ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/642))
- - Fixed RBAC breaking prometheus/grafana metric collection ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/635))
- - Fixed upstream Docker charm config option using wrong package source ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/620))
- - Fixed a timing issue where ceph can appear broken when it's not ([Issue](https://github.com/juju-solutions/kubernetes/pull/173))
- - Fixed status when cni is not ready ([Issue](https://github.com/juju-solutions/kubernetes/pull/174))
- - Fixed an issue with calico-node service failures not surfacing ([Issue](https://github.com/juju-solutions/layer-calico/pull/28))
- - Fixed empty configuration due to timing issue with cni. ([Issue](https://github.com/juju-solutions/layer-canal/pull/22))
- - Fixed an issue where the calico-node service failed to start ([Issue](https://github.com/juju-solutions/layer-canal/pull/24))
- - Fixed updating policy definitions during upgrade-charm on AWS integrator ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/30))
- - Fixed parsing credentials config value ([Issue](https://github.com/juju-solutions/charm-azure-integrator/pull/18))
- - Fixed pvc stuck in pending (azure-integrator)
- - Fixed updating properties of the openstack integrator charm do not propagate automatically (openstack-integrator)
- - Fixed flannel error during install hook due to incorrect resource (flannel)
- - Updated master and worker to handle upstream changes from OpenStack Integrator ([Issue](https://github.com/juju-solutions/kubernetes/pull/176))
- - Updated to CNI 0.7.4 ([Issue](https://github.com/juju-solutions/kubernetes/pull/194))
- - Updated to Flannel v0.10.0 ([Issue](https://github.com/juju-solutions/charm-flannel/pull/50))
- - Updated Calico and Canal charms to Calico v2.6.12 ([Issue](https://github.com/juju-solutions/layer-calico/pull/30), [Issue](https://github.com/juju-solutions/layer-canal/pull/27))
- - Updated to latest CUDA and removed version pins of nvidia-docker stack ([Issue](https://github.com/juju-solutions/layer-docker/pull/123))
- - Updated to nginx-ingress-controller v0.21.0 ([Issue](https://github.com/juju-solutions/kubernetes/pull/195))
- - Removed portmap from Calico resource ([Issue](https://github.com/juju-solutions/layer-calico/pull/29))
- - Removed CNI bins from flannel resource ([Issue](https://github.com/juju-solutions/layer-canal/pull/25))
+ - Added an action to upgrade Docker ([Issue](https://github.com/juju-solutions/layer-docker/pull/135))
+ - Added better multi-client support to EasyRSA ([Issue](https://github.com/juju-solutions/layer-easyrsa/pull/15))
+ - Added block storage options for OpenStack ([Issue](https://github.com/juju-solutions/kubernetes/pull/218))
+ - Added dashboard-auth config option to master ([Issue](https://github.com/juju-solutions/kubernetes/pull/222))
+ - Added docker registry handling to master ([Issue](https://github.com/juju-solutions/kubernetes/pull/210))
+ - Added more TLS options to Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/20))
+ - Added new folder/respool_path config for vSphere ([Issue](https://github.com/juju-solutions/charm-vsphere-integrator/pull/2))
+ - Added proxy support to Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/21))
+ - Added read-only mode for Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/22))
+ - Fixed `allow-privileged` not enabled when Ceph relation joins ([Issue](https://github.com/juju-solutions/kubernetes/pull/197))
+ - Fixed apt install source for VaultLocker ([Issue](https://github.com/juju-solutions/layer-vaultlocker/pull/3))
+ - Fixed Ceph relation join not creating necessary pools ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/631))
+ - Fixed Ceph volume provisioning fails with "No such file or directory" ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/710))
+ - Fixed detecting of changed AppKV values ([Issue](https://github.com/juju-solutions/layer-vault-kv/pull/6))
+ - Fixed docker-ce-version config not working for non-NVIDIA configuration ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/621))
+ - Fixed Docker registry behavior with multiple frontends ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/26))
+ - Fixed Docker registry not cleaning up old relation data ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/28))
+ - Fixed Docker registry to correctly handle frontend removal ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/29))
+ - Fixed Docker registry to work behind a TLS-terminating frontend ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/25))
+ - Fixed error: snap "etcd" is not compatible with --classic ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/727))
+ - Fixed file descriptor limit on api server ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/703))
+ - Fixed GCP NetworkUnavailable hack when only some pods pending ([Issue](https://github.com/juju-solutions/kubernetes/pull/211))
+ - Fixed handle_requests being called when no clients are related ([Issue](https://github.com/juju-solutions/charm-openstack-integrator/pull/14))
+ - Fixed handling of nameless and SANless server certificates ([Issue](https://github.com/juju-solutions/layer-easyrsa/pull/16))
+ - Fixed inconsistent cert flags ([Issue](https://github.com/juju-solutions/layer-easyrsa/pull/18))
+ - Fixed ingress=false not allowing custom ingress to be used ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/718))
+ - Fixed installing from outdated docker APT respository ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/388))
+ - Fixed IPv6 disabled on kubeapi-loadbalancer machines leads to error during installation ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/623))
+ - Fixed Keystone not working with multiple masters ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/681))
+ - Fixed kubeconfig should contain the VIP when keepalived used with kubeapi-load-balancer ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/712))
+ - Fixed metrics server for k8s 1.11 ([Issue](https://github.com/juju-solutions/cdk-addons/pull/81))
+ - Fixed proxy var to apply when adding an apt-key ([Issue](https://github.com/juju-solutions/layer-docker/pull/133))
+ - Fixed RBAC enabled results in error: unable to upgrade connection ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/696))
+ - Fixed registry action creating configmap in the wrong namespace  ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/721))
+ - Fixed rules for metrics-server ([Issue](https://github.com/juju-solutions/cdk-addons/pull/76))
+ - Fixed status when writing kubeconfig file ([Issue](https://github.com/juju-solutions/kubernetes/pull/202))
+ - Fixed "subnet not found" to be non-fatal ([Issue](https://github.com/juju-solutions/charm-aws-integrator/pull/34))
+ - Fixed vSphere integrator charm not updating cloud-config when setting new charm defaults  ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/695))
+ - Removed deprecated allow-privileged config from worker ([Issue](https://github.com/juju-solutions/kubernetes/pull/204))
+ - Removed use of global / shared client certificate ([Issue](https://github.com/juju-solutions/kubernetes/pull/207))
+ - Updated default nginx-ingress controller to 0.22.0 for amd64 and arm64 ([Issue](https://github.com/juju-solutions/kubernetes/pull/220))
 
-## Known issues
+## Previous releases
 
- - A [current bug](https://github.com/kubernetes/kubernetes/issues/70044) in Kubernetes could prevent the upgrade from properly deleting old pods. `kubectl delete pod <pod_name> --force --grace-period=0` can be used to clean them up.
-
-## Contact Us
-
-- Issues: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues
-- IRC: #cdk8s on freenode.net
-
-
-
-
-
-## 1.12 Release Notes
-
-- Added support for Ubuntu 18.04 (Bionic)
-
-New deployments will get Ubuntu 18.04 machines by default. We will also continue to support CDK on Ubuntu 16.04 (Xenial) machines for existing deployments.
-
-- Added kube-proxy to kubernetes-master
-
-The kubernetes-master charm now installs and runs kube-proxy along with the other master services. This makes it possible for the master services to reach Service IPs within the cluster, making it easier to enable certain integrations that depend on this functionality (e.g. Keystone).
-
-For operators of offline deployments, please note that this change may require you to attach a kube-proxy resource to kubernetes-master.
-
-- New kubernetes-worker charm config: kubelet-extra-config
-
-In Kubernetes 1.10, a new KubeletConfiguration file was introduced, and many of Kubelet's command line options were moved there and marked as deprecated. In order to accomodate this change, we've introduced a new charm config to kubernetes-worker: `kubelet-extra-config`.
-
-This config can be used to override KubeletConfiguration values provided by the charm, and is usable on any Canonical cluster running Kubernetes 1.10+.
-
-The value for this config must be a YAML mapping that can be safely merged with a KubeletConfiguration file. For example:
-
-```
-juju config kubernetes-worker kubelet-extra-config="{evictionHard: {memory.available: 200Mi}}"
-```
-
-For more information about KubeletConfiguration, see upstream docs:
-https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
-
-- Added support for Dynamic Kubelet Configuration
-
-While we recommend `kubelet-extra-config` as a more robust and approachable way to configure Kubelet, we've also made it possible to configure kubelet using the Dynamic Kubelet Configuration feature that comes with Kubernetes 1.11+. You can read about that here:
-https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/
-
-- New etcd charm config: bind_to_all_interfaces ([PR](https://github.com/juju-solutions/layer-etcd/pull/137))
-
-Default `true`, which retains the old behavior of binding to 0.0.0.0. Setting this to `false` makes etcd bind only to the addresses it expects traffic on, as determined by the configuration of [Juju endpoint bindings](https://docs.jujucharms.com/2.4/en/charms-deploying-advanced#deploying-to-network-spaces).
-
-Special thanks to [@rmescandon](https://github.com/rmescandon) for this contribution!
-
-- Updated proxy configuration
-
-For operators who currently use the `http-proxy`, `https-proxy` and `no-proxy` Juju model configs, we recommend using the newer `juju-http-proxy`, `juju-https-proxy` and `juju-no-proxy` model configs instead. See the [Proxy configuration](https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Proxy-configuration) page for details.
-
-## Fixes
-
-- Fixed kube-dns constantly restarting on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/655))
-- Fixed LXD machines not working on 18.04 ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/654))
-- Fixed kubernetes-worker unable to restart services after kubernetes-master leader is removed ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/627))
-- Fixed kubeapi-load-balancer default timeout might be too low ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/650))
-- Fixed unable to deploy on NVidia hardware ([Issue](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/664))
-
-## Contact Us
-
-- Issues: <https://github.com/juju-solutions/bundle-canonical-kubernetes/issues>
-
-- IRC: #cdk8s on freenode.net
-
-
+Please see [this page][historic] for release notes of earlier versions.
 
 <!--LINKS-->
-
-[docs-ldap]: /kubernetes/docs/ldap
-[docs-vault]: /kubernetes/docs/using-vault
-[docs-ear]: /kubernetes/docs/encryption-at-rest
-[docs-keepalived]: /kubernetes/docs/keepalived
-[docs-registry]: /kubernetes/docs/docker-registry
+[upgrade-notes]: /kubernetes/docs/upgrade-notes
+[bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-xxx/archive/bundle.yaml
+[historic]: /kubernetes/docs/release-notes-historic
+[upgrading-docker]: /kubernetes/docs/upgrading#upgrading-docker
+[tigera-home]: https://www.tigera.io/tigera-secure-ee/
+[tigera-docs]: /kubernetes/docs/tigera-secure-ee
+[haoverview]: /kubernetes/docs/high-availability
+[metallb-docs]: /kubernetes/docs/metallb
+[hacluster-docs]: /kubernetes/docs/hacluster

--- a/templates/kubernetes/docs/scaling.md
+++ b/templates/kubernetes/docs/scaling.md
@@ -5,13 +5,23 @@ markdown_includes:
 context:
   title: "Scaling"
   description: Learn how various components of CDK can be horizontally scaled to meet demand or increase reliability.
+keywords: juju, scaling, add-unit, ha, high availability
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: scaling.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
-The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** has been designed to be flexible enough to efficiently run your workloads. Various components of **CDK** can be horizontally scaled to meet demand or to increase reliability, as detailed below.
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** has been designed to
+be flexible enough to efficiently run your workloads. Various components of **CDK**
+can be horizontally scaled to meet demand or to increase reliability, as detailed below.
 
 ## kubernetes-master
 
-The kubernetes-master nodes act as the control plane for the cluster. **CDK** was designed with separate master nodes so that these nodes can be scaled independently of the worker units, to give better efficiency and flexibility.
+The kubernetes-master nodes act as the control plane for the cluster. **CDK** was
+designed with separate master nodes so that these nodes can be scaled independently
+of the worker units, to give better efficiency and flexibility.
 
 Additional units can be added like so:
 
@@ -27,7 +37,9 @@ juju add-unit kubernetes-master -n 3
 
 ## kubernetes-worker
 
-As the **Kubernetes** worker nodes handle the actual workloads, they usually run on machines with more resources. The resource profile of units is maintained by **Juju** using [constraints][juju-constraints].
+As the **Kubernetes** worker nodes handle the actual workloads, they usually run on
+machines with more resources. The resource profile of units is maintained by **Juju**
+using [constraints][juju-constraints].
 
 You can check the current constraints with the command:
 
@@ -41,7 +53,8 @@ Which will return the current settings, for example:
 cores=4 mem=4096M root-disk=16384M
 ```
 
-To create an additional kubernetes-worker unit with this resource profile, you can simply run:
+To create an additional kubernetes-worker unit with this resource profile, you can simply
+run:
 
 ```bash
 juju add-unit kubernetes-worker
@@ -53,38 +66,47 @@ To add multiple units, you can specify a number (for example 2):
 juju add-unit kubernetes-worker -n 2
 ```
 
-To add additional units with specific new resource constraints, these may also be specified in the command. For example:
+To add additional units with specific new resource constraints, these may also be
+specified in the command. For example:
 
 ```bash
 juju add-unit kubernetes-worker -n 2 --constraints "mem=6G cores=2"
 ```
 
-... will cause two new kubernetes-worker units to be added, with at least 2 cores, 6G of memory and 16G of storage (as the existing application constraints are inherited).
+... will cause two new kubernetes-worker units to be added, with at least 2 cores, 6G of
+memory and 16G of storage (as the existing application constraints are inherited).
 
-To change the constraints for all _future_ units of kubernetes-worker, you can set different constraints like so:
+To change the constraints for all _future_ units of kubernetes-worker, you can set
+different constraints like so:
 
 ```bash
 juju set-constraints kubernetes-worker cores=2 mem=6G root-disk=16G
 ```
 
-Note that in this case, any constraints you supply will **_replace all the exisiting constraints_**, so in this example, we also include the existing `root-disk` requirement.
+Note that in this case, any constraints you supply will
+**_replace all the exisiting constraints_**, so in this example, we also include the
+existing `root-disk` requirement.
 
 <div class="p-notification--information">
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
-Constraints are designed to supply the <i>minimum</i> of what is requested. This can result in the actual instances far exceeding these values, depending on the backing cloud.
+Constraints are designed to supply the <i>minimum</i> of what is requested. This can
+result in the actual instances far exceeding these values, depending on the backing cloud.
   </p>
 </div>
 
 ### Scaling down kubernetes-worker
 
-Should workloads reduce, it is also possible to scale down the number of worker nodes. In order to do this safely, the node to be removed can be paused.
+Should workloads reduce, it is also possible to scale down the number of worker nodes.
+In order to do this safely, the node to be removed can be paused.
 
 ```bash
 juju run-action kubernetes-worker/3 pause --wait
 ```
 
-Pausing the worker will indicate to **Kubernetes** that it is out of service. Any workloads will be migrated to alternative worker units. You can verify this with the command:
+Pausing the worker will indicate to **Kubernetes** that it is out of service. Any
+workloads will be migrated to alternative worker units. You can verify this with the
+command:
 
 ```bash
 kubectl get pod -o wide
@@ -96,23 +118,33 @@ The individual unit (in this example, number 3) can then be safely removed:
 juju remove-unit kubernetes-worker/3
 ```
 
-Note that due to the numbering system used by **Juju**, if you subsequently add additional units of this application, the numbers of any previously deleted units _will not_ be re-used.
+Note that due to the numbering system used by **Juju**, if you subsequently add
+additional units of this application, the numbers of any previously deleted
+units _will_not_ be re-used.
 
 ## etcd
 
-The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** installs a three machine cluster for etcd, which provides tolerence for a single failure. Should you wish to extend the fault tolerance, you can add additional units of etcd.
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** installs a three
+machine cluster for etcd, which provides tolerence for a single failure. Should you wish to
+extend the fault tolerance, you can add additional units of etcd.
 
 ```bash
 juju add-unit etcd -n 2
 ```
 
-The recommended cluster-size for etcd is three, five or seven machines. Adding large numbers of additional units has a negative effect on performance due to synchronising data.
+The recommended cluster-size for etcd is three, five or seven machines. Adding large
+numbers of additional units has a negative effect on performance due to synchronising
+data.
 
 ## Juju high availability
 
-On a default deployment of the **Charmed Distribution of Kubernetes<sup>&reg;</sup>**, there is only one controller instance, which isn't desirable for critical applications. It is possible to scale out the controller itself to prevent a single point of failure.
+On a default deployment of the **Charmed Distribution of
+Kubernetes<sup>&reg;</sup>**, there is only one controller instance, which isn't
+desirable for critical applications. It is possible to scale out the controller itself to
+prevent a single point of failure.
 
-**Juju** supports a high availability mode to run multiple controllers with an automatic failover.
+**Juju** supports a high availability mode to run multiple controllers with an automatic
+failover.
 
 A single command will automatically create and maintain high availability for **Juju**:
 
@@ -120,7 +152,8 @@ A single command will automatically create and maintain high availability for **
 juju enable-ha
 ```
 
-You can verify the additional machines have been added by listing the machines in the controller model:
+You can verify the additional machines have been added by listing the machines in the
+controller model:
 
 ```bash
 juju machines -m controller

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -20,8 +20,15 @@
   - [Using Vault as a CA](/kubernetes/docs/using-vault)
   - [Encryption at rest](/kubernetes/docs/encryption-at-rest)
   - [Private Docker Registry](/kubernetes/docs/docker-registry)
-  - [HA for kubeapi-load-balancer](/kubernetes/docs/keepalived)
+  - [Using GPU workers](/kubernetes/docs/gpu-workers)
+  - [Audit Logging](/kubernetes/docs/audit-logging)
+  - [Using Tigera Secure EE](/kubernetes/docs/tigera-secure-ee)
   - [Troubleshooting](/kubernetes/docs/troubleshooting)
+- **High Availability**
+  - [Overview](/kubernetes/docs/high-availability)
+  - [keepalived](/kubernetes/docs/keepalived)
+  - [HAcluster](/kubernetes/docs/hacluster)
+  - [MetalLB](/kubernetes/docs/metallb)
 - **Reference**
   - [Release notes](/kubernetes/docs/release-notes)
   - [Upgrade notes](/kubernetes/docs/upgrade-notes)

--- a/templates/kubernetes/docs/tigera-secure-ee.md
+++ b/templates/kubernetes/docs/tigera-secure-ee.md
@@ -1,0 +1,229 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "Using Tigera Secure EE"
+  description: Using Tigera Secure EE with CDK
+keywords: network, cni, tigera
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: tigera-secure-ee.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+Tigera Secure EE is a software-defined network solution that can be used with
+Kubernetes. For those familiar with Calico, Tigera Secure EE is essentially
+Calico with enterprise features on top.
+
+Support for Tigera Secure EE in **CDK** is provided in the form of a
+`tigera-secure-ee` subordinate charm, which can be used instead of `flannel` or
+`calico`.
+
+## Deploying CDK with Tigera Secure EE
+
+Before you start, you will need:
+
+*  Tigera Secure EE licence key
+*  Tigera private Docker registry credentials (provided as a Docker config.json)
+
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+    Tigera Secure EE's network traffic, much like Calico's, is filtered on
+    many clouds. It will work on MAAS, and can work on AWS if you manually
+    configure instances to disable source/destination checking.
+  </p>
+</div>
+
+
+To start, deploy **CDK** with Tigera Secure EE:
+
+```bash
+juju deploy cs:~containers/kubernetes-tigera-secure-ee
+```
+
+Configure the `tigera-secure-ee` charm with your licence key and registry
+credentials:
+
+```bash
+juju config tigera-secure-ee \
+  license-key=$(base64 -w0 license.yaml) \
+  registry-credentials=$(base64 -w0 config.json)
+```
+
+Wait for the deployment to settle before continuing on.
+
+## Using the built-in elasticsearch-operator
+
+<div class="p-notification--caution">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Caution:</span>
+     The built-in elasticsearch-operator is only recommended for testing or demonstrative
+     purposes. For production deployments, please skip down to the next section.  </p>
+</div>
+
+For testing and quick start purposes, the `tigera-secure-ee` charm deploys
+[elasticsearch-operator][] into your Kubernetes cluster by default. For it to
+properly work, you will need to create a StorageClass.
+
+The easiest way to do this is with the hostpath provisioner. Create a file named
+`elasticsearch-storage.yaml` containing the following:
+
+```yaml
+# This manifest implements elasticsearch-storage using local host-path volumes.
+# It is not suitable for production use; and only works on single node clusters.
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: elasticsearch-storage
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/host-path
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: tigera-elasticsearch-1
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /var/tigera/elastic-data/1
+  persistentVolumeReclaimPolicy: Recycle
+  storageClassName: elasticsearch-storage
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: tigera-elasticsearch-2
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /var/tigera/elastic-data/2
+  persistentVolumeReclaimPolicy: Recycle
+  storageClassName: elasticsearch-storage
+```
+
+Apply elasticsearch-storage.yaml:
+
+```bash
+kubectl apply -f elasticsearch-storage.yaml
+```
+
+Once you have a StorageClass available, delete the existing PVC and pods so
+Kubernetes will recreate them using the new StorageClass:
+```bash
+kubectl delete pvc -n calico-monitoring es-data-es-data-tigera-elasticsearch-default-0
+kubectl delete pvc -n calico-monitoring es-data-es-master-tigera-elasticsearch-default-0
+kubectl delete po -n calico-monitoring es-data-tigera-elasticsearch-default-0
+kubectl delete po -n calico-monitoring es-master-tigera-elasticsearch-default-0
+```
+
+For a more robust storage solution, consider deploying Ceph with **CDK**, as
+documented in the [Storage][] section. This will create a default StorageClass
+that elasticsearch-operator will use automatically.
+
+## Using your own ElasticSearch
+
+Disable the built-in elasticsearch operator:
+
+```bash
+juju config tigera-secure-ee enable-elasticsearch-operator=false
+```
+
+Then follow this guide from Tigera:
+[Using your own ElasticSearch for logs][tigera byo-elasticsearch]
+
+## Accessing cnx-manager
+
+The cnx-manager service is exposed as a NodePort on port 30003. Run the
+following command to open port 30003 on the workers:
+
+```bash
+juju run --application kubernetes-worker open-port 30003
+```
+
+Then connect to `https://<kubernetes-worker-ip>:30003` in your web browser. Use
+the Kubernetes admin credentials to log in (you can find these in the kubeconfig
+file created on kubernetes-master units at `/home/ubuntu/config`).
+
+## Accessing kibana
+
+The kibana service is exposed as a NodePort on port 30601. Run the following
+command to open port 30601 on the workers:
+
+```bash
+juju run --application kubernetes-worker open-port 30601
+```
+
+<div class="p-notification--caution">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Caution:</span>
+    Do not open this port if your kubernetes-worker units are exposed on a
+    network you do not trust. Kibana does not require credentials to use</p>
+</div>
+
+Then connect to `http://<kubernetes-worker-ip>:30601` in your web browser.
+
+## Using a private Docker registry
+
+For a general introduction to using a private Docker registry with **CDK**, please
+refer to the [Private Docker Registry][] page.
+
+In addition to the steps documented there, you will need to upload the
+following images to the registry:
+
+```no-highlight
+docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.3
+docker.elastic.co/kibana/kibana-oss:6.4.3
+quay.io/tigera/calicoctl:v2.3.0
+quay.io/tigera/calicoq:v2.3.0
+quay.io/tigera/cnx-apiserver:v2.3.0
+quay.io/tigera/cnx-manager:v2.3.0
+quay.io/tigera/cnx-manager-proxy:v2.3.0
+quay.io/tigera/cnx-node:v2.3.0
+quay.io/tigera/cnx-queryserver:v2.3.0
+quay.io/tigera/es-proxy:v2.3.0
+quay.io/tigera/fluentd:v2.3.0
+quay.io/tigera/kube-controllers:v2.3.0
+quay.io/tigera/cloud-controllers:v2.3.0
+quay.io/tigera/typha:v2.3.0
+quay.io/tigera/intrusion-detection-job-installer:v2.3.0
+quay.io/tigera/es-curator:v2.3.0
+quay.io/coreos/configmap-reload:v0.0.1
+quay.io/coreos/prometheus-config-reloader:v0.0.3
+quay.io/coreos/prometheus-operator:v0.18.1
+quay.io/prometheus/alertmanager:v0.14.0
+quay.io/prometheus/prometheus:v2.2.1
+docker.io/upmcenterprises/elasticsearch-operator:0.2.0
+docker.io/busybox:latest
+docker.io/alpine:3.7
+```
+
+And configure Tigera Secure EE to use the registry with this shell script:
+
+```bash
+export IP=`juju run --unit docker-registry/0 'network-get website --ingress-address'`
+export PORT=`juju config docker-registry registry-port`
+export REGISTRY=$IP:$PORT
+juju config tigera-secure-ee registry=$REGISTRY
+```
+
+<!-- LINKS -->
+
+[elasticsearch-operator]: https://github.com/upmc-enterprises/elasticsearch-operator
+[tigera byo-elasticsearch]: https://docs.tigera.io/v2.2/getting-started/kubernetes/installation/byo-elasticsearch
+[storage]: /kubernetes/docs/storage
+[private docker registry]: /kubernetes/docs/docker-registry

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -5,15 +5,60 @@ markdown_includes:
 context:
   title: "Upgrade notes"
   description: How to deal with specific, special circumstances you may encounter when upgrading between versions of Kubernetes.
+keywords: juju, upgrading, track, version
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: upgrade-notes.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
-This page is intended to deal with specific, special circumstances you may encounter when upgrading between versions of the **Charmed Distribution of Kubernetes<sup>&reg;</sup>.** The notes are organised according to the upgrade path below, but also be aware that any upgrade that spans more than one minor version may need to beware of notes in any of the intervening steps.
+This page is intended to deal with specific, special circumstances you may
+encounter when upgrading between versions of the
+**Charmed Distribution of Kubernetes<sup>&reg;</sup>.** The notes are
+organised according to the upgrade path below, but also be aware that any
+upgrade that spans more than one minor version may need to beware of notes in
+any of the intervening steps.
+
+<a  id="1.14"> </a>
+
+## Upgrading to 1.14
+
+This upgrade includes support for **CoreDNS 1.4.0**. All new deployments of
+**CDK 1.14** will install **CoreDNS** by default instead of **KubeDNS**.
+
+Existing deployments which are upgraded to **CDK 1.14** will continue to use
+**KubeDNS** until the operator chooses to upgrade to **CoreDNS**. To upgrade,
+set the new dns-provider config:
+
+
+```bash
+juju config kubernetes-master dns-provider=core-dns
+```
+
+Please be aware that changing DNS providers will momentarily interrupt DNS
+availability within the cluster. It is not necessary to recreate pods after the
+upgrade completes.
+
+The `enable-kube-dns` option has been removed to avoid confusion. The new
+`dns-provider` option allows you to enable or disable **KubeDNS** as needed.
+
+For more information on the new `dns-provider config`, see the
+[dns-provider config description][dns-provider-config].
+
+<a  id="1.10"> </a>
 
 ## Upgrading from 1.9.x to 1.10.x
 
 This upgrade includes a transistion between major versions of **etcd**, from 2.3 to 3.x. Between these releases, **etcd** changed the way it accesses storage, so it is necessary to reconfigure this. There is more detailed information on the change and the upgrade proceedure in the [upstream **etcd** documentation][etcd-upgrade].
 
-!!! Warning: This upgrade **must** be completed before attempting to upgrade the running cluster.
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Caution:</span>
+    This upgrade <strong>must</strong> be completed before attempting to upgrade the running cluster.
+  </p>
+</div>
 
 To make this upgrade more convenient for users of **CDK**, a script has been prepared to manage the transition. The script can be [examined here][script].
 
@@ -24,23 +69,19 @@ To use the script to update **etcd**, follow these steps:
 ```bash
 curl -O https://raw.githubusercontent.com/juju-solutions/cdk-etcd-2to3/master/migrate
 ```
-
 ### 2. Make the script executable:
 
 ```bash
 chmod +x migrate
 ```
-
 ### 3. Execute the script:
 
-```
+```bash
 ./migrate
 ```
-
 ### 4. etcd OutputSed
 
 The script should update **etcd** and you will see output similar to the following:
-
 ```no-highlight
 · Waiting for etcd units to be active and idle...
 · Acquiring configured version of etcd...
@@ -60,9 +101,11 @@ The script should update **etcd** and you will see output similar to the followi
 · Done.
 ```
 
+
 You can now proceed with the rest of the upgrade.
 
 <!--LINKS-->
 
 [etcd-upgrade]: https://github.com/etcd-io/etcd/blob/master/Documentation/upgrades/upgrade_3_0.md
 [script]: https://raw.githubusercontent.com/juju-solutions/cdk-etcd-2to3/master/migrate
+[dns-provider-config]: https://github.com/juju-solutions/kubernetes/blob/5f4868af82705a0636680a38d7f3ea760d35dadb/cluster/juju/layers/kubernetes-master/config.yaml#L58-L67

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -51,11 +51,54 @@ The applications which run alongside the core Kubernetes components can be upgra
 
 This includes:
 
+- Docker
 - easyrsa
 - etcd
 - flannel
 
 Note that this may include other applications which you may have installed, such as Elasticsearch, Prometheus, Nagios, Helm, etc.
+
+<a id='upgrading-docker'> </a>
+
+### Upgrading Docker
+
+**CDK** will use the latest stable version of Docker when it is deployed. Since upgrading Docker
+can cause service disruption, there will be no automatic upgrades and instead this process must
+be triggered by the operator.
+
+Only the `kubernetes-master` and `kubernetes-worker` units require Docker. The charms for each
+include an action to trigger the upgrade.
+
+Before the upgrade, it is useful to list all the units effected:
+
+```bash 
+juju status kubernetes-* --format=short
+```
+
+...will return a list of the current `kubernetes-master` and `kubernetes-worker` units.
+
+Start with the `kubernetes-master` units and run the upgrade action on one unit at a time:
+
+```bash
+juju run-action kubernetes-master/0 upgrade-docker --wait
+```
+
+As Docker is restarted on the unit, pods will be terminated. Wait for them to respawn before
+moving on to the next unit:
+
+```bash
+juju run-action kubernetes-master/1 upgrade-docker --wait
+```
+
+Once all the `kubernetes-master` units have been upgraded and the pods have respawned, the
+same procedure can then be applied to the `kubernetes-worker` units.
+
+```bash 
+juju run-action kubernetes-worker/0 upgrade-docker --wait
+```
+
+As previously, wait between running the action on sucessive units to allow pods to migrate.
+
 
 ### Upgrading etcd
 

--- a/templates/kubernetes/docs/using-vault.md
+++ b/templates/kubernetes/docs/using-vault.md
@@ -51,6 +51,8 @@ relations:
   - vault:certificates
 - - kubernetes-worker:certificates
   - vault:certificates
+- - kubeapi-load-balancer:certificates
+  - vault:certificates
 - - vault:shared-db
   - percona-cluster:shared-db
 ```

--- a/templates/kubernetes/docs/validation.md
+++ b/templates/kubernetes/docs/validation.md
@@ -5,6 +5,12 @@ markdown_includes:
 context:
   title: "Validation"
   description: How to run end-to-end (e2e) tests for Kubernetes.
+keywords: juju, validation, e2e, debug-log
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: validation.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
 End-to-end (e2e) tests for **Kubernetes** provide a mechanism to test the behaviour of the system. This is a useful indicator that the cluster is performing properly, as well as a good validation of any code changes.
@@ -26,15 +32,18 @@ Add the charm to your cluster:
 juju deploy cs:~containers/kubernetes-e2e --constraints mem=4G --channel edge
 ```
 
-We also need to configure the charm to select the appropriate version of tests. This relates to the installed version of Kubernetes. You can check which version your cluster is set to by running:
+We also need to configure the charm to select the appropriate version of tests. This
+relates to the installed version of Kubernetes. You can check which version your cluster is
+set to by running:
 
 ```bash
 juju config kubernetes-master channel
 ```
 
-The output will be in the form of 'version.number/risk', e.g '1.12/stable'. You should set the `kubernetes-e2e` channel to the same value.
+The output will be in the form of 'version.number/risk', e.g '1.12/stable'. You should set
+the `kubernetes-e2e` channel to the same value.
 
-```bash
+```
 juju config kubernetes-e2e channel=1.12/stable
 ```
 
@@ -82,7 +91,7 @@ You can check on the current status of the test by running:
 juju show-action-status 8f8ec748-6ca7-4bbb-86f8-f37e44ba46f9
 ```
 
-... where `8f8ec748-6ca7-4bbb-86f8-f37e44ba46f9` is the uuid of the action returned when we initiated the test. This will return YAML output indicating the current status, which can be either `running`, `completed` or `failed`.
+where `8f8ec748-6ca7-4bbb-86f8-f37e44ba46f9` is the uuid of the action returned when we initiated the test. This will return YAML output indicating the current status, which can be either `running`, `completed` or `failed`.
 
 ```yaml
 actions:


### PR DESCRIPTION
## Done

**Various docss updates and new docs for 1.14**

update decommissioning page
update local install page
small tweak to keepalived
rename contacts 
various reformatting changes (no content change)
relations change for vault
Add tigera page
Add MetalLB page
Add hacluster page
Add High availability overview
Add gpu workers page
Add audit logging page
Compile previous releases into single page
Minor relations change for Ceph
Add upgrading details for Docker
Add 1.14 upgrade notes
Add release notes for 1.14
update k8s docs navigation
update navigation.yaml

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [List additional steps to QA the new features or prove the bug has been resolved]

