### PR TITLE
Small tweak to metallb page in k8s docs

### DIFF
--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -38,8 +38,6 @@ helm install --name metallb stable/metallb
 ```
 Further configuration can be performed by using a [MetalLB configmap][configmap].
 
-See also the [Helm with CDK documentation][helm] for using Helm with CDK
-
 <!-- LINKS -->
 
 [metallb]: https://metallb.universe.tf

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -31,13 +31,14 @@ traffic, but they will each receive 50% of the traffic even if one of the nodes 
 three pods and the other only has one pod running on it. It is recommended to use node
 anti-affinity to prevent Kubernetes pods from stacking on a single node. 
 
-MetalLB is not currently available as a Juju CaaS charm, so the best way to install
-it is with a helm chart:
+Currently, the best way to install MetalLB on CDK is with a helm chart:
 
 ```bash
 helm install --name metallb stable/metallb
 ```
 Further configuration can be performed by using a [MetalLB configmap][configmap].
+
+See also the [Helm with CDK documentation][helm] for using Helm with CDK
 
 <!-- LINKS -->
 


### PR DESCRIPTION
## Done

Remove mention of CAAS charm in Metallb page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/kubernetes/docs/metallb](http://0.0.0.0:8001/kubernetes/docs/metallb)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
