### PR TITLE
Remove old takeovers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,12 +29,10 @@
   {% include "takeovers/_german_ai_webinar.html" %}
   {% include "takeovers/_german-compliance-webinar.html" %}
   {% include "takeovers/_german_takeover_k8.html" %}
-  {% include "takeovers/_german_takeover_openstack_made_easy.html" %}
   {# FRENCH #}
   {% include "takeovers/_french-k8s-case-study.html" %}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
-  {% include "takeovers/_french_vmware-to-os.html" %}
   {# ALL #}
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}


### PR DESCRIPTION
## Done

- removed two takeovers based on the [calendar](https://docs.google.com/spreadsheets/d/1MaFd-ZHWpRVjIP9Sj_dOCIGOtl-GJYbrXewt5EG4m80/edit#gid=564832475)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that 1 german and 1 french takeover have been removed

## Issue / Card

Fixes #4930

