### PR TITLE
Drops external-link symbol from BitTorrent headings

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -43,21 +43,21 @@
 
   <div class="row">
     <div class="col-3">
-      <h3 class="p-link--external p-heading--four"><span>Ubuntu {{latest_release_with_point}}</span></h3>
+      <h3 class="p-heading--four"><span>Ubuntu {{latest_release_with_point}}</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ latest_release }}/ubuntu-{{ latest_release_with_point }}-desktop-amd64.iso.torrent">Ubuntu {{ latest_release_with_point }} Desktop (64-bit)</a></li>
         <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ latest_release }}/ubuntu-{{ latest_release_with_point }}-live-server-amd64.iso.torrent">Ubuntu {{ latest_release_with_point }} Server (64-bit)</a></li>
       </ul>
     </div>
     <div class="col-3">
-      <h3 class="p-link--external p-heading--four"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
+      <h3 class="p-heading--four"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-desktop-amd64.iso.torrent">Ubuntu {{ lts_release_with_point }} Desktop (64-bit)</a></li>
         <li class="p-list__item"><a class="download-torrent" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release_with_point }}-live-server-amd64.iso.torrent">Ubuntu {{ lts_release_with_point }} Server (64-bit)</a></li>
       </ul>
     </div>
     <div class="col-3">
-      <h3 class="p-link--external p-heading--four"><span>Ubuntu {{previous_lts_release_full_with_point}}</span></h3>
+      <h3 class="p-heading--four"><span>Ubuntu {{previous_lts_release_full_with_point}}</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-desktop-amd64.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Desktop (64-bit)</a></li>
         <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-desktop-i386.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Desktop (32-bit)</a></li>
@@ -66,7 +66,7 @@
       </ul>
     </div>
     <div class="col-3">
-      <h3 class="p-link--external p-heading--four"><span>Ubuntu 14.04.6 LTS</span></h3>
+      <h3 class="p-heading--four"><span>Ubuntu 14.04.6 LTS</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso.torrent">Ubuntu 14.04.6 Desktop (64-bit)</a></li>
         <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-i386.iso.torrent">Ubuntu 14.04.6 Desktop (32-bit)</a></li>


### PR DESCRIPTION
## Done

- Drops the external-link symbol from the BitTorrent headings on the “Alternative downloads” page.

The point of an external-link icon is to warn you that the navigation (or the credibility, or both) of the linked site is likely to be different from the site you’re on at the moment.

That doesn’t apply here, because the links don’t take you to any site at all — they are downloads. (In contrast, the “Network installer” links above, and the other links below, _do_ take you to a different site, so the external-link icon is appropriate for those.)

([The copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit) does not show external-link icons for these headings.)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the “Alternative downloads” page locally at: [http://0.0.0.0:8001/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads)