### PR TITLE
Stopped the at&t logo from being streched 

### DIFF
--- a/templates/openstack/shared/_openstack_clients.html
+++ b/templates/openstack/shared/_openstack_clients.html
@@ -33,7 +33,7 @@
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}c26cade5-1024px-BNP_Paribas.svg1_.png?w=144" width="144" alt="BNP" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}071c255b-AT%26T_logo.svg" width="80" alt="AT&amp;T" />
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}6e1552a8-atandt-logo.png?w=74" width="74" alt="AT&amp;T" />
       </li>
       <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}5cba4548-logo-ebay.svg" width="80" alt="eBay" />

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/one-column.html" %}
+6e1552a8-atandt-logo.png?w=74" width="74"{% extends "templates/one-column.html" %}
 
 {% block title %}Security{% endblock %}
 {% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
@@ -136,7 +136,7 @@
             <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg logo" />
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}071c255b-AT%26T_logo.svg" width="80" alt="AT&amp;T logo" />
+            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}6e1552a8-atandt-logo.png?w=74" width="74" alt="AT&amp;T logo" />
           </li>
           <li class="p-inline-images__item">
             <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b3315d88-walmart.svg" width="144" alt="Walmart" />

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -169,7 +169,7 @@
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1a062141-logo-bloomberg.svg" width="187" alt="Bloomburg logo">
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c7e83fc-atandt-logo.svg" width="80" alt="at&amp;t  logo">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}6e1552a8-atandt-logo.png?w=74" width="74" alt="at&amp;t  logo">
       </li>
       <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3161e6ba-logo-walmart.svg" width="210" alt="Walmart logo">

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -122,7 +122,7 @@
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}481063cd-pccw.svg" width="144" alt="PCCW" />
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}071c255b-AT%26T_logo.svg" width="80" alt="AT&T" />
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}6e1552a8-atandt-logo.png?w=74" width="74" alt="AT&T" />
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}9ca791fd-Sky_Logo_seit_Dezember_2015.png?w=90" width="90" alt="Sky" style="max-width:90px;" />


### PR DESCRIPTION
## Done

- Replaced the at&t logo with a png

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/openstack/
    - http://0.0.0.0:8001/security/
    - http://0.0.0.0:8001/support/
    - http://0.0.0.0:8001/telecommunications/
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the logo looks ok

## Issue / Card

Fixes #3928
