### PR TITLE
Remove cursor on non-link Sectors in footer

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -4,9 +4,9 @@
   line-height: 1.5;
   margin-bottom: 0;
 
-      @media only screen and (max-width: $breakpoint-medium) {
-        cursor: pointer;
-      }
+    @media only screen and (max-width: $breakpoint-medium) {
+      cursor: pointer;
+    }
 }
 
 @mixin ubuntu-p-footer {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -1,9 +1,12 @@
 // Footer pattern styling
 @mixin footer-title {
   color: $color-mid-dark;
-  cursor: pointer;
   line-height: 1.5;
   margin-bottom: 0;
+
+      @media only screen and (max-width: $breakpoint-medium) {
+        cursor: pointer;
+      }
 }
 
 @mixin ubuntu-p-footer {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -4,9 +4,9 @@
   line-height: 1.5;
   margin-bottom: 0;
 
-    @media only screen and (max-width: $breakpoint-medium) {
-      cursor: pointer;
-    }
+  @media only screen and (max-width: $breakpoint-medium) {
+    cursor: pointer;
+  }
 }
 
 @mixin ubuntu-p-footer {

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -35,7 +35,7 @@
       <div class="p-footer__nav-col col-2 u-no-margin--bottom last-col">
         <ul class="p-footer__links">
           <li class="p-footer__item p-footer__item--spaced">
-            <h2 class="p-footer__title p-footer__title-text" >
+            <h2 class="p-footer__title p-footer__title-text"  style="cursor: default;">
                 <span>Sectors</span>
             </h2>
             <ul class="second-level-nav">

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -35,7 +35,7 @@
       <div class="p-footer__nav-col col-2 u-no-margin--bottom last-col">
         <ul class="p-footer__links">
           <li class="p-footer__item p-footer__item--spaced">
-            <h2 class="p-footer__title p-footer__title-text"  style="cursor: default;">
+            <h2 class="p-footer__title p-footer__title-text">
                 <span>Sectors</span>
             </h2>
             <ul class="second-level-nav">


### PR DESCRIPTION
## Done

- Remove cursor on non-link Sectors in footer on large screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Hover over 'Sectors' in the footer and see that the cursor doesn't change on large screens, but does for medium and small

## Issue / Card

Fixes #4849
