### PR TITLE
Build the french k8s takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
   {% include "takeovers/_german_takeover_k8.html" %}
   {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {# FRENCH #}
+  {% include "takeovers/_french-k8s-case-study.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {% include "takeovers/_french_vmware-to-os.html" %}

--- a/templates/takeovers/_french-k8s-case-study.html
+++ b/templates/takeovers/_french-k8s-case-study.html
@@ -12,7 +12,7 @@
         <img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="Kubernetes logo" class="p-improving-prod-takeover__image" />
       </div>
       <p class="u-hide--large u-hide--medium">
-        <a href="https://www.brighttalk.com/webcast/17466/354383?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack" class="p-button--neutral"><span class="p-link--extneral">S'inscrire au webinar</span></a>
+        <a href="https://www.brighttalk.com/webcast/17466/354383?utm_source=takeover&utm_campaign=CY19_DC_France_Kubernetes_WBN_WhatCanYouDoK8" class="p-button--neutral"><span class="p-link--extneral">S'inscrire au webinar</span></a>
       </p>
     </div>
   </div>

--- a/templates/takeovers/_french-k8s-case-study.html
+++ b/templates/takeovers/_french-k8s-case-study.html
@@ -1,0 +1,43 @@
+<section lang="fr" class="p-strip--image is-dark is-deep u-image-position js-takeover p-improving-prod-takeover">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>Que pouvez-vous faire avec Kubernetes?</h1>
+      <p class="p-heading--four">Apprenez comment débuter avec Kubernetes, du déploiement aux premières charges de travail</p>
+      <p class="u-hide--small">
+          <a href="https://www.brighttalk.com/webcast/17466/354383?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack" class="p-button--neutral"><span class="p-link--extneral">S'inscrire au webinar</span></a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center">
+      <div class="u-sv3">
+        <img src="{{ ASSET_SERVER_URL }}1db850da-K8s+logo.svg" alt="Kubernetes logo" class="p-improving-prod-takeover__image" />
+      </div>
+      <p class="u-hide--large u-hide--medium">
+        <a href="https://www.brighttalk.com/webcast/17466/354383?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack" class="p-button--neutral"><span class="p-link--extneral">S'inscrire au webinar</span></a>
+      </p>
+    </div>
+  </div>
+  <style>
+    .p-improving-prod-takeover__image {
+      width: 240px;
+      height: 240px;
+    }
+
+    @media screen and (max-width: 1365px) {
+      .p-improving-prod-takeover {
+        background-image: linear-gradient(74deg, #173D8B 0%, #326DE6 92%)
+      }
+    }
+
+    @media screen and (min-width: 1366px) {
+      .p-improving-prod-takeover {
+        background-blend-mode: multiply;
+        background-image: url("{{ ASSET_SERVER_URL }}c55b9357-suru-letf.png"),
+        url("{{ ASSET_SERVER_URL }}335c5ed7-suru+right.png"),
+        linear-gradient(74deg, #173D8B 0%, #326DE6 92%);
+        background-position: bottom left, bottom right;
+        background-repeat: no-repeat;
+        background-size: contain;
+      }
+    }
+  </style>
+</section>

--- a/templates/takeovers/_french-k8s-case-study.html
+++ b/templates/takeovers/_french-k8s-case-study.html
@@ -4,7 +4,7 @@
       <h1>Que pouvez-vous faire avec Kubernetes?</h1>
       <p class="p-heading--four">Apprenez comment débuter avec Kubernetes, du déploiement aux premières charges de travail</p>
       <p class="u-hide--small">
-          <a href="https://www.brighttalk.com/webcast/17466/354383?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack" class="p-button--neutral"><span class="p-link--extneral">S'inscrire au webinar</span></a>
+          <a href="https://www.brighttalk.com/webcast/17466/354383?utm_source=takeover&utm_campaign=CY19_DC_France_Kubernetes_WBN_WhatCanYouDoK8" class="p-button--neutral"><span class="p-link--extneral">S'inscrire au webinar</span></a>
       </p>
     </div>
     <div class="col-5 u-vertically-center u-align--center">


### PR DESCRIPTION
## Done
Build the french k8s takeover.

## QA
- Set your browsers lang to french
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Refresh until you see the takeover below
- Make sure it matches the [copy doc](https://docs.google.com/document/d/1gGVEdQapEa4uIHjNr15eim57mfFKmfbMXqQ274aEUEI/edit)

## Issue / Card
Fixes https://github.com/ubuntudesign/web-squad/issues/1071

## Screenshots
![Screenshot_2019-04-02 The leading operating system for PCs, IoT devices, servers and the cloud Ubuntu](https://user-images.githubusercontent.com/1413534/55390919-250e5c00-5530-11e9-895e-a9107cb061ea.png)

