### PR TITLE
Add /embedded page to the nav and iot section

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -285,6 +285,8 @@ iot:
       path: /internet-of-things/gateways
     - title: App store
       path: /internet-of-things/appstore
+    - title: Embedded Linux
+      path: /embedded
 
     - title: Thank you
       path: /internet-of-things/newsletter-thank-you

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -73,6 +73,7 @@
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/internet-of-things">Build your IoT on Ubuntu</a></li>
             <li class="p-list__item"><a href="/core">Ubuntu Core - embedded &amp; secure</a></li>
+            <li class="p-list__item"><a href="/embedded">Embedded Linux with Ubuntu</a></li>
             <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure packages for IoT</a></li>
             <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>
             <li class="p-list__item"><a href="/internet-of-things/digital-signage">Digital signage and smart displays</a></li>


### PR DESCRIPTION
## Done

- Added /embedded page to the enterprise nav and iot section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the page appears in the dropdown nav like the [copy doc](https://docs.google.com/document/d/15Tz87YRg4SnX4DWGOSl2TDTHLSStJoma879xHnF0nuo/edit?ts=5cae5dcf#) and in the iot section secondary nav


## Issue / Card

Fixes #4935
