### PR TITLE
K8s docs - minor updates to bundle refs and CA

### DIFF
--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -108,11 +108,11 @@ watch -c juju status --color
 ```
 
 It is also possible to deploy a specific version of the bundle by including the
-revision number. For example, to deploy the **CDK** bundle for the Kubernetes 1.12
+revision number. For example, to deploy the **CDK** bundle for the Kubernetes 1.13
 release, you could run:
 
 ```bash
-juju deploy cs:~containers/canonical-kubernetes-357
+juju deploy cs:~containers/canonical-kubernetes-435
 ```
 
 The revision numbers for bundles are generated automatically when the bundle is
@@ -124,7 +124,8 @@ versions of the **CDK** bundle are shown in the table below:
 
 | Kubernetes version | CDK bundle |
 | --- | --- |
-| 1.13.x         | [canonical-kubernetes-412](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-412/archive/bundle.yaml?channel=stable) |
+| 1.14.x         | [canonical-kubernetes-466](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-466/archive/bundle.yaml?channel=stable) |
+| 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
 | 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
 | 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |
 | 1.10.x         | [canonical-kubernetes-211](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-211/archive/bundle.yaml?channel=stable)  |

--- a/templates/kubernetes/docs/ldap.md
+++ b/templates/kubernetes/docs/ldap.md
@@ -107,6 +107,19 @@ juju status openstack-dashboard
 
 Open the address in a web browser and log in with the token obtained previously.
 
+```bash
+https://<openstack_dashboard_ip>/horizon
+```
+
+If you just deployed Keystone and do not have any credentials set, it is useful
+to note that Keystone creates the domain `admin_domain` by default and has a user
+named `admin` with a randomly-generated password. You can find the admin password
+with:
+
+```bash
+juju run --unit keystone/0 leader-get admin_password
+```
+
 ## Create the domain for Kubernetes
 You should now be able to access the OpenStack Dashboard and create a new domain.
 
@@ -196,6 +209,24 @@ juju config kubernetes-master keystone-policy=$(cat policy.yaml)
 ```
 
 The [default policy may be downloaded][policy] for easy editing.
+
+
+## Custom Certificate Authority
+
+When using a custom certificate authority attached to Keystone, some additional configuration is
+required.
+
+ * Add CA to client machines that will run `kubectl`.
+
+```
+sudo cp custom_ca.crt /usr/local/share/ca-certificates
+sudo update-ca-certificates
+```
+ * Add CA to the kubernetes-master configuration
+
+```bash
+juju config kubernetes-master keystone-ssl-ca="$(base64 custom_ca.crt)"
+```
 
 ## Troubleshooting
 

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -15,6 +15,8 @@ toc: False
 
 # 1.14
 
+### March 27, 2019 - [canonical-kubernetes-466](https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-466/archive/bundle.yaml)
+
 ## What's new
 
 - Tigera Secure EE support


### PR DESCRIPTION
## Done

Updated manual-install page with reference to new bundles
Added detail for using Keystone with additional CA

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
