### PR TITLE
Sync updated file release-notes.md from kubernetes-docs into website

### DIFF
--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -16,8 +16,7 @@ toc: False
 
 # 1.14 Bugfix release
 
-### April 4th, 2019 -
-[canonical-kubernetes-471][bundle]
+### April 4th, 2019 - [canonical-kubernetes-471][bundle]
 
 ## Fixes
 


### PR DESCRIPTION
## Done

Just removed an unwanted linebreak in the kubernetes release notes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)