### PR TITLE
Update Keystone/dashboard docs

### DIFF
--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -23,7 +23,7 @@ Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because 
     </div>
     <div class="col-4 p-divider__block">
       <h3>What's new</h3>
-      <p><a href="/kubernetes/docs/release-notes">Version 1.13 released&nbsp;&rsaquo;</a></p>
+      <p><a href="/kubernetes/docs/release-notes">Version 1.14 released&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Tutorials</h3>

--- a/templates/kubernetes/docs/ldap.md
+++ b/templates/kubernetes/docs/ldap.md
@@ -97,7 +97,7 @@ The script should prompt you to enter an additional command to retrieve the toke
 login to the OpenStack Dashboard. If this step fails, check that the details in the
 `kube-keystone.sh` file are correct.
 
-## Access the dashboard
+## Access the OpenStack dashboard
 
 You can determine the web address for the OpenStack dashboard by running:
 
@@ -120,8 +120,8 @@ with:
 juju run --unit keystone/0 leader-get admin_password
 ```
 
-## Create the domain for Kubernetes
-You should now be able to access the OpenStack Dashboard and create a new domain.
+### Create the domain for Kubernetes
+You should now create a new domain for Kubernetes.
 
 ![dashboard image](https://assets.ubuntu.com/v1/00468cda-ldap1.png)
 
@@ -130,7 +130,7 @@ proper domain.
 
 ![dashboard image](https://assets.ubuntu.com/v1/f6913d43-ldap2.png)
 
-## Create a role for Kubernetes
+### Create a role for Kubernetes
 
 Create an appropriate role for Kubernetes:
 
@@ -140,20 +140,65 @@ Repeat the process for `k8s-viewers` and `k8s-users` if desired. These values
 match with the `keystone-policy` configuration option on the kubernetes-master
 charm.
 
-## Create a project for Kubernetes
+### Create a project for Kubernetes
 
 As with the roles, the project name must match the value in the
 `keystone-policy` configuration option on the kubernetes-master charm.
 
 ![dashboard image](https://assets.ubuntu.com/v1/442f2a24-ldap4.png)
 
-## Create a user for Kubernetes
+### Create a user for Kubernetes
 
 Now ensure the user is added to the project created above.
 
 ![dashboard image](https://assets.ubuntu.com/v1/d6149d7c-ldap5.png)
 
-##  LDAP via Keystone
+## Using kubectl with Keystone
+
+At this point, Keystone is set up and we have a domain, project, and user
+created in Keystone. With the updated config file copied above in
+`~/.kube/config`, we can use `kubectl` to authenticate with the api server
+via a token from Keystone. The `client-keystone-auth` snap will automate
+retrieving a token for us using the environment variables common to
+OpenStack such as `OS_USERNAME`. These environment variables are exported in
+the `kube-keystone.sh` script we downloaded earlier. To use it, update the
+variables in `kube-keystone.sh` to match valid user credentials. Pay
+special attention to the `OS_AUTH_URL` variable and ensure it is using an
+IP address that is reachable from the client. Source that file into
+your environment with `source ./kube-keystone.sh`. Any credentials that
+are not supplied via environment variable are queried at run-time for
+each invocation of kubectl.
+
+## Using Keystone with the kubernetes-dashboard
+
+When using Keystone with Kubernetes, the Kubernetes dashboard is
+updated by the charms to use token authentication. This means that a token
+from Keystone is required to log in to the Kubernetes dashboard. There is
+currently no way to automate this, but the `kube-keystone.sh` file includes
+a function called `get_keystone_token`, which uses the `OS_` environment
+variables in order to retrieve a token from Keystone.
+
+```bash
+source ~/bin/kube-keystone.sh
+```
+```
+Function get_keystone_token created. Type get_keystone_token in order to
+generate a login token for the Kubernetes dashboard.
+```
+Enter the command...
+```bash
+get_keystone_token
+```
+...and a token will be generated:
+```
+ccf9b218845f4d67835f8c6a7c2d1cd4
+```
+
+This token can then be used to log in to the Kubernetes dashboard.
+
+![dashboard image](https://assets.ubuntu.com/v1/4b79b35c-token-login.png)
+
+## LDAP via Keystone
 
 Keystone has the ability to use LDAP for authentication.
 The Keystone charm is related to the Keystone-LDAP subordinate charm in order to
@@ -234,6 +279,7 @@ As with any application configuration, it is easy to make simple mistakes when e
 different values or editing config files. If you are having problems, please
 [read the troubleshooting guide][trouble] for specific tips and information on
 configuring Keystone/LDAP.
+
 
 <!--LINKS-->
 [install]: /kubernetes/docs/quickstart


### PR DESCRIPTION
## Done

Adds a section to ldap.md to explain retrieving token and logging in to dashboard
Updates link on home page to advertise the correct version of docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
