### PR TITLE
Fix loading the dynamic navigation on second level pages

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -1,4 +1,4 @@
-6e1552a8-atandt-logo.png?w=74" width="74"{% extends "templates/one-column.html" %}
+{% extends "templates/one-column.html" %}
 
 {% block title %}Security{% endblock %}
 {% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -21,17 +21,17 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__links u-hide js-show-nav" >
-        <li class="p-navigation__dropdown-link" role="menuitem" id="enterprise" onmouseover="fetchDropdown('templates/_navigation-enterprise-h', 'enterprise-content'); this.onmouseover = null;">
-          <a class="p-navigation__link-anchor" href="#enterprise-content" onfocus="fetchDropdown('templates/_navigation-enterprise-h', 'enterprise-content');">Enterprise</a>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="enterprise" onmouseover="fetchDropdown('/templates/_navigation-enterprise-h', 'enterprise-content'); this.onmouseover = null;">
+          <a class="p-navigation__link-anchor" href="#enterprise-content" onfocus="fetchDropdown('/templates/_navigation-enterprise-h', 'enterprise-content');">Enterprise</a>
         </li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="developer" onmouseover="fetchDropdown('templates/_navigation-developer-h', 'developer-content'); this.onmouseover = null;">
-          <a class="p-navigation__link-anchor" href="#developer-content" onfocus="fetchDropdown('templates/_navigation-developer-h', 'developer-content');">Developer</a>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="developer" onmouseover="fetchDropdown('/templates/_navigation-developer-h', 'developer-content'); this.onmouseover = null;">
+          <a class="p-navigation__link-anchor" href="#developer-content" onfocus="fetchDropdown('/templates/_navigation-developer-h', 'developer-content');">Developer</a>
         </li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="community" onmouseover="fetchDropdown('templates/_navigation-community-h', 'community-content'); this.onmouseover = null;">
-          <a class="p-navigation__link-anchor" href="#community-content" onfocus="fetchDropdown('templates/_navigation-community-h', 'community-content');">Community</a>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="community" onmouseover="fetchDropdown('/templates/_navigation-community-h', 'community-content'); this.onmouseover = null;">
+          <a class="p-navigation__link-anchor" href="#community-content" onfocus="fetchDropdown('/templates/_navigation-community-h', 'community-content');">Community</a>
         </li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="download" onmouseover="fetchDropdown('templates/_navigation-download-h', 'download-content'); this.onmouseover = null;">
-          <a class="p-navigation__link-anchor" href="#download-content" onfocus="fetchDropdown('templates/_navigation-download-h', 'download-content');">Download</a>
+        <li class="p-navigation__dropdown-link" role="menuitem" id="download" onmouseover="fetchDropdown('/templates/_navigation-download-h', 'download-content'); this.onmouseover = null;">
+          <a class="p-navigation__link-anchor" href="#download-content" onfocus="fetchDropdown('/templates/_navigation-download-h', 'download-content');">Download</a>
         </li>
       </ul>
       <noscript>


### PR DESCRIPTION
## Done
Fix loading the dynamic navigation on second level pages

Drive by: https://github.com/canonical-websites/www.ubuntu.com/issues/4914

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to /download/desktop
- Click the navigation items (Enterprise for example)
- Check the dropdown loads

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4913
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4914
