### PR TITLE
Only display DE and FR takeovers for these locales

### DIFF
--- a/templates/takeovers/_14-04-esm.html
+++ b/templates/takeovers/_14-04-esm.html
@@ -1,4 +1,4 @@
-<section class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance" lang-skip="fr">
+<section class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance" lang-skip="fr de">
   <div class="row u-vertically-center">
     <div class="col-7 u-fade-left--medium">
       <h1>Still running Ubuntu 14.04 LTS?</h1>

--- a/templates/takeovers/_ci-cd-webinar.html
+++ b/templates/takeovers/_ci-cd-webinar.html
@@ -1,4 +1,4 @@
-<section class="js-takeover is-bordered p-takeover p-strip--image is-deep is-dark">
+<section class="js-takeover is-bordered p-takeover p-strip--image is-deep is-dark" lang-skip="fr de">
   <div class="row u-vertically-center">
     <div class="col-8">
       <h1>Learn DevOps best practices</h1>

--- a/templates/takeovers/_fin-serv-whitepaper-takeover.html
+++ b/templates/takeovers/_fin-serv-whitepaper-takeover.html
@@ -1,4 +1,4 @@
-<section class="js-takeover is-bordered p-takeover--fin-serv-whitepaper">
+<section class="js-takeover is-bordered p-takeover--fin-serv-whitepaper" lang-skip="fr de">
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="row u-vertically-center">
       <div class="col-7">

--- a/templates/takeovers/_snap-deltas-takeover.html
+++ b/templates/takeovers/_snap-deltas-takeover.html
@@ -1,4 +1,4 @@
-<section class="js-takeover is-bordered p-takeover--snap-deltas">
+<section class="js-takeover is-bordered p-takeover--snap-deltas" lang-skip="fr de">
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="row u-vertically-center">
       <div class="col-7">


### PR DESCRIPTION
## Done

* Skipped EN takeovers for DE and FR to increase visibility of localized content

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Change your browser to French, if it's not already the case, and ensure all takeovers are in French
- Repeat with German
